### PR TITLE
Libinput config

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -58,7 +58,6 @@ struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 
 static void seat_configure_pointer(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
-	// TODO pointer configuration
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 }


### PR DESCRIPTION
Restore the code that used to be in config.c:apply_input_config() pre-wlroots.

Lines were very long in the original code, do we want to use the heavy rewrite as a chance to wrap these?