### PR TITLE
Prevent invalid free of workspace name

### DIFF
--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -68,8 +68,9 @@ char *workspace_next_name(const char *output_name) {
 			sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", name);
 			char *_target = strdup(name);
 			strip_quotes(_target);
-			while (isspace(*_target))
-				_target++;
+			while (isspace(*_target)) {
+				memmove(_target, _target+1, strlen(_target+1));
+			}
 
 			// Make sure that the command references an actual workspace
 			// not a command about workspaces


### PR DESCRIPTION
An allocated pointer was incremented before being freed in
`sway/workspace.c` which led to an invalid free. This has been fixed by
keeping the pointer in place and moving the data instead.

Fixes #1548