### PR TITLE
partial fix #1056

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -449,8 +449,10 @@ static bool handle_view_created(wlc_handle handle) {
 
 	// Modals, get focus, popups do not
 	case WLC_BIT_MODAL:
-		wlc_view_focus(handle);
-		wlc_view_bring_to_front(handle);
+		if (!desktop_shell.is_locked) {
+			wlc_view_focus(handle);
+			wlc_view_bring_to_front(handle);
+		}
 		newview = new_floating_view(handle);
 		/* fallthrough */
 	case WLC_BIT_POPUP:


### PR DESCRIPTION
this patch allow the user to type its password when a modal window is shown
while the desktop is locked by swaylock.
It is a partial fix of the bug since the window should not be visible (see bug
https://github.com/swaywm/sway/issues/1056 for details).