### PR TITLE
basic wl_shell

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -42,5 +42,6 @@ void output_add_notify(struct wl_listener *listener, void *data);
 void output_remove_notify(struct wl_listener *listener, void *data);
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
+void handle_wl_shell_surface(struct wl_listener *listener, void *data);
 
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -30,6 +30,9 @@ struct sway_server {
 
 	struct wlr_xdg_shell_v6 *xdg_shell_v6;
 	struct wl_listener xdg_shell_v6_surface;
+
+	struct wlr_wl_shell *wl_shell;
+	struct wl_listener wl_shell_surface;
 };
 
 struct sway_server server;

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -19,6 +19,18 @@ struct sway_xdg_surface_v6 {
 	int pending_width, pending_height;
 };
 
+struct sway_wl_shell_surface {
+	struct sway_view *view;
+
+	struct wl_listener commit;
+	struct wl_listener request_move;
+	struct wl_listener request_resize;
+	struct wl_listener request_maximize;
+	struct wl_listener destroy;
+
+	int pending_width, pending_height;
+};
+
 enum sway_view_type {
 	SWAY_WL_SHELL_VIEW,
 	SWAY_XDG_SHELL_V6_VIEW,

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -42,6 +42,7 @@ enum sway_view_type {
 enum sway_view_prop {
 	VIEW_PROP_TITLE,
 	VIEW_PROP_APP_ID,
+	VIEW_PROP_CLASS,
 	VIEW_PROP_INSTANCE,
 };
 

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -29,9 +29,8 @@ enum sway_view_type {
 
 enum sway_view_prop {
 	VIEW_PROP_TITLE,
-	VIEW_PROP_CLASS,
-	VIEW_PROP_INSTANCE,
 	VIEW_PROP_APP_ID,
+	VIEW_PROP_INSTANCE,
 };
 
 /**
@@ -46,10 +45,12 @@ struct sway_view {
 
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
+		struct wlr_wl_shell_surface *wlr_wl_shell_surface;
 	};
 
 	union {
 		struct sway_xdg_surface_v6 *sway_xdg_surface_v6;
+		struct sway_wl_shell_surface *sway_wl_shell_surface;
 	};
 
 	struct {

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -1,0 +1,30 @@
+#define _POSIX_C_SOURCE 199309L
+#include <stdbool.h>
+#include <stdlib.h>
+#include <wayland-server.h>
+#include <wlr/types/wlr_wl_shell.h>
+#include "sway/container.h"
+#include "sway/layout.h"
+#include "sway/server.h"
+#include "sway/view.h"
+#include "log.h"
+
+static bool assert_wl_shell(struct sway_view *view) {
+	return sway_assert(view->type == SWAY_WL_SHELL_VIEW,
+		"Expecting wl_shell view!");
+}
+
+static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
+	if (!assert_wl_shell(view)) {
+		return NULL;
+	}
+	switch (prop) {
+	case VIEW_PROP_TITLE:
+		return view->wlr_wl_shell_surface->title;
+	case VIEW_PROP_APP_ID:
+		return view->wlr_wl_shell_surface->class;
+	default:
+		return NULL;
+	}
+}
+

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -28,7 +28,7 @@ static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
 	}
 }
 
-static void set_dimensions(struct sway_view *view, int width, int height) {
+static void set_size(struct sway_view *view, int width, int height) {
 	if (!assert_wl_shell(view)) {
 		return;
 	}
@@ -86,7 +86,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	}
 	sway_view->type = SWAY_WL_SHELL_VIEW;
 	sway_view->iface.get_prop = get_prop;
-	sway_view->iface.set_dimensions = set_dimensions;
+	sway_view->iface.set_size = set_size;
 	sway_view->wlr_wl_shell_surface = shell_surface;
 	sway_view->sway_wl_shell_surface = sway_surface;
 	sway_view->surface = shell_surface->surface;

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -21,7 +21,7 @@ static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
 	switch (prop) {
 	case VIEW_PROP_TITLE:
 		return view->wlr_wl_shell_surface->title;
-	case VIEW_PROP_APP_ID:
+	case VIEW_PROP_CLASS:
 		return view->wlr_wl_shell_surface->class;
 	default:
 		return NULL;

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -28,3 +28,88 @@ static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
 	}
 }
 
+static void set_dimensions(struct sway_view *view, int width, int height) {
+	if (!assert_wl_shell(view)) {
+		return;
+	}
+	view->sway_wl_shell_surface->pending_width = width;
+	view->sway_wl_shell_surface->pending_height = height;
+	wlr_wl_shell_surface_configure(view->wlr_wl_shell_surface, 0, width, height);
+}
+
+static void handle_commit(struct wl_listener *listener, void *data) {
+	struct sway_wl_shell_surface *sway_surface =
+		wl_container_of(listener, sway_surface, commit);
+	struct sway_view *view = sway_surface->view;
+	sway_log(L_DEBUG, "wl_shell surface commit %dx%d",
+			sway_surface->pending_width, sway_surface->pending_height);
+	// NOTE: We intentionally discard the view's desired width here
+	// TODO: Let floating views do whatever
+	view->width = sway_surface->pending_width;
+	view->height = sway_surface->pending_height;
+}
+
+static void handle_destroy(struct wl_listener *listener, void *data) {
+	struct sway_wl_shell_surface *sway_surface =
+		wl_container_of(listener, sway_surface, destroy);
+	wl_list_remove(&sway_surface->commit.link);
+	wl_list_remove(&sway_surface->destroy.link);
+	swayc_t *parent = destroy_view(sway_surface->view->swayc);
+	free(sway_surface->view);
+	free(sway_surface);
+	arrange_windows(parent, -1, -1);
+}
+
+void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
+	struct sway_server *server = wl_container_of(
+			listener, server, wl_shell_surface);
+	struct wlr_wl_shell_surface *shell_surface = data;
+
+	if (shell_surface->state != WLR_WL_SHELL_SURFACE_STATE_TOPLEVEL) {
+		// TODO: transient and popups should be floating
+		return;
+	}
+
+	sway_log(L_DEBUG, "New wl_shell toplevel title='%s' app_id='%s'",
+			shell_surface->title, shell_surface->class);
+	wlr_wl_shell_surface_ping(shell_surface);
+
+	struct sway_wl_shell_surface *sway_surface =
+		calloc(1, sizeof(struct sway_wl_shell_surface));
+	if (!sway_assert(sway_surface, "Failed to allocate surface!")) {
+		return;
+	}
+
+	struct sway_view *sway_view = calloc(1, sizeof(struct sway_view));
+	if (!sway_assert(sway_view, "Failed to allocate view!")) {
+		return;
+	}
+	sway_view->type = SWAY_WL_SHELL_VIEW;
+	sway_view->iface.get_prop = get_prop;
+	sway_view->iface.set_dimensions = set_dimensions;
+	sway_view->wlr_wl_shell_surface = shell_surface;
+	sway_view->sway_wl_shell_surface = sway_surface;
+	sway_view->surface = shell_surface->surface;
+	sway_surface->view = sway_view;
+
+	// TODO:
+	// - Wire up listeners
+	// - Handle popups
+	// - Look up pid and open on appropriate workspace
+	// - Set new view to maximized so it behaves nicely
+	// - Criteria
+
+	sway_surface->commit.notify = handle_commit;
+	wl_signal_add(&shell_surface->events.commit, &sway_surface->commit);
+	sway_surface->destroy.notify = handle_destroy;
+	wl_signal_add(&shell_surface->events.destroy, &sway_surface->destroy);
+
+	// TODO: actual focus semantics
+	swayc_t *parent = root_container.children->items[0];
+	parent = parent->children->items[0]; // workspace
+
+	swayc_t *cont = new_view(parent, sway_view);
+	sway_view->swayc = cont;
+
+	arrange_windows(cont->parent, -1, -1);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -6,6 +6,7 @@ sway_sources = files(
 	'ipc-json.c',
 	'ipc-server.c',
 	'desktop/output.c',
+	'desktop/wl_shell.c',
 	'desktop/xdg_shell_v6.c',
 	'tree/container.c',
 	'tree/layout.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -7,6 +7,7 @@
 #include <wlr/render.h>
 #include <wlr/render/gles2.h>
 #include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_wl_shell.h>
 // TODO WLR: make Xwayland optional
 #include <wlr/xwayland.h>
 #include "sway/server.h"
@@ -39,6 +40,11 @@ bool server_init(struct sway_server *server) {
 	wl_signal_add(&server->xdg_shell_v6->events.new_surface,
 		&server->xdg_shell_v6_surface);
 	server->xdg_shell_v6_surface.notify = handle_xdg_shell_v6_surface;
+
+	server->wl_shell = wlr_wl_shell_create(server->wl_display);
+	wl_signal_add(&server->wl_shell->events.new_surface,
+		&server->wl_shell_surface);
+	server->wl_shell_surface.notify = handle_wl_shell_surface;
 
 	server->socket = wl_display_add_socket_auto(server->wl_display);
 	if (!sway_assert(server->socket,  "Unable to open wayland socket")) {


### PR DESCRIPTION
Pretty much the same features as xdg_shell currently. Gives us a basis for improvement.

QT can be made to use wl_shell.

Will post this diff for testing again to make that work in case you missed it:

```diff
diff --git a/sway/server.c b/sway/server.c
index bf5c37e..e24b607 100644
--- a/sway/server.c
+++ b/sway/server.c
@@ -36,10 +36,12 @@ bool server_init(struct sway_server *server) {
 	wl_signal_add(&server->backend->events.output_remove,
 			&server->output_remove);
 
+	/*
 	server->xdg_shell_v6 = wlr_xdg_shell_v6_create(server->wl_display);
 	wl_signal_add(&server->xdg_shell_v6->events.new_surface,
 		&server->xdg_shell_v6_surface);
 	server->xdg_shell_v6_surface.notify = handle_xdg_shell_v6_surface;
+	*/
 
 	server->wl_shell = wlr_wl_shell_create(server->wl_display);
 	wl_signal_add(&server->wl_shell->events.new_surface,
```