### PR TITLE
build: add wlroots dependency to common

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -7,5 +7,6 @@ lib_sway_common = static_library('sway-common',
 		'readline.c',
 		'ipc-client.c'
 	),
+	dependencies: [ wlroots ],
 	include_directories: sway_inc
 )


### PR DESCRIPTION
It is required for include path if wlroots is not built in standard path,
but found through pkg-config