### PR TITLE
Allow to configure outputs by their identifier

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -397,6 +397,8 @@ struct seat_attachment_config *seat_config_get_attachment(
 void apply_seat_config(struct seat_config *seat);
 
 int output_name_cmp(const void *item, const void *data);
+void output_get_identifier(char *identifier, size_t len,
+	struct sway_output *output);
 struct output_config *new_output_config(const char *name);
 void merge_output_config(struct output_config *dst, struct output_config *src);
 void apply_output_config(struct output_config *oc, swayc_t *output);

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 700
+#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 #include <wlr/types/wlr_output.h>
@@ -12,6 +13,13 @@ int output_name_cmp(const void *item, const void *data) {
 	const char *name = data;
 
 	return strcmp(output->name, name);
+}
+
+void output_get_identifier(char *identifier, size_t len,
+		struct sway_output *output) {
+	struct wlr_output *wlr_output = output->wlr_output;
+	snprintf(identifier, len, "%s %s %s", wlr_output->make, wlr_output->model,
+		wlr_output->serial);
 }
 
 struct output_config *new_output_config(const char *name) {


### PR DESCRIPTION
Test plan:

```
output "wayland wayland " scale 2
```