### PR TITLE
use app_id instead of class

### DIFF
--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -29,9 +29,8 @@ enum sway_view_type {
 
 enum sway_view_prop {
 	VIEW_PROP_TITLE,
-	VIEW_PROP_CLASS,
-	VIEW_PROP_INSTANCE,
 	VIEW_PROP_APP_ID,
+	VIEW_PROP_INSTANCE,
 };
 
 /**


### PR DESCRIPTION
The app_id and class are essentially the same thing and should be treated the same. Pick one name and stick with it.