### PR TITLE
Clean up output command

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -128,6 +128,8 @@ void free_output_config(struct output_config *oc) {
 		return;
 	}
 	free(oc->name);
+	free(oc->background);
+	free(oc->background_option);
 	free(oc);
 }
 


### PR DESCRIPTION
Plugs memory leaks during failure of the output command and in other
circumstances and fixes `bg` option.

Fixes #1381

How outputs are applied is still buggy, but I decided to just focus on these changes now.