### PR TITLE
Fix init_tray function declaration

### DIFF
--- a/include/swaybar/tray/tray.h
+++ b/include/swaybar/tray/tray.h
@@ -27,6 +27,6 @@ void tray_upkeep(struct bar *bar);
 /**
  * Initializes the tray with D-Bus
  */
-void init_tray();
+void init_tray(struct bar *bar);
 
 #endif /* _SWAYBAR_TRAY_H */


### PR DESCRIPTION
This fixes compilation failure:
error: call to function 'init_tray' without a real prototype