### PR TITLE
Add Address Sanitized build type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ compiler:
   - gcc
   - clang
 
+env:
+  - BUILD_TYPE=Release
+  - BUILD_TYPE=Debug
+  - BUILD_TYPE=ASAN
+
 arch:
   packages:
     - cmake
@@ -19,7 +24,7 @@ arch:
     - wlc-git
     - libcap
   script:
-    - "cmake ."
+    - "cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ."
     - "make"
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Werror)
 
+# Add Address Sanitiezed build type
+set(CMAKE_C_FLAGS_ASAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer"
+    CACHE STRING "Flags used by the C compiler during address sanitizer builds."
+    FORCE )
+mark_as_advanced(
+    CMAKE_C_FLAGS_ASAN
+    CMAKE_EXE_LINKER_FLAGS_DEBUG
+    CMAKE_SHARED_LINKER_FLAGS_DEBUG
+    )
+
 list(INSERT CMAKE_MODULE_PATH 0
 	${CMAKE_CURRENT_SOURCE_DIR}/CMake
 	)


### PR DESCRIPTION
 - Add `-DCMAKE_BUILD_TYPE=ASAN` to possible build types

I've found address sanitized builds to be super helpful for finding leaks etc.