### PR TITLE
Use add_compile_options instead of interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,12 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(sway C)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+add_compile_options(-g)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Werror)
 
 list(INSERT CMAKE_MODULE_PATH 0
 	${CMAKE_CURRENT_SOURCE_DIR}/CMake


### PR DESCRIPTION
Uses CMake's `add_compile_options` directive instead of interpolating  `CMAKE_C_FLAGS` for adding compilation flags.

Also, I have a question: why adding `-g` to all build types instead of recommending `RelWithDebInfo` (essentially `Release` with `-g`) as default?