### PR TITLE
Patch #1507: Clicking on invisible title bars switches focus

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -931,7 +931,7 @@ static bool swayc_border_check(swayc_t *c, const void *_origin) {
 	const struct wlc_point *origin = _origin;
 	const struct wlc_geometry title_bar = c->title_bar_geometry;
 
-	if (c->border_type != B_NORMAL) {
+	if (c->border_type != B_NORMAL || !c->visible) {
 		return false;
 	}
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -931,7 +931,8 @@ static bool swayc_border_check(swayc_t *c, const void *_origin) {
 	const struct wlc_point *origin = _origin;
 	const struct wlc_geometry title_bar = c->title_bar_geometry;
 
-	if (c->border_type != B_NORMAL || !c->visible) {
+	if (c->border_type != B_NORMAL
+		|| (c->parent != NULL && !c->parent->visible)) {
 		return false;
 	}
 


### PR DESCRIPTION
The initial problem that sparked #1507 was when I had views inside a container inside a tabbed container and could focus those views by clicking in their title bar region when the tab wasn't focused. This patch resolves that bug, but the issue remains open because there is a lot more to fix in those scenarios.