### PR TITLE
sway main: init old log system until end of switch to wlr_log

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -16,6 +16,7 @@
 #include <sys/prctl.h>
 #endif
 #include <wlr/util/log.h>
+void init_log(log_importance_t verbosity); // log.h, but can't include because of conflict
 #include "sway/config.h"
 #include "sway/server.h"
 #include "sway/layout.h"
@@ -331,10 +332,13 @@ int main(int argc, char **argv) {
 	// TODO: switch logging over to wlroots?
 	if (debug) {
 		wlr_log_init(L_DEBUG, NULL);
+		init_log(L_DEBUG);
 	} else if (verbose || validate) {
 		wlr_log_init(L_INFO, NULL);
+		init_log(L_INFO);
 	} else {
 		wlr_log_init(L_ERROR, NULL);
+		init_log(L_ERROR);
 	}
 
 	if (optind < argc) { // Behave as IPC client


### PR DESCRIPTION
We need to keep the old log init if we do not want all current calls to sway_log to be silent

The function declaration next to log headers is fugly but I don't have a better idea for something quick, I guess I can try to fix sway's log.h to be compatible if we care but it'd probaby be just as fast to finish converting all sway_logs to wlr_logs...