### PR TITLE
Fix build with recent wlroots

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <wlc/wlc.h>
 #include <xkbcommon/xkbcommon-names.h>
+#include <wlr/types/wlr_keyboard.h>
 #include "log.h"
 #include "readline.h"
 #include "util.h"
@@ -29,16 +29,16 @@ static struct modifier_key {
 	char *name;
 	uint32_t mod;
 } modifiers[] = {
-	{ XKB_MOD_NAME_SHIFT, WLC_BIT_MOD_SHIFT },
-	{ XKB_MOD_NAME_CAPS, WLC_BIT_MOD_CAPS },
-	{ XKB_MOD_NAME_CTRL, WLC_BIT_MOD_CTRL },
-	{ "Ctrl", WLC_BIT_MOD_CTRL },
-	{ XKB_MOD_NAME_ALT, WLC_BIT_MOD_ALT },
-	{ "Alt", WLC_BIT_MOD_ALT },
-	{ XKB_MOD_NAME_NUM, WLC_BIT_MOD_MOD2 },
-	{ "Mod3", WLC_BIT_MOD_MOD3 },
-	{ XKB_MOD_NAME_LOGO, WLC_BIT_MOD_LOGO },
-	{ "Mod5", WLC_BIT_MOD_MOD5 },
+	{ XKB_MOD_NAME_SHIFT, WLR_MODIFIER_SHIFT },
+	{ XKB_MOD_NAME_CAPS, WLR_MODIFIER_CAPS },
+	{ XKB_MOD_NAME_CTRL, WLR_MODIFIER_CTRL },
+	{ "Ctrl", WLR_MODIFIER_CTRL },
+	{ XKB_MOD_NAME_ALT, WLR_MODIFIER_ALT },
+	{ "Alt", WLR_MODIFIER_ALT },
+	{ XKB_MOD_NAME_NUM, WLR_MODIFIER_MOD2 },
+	{ "Mod3", WLR_MODIFIER_MOD3 },
+	{ XKB_MOD_NAME_LOGO, WLR_MODIFIER_LOGO },
+	{ "Mod5", WLR_MODIFIER_MOD5 },
 };
 
 uint32_t get_modifier_mask_by_name(const char *name) {

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -4,7 +4,7 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/types/wlr_data_device_manager.h>
+#include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/render.h>
 // TODO WLR: make Xwayland optional

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>

--- a/sway/server.c
+++ b/sway/server.c
@@ -4,7 +4,6 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
-#include <wlr/types/wlr_data_device_manager.h>
 #include <wlr/render.h>
 #include <wlr/render/gles2.h>
 // TODO WLR: make Xwayland optional


### PR DESCRIPTION
A couple of trivial fix ; this should build with wlroots/master and remove the last need for wlc includes that I didn't have in a standard path.