### PR TITLE
Cleanup logging

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -79,7 +79,7 @@ struct ipc_response *ipc_recv_response(int socketfd) {
 error_2:
 	free(response);
 error_1:
-	sway_log(L_ERROR, "Unable to allocate memory for IPC response");
+	wlr_log(L_ERROR, "Unable to allocate memory for IPC response");
 	return NULL;
 }
 

--- a/common/log.c
+++ b/common/log.c
@@ -1,167 +1,26 @@
-#define _POSIX_C_SOURCE 199506L
-#include <errno.h>
-#include <libgen.h>
 #include <signal.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <time.h>
 #include "log.h"
-#include "readline.h"
-
-static int colored = 1;
-static log_importance_t loglevel_default = L_ERROR;
-static log_importance_t v = L_SILENT;
-
-static const char *verbosity_colors[] = {
-	[L_SILENT] = "",
-	[L_ERROR ] = "\x1B[1;31m",
-	[L_INFO  ] = "\x1B[1;34m",
-	[L_DEBUG ] = "\x1B[1;30m",
-};
-static const char verbosity_chars[] = {
-	[L_SILENT] = '\0',
-	[L_ERROR ] = 'E',
-	[L_INFO  ] = 'I',
-	[L_DEBUG ] = 'D',
-};
-
-void init_log(log_importance_t verbosity) {
-	if (verbosity != L_DEBUG) {
-		// command "debuglog" needs to know the user specified log level when
-		// turning off debug logging.
-		loglevel_default = verbosity;
-	}
-	v = verbosity;
-}
-
-void set_log_level(log_importance_t verbosity) {
-	v = verbosity;
-}
-
-log_importance_t get_log_level(void) {
-	return v;
-}
-
-void reset_log_level(void) {
-	v = loglevel_default;
-}
-
-bool toggle_debug_logging(void) {
-	v = (v == L_DEBUG) ? loglevel_default : L_DEBUG;
-	return (v == L_DEBUG);
-}
-
-void sway_log_colors(int mode) {
-	colored = (mode == 1) ? 1 : 0;
-}
-
-void _sway_vlog(const char *filename, int line, log_importance_t verbosity,
-		const char *format, va_list args) {
-	if (verbosity <= v) {
-		// prefix the time to the log message
-		static struct tm result;
-		static time_t t;
-		static struct tm *tm_info;
-		char buffer[26];
-
-		unsigned int c = verbosity;
-		if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
-			c = sizeof(verbosity_colors) / sizeof(char *) - 1;
-		}
-
-		// First, if not printing color, show the log level
-		if (!(colored && isatty(STDERR_FILENO)) && c != L_SILENT) {
-			fprintf(stderr, "%c: ", verbosity_chars[c]);
-		}
-
-		// get current time
-		t = time(NULL);
-		// convert time to local time (determined by the locale)
-		tm_info = localtime_r(&t, &result);
-		// generate time prefix
-		strftime(buffer, sizeof(buffer), "%x %X - ", tm_info);
-		fprintf(stderr, "%s", buffer);
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "%s", verbosity_colors[c]);
-		}
-
-		if (filename && line) {
-			const char *file = filename + strlen(filename);
-			while (file != filename && *file != '/') {
-				--file;
-			}
-			if (*file == '/') {
-				++file;
-			}
-			fprintf(stderr, "[%s:%d] ", file, line);
-		}
-
-		vfprintf(stderr, format, args);
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "\x1B[0m");
-		}
-		fprintf(stderr, "\n");
-	}
-}
-
-void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) {
-	va_list args;
-	va_start(args, format);
-	_sway_vlog(filename, line, verbosity, format, args);
-	va_end(args);
-}
 
 void sway_terminate(int code);
 
-void _sway_abort(const char *filename, int line, const char* format, ...) {
+void _sway_abort(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
-	_sway_vlog(filename, line, L_ERROR, format, args);
+	_wlr_vlog(L_ERROR, format, args);
 	va_end(args);
 	sway_terminate(EXIT_FAILURE);
 }
 
-void sway_log_errno(log_importance_t verbosity, char* format, ...) {
-	if (verbosity <= v) {
-		unsigned int c = verbosity;
-		if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
-			c = sizeof(verbosity_colors) / sizeof(char *) - 1;
-		}
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "%s", verbosity_colors[c]);
-		} else if (c != L_SILENT) {
-			fprintf(stderr, "%c: ", verbosity_chars[c]);
-		}
-
-		va_list args;
-		va_start(args, format);
-		vfprintf(stderr, format, args);
-		va_end(args);
-
-		fprintf(stderr, ": ");
-		fprintf(stderr, "%s", strerror(errno));
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "\x1B[0m");
-		}
-		fprintf(stderr, "\n");
-	}
-}
-
-bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) {
+bool _sway_assert(bool condition, const char *format, ...) {
 	if (condition) {
 		return true;
 	}
 
 	va_list args;
 	va_start(args, format);
-	_sway_vlog(filename, line, L_ERROR, format, args);
+	_wlr_vlog(L_ERROR, format, args);
 	va_end(args);
 
 #ifndef NDEBUG

--- a/common/readline.c
+++ b/common/readline.c
@@ -8,7 +8,7 @@ char *read_line(FILE *file) {
 	char *string = malloc(size);
 	char lastChar = '\0';
 	if (!string) {
-		sway_log(L_ERROR, "Unable to allocate memory for read_line");
+		wlr_log(L_ERROR, "Unable to allocate memory for read_line");
 		return NULL;
 	}
 	while (1) {
@@ -29,7 +29,7 @@ char *read_line(FILE *file) {
 			char *new_string = realloc(string, size *= 2);
 			if (!new_string) {
 				free(string);
-				sway_log(L_ERROR, "Unable to allocate memory for read_line");
+				wlr_log(L_ERROR, "Unable to allocate memory for read_line");
 				return NULL;
 			}
 			string = new_string;

--- a/common/util.c
+++ b/common/util.c
@@ -113,7 +113,7 @@ uint32_t parse_color(const char *color) {
 
 	int len = strlen(color);
 	if (len != 6 && len != 8) {
-		sway_log(L_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
+		wlr_log(L_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
 		return 0xFFFFFFFF;
 	}
 	uint32_t res = (uint32_t)strtoul(color, NULL, 16);

--- a/include/log.h
+++ b/include/log.h
@@ -1,22 +1,7 @@
 #ifndef _SWAY_LOG_H
 #define _SWAY_LOG_H
 #include <stdbool.h>
-
-typedef enum {
-	L_SILENT = 0,
-	L_ERROR = 1,
-	L_INFO = 2,
-	L_DEBUG = 3,
-} log_importance_t;
-
-void init_log(log_importance_t verbosity);
-void set_log_level(log_importance_t verbosity);
-log_importance_t get_log_level(void);
-void reset_log_level(void);
-// returns whether debug logging is on after switching.
-bool toggle_debug_logging(void);
-void sway_log_colors(int mode);
-void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
+#include <wlr/util/log.h>
 
 void _sway_abort(const char *filename, int line, const char* format, ...) __attribute__((format(printf,3,4)));
 #define sway_abort(FMT, ...) \
@@ -25,14 +10,6 @@ void _sway_abort(const char *filename, int line, const char* format, ...) __attr
 bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) __attribute__((format(printf,4,5)));
 #define sway_assert(COND, FMT, ...) \
 	_sway_assert(COND, __FILE__, __LINE__, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
-
-void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,4,5)));
-
-#define sway_log(VERBOSITY, FMT, ...) \
-	_sway_log(__FILE__, __LINE__, VERBOSITY, FMT, ##__VA_ARGS__)
-
-#define sway_vlog(VERBOSITY, FMT, VA_ARGS) \
-    _sway_vlog(__FILE__, __LINE__, VERBOSITY, FMT, VA_ARGS)
 
 void error_handler(int sig);
 

--- a/include/log.h
+++ b/include/log.h
@@ -3,13 +3,13 @@
 #include <stdbool.h>
 #include <wlr/util/log.h>
 
-void _sway_abort(const char *filename, int line, const char* format, ...) __attribute__((format(printf,3,4)));
+void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
 #define sway_abort(FMT, ...) \
-    _sway_abort(__FILE__, __LINE__, FMT, ##__VA_ARGS__)
+    _sway_abort("[%s:%d] " FMT, _strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
 
-bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) __attribute__((format(printf,4,5)));
+bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
 #define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, __FILE__, __LINE__, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+	_sway_assert(COND, "[%s:%d] %s:" FMT, _strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 void error_handler(int sig);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -176,7 +176,7 @@ static struct cmd_handler seat_handlers[] = {
 static struct cmd_handler *find_handler(char *line, enum cmd_status block) {
 	struct cmd_handler d = { .command=line };
 	struct cmd_handler *res = NULL;
-	sway_log(L_DEBUG, "find_handler(%s) %d", line, block == CMD_BLOCK_SEAT);
+	wlr_log(L_DEBUG, "find_handler(%s) %d", line, block == CMD_BLOCK_SEAT);
 
 	if (block == CMD_BLOCK_INPUT) {
 		res = bsearch(&d, input_handlers,
@@ -215,10 +215,10 @@ struct cmd_results *handle_command(char *_exec) {
 			cmd = argsep(&cmdlist, ",");
 			cmd += strspn(cmd, whitespace);
 			if (strcmp(cmd, "") == 0) {
-				sway_log(L_INFO, "Ignoring empty command.");
+				wlr_log(L_INFO, "Ignoring empty command.");
 				continue;
 			}
-			sway_log(L_INFO, "Handling command '%s'", cmd);
+			wlr_log(L_INFO, "Handling command '%s'", cmd);
 			//TODO better handling of argv
 			int argc;
 			char **argv = split_args(cmd, &argc);
@@ -276,7 +276,7 @@ struct cmd_results *config_command(char *exec, enum cmd_status block) {
 		goto cleanup;
 	}
 
-	sway_log(L_INFO, "handling config command '%s'", exec);
+	wlr_log(L_INFO, "handling config command '%s'", exec);
 	// Endblock
 	if (**argv == '}') {
 		results = cmd_results_new(CMD_BLOCK_END, NULL, NULL);
@@ -380,7 +380,7 @@ struct cmd_results *config_commands_command(char *exec) {
 	}
 	policy->context = context;
 
-	sway_log(L_INFO, "Set command policy for %s to %d",
+	wlr_log(L_INFO, "Set command policy for %s to %d",
 			policy->command, policy->context);
 
 	results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
@@ -394,7 +394,7 @@ struct cmd_results *cmd_results_new(enum cmd_status status,
 		const char *input, const char *format, ...) {
 	struct cmd_results *results = malloc(sizeof(struct cmd_results));
 	if (!results) {
-		sway_log(L_ERROR, "Unable to allocate command results");
+		wlr_log(L_ERROR, "Unable to allocate command results");
 		return NULL;
 	}
 	results->status = status;

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -145,7 +145,7 @@ struct cmd_results *cmd_bindsym(int argc, char **argv) {
 	for (int i = 0; i < mode_bindings->length; ++i) {
 		struct sway_binding *config_binding = mode_bindings->items[i];
 		if (binding_key_compare(binding, config_binding)) {
-			sway_log(L_DEBUG, "overwriting old binding with command '%s'",
+			wlr_log(L_DEBUG, "overwriting old binding with command '%s'",
 				config_binding->command);
 			free_sway_binding(config_binding);
 			mode_bindings->items[i] = binding;
@@ -157,7 +157,7 @@ struct cmd_results *cmd_bindsym(int argc, char **argv) {
 		list_add(mode_bindings, binding);
 	}
 
-	sway_log(L_DEBUG, "bindsym - Bound %s to command %s",
+	wlr_log(L_DEBUG, "bindsym - Bound %s to command %s",
 		argv[0], binding->command);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
@@ -227,7 +227,7 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 	for (int i = 0; i < mode_bindings->length; ++i) {
 		struct sway_binding *config_binding = mode_bindings->items[i];
 		if (binding_key_compare(binding, config_binding)) {
-			sway_log(L_DEBUG, "overwriting old binding with command '%s'",
+			wlr_log(L_DEBUG, "overwriting old binding with command '%s'",
 				config_binding->command);
 			free_sway_binding(config_binding);
 			mode_bindings->items[i] = binding;
@@ -239,7 +239,7 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 		list_add(mode_bindings, binding);
 	}
 
-	sway_log(L_DEBUG, "bindcode - Bound %s to command %s",
+	wlr_log(L_DEBUG, "bindcode - Bound %s to command %s",
 		argv[0], binding->command);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -8,7 +8,7 @@ struct cmd_results *cmd_exec(int argc, char **argv) {
 	if (!config->active) return cmd_results_new(CMD_DEFER, "exec", NULL);
 	if (config->reloading) {
 		char *args = join_args(argv, argc);
-		sway_log(L_DEBUG, "Ignoring 'exec %s' due to reload", args);
+		wlr_log(L_DEBUG, "Ignoring 'exec %s' due to reload", args);
 		free(args);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -20,7 +20,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 
 	char *tmp = NULL;
 	if (strcmp((char*)*argv, "--no-startup-id") == 0) {
-		sway_log(L_INFO, "exec switch '--no-startup-id' not supported, ignored.");
+		wlr_log(L_INFO, "exec switch '--no-startup-id' not supported, ignored.");
 		if ((error = checkarg(argc - 1, "exec_always", EXPECTED_MORE_THAN, 0))) {
 			return error;
 		}
@@ -35,11 +35,11 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	strncpy(cmd, tmp, sizeof(cmd));
 	cmd[sizeof(cmd) - 1] = 0;
 	free(tmp);
-	sway_log(L_DEBUG, "Executing %s", cmd);
+	wlr_log(L_DEBUG, "Executing %s", cmd);
 
 	int fd[2];
 	if (pipe(fd) != 0) {
-		sway_log(L_ERROR, "Unable to create pipe for fork");
+		wlr_log(L_ERROR, "Unable to create pipe for fork");
 	}
 
 	pid_t pid;
@@ -75,7 +75,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	// cleanup child process
 	wait(0);
 	if (*child > 0) {
-		sway_log(L_DEBUG, "Child process created with pid %d", *child);
+		wlr_log(L_DEBUG, "Child process created with pid %d", *child);
 		// TODO: add PID to active workspace
 	} else {
 		free(child);

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -12,7 +12,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 
 	if (config->reading && strcmp("{", argv[1]) == 0) {
 		current_input_config = new_input_config(argv[0]);
-		sway_log(L_DEBUG, "entering input block: %s", current_input_config->identifier);
+		wlr_log(L_DEBUG, "entering input block: %s", current_input_config->identifier);
 		return cmd_results_new(CMD_BLOCK_INPUT, NULL, NULL);
 	}
 

--- a/sway/commands/input/click_method.c
+++ b/sway/commands/input/click_method.c
@@ -6,7 +6,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_click_method(int argc, char **argv) {
-	sway_log(L_DEBUG, "click_method for device:  %d %s",
+	wlr_log(L_DEBUG, "click_method for device:  %d %s",
 		current_input_config==NULL, current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "click_method", EXPECTED_AT_LEAST, 1))) {

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -6,7 +6,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_events(int argc, char **argv) {
-	sway_log(L_DEBUG, "events for device: %s",
+	wlr_log(L_DEBUG, "events for device: %s",
 		current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "events", EXPECTED_AT_LEAST, 1))) {

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -6,7 +6,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_tap(int argc, char **argv) {
-	sway_log(L_DEBUG, "tap for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "tap for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "tap", EXPECTED_AT_LEAST, 1))) {
 		return error;
@@ -26,7 +26,7 @@ struct cmd_results *input_cmd_tap(int argc, char **argv) {
 			"Expected 'tap <enabled|disabled>'");
 	}
 
-	sway_log(L_DEBUG, "apply-tap for device: %s",
+	wlr_log(L_DEBUG, "apply-tap for device: %s",
 		current_input_config->identifier);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -5,7 +5,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
-	sway_log(L_DEBUG, "xkb layout for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "xkb layout for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_layout", EXPECTED_EQUAL_TO, 1))) {
 		return error;
@@ -18,7 +18,7 @@ struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
 
 	new_config->xkb_layout = strdup(argv[0]);
 
-	sway_log(L_DEBUG, "apply-xkb_layout for device: %s layout: %s",
+	wlr_log(L_DEBUG, "apply-xkb_layout for device: %s layout: %s",
 		current_input_config->identifier, new_config->xkb_layout);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -5,7 +5,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
-	sway_log(L_DEBUG, "xkb model for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "xkb model for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_model", EXPECTED_EQUAL_TO, 1))) {
 		return error;
@@ -18,7 +18,7 @@ struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
 
 	new_config->xkb_model = strdup(argv[0]);
 
-	sway_log(L_DEBUG, "apply-xkb_model for device: %s model: %s",
+	wlr_log(L_DEBUG, "apply-xkb_model for device: %s model: %s",
 		current_input_config->identifier, new_config->xkb_model);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -5,7 +5,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
-	sway_log(L_DEBUG, "xkb options for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "xkb options for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_options", EXPECTED_EQUAL_TO, 1))) {
 		return error;
@@ -18,7 +18,7 @@ struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
 
 	new_config->xkb_options = strdup(argv[0]);
 
-	sway_log(L_DEBUG, "apply-xkb_options for device: %s options: %s",
+	wlr_log(L_DEBUG, "apply-xkb_options for device: %s options: %s",
 		current_input_config->identifier, new_config->xkb_options);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -5,7 +5,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
-	sway_log(L_DEBUG, "xkb rules for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "xkb rules for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_rules", EXPECTED_EQUAL_TO, 1))) {
 		return error;
@@ -18,7 +18,7 @@ struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
 
 	new_config->xkb_rules = strdup(argv[0]);
 
-	sway_log(L_DEBUG, "apply-xkb_rules for device: %s rules: %s",
+	wlr_log(L_DEBUG, "apply-xkb_rules for device: %s rules: %s",
 		current_input_config->identifier, new_config->xkb_rules);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -5,7 +5,7 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
-	sway_log(L_DEBUG, "xkb variant for device: %s", current_input_config->identifier);
+	wlr_log(L_DEBUG, "xkb variant for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_variant", EXPECTED_EQUAL_TO, 1))) {
 		return error;
@@ -18,7 +18,7 @@ struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
 
 	new_config->xkb_variant = strdup(argv[0]);
 
-	sway_log(L_DEBUG, "apply-xkb_variant for device: %s variant: %s",
+	wlr_log(L_DEBUG, "apply-xkb_variant for device: %s variant: %s",
 		current_input_config->identifier, new_config->xkb_variant);
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -203,12 +203,12 @@ static struct cmd_results *cmd_output_background(struct output_config *output,
 				if (src) {
 					sprintf(src, "%s/%s", conf_path, p.we_wordv[0]);
 				} else {
-					sway_log(L_ERROR,
+					wlr_log(L_ERROR,
 						"Unable to allocate background source");
 				}
 				free(conf);
 			} else {
-				sway_log(L_ERROR, "Unable to allocate background source");
+				wlr_log(L_ERROR, "Unable to allocate background source");
 			}
 		}
 		if (!src || access(src, F_OK) == -1) {
@@ -238,7 +238,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 
 	struct output_config *output = new_output_config(argv[0]);
 	if (!output) {
-		sway_log(L_ERROR, "Failed to allocate output config");
+		wlr_log(L_ERROR, "Failed to allocate output config");
 		return NULL;
 	}
 
@@ -284,7 +284,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 		list_add(config->output_configs, output);
 	}
 
-	sway_log(L_DEBUG, "Config stored for output %s (enabled: %d) (%dx%d@%fHz "
+	wlr_log(L_DEBUG, "Config stored for output %s (enabled: %d) (%dx%d@%fHz "
 		"position %d,%d scale %f transform %d) (bg %s %s)",
 		output->name, output->enabled, output->width, output->height,
 		output->refresh_rate, output->x, output->y, output->scale,

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -12,7 +12,7 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 
 	if (config->reading && strcmp("{", argv[1]) == 0) {
 		current_seat_config = new_seat_config(argv[0]);
-		sway_log(L_DEBUG, "entering seat block: %s", current_seat_config->name);
+		wlr_log(L_DEBUG, "entering seat block: %s", current_seat_config->name);
 		return cmd_results_new(CMD_BLOCK_SEAT, NULL, NULL);
 	}
 

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -33,7 +33,7 @@ struct cmd_results *cmd_set(int argc, char **argv) {
 	}
 
 	if (argv[0][0] != '$') {
-		sway_log(L_INFO, "Warning: variable '%s' doesn't start with $", argv[0]);
+		wlr_log(L_INFO, "Warning: variable '%s' doesn't start with $", argv[0]);
 
 		size_t size = snprintf(NULL, 0, "$%s", argv[0]);
 		tmp = malloc(size + 1);

--- a/sway/config.c
+++ b/sway/config.c
@@ -232,12 +232,12 @@ static char *get_config_path(void) {
 		char *home = getenv("HOME");
 		char *config_home = malloc(strlen(home) + strlen("/.config") + 1);
 		if (!config_home) {
-			sway_log(L_ERROR, "Unable to allocate $HOME/.config");
+			wlr_log(L_ERROR, "Unable to allocate $HOME/.config");
 		} else {
 			strcpy(config_home, home);
 			strcat(config_home, "/.config");
 			setenv("XDG_CONFIG_HOME", config_home, 1);
-			sway_log(L_DEBUG, "Set XDG_CONFIG_HOME to %s", config_home);
+			wlr_log(L_DEBUG, "Set XDG_CONFIG_HOME to %s", config_home);
 			free(config_home);
 		}
 	}
@@ -263,7 +263,7 @@ static char *get_config_path(void) {
 const char *current_config_path;
 
 static bool load_config(const char *path, struct sway_config *config) {
-	sway_log(L_INFO, "Loading config from %s", path);
+	wlr_log(L_INFO, "Loading config from %s", path);
 	current_config_path = path;
 
 	struct stat sb;
@@ -272,13 +272,13 @@ static bool load_config(const char *path, struct sway_config *config) {
 	}
 
 	if (path == NULL) {
-		sway_log(L_ERROR, "Unable to find a config file!");
+		wlr_log(L_ERROR, "Unable to find a config file!");
 		return false;
 	}
 
 	FILE *f = fopen(path, "r");
 	if (!f) {
-		sway_log(L_ERROR, "Unable to open %s for reading", path);
+		wlr_log(L_ERROR, "Unable to open %s for reading", path);
 		return false;
 	}
 
@@ -286,7 +286,7 @@ static bool load_config(const char *path, struct sway_config *config) {
 	fclose(f);
 
 	if (!config_load_success) {
-		sway_log(L_ERROR, "Error(s) loading config!");
+		wlr_log(L_ERROR, "Error(s) loading config!");
 	}
 
 	current_config_path = NULL;
@@ -313,7 +313,7 @@ bool load_main_config(const char *file, bool is_active) {
 
 	config_defaults(config);
 	if (is_active) {
-		sway_log(L_DEBUG, "Performing configuration file reload");
+		wlr_log(L_DEBUG, "Performing configuration file reload");
 		config->reloading = true;
 		config->active = true;
 	}
@@ -327,7 +327,7 @@ bool load_main_config(const char *file, bool is_active) {
 	bool success = true;
 	DIR *dir = opendir(SYSCONFDIR "/sway/security.d");
 	if (!dir) {
-		sway_log(L_ERROR,
+		wlr_log(L_ERROR,
 			"%s does not exist, sway will have no security configuration"
 			" and will probably be broken", SYSCONFDIR "/sway/security.d");
 	} else {
@@ -356,7 +356,7 @@ bool load_main_config(const char *file, bool is_active) {
 			if (stat(_path, &s) || s.st_uid != 0 || s.st_gid != 0 ||
 					(((s.st_mode & 0777) != 0644) &&
 					(s.st_mode & 0777) != 0444)) {
-				sway_log(L_ERROR,
+				wlr_log(L_ERROR,
 					"Refusing to load %s - it must be owned by root "
 					"and mode 644 or 444", _path);
 				success = false;
@@ -398,7 +398,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 		len = len + strlen(parent_dir) + 2;
 		full_path = malloc(len * sizeof(char));
 		if (!full_path) {
-			sway_log(L_ERROR,
+			wlr_log(L_ERROR,
 				"Unable to allocate full path to included config");
 			return false;
 		}
@@ -409,7 +409,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 	free(full_path);
 
 	if (real_path == NULL) {
-		sway_log(L_DEBUG, "%s not found.", path);
+		wlr_log(L_DEBUG, "%s not found.", path);
 		return false;
 	}
 
@@ -418,7 +418,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 	for (j = 0; j < config->config_chain->length; ++j) {
 		char *old_path = config->config_chain->items[j];
 		if (strcmp(real_path, old_path) == 0) {
-			sway_log(L_DEBUG,
+			wlr_log(L_DEBUG,
 				"%s already included once, won't be included again.",
 				real_path);
 			free(real_path);
@@ -472,7 +472,7 @@ bool load_include_configs(const char *path, struct sway_config *config) {
 	// restore wd
 	if (chdir(wd) < 0) {
 		free(wd);
-		sway_log(L_ERROR, "failed to restore working directory");
+		wlr_log(L_ERROR, "failed to restore working directory");
 		return false;
 	}
 
@@ -508,13 +508,13 @@ bool read_config(FILE *file, struct sway_config *config) {
 		switch(res->status) {
 		case CMD_FAILURE:
 		case CMD_INVALID:
-			sway_log(L_ERROR, "Error on line %i '%s': %s (%s)", line_number,
+			wlr_log(L_ERROR, "Error on line %i '%s': %s (%s)", line_number,
 				line, res->error, config->current_config);
 			success = false;
 			break;
 
 		case CMD_DEFER:
-			sway_log(L_DEBUG, "Deferring command `%s'", line);
+			wlr_log(L_DEBUG, "Deferring command `%s'", line);
 			list_add(config->cmd_queue, strdup(line));
 			break;
 
@@ -522,7 +522,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_MODE;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -530,7 +530,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_INPUT;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -538,7 +538,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_SEAT;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -546,7 +546,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_BAR;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -554,7 +554,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_BAR) {
 				block = CMD_BLOCK_BAR_COLORS;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -562,7 +562,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_COMMANDS;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -570,7 +570,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_END) {
 				block = CMD_BLOCK_IPC;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
@@ -578,59 +578,59 @@ bool read_config(FILE *file, struct sway_config *config) {
 			if (block == CMD_BLOCK_IPC) {
 				block = CMD_BLOCK_IPC_EVENTS;
 			} else {
-				sway_log(L_ERROR, "Invalid block '%s'", line);
+				wlr_log(L_ERROR, "Invalid block '%s'", line);
 			}
 			break;
 
 		case CMD_BLOCK_END:
 			switch(block) {
 			case CMD_BLOCK_MODE:
-				sway_log(L_DEBUG, "End of mode block");
+				wlr_log(L_DEBUG, "End of mode block");
 				config->current_mode = config->modes->items[0];
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_INPUT:
-				sway_log(L_DEBUG, "End of input block");
+				wlr_log(L_DEBUG, "End of input block");
 				free_input_config(current_input_config);
 				current_input_config = NULL;
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_SEAT:
-				sway_log(L_DEBUG, "End of seat block");
+				wlr_log(L_DEBUG, "End of seat block");
 				current_seat_config = NULL;
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_BAR:
-				sway_log(L_DEBUG, "End of bar block");
+				wlr_log(L_DEBUG, "End of bar block");
 				config->current_bar = NULL;
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_BAR_COLORS:
-				sway_log(L_DEBUG, "End of bar colors block");
+				wlr_log(L_DEBUG, "End of bar colors block");
 				block = CMD_BLOCK_BAR;
 				break;
 
 			case CMD_BLOCK_COMMANDS:
-				sway_log(L_DEBUG, "End of commands block");
+				wlr_log(L_DEBUG, "End of commands block");
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_IPC:
-				sway_log(L_DEBUG, "End of IPC block");
+				wlr_log(L_DEBUG, "End of IPC block");
 				block = CMD_BLOCK_END;
 				break;
 
 			case CMD_BLOCK_IPC_EVENTS:
-				sway_log(L_DEBUG, "End of IPC events block");
+				wlr_log(L_DEBUG, "End of IPC events block");
 				block = CMD_BLOCK_IPC;
 				break;
 
 			case CMD_BLOCK_END:
-				sway_log(L_ERROR, "Unmatched }");
+				wlr_log(L_ERROR, "Unmatched }");
 				break;
 
 			default:;
@@ -663,7 +663,7 @@ char *do_var_replacement(char *str) {
 				int vvlen = strlen(var->value);
 				char *newstr = malloc(strlen(str) - vnlen + vvlen + 1);
 				if (!newstr) {
-					sway_log(L_ERROR,
+					wlr_log(L_ERROR,
 						"Unable to allocate replacement "
 						"during variable expansion");
 					break;

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -8,13 +8,13 @@
 struct input_config *new_input_config(const char* identifier) {
 	struct input_config *input = calloc(1, sizeof(struct input_config));
 	if (!input) {
-		sway_log(L_DEBUG, "Unable to allocate input config");
+		wlr_log(L_DEBUG, "Unable to allocate input config");
 		return NULL;
 	}
-	sway_log(L_DEBUG, "new_input_config(%s)", identifier);
+	wlr_log(L_DEBUG, "new_input_config(%s)", identifier);
 	if (!(input->identifier = strdup(identifier))) {
 		free(input);
-		sway_log(L_DEBUG, "Unable to allocate input config");
+		wlr_log(L_DEBUG, "Unable to allocate input config");
 		return NULL;
 	}
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -84,7 +84,7 @@ static void set_mode(struct wlr_output *output, int width, int height,
 		float refresh_rate) {
 	int mhz = (int)(refresh_rate * 1000);
 	if (wl_list_empty(&output->modes)) {
-		sway_log(L_DEBUG, "Assigning custom mode to %s", output->name);
+		wlr_log(L_DEBUG, "Assigning custom mode to %s", output->name);
 		wlr_output_set_custom_mode(output, width, height, mhz);
 		return;
 	}
@@ -100,9 +100,9 @@ static void set_mode(struct wlr_output *output, int width, int height,
 		}
 	}
 	if (!best) {
-		sway_log(L_ERROR, "Configured mode for %s not available", output->name);
+		wlr_log(L_ERROR, "Configured mode for %s not available", output->name);
 	} else {
-		sway_log(L_DEBUG, "Assigning configured mode to %s", output->name);
+		wlr_log(L_DEBUG, "Assigning configured mode to %s", output->name);
 		wlr_output_set_mode(output, best);
 	}
 }
@@ -119,22 +119,22 @@ void apply_output_config(struct output_config *oc, swayc_t *output) {
 	}
 
 	if (oc && oc->width > 0 && oc->height > 0) {
-		sway_log(L_DEBUG, "Set %s mode to %dx%d (%f GHz)", oc->name, oc->width,
+		wlr_log(L_DEBUG, "Set %s mode to %dx%d (%f GHz)", oc->name, oc->width,
 			oc->height, oc->refresh_rate);
 		set_mode(wlr_output, oc->width, oc->height, oc->refresh_rate);
 	}
 	if (oc && oc->scale > 0) {
-		sway_log(L_DEBUG, "Set %s scale to %f", oc->name, oc->scale);
+		wlr_log(L_DEBUG, "Set %s scale to %f", oc->name, oc->scale);
 		wlr_output_set_scale(wlr_output, oc->scale);
 	}
 	if (oc && oc->transform >= 0) {
-		sway_log(L_DEBUG, "Set %s transform to %d", oc->name, oc->transform);
+		wlr_log(L_DEBUG, "Set %s transform to %d", oc->name, oc->transform);
 		wlr_output_set_transform(wlr_output, oc->transform);
 	}
 
 	// Find position for it
 	if (oc && (oc->x != -1 || oc->y != -1)) {
-		sway_log(L_DEBUG, "Set %s position to %d, %d", oc->name, oc->x, oc->y);
+		wlr_log(L_DEBUG, "Set %s position to %d, %d", oc->name, oc->x, oc->y);
 		wlr_output_layout_add(root_container.sway_root->output_layout,
 			wlr_output, oc->x, oc->y);
 	} else {
@@ -165,7 +165,7 @@ void apply_output_config(struct output_config *oc, swayc_t *output) {
 			terminate_swaybg(output->bg_pid);
 		}
 
-		sway_log(L_DEBUG, "Setting background for output %d to %s", output_i, oc->background);
+		wlr_log(L_DEBUG, "Setting background for output %d to %s", output_i, oc->background);
 
 		size_t bufsize = 12;
 		char output_id[bufsize];

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -7,11 +7,11 @@
 struct seat_config *new_seat_config(const char* name) {
 	struct seat_config *seat = calloc(1, sizeof(struct seat_config));
 	if (!seat) {
-		sway_log(L_DEBUG, "Unable to allocate seat config");
+		wlr_log(L_DEBUG, "Unable to allocate seat config");
 		return NULL;
 	}
 
-	sway_log(L_DEBUG, "new_seat_config(%s)", name);
+	wlr_log(L_DEBUG, "new_seat_config(%s)", name);
 	seat->name = strdup(name);
 	if (!sway_assert(seat->name, "could not allocate name for seat")) {
 		free(seat);
@@ -34,7 +34,7 @@ struct seat_attachment_config *seat_attachment_config_new() {
 	struct seat_attachment_config *attachment =
 		calloc(1, sizeof(struct seat_attachment_config));
 	if (!attachment) {
-		sway_log(L_DEBUG, "cannot allocate attachment config");
+		wlr_log(L_DEBUG, "cannot allocate attachment config");
 		return NULL;
 	}
 	return attachment;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -110,7 +110,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 void output_add_notify(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, output_add);
 	struct wlr_output *wlr_output = data;
-	sway_log(L_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
+	wlr_log(L_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
 
 	struct sway_output *output = calloc(1, sizeof(struct sway_output));
 	if (!output) {
@@ -140,7 +140,7 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 void output_remove_notify(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, output_remove);
 	struct wlr_output *wlr_output = data;
-	sway_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
+	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
 
 	swayc_t *output_container = NULL;
 	for (int i = 0 ; i < root_container.children->length; ++i) {

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -82,7 +82,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	sway_log(L_DEBUG, "New wl_shell toplevel title='%s' app_id='%s'",
+	wlr_log(L_DEBUG, "New wl_shell toplevel title='%s' app_id='%s'",
 			shell_surface->title, shell_surface->class);
 	wlr_wl_shell_surface_ping(shell_surface);
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -88,7 +88,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	sway_log(L_DEBUG, "New xdg_shell_v6 toplevel title='%s' app_id='%s'",
+	wlr_log(L_DEBUG, "New xdg_shell_v6 toplevel title='%s' app_id='%s'",
 			xdg_surface->title, xdg_surface->app_id);
 	wlr_xdg_surface_v6_ping(xdg_surface);
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -124,7 +124,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	sway_log(L_DEBUG, "New xwayland surface title='%s' class='%s'",
+	wlr_log(L_DEBUG, "New xwayland surface title='%s' class='%s'",
 			xsurface->title, xsurface->class);
 
 	struct sway_xwayland_surface *sway_surface =

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -85,35 +85,35 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, touch_down);
 	struct wlr_event_touch_down *event = data;
-	sway_log(L_DEBUG, "TODO: handle touch down event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle touch down event: %p", event);
 }
 
 static void handle_touch_up(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, touch_up);
 	struct wlr_event_touch_up *event = data;
-	sway_log(L_DEBUG, "TODO: handle touch up event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle touch up event: %p", event);
 }
 
 static void handle_touch_motion(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, touch_motion);
 	struct wlr_event_touch_motion *event = data;
-	sway_log(L_DEBUG, "TODO: handle touch motion event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle touch motion event: %p", event);
 }
 
 static void handle_tool_axis(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, tool_axis);
 	struct wlr_event_tablet_tool_axis *event = data;
-	sway_log(L_DEBUG, "TODO: handle tool axis event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle tool axis event: %p", event);
 }
 
 static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, tool_tip);
 	struct wlr_event_tablet_tool_tip *event = data;
-	sway_log(L_DEBUG, "TODO: handle tool tip event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle tool tip event: %p", event);
 }
 
 static void handle_request_set_cursor(struct wl_listener *listener,
@@ -121,7 +121,7 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, request_set_cursor);
 	struct wlr_seat_pointer_request_set_cursor_event *event = data;
-	sway_log(L_DEBUG, "TODO: handle request set cursor event: %p", event);
+	wlr_log(L_DEBUG, "TODO: handle request set cursor event: %p", event);
 }
 
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -52,7 +52,7 @@ static char *get_device_identifier(struct wlr_input_device *device) {
 	int len = snprintf(NULL, 0, fmt, vendor, product, name) + 1;
 	char *identifier = malloc(len);
 	if (!identifier) {
-		sway_log(L_ERROR, "Unable to allocate unique input device name");
+		wlr_log(L_ERROR, "Unable to allocate unique input device name");
 		return NULL;
 	}
 
@@ -93,60 +93,60 @@ static void sway_input_manager_libinput_config_pointer(struct sway_input_device 
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	sway_log(L_DEBUG, "sway_input_manager_libinput_config_pointer(%s)", ic->identifier);
+	wlr_log(L_DEBUG, "sway_input_manager_libinput_config_pointer(%s)", ic->identifier);
 
 	if (ic->accel_profile != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
 			ic->identifier, ic->accel_profile);
 		libinput_device_config_accel_set_profile(libinput_device, ic->accel_profile);
 	}
 	if (ic->click_method != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
 			ic->identifier, ic->click_method);
 		libinput_device_config_click_set_method(libinput_device, ic->click_method);
 	}
 	if (ic->drag_lock != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			ic->identifier, ic->click_method);
 		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, ic->drag_lock);
 	}
 	if (ic->dwt != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
 			ic->identifier, ic->dwt);
 		libinput_device_config_dwt_set_enabled(libinput_device, ic->dwt);
 	}
 	if (ic->left_handed != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) left_handed_set_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) left_handed_set_enabled(%d)",
 			ic->identifier, ic->left_handed);
 		libinput_device_config_left_handed_set(libinput_device, ic->left_handed);
 	}
 	if (ic->middle_emulation != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
 			ic->identifier, ic->middle_emulation);
 		libinput_device_config_middle_emulation_set_enabled(libinput_device, ic->middle_emulation);
 	}
 	if (ic->natural_scroll != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
 			ic->identifier, ic->natural_scroll);
 		libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, ic->natural_scroll);
 	}
 	if (ic->pointer_accel != FLT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
 			ic->identifier, ic->pointer_accel);
 		libinput_device_config_accel_set_speed(libinput_device, ic->pointer_accel);
 	}
 	if (ic->scroll_method != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
 			ic->identifier, ic->scroll_method);
 		libinput_device_config_scroll_set_method(libinput_device, ic->scroll_method);
 	}
 	if (ic->send_events != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
 		libinput_device_config_send_events_set_mode(libinput_device, ic->send_events);
 	}
 	if (ic->tap != INT_MIN) {
-		sway_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",
+		wlr_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",
 			ic->identifier, ic->tap);
 		libinput_device_config_tap_set_enabled(libinput_device, ic->tap);
 	}
@@ -167,7 +167,7 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 	input_device->identifier = get_device_identifier(device);
 	wl_list_insert(&input->devices, &input_device->link);
 
-	sway_log(L_DEBUG, "adding device: '%s'",
+	wlr_log(L_DEBUG, "adding device: '%s'",
 		input_device->identifier);
 
 	// find config
@@ -185,7 +185,7 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 
 	struct sway_seat *seat = NULL;
 	if (!input_has_seat_configuration(input)) {
-		sway_log(L_DEBUG, "no seat configuration, using default seat");
+		wlr_log(L_DEBUG, "no seat configuration, using default seat");
 		seat = input_manager_get_seat(input, default_seat);
 		sway_seat_add_device(seat, input_device);
 		return;
@@ -213,7 +213,7 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 	}
 
 	if (!added) {
-		sway_log(L_DEBUG,
+		wlr_log(L_DEBUG,
 			"device '%s' is not configured on any seats",
 			input_device->identifier);
 	}
@@ -231,7 +231,7 @@ static void input_remove_notify(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	sway_log(L_DEBUG, "removing device: '%s'",
+	wlr_log(L_DEBUG, "removing device: '%s'",
 		input_device->identifier);
 
 	struct sway_seat *seat = NULL;
@@ -309,7 +309,7 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 
 void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 		struct seat_config *seat_config) {
-	sway_log(L_DEBUG, "applying new seat config for seat %s",
+	wlr_log(L_DEBUG, "applying new seat config for seat %s",
 		seat_config->name);
 	struct sway_seat *seat = input_manager_get_seat(input, seat_config->name);
 	if (!seat) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -90,11 +90,11 @@ static bool binding_matches_key_state(struct sway_binding *binding,
 }
 
 static void binding_execute_command(struct sway_binding *binding) {
-	sway_log(L_DEBUG, "running command for binding: %s",
+	wlr_log(L_DEBUG, "running command for binding: %s",
 		binding->command);
 	struct cmd_results *results = handle_command(binding->command);
 	if (results->status != CMD_SUCCESS) {
-		sway_log(L_DEBUG, "could not run command for binding: %s",
+		wlr_log(L_DEBUG, "could not run command for binding: %s",
 			binding->command);
 	}
 	free_cmd_results(results);
@@ -467,7 +467,7 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 		xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
 
 	if (!keymap) {
-		sway_log(L_DEBUG, "cannot configure keyboard: keymap does not exist");
+		wlr_log(L_DEBUG, "cannot configure keyboard: keymap does not exist");
 		xkb_context_unref(context);
 		return;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -112,7 +112,7 @@ void sway_seat_configure_device(struct sway_seat *seat,
 		case WLR_INPUT_DEVICE_TOUCH:
 		case WLR_INPUT_DEVICE_TABLET_PAD:
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
-			sway_log(L_DEBUG, "TODO: configure other devices");
+			wlr_log(L_DEBUG, "TODO: configure other devices");
 			break;
 	}
 }
@@ -127,11 +127,11 @@ void sway_seat_add_device(struct sway_seat *seat,
 	struct sway_seat_device *seat_device =
 		calloc(1, sizeof(struct sway_seat_device));
 	if (!seat_device) {
-		sway_log(L_DEBUG, "could not allocate seat device");
+		wlr_log(L_DEBUG, "could not allocate seat device");
 		return;
 	}
 
-	sway_log(L_DEBUG, "adding device %s to seat %s",
+	wlr_log(L_DEBUG, "adding device %s to seat %s",
 		input_device->identifier, seat->wlr_seat->name);
 
 	seat_device->sway_seat = seat;
@@ -150,7 +150,7 @@ void sway_seat_remove_device(struct sway_seat *seat,
 		return;
 	}
 
-	sway_log(L_DEBUG, "removing device %s from seat %s",
+	wlr_log(L_DEBUG, "removing device %s from seat %s",
 		input_device->identifier, seat->wlr_seat->name);
 
 	seat_device_destroy(seat_device);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -92,11 +92,11 @@ swayc_t *new_output(struct sway_output *sway_output) {
 
 		if (strcasecmp(name, cur->name) == 0 ||
 				strcasecmp(identifier, cur->name) == 0) {
-			sway_log(L_DEBUG, "Matched output config for %s", name);
+			wlr_log(L_DEBUG, "Matched output config for %s", name);
 			oc = cur;
 		}
 		if (strcasecmp("*", cur->name) == 0) {
-			sway_log(L_DEBUG, "Matched wildcard output config for %s", name);
+			wlr_log(L_DEBUG, "Matched wildcard output config for %s", name);
 			all = cur;
 		}
 
@@ -126,7 +126,7 @@ swayc_t *new_output(struct sway_output *sway_output) {
 
 	// Create workspace
 	char *ws_name = workspace_next_name(output->name);
-	sway_log(L_DEBUG, "Creating default workspace %s", ws_name);
+	wlr_log(L_DEBUG, "Creating default workspace %s", ws_name);
 	new_workspace(output, ws_name);
 	free(ws_name);
 	return output;
@@ -136,7 +136,7 @@ swayc_t *new_workspace(swayc_t *output, const char *name) {
 	if (!sway_assert(output, "new_workspace called with null output")) {
 		return NULL;
 	}
-	sway_log(L_DEBUG, "Added workspace %s for output %s", name, output->name);
+	wlr_log(L_DEBUG, "Added workspace %s for output %s", name, output->name);
 	swayc_t *workspace = new_swayc(C_WORKSPACE);
 
 	workspace->x = output->x;
@@ -159,7 +159,7 @@ swayc_t *new_view(swayc_t *sibling, struct sway_view *sway_view) {
 	}
 	const char *title = sway_view->iface.get_prop(sway_view, VIEW_PROP_TITLE);
 	swayc_t *swayc = new_swayc(C_VIEW);
-	sway_log(L_DEBUG, "Adding new view %p:%s to container %p %d",
+	wlr_log(L_DEBUG, "Adding new view %p:%s to container %p %d",
 		swayc, title, sibling, sibling ? sibling->type : 0);
 	// Setup values
 	swayc->sway_view = sway_view;
@@ -200,7 +200,7 @@ swayc_t *destroy_output(swayc_t *output) {
 		}
 	}
 
-	sway_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
+	wlr_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
 	free_swayc(output);
 
 	return &root_container;
@@ -210,7 +210,7 @@ swayc_t *destroy_view(swayc_t *view) {
 	if (!sway_assert(view, "null view passed to destroy_view")) {
 		return NULL;
 	}
-	sway_log(L_DEBUG, "Destroying view '%s'", view->name);
+	wlr_log(L_DEBUG, "Destroying view '%s'", view->name);
 	swayc_t *parent = view->parent;
 	free_swayc(view);
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -59,7 +59,7 @@ void init_layout(void) {
 }
 
 void add_child(swayc_t *parent, swayc_t *child) {
-	sway_log(L_DEBUG, "Adding %p (%d, %fx%f) to %p (%d, %fx%f)",
+	wlr_log(L_DEBUG, "Adding %p (%d, %fx%f) to %p (%d, %fx%f)",
 			child, child->type, child->width, child->height,
 			parent, parent->type, parent->width, parent->height);
 	list_add(parent->children, child);
@@ -145,7 +145,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 	width = floor(width);
 	height = floor(height);
 
-	sway_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", container,
+	wlr_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", container,
 		 container->name, container->width, container->height, container->x,
 		 container->y);
 
@@ -155,7 +155,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 		// TODO: wlr_output_layout probably
 		for (i = 0; i < container->children->length; ++i) {
 			swayc_t *output = container->children->items[i];
-			sway_log(L_DEBUG, "Arranging output '%s' at %f,%f",
+			wlr_log(L_DEBUG, "Arranging output '%s' at %f,%f",
 					output->name, output->x, output->y);
 			arrange_windows(output, -1, -1);
 		}
@@ -181,7 +181,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 			container->height = output->height;
 			container->x = x;
 			container->y = y;
-			sway_log(L_DEBUG, "Arranging workspace '%s' at %f, %f",
+			wlr_log(L_DEBUG, "Arranging workspace '%s' at %f, %f",
 					container->name, container->x, container->y);
 		}
 		// children are properly handled below
@@ -192,7 +192,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 			container->height = height;
 			container->sway_view->iface.set_size(container->sway_view,
 					container->width, container->height);
-			sway_log(L_DEBUG, "Set view to %.f x %.f @ %.f, %.f",
+			wlr_log(L_DEBUG, "Set view to %.f x %.f @ %.f, %.f",
 					container->width, container->height,
 					container->x, container->y);
 		}
@@ -215,7 +215,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 			container->children->length);
 		break;
 	default:
-		sway_log(L_DEBUG, "TODO: arrange layout type %d", container->layout);
+		wlr_log(L_DEBUG, "TODO: arrange layout type %d", container->layout);
 		apply_horiz_layout(container, x, y, width, height, 0,
 			container->children->length);
 		break;
@@ -244,10 +244,10 @@ static void apply_horiz_layout(swayc_t *container,
 	// Resize windows
 	double child_x = x;
 	if (scale > 0.1) {
-		sway_log(L_DEBUG, "Arranging %p horizontally", container);
+		wlr_log(L_DEBUG, "Arranging %p horizontally", container);
 		for (int i = start; i < end; ++i) {
 			swayc_t *child = container->children->items[i];
-			sway_log(L_DEBUG,
+			wlr_log(L_DEBUG,
 				 "Calculating arrangement for %p:%d (will scale %f by %f)",
 				 child, child->type, width, scale);
 			child->sway_view->iface.set_position(child->sway_view, child_x, y);
@@ -294,10 +294,10 @@ void apply_vert_layout(swayc_t *container,
 	// Resize
 	double child_y = y;
 	if (scale > 0.1) {
-		sway_log(L_DEBUG, "Arranging %p vertically", container);
+		wlr_log(L_DEBUG, "Arranging %p vertically", container);
 		for (i = start; i < end; ++i) {
 			swayc_t *child = container->children->items[i];
-			sway_log(L_DEBUG,
+			wlr_log(L_DEBUG,
 				 "Calculating arrangement for %p:%d (will scale %f by %f)",
 				 child, child->type, height, scale);
 			child->sway_view->iface.set_position(child->sway_view, x, child_y);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -11,7 +11,7 @@ void next_name_map(swayc_t *ws, void *data) {
 }
 
 char *workspace_next_name(const char *output_name) {
-	sway_log(L_DEBUG, "Workspace: Generating new workspace name for output %s",
+	wlr_log(L_DEBUG, "Workspace: Generating new workspace name for output %s",
 			output_name);
 	int count = 0;
 	next_name_map(&root_container, &count);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -232,7 +232,7 @@ int main(int argc, char **argv) {
 	char *socket_path = NULL;
 	char *cmdtype = NULL;
 
-	init_log(L_INFO);
+	wlr_log_init(L_INFO, NULL);
 
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},

--- a/swaymsg/meson.build
+++ b/swaymsg/meson.build
@@ -2,7 +2,7 @@ executable(
     'swaymsg',
     'main.c',
     include_directories: [sway_inc],
-    dependencies: [jsonc],
+    dependencies: [jsonc, wlroots],
     link_with: [lib_sway_common],
     install: true
 )


### PR DESCRIPTION
This finishes cleaning up all sway_log that are currently compiled.

It's the first time I'm actually looking at wlroots logging, I'm not sure I like the way we call _strip_path in the macro because this calls _strip_path all the time even if log level isn't verbose enough or if condition doesn't match in sway_assert.
I guess ultimately it doesn't matter much, but was that a conscious decision when wlr_log was implemented? I'd be happy to transform it back like sway's by adding file/line as separate arguments to callback if there are afterthoughts.