### PR TITLE
Update to json-c 0.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (LD_LIBRARY_PATH)
 	add_definitions(-D_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}")
 endif()
 
-find_package(JsonC 0.12.1 REQUIRED)
+find_package(JsonC REQUIRED)
 find_package(PCRE REQUIRED)
 find_package(WLC REQUIRED)
 find_package(Wayland REQUIRED)

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -724,7 +724,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 
 		// parse requested event types
-		for (int i = 0; i < json_object_array_length(request); i++) {
+		for (size_t i = 0; i < json_object_array_length(request); i++) {
 			const char *event_type = json_object_get_string(json_object_array_get_idx(request, i));
 			if (strcmp(event_type, "workspace") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_WORKSPACE);

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -70,7 +70,7 @@ static void parse_json(struct bar *bar, const char *text) {
 
 	bar->status->block_line = create_list();
 
-	int i;
+	size_t i;
 	for (i = 0; i < json_object_array_length(results); ++i) {
 		json_object *full_text, *short_text, *color, *min_width, *align, *urgent;
 		json_object *name, *instance, *separator, *separator_block_width;

--- a/swaygrab/json.c
+++ b/swaygrab/json.c
@@ -50,7 +50,7 @@ static json_object *get_focused_container_r(json_object *c) {
 	} else {
 		json_object *nodes, *node, *child;
 		json_object_object_get_ex(c, "nodes", &nodes);
-		int i;
+		size_t i;
 		for (i = 0; i < json_object_array_length(nodes); i++) {
 			node = json_object_array_get_idx(nodes, i);
 
@@ -83,7 +83,7 @@ char *get_focused_output() {
 	if (!outputs) {
 		sway_abort("Unabled to get focused output. No nodes in tree.");
 	}
-	for (int i = 0; i < json_object_array_length(outputs); i++) {
+	for (size_t i = 0; i < json_object_array_length(outputs); i++) {
 		output = json_object_array_get_idx(outputs, i);
 
 		if (get_focused_container_r(output)) {
@@ -131,7 +131,7 @@ json_object *get_output_container(const char *output) {
 	json_object *outputs, *json_output, *name;
 	json_object_object_get_ex(tree, "nodes", &outputs);
 
-	for (int i = 0; i < json_object_array_length(outputs); i++) {
+	for (size_t i = 0; i < json_object_array_length(outputs); i++) {
 		json_output = json_object_array_get_idx(outputs, i);
 		json_object_object_get_ex(json_output, "name", &name);
 

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -584,7 +584,7 @@ int main(int argc, char **argv) {
 
 		for (i = 0; i < registry->outputs->length; ++i) {
 			if (displays_paths[i * 2] != NULL) {
-				for (int j = 0;; ++j) {
+				for (size_t j = 0;; ++j) {
 					if (j >= json_object_array_length(json_outputs)) {
 						sway_log(L_ERROR, "%s is not an extant output", displays_paths[i * 2]);
 						exit(EXIT_FAILURE);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -149,7 +149,7 @@ static void pretty_print_version(json_object *v) {
 static void pretty_print_clipboard(json_object *v) {
 	if (success(v, true)) {
 		if (json_object_is_type(v, json_type_array)) {
-			for (int i = 0; i < json_object_array_length(v); ++i) {
+			for (size_t i = 0; i < json_object_array_length(v); ++i) {
 				json_object *o = json_object_array_get_idx(v, i);
 				printf("%s\n", json_object_get_string(o));
 			}


### PR DESCRIPTION
Update json-c dependency to 0.13, which changed the return type of
json_object_array_length to support only a size_t instead of an int as
fallback.

Not sure if you want to take this patch, otherwise I'll apply it manually in the Arch Linux package.