### PR TITLE
commands: add 'reload' command

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -25,6 +25,7 @@ struct sway_cursor {
 	struct wl_listener request_set_cursor;
 };
 
+void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 
 #endif

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -46,4 +46,6 @@ void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 struct sway_seat *sway_input_manager_get_default_seat(
 		struct sway_input_manager *input);
 
+struct sway_seat *input_manager_get_seat(struct sway_input_manager *input,
+		const char *seat_name);
 #endif

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -29,6 +29,8 @@ struct sway_seat {
 struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 		const char *seat_name);
 
+void sway_seat_destroy(struct sway_seat *seat);
+
 void sway_seat_add_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -136,6 +136,7 @@ static struct cmd_handler handlers[] = {
 	{ "input", cmd_input },
 	{ "kill", cmd_kill },
 	{ "output", cmd_output },
+	{ "reload", cmd_reload },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 };

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -1,0 +1,21 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/layout.h"
+
+struct cmd_results *cmd_reload(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if (config->reading) {
+		return cmd_results_new(CMD_FAILURE, "reload", "Can't be used in config file.");
+	}
+	if ((error = checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0))) {
+		return error;
+	}
+	if (!load_main_config(config->current_config, true)) {
+		return cmd_results_new(CMD_FAILURE, "reload", "Error(s) reloading config.");
+	}
+
+	load_swaybars();
+
+	arrange_windows(&root_container, -1, -1);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -14,7 +14,7 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "reload", "Error(s) reloading config.");
 	}
 
-	load_swaybars();
+	/* load_swaybars(); -- for when it's implemented */
 
 	arrange_windows(&root_container, -1, -1);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/config.c
+++ b/sway/config.c
@@ -698,3 +698,7 @@ char *do_var_replacement(char *str) {
 	}
 	return str;
 }
+
+void load_swaybars() {
+	/* stub function for reload commnd, to fill when we restore swaybars */
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -717,7 +717,3 @@ char *do_var_replacement(char *str) {
 	}
 	return str;
 }
-
-void load_swaybars() {
-	/* stub function for reload commnd, to fill when we restore swaybars */
-}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -149,6 +149,16 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 	wlr_log(L_DEBUG, "TODO: handle request set cursor event: %p", event);
 }
 
+void sway_cursor_destroy(struct sway_cursor *cursor) {
+	if (!cursor) {
+		return;
+	}
+
+	wlr_xcursor_manager_destroy(cursor->xcursor_manager);
+	wlr_cursor_destroy(cursor->cursor);
+	free(cursor);
+}
+
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 	struct sway_cursor *cursor = calloc(1, sizeof(struct sway_cursor));
 	if (!sway_assert(cursor, "could not allocate sway cursor")) {

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -23,7 +23,7 @@ struct sway_input_manager *input_manager;
 struct input_config *current_input_config = NULL;
 struct seat_config *current_seat_config = NULL;
 
-static struct sway_seat *input_manager_get_seat(
+struct sway_seat *input_manager_get_seat(
 		struct sway_input_manager *input, const char *seat_name) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -21,6 +21,16 @@ static void seat_device_destroy(struct sway_seat_device *seat_device) {
 	free(seat_device);
 }
 
+void sway_seat_destroy(struct sway_seat *seat) {
+	struct sway_seat_device *seat_device, *next;
+	wl_list_for_each_safe(seat_device, next, &seat->devices, link) {
+		seat_device_destroy(seat_device);
+	}
+	sway_cursor_destroy(seat->cursor);
+	wl_list_remove(&seat->link);
+	wlr_seat_destroy(seat->wlr_seat);
+}
+
 struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 		const char *seat_name) {
 	struct sway_seat *seat = calloc(1, sizeof(struct sway_seat));

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -34,6 +34,7 @@ sway_sources = files(
 	'commands/input/xkb_rules.c',
 	'commands/input/xkb_variant.c',
 	'commands/output.c',
+	'commands/reload.c',
 	'config.c',
 	'config/output.c',
 	'config/seat.c',


### PR DESCRIPTION
This is actually pretty straightforward, and doesn't seem to leak anything.

I've tested:
 - key bindings: added/removed/changed, no problem seen
 - input config: changed some libinput config option without problem.

Not sure how the other options work, I'm not using them.

Note that when I open an urxvt before reloading, sometimes reloading will resize it, but I think this is working as intended as it's called arrange_windows(). I'm not sure why it doesn't happen everytime, but I'm not going to look at window placements right now as there is nothing done there (is there?)
I've also had the choice of commenting out load_swaybars() in commands or adding a stub in config.c and decided to add a stub, happy to go the other way, but we'll probably want that function eventually.