### PR TITLE
Explicitly setting the version of json-c required

### DIFF
--- a/CMake/FindJsonC.cmake
+++ b/CMake/FindJsonC.cmake
@@ -8,10 +8,22 @@
 #
 
 find_package(PkgConfig)
-pkg_check_modules(PC_JSONC QUIET JSONC)
+
+if (JsonC_FIND_REQUIRED)
+	set(_pkgconfig_REQUIRED "REQUIRED")
+else()
+	set(_pkgconfig_REQUIRED "")
+endif()
+
+if(JsonC_FIND_VERSION)
+    pkg_check_modules(PC_JSONC ${_pkgconfig_REQUIRED} json-c=${JsonC_FIND_VERSION})
+else()
+    pkg_check_modules(PC_JSONC ${_pkgconfig_REQUIRED} json-c)
+endif()
+
 find_path(JSONC_INCLUDE_DIRS NAMES json-c/json.h HINTS ${PC_JSONC_INCLUDE_DIRS})
 find_library(JSONC_LIBRARIES NAMES json-c HINTS ${PC_JSONC_LIBRARY_DIRS})
-
 include(FindPackageHandleStandardArgs)
+
 find_package_handle_standard_args(JSONC DEFAULT_MSG JSONC_LIBRARIES JSONC_INCLUDE_DIRS)
 mark_as_advanced(JSONC_LIBRARIES JSONC_INCLUDE_DIRS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (LD_LIBRARY_PATH)
 	add_definitions(-D_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}")
 endif()
 
-find_package(JsonC REQUIRED)
+find_package(JsonC 0.12.1 REQUIRED)
 find_package(PCRE REQUIRED)
 find_package(WLC REQUIRED)
 find_package(Wayland REQUIRED)

--- a/README.de.md
+++ b/README.de.md
@@ -60,7 +60,7 @@ Abhängigkeiten:
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.el.md
+++ b/README.el.md
@@ -53,7 +53,7 @@ To username μου στο Freenode είναι kon14 και θα με βρείτ�
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.fr.md
+++ b/README.fr.md
@@ -55,7 +55,7 @@ Installez les dépendances :
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.it.md
+++ b/README.it.md
@@ -56,7 +56,7 @@ Installa queste dipendenze:
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,7 +49,7 @@ Swayは沢山のディストリビューションで提供されています。"
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install dependencies:
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.pt.md
+++ b/README.pt.md
@@ -62,7 +62,7 @@ Antes de iniciar a compilação, instale as dependências:
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.ru.md
+++ b/README.ru.md
@@ -55,7 +55,7 @@ Sway доступен во многих дистрибутивах и наход
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.uk.md
+++ b/README.uk.md
@@ -62,7 +62,7 @@ Sway доступний у багатьох дистрибутивах Linux (а
 * libcap
 * asciidoc
 * pcre
-* json-c
+* json-c <= 0.12.1
 * pango
 * cairo
 * gdk-pixbuf2 *


### PR DESCRIPTION
 to 0.12.1. This is needed because the development

 version breaks the existing API of json_object_array_length()

 by moving the return from int to size_t.

This would fix #1355