### PR TITLE
Fixes to changing scale factor with output command

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -912,6 +912,9 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 	if (src->y != -1) {
 		dst->y = src->y;
 	}
+  if (src->scale != -1) {
+    dst->scale = src->scale;
+  }
 	if (src->background) {
 		if (dst->background) {
 			free(dst->background);
@@ -1127,7 +1130,7 @@ void apply_output_config(struct output_config *oc, swayc_t *output) {
 		sway_log(L_DEBUG, "Set %s size to %ix%i (%d)", oc->name, oc->width, oc->height, oc->scale);
 		struct wlc_size new_size = { .w = oc->width, .h = oc->height };
 		wlc_output_set_resolution(output->handle, &new_size, (uint32_t)oc->scale);
-	} else if (oc && oc->scale != 1) {
+	} else if (oc) {
 		const struct wlc_size *new_size = wlc_output_get_resolution(output->handle);
 		wlc_output_set_resolution(output->handle, new_size, (uint32_t)oc->scale);
 	}


### PR DESCRIPTION
Poking around with the output command with `swaymsg -t command output` I noticed a couple oddities with setting scaling on the fly.

Without this change, only the first output command would cause the scaling factor to change.  This change allows subsequent output commands to adjust scaling, as well as revert the scaling factor back to 1 (the default).

Tested by:

![untitled](https://user-images.githubusercontent.com/2600574/31580604-fcf14fc0-b111-11e7-9fe2-34e1ac73df5e.png)

