### PR TITLE
Bindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -46,7 +46,8 @@ struct sway_mouse_binding {
  */
 struct sway_mode {
 	char *name;
-	list_t *bindings;
+	list_t *keysym_bindings;
+	list_t *keycode_bindings;
 };
 
 /**

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -3,6 +3,8 @@
 
 #include "sway/input/seat.h"
 
+#define SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP 32
+
 struct sway_keyboard {
 	struct sway_seat_device *seat_device;
 
@@ -10,6 +12,9 @@ struct sway_keyboard {
 
 	struct wl_listener keyboard_key;
 	struct wl_listener keyboard_modifiers;
+
+	xkb_keysym_t pressed_keysyms_translated[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
+	xkb_keysym_t pressed_keysyms_raw[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
 };
 
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -14,7 +14,10 @@ struct sway_keyboard {
 	struct wl_listener keyboard_modifiers;
 
 	xkb_keysym_t pressed_keysyms_translated[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
+	uint32_t modifiers_translated;
+
 	xkb_keysym_t pressed_keysyms_raw[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
+	uint32_t modifiers_raw;
 };
 
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -127,6 +127,8 @@ struct cmd_results *add_color(const char *name, char *buffer, const char *color)
 
 /* Keep alphabetized */
 static struct cmd_handler handlers[] = {
+	{ "bindcode", cmd_bindcode },
+	{ "bindsym", cmd_bindsym },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "exit", cmd_exit },

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -1,0 +1,173 @@
+#ifdef __linux__
+#include <linux/input-event-codes.h>
+#elif __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#endif
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-names.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "list.h"
+#include "log.h"
+#include "stringop.h"
+#include "util.h"
+
+int binding_order = 0;
+
+void free_sway_binding(struct sway_binding *binding) {
+	if (binding->keys) {
+		for (int i = 0; i < binding->keys->length; i++) {
+			free(binding->keys->items[i]);
+		}
+		list_free(binding->keys);
+	}
+	if (binding->command) {
+		free(binding->command);
+	}
+	free(binding);
+}
+
+struct cmd_results *cmd_bindsym(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "bindsym", EXPECTED_MORE_THAN, 1))) {
+		return error;
+	}
+
+	struct sway_binding *binding = malloc(sizeof(struct sway_binding));
+	if (!binding) {
+		return cmd_results_new(CMD_FAILURE, "bindsym",
+				"Unable to allocate binding");
+	}
+	binding->keys = create_list();
+	binding->modifiers = 0;
+	binding->release = false;
+	binding->bindcode = false;
+
+	// Handle --release
+	if (strcmp("--release", argv[0]) == 0) {
+		if (argc >= 3) {
+			binding->release = true;
+			argv++;
+			argc--;
+		} else {
+			free_sway_binding(binding);
+			return cmd_results_new(CMD_FAILURE, "bindsym",
+				"Invalid bindsym command "
+				"(expected more than 2 arguments, got %d)", argc);
+		}
+	}
+
+	binding->command = join_args(argv + 1, argc - 1);
+
+	list_t *split = split_string(argv[0], "+");
+	for (int i = 0; i < split->length; ++i) {
+		// Check for a modifier key
+		uint32_t mod;
+		if ((mod = get_modifier_mask_by_name(split->items[i])) > 0) {
+			binding->modifiers |= mod;
+			continue;
+		}
+		// Check for xkb key
+		xkb_keysym_t sym = xkb_keysym_from_name(split->items[i],
+				XKB_KEYSYM_CASE_INSENSITIVE);
+
+		// Check for mouse binding
+		if (strncasecmp(split->items[i], "button", strlen("button")) == 0 &&
+				strlen(split->items[i]) == strlen("button0")) {
+			sym = ((char *)split->items[i])[strlen("button")] - '1' + BTN_LEFT;
+		}
+		if (!sym) {
+			struct cmd_results *ret = cmd_results_new(CMD_INVALID, "bindsym",
+					"Unknown key '%s'", (char *)split->items[i]);
+			free_sway_binding(binding);
+			free_flat_list(split);
+			return ret;
+		}
+		xkb_keysym_t *key = malloc(sizeof(xkb_keysym_t));
+		if (!key) {
+			free_sway_binding(binding);
+			free_flat_list(split);
+			return cmd_results_new(CMD_FAILURE, "bindsym",
+					"Unable to allocate binding");
+		}
+		*key = sym;
+		list_add(binding->keys, key);
+	}
+	free_flat_list(split);
+
+	struct sway_mode *mode = config->current_mode;
+	// TODO overwrite the binding if it already exists
+	binding->order = binding_order++;
+	list_add(mode->keysym_bindings, binding);
+
+	sway_log(L_DEBUG, "bindsym - Bound %s to command %s",
+		argv[0], binding->command);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
+struct cmd_results *cmd_bindcode(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "bindcode", EXPECTED_MORE_THAN, 1))) {
+		return error;
+	}
+
+	struct sway_binding *binding = malloc(sizeof(struct sway_binding));
+	if (!binding) {
+		return cmd_results_new(CMD_FAILURE, "bindsym",
+				"Unable to allocate binding");
+	}
+	binding->keys = create_list();
+	binding->modifiers = 0;
+	binding->release = false;
+	binding->bindcode = true;
+
+	// Handle --release
+	if (strcmp("--release", argv[0]) == 0) {
+		if (argc >= 3) {
+			binding->release = true;
+			argv++;
+			argc--;
+		} else {
+			free_sway_binding(binding);
+			return cmd_results_new(CMD_FAILURE, "bindcode",
+				"Invalid bindcode command "
+				"(expected more than 2 arguments, got %d)", argc);
+		}
+	}
+
+	binding->command = join_args(argv + 1, argc - 1);
+
+	list_t *split = split_string(argv[0], "+");
+	for (int i = 0; i < split->length; ++i) {
+		// Check for a modifier key
+		uint32_t mod;
+		if ((mod = get_modifier_mask_by_name(split->items[i])) > 0) {
+			binding->modifiers |= mod;
+			continue;
+		}
+		// parse keycode
+		xkb_keycode_t keycode = (int)strtol(split->items[i], NULL, 10);
+		if (!xkb_keycode_is_legal_ext(keycode)) {
+			error =
+				cmd_results_new(CMD_INVALID, "bindcode",
+					"Invalid keycode '%s'", (char *)split->items[i]);
+			free_sway_binding(binding);
+			list_free(split);
+			return error;
+		}
+		xkb_keycode_t *key = malloc(sizeof(xkb_keycode_t));
+		*key = keycode - 8;
+		list_add(binding->keys, key);
+	}
+	free_flat_list(split);
+
+	struct sway_mode *mode = config->current_mode;
+	// TODO overwrite binding if it already exists
+	binding->order = binding_order++;
+	list_add(mode->keycode_bindings, binding);
+
+	sway_log(L_DEBUG, "bindcode - Bound %s to command %s",
+		argv[0], binding->command);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -34,6 +34,10 @@ void free_sway_binding(struct sway_binding *binding) {
  */
 bool binding_key_compare(struct sway_binding *binding_a,
 		struct sway_binding *binding_b) {
+	if (binding_a->release != binding_b->release) {
+		return false;
+	}
+
 	if (binding_a->bindcode != binding_b->bindcode) {
 		return false;
 	}

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -16,15 +16,14 @@
 int binding_order = 0;
 
 void free_sway_binding(struct sway_binding *binding) {
+	if (!binding) {
+		return;
+	}
+
 	if (binding->keys) {
-		for (int i = 0; i < binding->keys->length; i++) {
-			free(binding->keys->items[i]);
-		}
-		list_free(binding->keys);
+		free_flat_list(binding->keys);
 	}
-	if (binding->command) {
-		free(binding->command);
-	}
+	free(binding->command);
 	free(binding);
 }
 
@@ -72,7 +71,7 @@ struct cmd_results *cmd_bindsym(int argc, char **argv) {
 		return error;
 	}
 
-	struct sway_binding *binding = malloc(sizeof(struct sway_binding));
+	struct sway_binding *binding = calloc(1, sizeof(struct sway_binding));
 	if (!binding) {
 		return cmd_results_new(CMD_FAILURE, "bindsym",
 				"Unable to allocate binding");
@@ -122,7 +121,7 @@ struct cmd_results *cmd_bindsym(int argc, char **argv) {
 			free_flat_list(split);
 			return ret;
 		}
-		xkb_keysym_t *key = malloc(sizeof(xkb_keysym_t));
+		xkb_keysym_t *key = calloc(1, sizeof(xkb_keysym_t));
 		if (!key) {
 			free_sway_binding(binding);
 			free_flat_list(split);
@@ -165,7 +164,7 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 		return error;
 	}
 
-	struct sway_binding *binding = malloc(sizeof(struct sway_binding));
+	struct sway_binding *binding = calloc(1, sizeof(struct sway_binding));
 	if (!binding) {
 		return cmd_results_new(CMD_FAILURE, "bindsym",
 				"Unable to allocate binding");
@@ -209,7 +208,7 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 			list_free(split);
 			return error;
 		}
-		xkb_keycode_t *key = malloc(sizeof(xkb_keycode_t));
+		xkb_keycode_t *key = calloc(1, sizeof(xkb_keycode_t));
 		*key = keycode - 8;
 		list_add(binding->keys, key);
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -53,7 +53,8 @@ static void config_defaults(struct sway_config *config) {
 		goto cleanup;
 	if (!(config->current_mode->name = malloc(sizeof("default")))) goto cleanup;
 	strcpy(config->current_mode->name, "default");
-	if (!(config->current_mode->bindings = create_list())) goto cleanup;
+	if (!(config->current_mode->keysym_bindings = create_list())) goto cleanup;
+	if (!(config->current_mode->keycode_bindings = create_list())) goto cleanup;
 	list_add(config->modes, config->current_mode);
 
 	config->floating_mod = 0;

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -3,6 +3,7 @@
 #include "sway/input/seat.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/input-manager.h"
+#include "sway/commands.h"
 #include "log.h"
 
 static size_t pressed_keysyms_length(xkb_keysym_t *pressed_keysyms) {
@@ -80,7 +81,7 @@ static bool keyboard_execute_binding(struct sway_keyboard *keyboard,
 		for (int j = 0; j < binding->keys->length; ++j) {
 			match =
 				pressed_keysyms_index(pressed_keysyms,
-					*(int*)binding->keys->items[j]) < 0;
+					*(int*)binding->keys->items[j]) >= 0;
 
 			if (!match) {
 				break;
@@ -88,7 +89,13 @@ static bool keyboard_execute_binding(struct sway_keyboard *keyboard,
 		}
 
 		if (match) {
-			sway_log(L_DEBUG, "TODO: executing binding command: %s", binding->command);
+			sway_log(L_DEBUG, "running command for binding: %s", binding->command);
+			struct cmd_results *results = handle_command(binding->command);
+			if (results->status != CMD_SUCCESS) {
+				sway_log(L_DEBUG, "could not run command for binding: %s",
+					binding->command);
+			}
+			free_cmd_results(results);
 			return true;
 		}
 	}

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -67,9 +67,7 @@ static bool keyboard_execute_bindsym(struct sway_keyboard *keyboard,
 	list_t *keysym_bindings = config->current_mode->keysym_bindings;
 	for (int i = 0; i < keysym_bindings->length; ++i) {
 		struct sway_binding *binding = keysym_bindings->items[i];
-		sway_log(L_DEBUG, "@@ checking binding: %s", binding->command);
 		if (modifiers ^ binding->modifiers || n != binding->keys->length) {
-			sway_log(L_DEBUG, "@@ modifiers or key num dont match");
 			continue;
 		}
 
@@ -85,7 +83,8 @@ static bool keyboard_execute_bindsym(struct sway_keyboard *keyboard,
 		}
 
 		if (match) {
-			sway_log(L_DEBUG, "running command for binding: %s", binding->command);
+			sway_log(L_DEBUG, "running command for binding: %s",
+				binding->command);
 			struct cmd_results *results = handle_command(binding->command);
 			if (results->status != CMD_SUCCESS) {
 				sway_log(L_DEBUG, "could not run command for binding: %s",
@@ -291,7 +290,6 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 
 	// handle keycodes
 	handled = keyboard_execute_bindcode(keyboard);
-	sway_log(L_DEBUG, "@@ handled by bindcode? %d", handled);
 
 	// handle translated keysyms
 	const xkb_keysym_t *translated_keysyms;
@@ -299,8 +297,8 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	size_t translated_keysyms_len =
 		keyboard_keysyms_translated(keyboard, keycode, &translated_keysyms,
 			&translated_modifiers);
-	pressed_keysyms_update(keyboard->pressed_keysyms_translated, translated_keysyms,
-		translated_keysyms_len, event->state);
+	pressed_keysyms_update(keyboard->pressed_keysyms_translated,
+		translated_keysyms, translated_keysyms_len, event->state);
 	if (event->state == WLR_KEY_PRESSED && !handled) {
 		handled = keyboard_execute_bindsym(keyboard,
 			keyboard->pressed_keysyms_translated, translated_modifiers,
@@ -310,9 +308,10 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	// Handle raw keysyms
 	const xkb_keysym_t *raw_keysyms;
 	uint32_t raw_modifiers;
-	size_t raw_keysyms_len = keyboard_keysyms_raw(keyboard, keycode, &raw_keysyms, &raw_modifiers);
-	pressed_keysyms_update(keyboard->pressed_keysyms_raw, raw_keysyms, raw_keysyms_len,
-		event->state);
+	size_t raw_keysyms_len =
+		keyboard_keysyms_raw(keyboard, keycode, &raw_keysyms, &raw_modifiers);
+	pressed_keysyms_update(keyboard->pressed_keysyms_raw, raw_keysyms,
+		raw_keysyms_len, event->state);
 	if (event->state == WLR_KEY_PRESSED && !handled) {
 		handled = keyboard_execute_bindsym(keyboard,
 			keyboard->pressed_keysyms_raw, raw_modifiers,

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -183,17 +183,14 @@ static bool keyboard_execute_bindcode(struct sway_keyboard *keyboard) {
 	list_t *keycode_bindings = config->current_mode->keycode_bindings;
 	for (int i = 0; i < keycode_bindings->length; ++i) {
 		struct sway_binding *binding = keycode_bindings->items[i];
-		//bool match = true;
-		for (int j = 0; j < binding->keys->length; ++j) {
-			if (binding_matches_keycodes(wlr_keyboard, binding)) {
-				struct cmd_results *results = handle_command(binding->command);
-				if (results->status != CMD_SUCCESS) {
-					sway_log(L_DEBUG, "could not run command for binding: %s",
-							binding->command);
-				}
-				free_cmd_results(results);
-				return true;
+		if (binding_matches_keycodes(wlr_keyboard, binding)) {
+			struct cmd_results *results = handle_command(binding->command);
+			if (results->status != CMD_SUCCESS) {
+				sway_log(L_DEBUG, "could not run command for binding: %s",
+						binding->command);
 			}
+			free_cmd_results(results);
+			return true;
 		}
 	}
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -6,6 +6,7 @@ sway_sources = files(
 	'input/seat.c',
 	'input/cursor.c',
 	'input/keyboard.c',
+	'commands/bind.c',
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',


### PR DESCRIPTION
Make bindings work.

TODO

* [x] parse binding command
* [x] overwrite old bindings
* [x] translate keysyms
* [x] compositor bindings
* [x] user keysym bindings
* [x] user keycode bindings
* [x] bindings with `--release`

**Tests**

Example config:

These are not valid commands, so you'll have to check the logs to see if they run.

```
# bindsym translated
bindsym Alt+at pressed shift-alt-2

# bindsym raw
bindsym Alt+Shift+1 pressed shift-alt-1

# bindsym release
bindsym --release a do-it-on-release

# make sure these get overwritten and only cmd3 runs when you press "s"
bindsym s cmd1
bindsym s cmd2
bindsym s cmd3

# Check bindcode with and without modifiers (use xev or similar to check keycodes)
bindcode 39 bindcode no modifier
bindcode Alt+39 bindcode one modifier
bindcode Alt+Shift+39 bindcode two modifiers
bindcode --release 40 bindcode-release
```

**Open questions**

Getting the keysym from the name during parsing the bindings is currently done in a case insensitive way. So `bindsym A <cmd>` is equivalent to `bindsym a <cmd>` in that the keysym that is returned from the parsing is `a` and neither will respond to the raw `Shift+a`.

What order should bindings run in if they are equivalent? Before, when there was only one keyboard layout during the lifetime of the wm, we could do this test when we parse the config, but now there is the possibility that many keyboards can have many layouts so the check is no longer possible until the key is pressed. Right now, we prioritize `bindcode` bindings (because that was the easiest to do), but we could also run them in the order they were applied in the config with just a little more complexity.

Should hardcoded compositor bindings (currently only VT switching, but there will be more) run before or after? Current thinking is no, but an interesting case that will come up is that i3 has a hardcoded binding to Esc which cancels an interactive resize. If this feature is implemented, then the consequence will be that you can't bind to Esc.
