### PR TITLE
json-c: add support for both 0.12.1 and 0.13

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ datadir = get_option('datadir')
 sysconfdir = get_option('sysconfdir')
 prefix = get_option('prefix')
 
-jsonc          = dependency('json-c', version: '>=0.13')
+jsonc          = dependency('json-c', version: '>=0.12.1')
 pcre           = dependency('libpcre')
 wlroots        = dependency('wlroots')
 wayland_server = dependency('wayland-server')

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -156,7 +156,11 @@ static void pretty_print_version(json_object *v) {
 static void pretty_print_clipboard(json_object *v) {
 	if (success(v, true)) {
 		if (json_object_is_type(v, json_type_array)) {
+#if JSON_C_MAJOR_VERSION > 0 || JSON_C_MINOR_VERSION >= 13
 			for (size_t i = 0; i < json_object_array_length(v); ++i) {
+#else
+			for (int i = 0; i < json_object_array_length(v); ++i) {
+#endif
 				json_object *o = json_object_array_get_idx(v, i);
 				printf("%s\n", json_object_get_string(o));
 			}


### PR DESCRIPTION
json-c 0.13 is still *very* new (less than a month old) and even "up to date" distros like the latest fedora don't have it yet.

Given the difference is minor I'd like to support both for a short while until the distros slightly behind arch follow up with it ; I don't mind keeping this in my local branch (I test wlroots/sway both on arch and non-arch so I need something like this), but I figured this might be useful for others.

I've tested this commit with both json-c 0.13 and 0.12.1