### PR TITLE
Warning fixes for json-c json_object_array_length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (LD_LIBRARY_PATH)
 	add_definitions(-D_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}")
 endif()
 
-find_package(JsonC 0.12.1 REQUIRED)
+find_package(JsonC REQUIRED)
 find_package(PCRE REQUIRED)
 find_package(WLC REQUIRED)
 find_package(Wayland REQUIRED)

--- a/README.de.md
+++ b/README.de.md
@@ -60,7 +60,7 @@ Abhängigkeiten:
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.el.md
+++ b/README.el.md
@@ -53,7 +53,7 @@ To username μου στο Freenode είναι kon14 και θα με βρείτ�
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.fr.md
+++ b/README.fr.md
@@ -55,7 +55,7 @@ Installez les dépendances :
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.it.md
+++ b/README.it.md
@@ -56,7 +56,7 @@ Installa queste dipendenze:
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,7 +49,7 @@ Swayは沢山のディストリビューションで提供されています。"
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install dependencies:
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.pt.md
+++ b/README.pt.md
@@ -62,7 +62,7 @@ Antes de iniciar a compilação, instale as dependências:
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.ru.md
+++ b/README.ru.md
@@ -55,7 +55,7 @@ Sway доступен во многих дистрибутивах и наход
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/README.uk.md
+++ b/README.uk.md
@@ -62,7 +62,7 @@ Sway доступний у багатьох дистрибутивах Linux (а
 * libcap
 * asciidoc
 * pcre
-* json-c <= 0.12.1
+* json-c
 * pango
 * cairo
 * gdk-pixbuf2 *

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -724,7 +724,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 
 		// parse requested event types
-		for (int i = 0; i < json_object_array_length(request); i++) {
+		for (size_t i = 0; i < (size_t)json_object_array_length(request); i++) {
 			const char *event_type = json_object_get_string(json_object_array_get_idx(request, i));
 			if (strcmp(event_type, "workspace") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_WORKSPACE);

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -120,18 +120,17 @@ static void ipc_parse_config(struct config *config, const char *payload) {
 #endif
 
 	// free previous outputs list
-	int i;
-	for (i = 0; i < config->outputs->length; ++i) {
+	for (int i = 0; i < config->outputs->length; ++i) {
 		free(config->outputs->items[i]);
 	}
 	list_free(config->outputs);
 	config->outputs = create_list();
 
 	if (outputs) {
-		int length = json_object_array_length(outputs);
+		size_t length = (size_t)json_object_array_length(outputs);
 		json_object *output;
 		const char *output_str;
-		for (i = 0; i < length; ++i) {
+		for (size_t i = 0; i < length; ++i) {
 			output = json_object_array_get_idx(outputs, i);
 			output_str = json_object_get_string(output);
 			if (strcmp("*", output_str) == 0) {

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -70,8 +70,7 @@ static void parse_json(struct bar *bar, const char *text) {
 
 	bar->status->block_line = create_list();
 
-	int i;
-	for (i = 0; i < json_object_array_length(results); ++i) {
+	for (size_t i = 0; i < (size_t)json_object_array_length(results); ++i) {
 		json_object *full_text, *short_text, *color, *min_width, *align, *urgent;
 		json_object *name, *instance, *separator, *separator_block_width;
 		json_object *background, *border, *border_top, *border_bottom;
@@ -430,7 +429,7 @@ bool status_line_mouse_event(struct bar *bar, int x, int y, uint32_t button) {
 		}
 
 		// event example {"name":"capture","instance":"label","button":1,"x":3431,"y":18}
-	
+
 		struct json_object *event_json = json_object_new_object();
 		json_object_object_add(event_json, "name", json_object_new_string(clicked_block->name));
 		if (clicked_block->instance) {

--- a/swaygrab/json.c
+++ b/swaygrab/json.c
@@ -50,8 +50,7 @@ static json_object *get_focused_container_r(json_object *c) {
 	} else {
 		json_object *nodes, *node, *child;
 		json_object_object_get_ex(c, "nodes", &nodes);
-		int i;
-		for (i = 0; i < json_object_array_length(nodes); i++) {
+		for (size_t i = 0; i < (size_t)json_object_array_length(nodes); i++) {
 			node = json_object_array_get_idx(nodes, i);
 
 			if ((child = get_focused_container_r(node))) {
@@ -60,7 +59,7 @@ static json_object *get_focused_container_r(json_object *c) {
 		}
 
 		json_object_object_get_ex(c, "floating_nodes", &nodes);
-		for (i = 0; i < json_object_array_length(nodes); i++) {
+		for (size_t i = 0; i < (size_t)json_object_array_length(nodes); i++) {
 			node = json_object_array_get_idx(nodes, i);
 
 			if ((child = get_focused_container_r(node))) {
@@ -81,9 +80,9 @@ char *get_focused_output() {
 	json_object *outputs, *output, *name;
 	json_object_object_get_ex(tree, "nodes", &outputs);
 	if (!outputs) {
-		sway_abort("Unabled to get focused output. No nodes in tree.");
+		sway_abort("Unable to get focused output. No nodes in tree.");
 	}
-	for (int i = 0; i < json_object_array_length(outputs); i++) {
+	for (size_t i = 0; i < (size_t)json_object_array_length(outputs); i++) {
 		output = json_object_array_get_idx(outputs, i);
 
 		if (get_focused_container_r(output)) {
@@ -131,7 +130,7 @@ json_object *get_output_container(const char *output) {
 	json_object *outputs, *json_output, *name;
 	json_object_object_get_ex(tree, "nodes", &outputs);
 
-	for (int i = 0; i < json_object_array_length(outputs); i++) {
+	for (size_t i = 0; i < (size_t)json_object_array_length(outputs); i++) {
 		json_output = json_object_array_get_idx(outputs, i);
 		json_object_object_get_ex(json_output, "name", &name);
 

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -584,8 +584,8 @@ int main(int argc, char **argv) {
 
 		for (i = 0; i < registry->outputs->length; ++i) {
 			if (displays_paths[i * 2] != NULL) {
-				for (int j = 0;; ++j) {
-					if (j >= json_object_array_length(json_outputs)) {
+				for (size_t j = 0;; ++j) {
+					if (j >= (size_t)json_object_array_length(json_outputs)) {
 						sway_log(L_ERROR, "%s is not an extant output", displays_paths[i * 2]);
 						exit(EXIT_FAILURE);
 					}

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -149,7 +149,7 @@ static void pretty_print_version(json_object *v) {
 static void pretty_print_clipboard(json_object *v) {
 	if (success(v, true)) {
 		if (json_object_is_type(v, json_type_array)) {
-			for (int i = 0; i < json_object_array_length(v); ++i) {
+			for (size_t i = 0; i < (size_t)json_object_array_length(v); ++i) {
 				json_object *o = json_object_array_get_idx(v, i);
 				printf("%s\n", json_object_get_string(o));
 			}


### PR DESCRIPTION
A better patch for quieting the warnings related to json_object_array_length
This grants some future-proofing for the next json-c version which contains this API breaking change.