### PR TITLE
Added BUILDPKG for Arch (sway-wlroots)

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -2,7 +2,6 @@
 image: archlinux
 packages:
   - meson
-  - wlc-git
   - xorg-server-xwayland
   - xcb-util-image
   - json-c

--- a/dist/archlinux/PKGBUILD
+++ b/dist/archlinux/PKGBUILD
@@ -51,10 +51,7 @@ build() {
   meson build \
 		--prefix=/usr \
 		-Dbuildtype=debugoptimized \
-		-Db_lto=True \
-		-Denable-systemd=True \
-		-Denable-elogind=False \
-		-Denable-libcap=True
+		-Db_lto=True
     
     ninja -C build
 }

--- a/dist/archlinux/PKGBUILD
+++ b/dist/archlinux/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Drew DeVault <sir@cmpwn.com>
+# Contributor: chrisaw <home@chrisaw.com>
+
+pkgname=sway
+pkgver=git
+pkgrel=1
+license=('MIT')
+pkgdesc='i3 compatible window manager for Wayland'
+makedepends=(
+  "meson"
+  "git"
+  "asciidoc"
+)
+depends=(
+  "wlroots"
+  "wayland"
+  "xorg-server-xwayland"
+  "libinput"
+  "libcap"
+  "pcre"
+  "json-c"
+  "pango"
+  "cairo"
+  "gdk-pixbuf2"
+  "pam"
+  "dbus"
+)
+optdepends=(
+	"rxvt-unicode: Default terminal emulator."
+	"dmenu: Default for launching applications."
+	"imagemagick: For taking screenshots."
+	"ffmpeg: For recording screencasts."
+	"i3status: To display system information with a bar."
+)
+arch=("i686" "x86_64")
+url='http://swaywm.org'
+source=("${pkgname%-*}::git+https://github.com/SirCmpwn/sway.git#wlroots")
+sha1sums=('SKIP')
+provides=('sway')
+conflicts=('sway-git')
+install=sway.install
+
+pkgver() {
+	cd "${srcdir}/${pkgname}"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	cd "${srcdir}/${pkgname}"
+
+  meson build \
+		--prefix=/usr \
+		-Dbuildtype=debugoptimized \
+		-Db_lto=True \
+		-Denable-systemd=True \
+		-Denable-elogind=False \
+		-Denable-libcap=True
+    
+    ninja -C build
+}
+
+package() {
+	cd "${srcdir}/${pkgname}"
+
+	DESTDIR="${pkgdir}" ninja -C build install
+}

--- a/dist/archlinux/PKGBUILD
+++ b/dist/archlinux/PKGBUILD
@@ -34,7 +34,7 @@ optdepends=(
 )
 arch=("i686" "x86_64")
 url='http://swaywm.org'
-source=("${pkgname%-*}::git+https://github.com/SirCmpwn/sway.git#wlroots")
+source=("${pkgname%-*}::git+https://github.com/SirCmpwn/sway.git#branch=wlroots")
 sha1sums=('SKIP')
 provides=('sway')
 conflicts=('sway-git')

--- a/dist/archlinux/sway.install
+++ b/dist/archlinux/sway.install
@@ -1,0 +1,3 @@
+post_install() {
+    setcap "cap_sys_ptrace,cap_sys_tty_config=eip" /usr/bin/sway
+}


### PR DESCRIPTION
To bring the sway repo in-line with the wlroots repo I have created a BUILDPKG to build sway against wlroots. This should obviously only be used for the development branch of sway but can be used to build the final package once sway 1.0 goes live.

Feedback welcome!