### PR TITLE
Fix out of focus when using mouse to change workspace

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -162,12 +162,12 @@ bool set_focused_container(swayc_t *c) {
 		}
 		if (c->type == C_VIEW) {
 			wlc_view_set_state(c->handle, WLC_BIT_ACTIVATED, true);
-		}
-		if (!desktop_shell.is_locked) {
-			// If the system is locked, we do everything _but_ actually setting
-			// focus. This includes making our internals think that this view is
-			// focused.
-			wlc_view_focus(c->handle);
+			if (!desktop_shell.is_locked) {
+				// If the system is locked, we do everything _but_ actually setting
+				// focus. This includes making our internals think that this view is
+				// focused.
+				wlc_view_focus(c->handle);
+			}
 		}
 		if (c->parent->layout != L_TABBED && c->parent->layout != L_STACKED) {
 			update_container_border(c);


### PR DESCRIPTION
When you try to change the workspace with the mouse, upon mouse release event it will try focus on the OUTPUT 'WLC-1' handler for some reason, we just prevent it. Additionally it seems wlc_view_focus should be called with C_VIEW only.

[debug_log.c:98] Setting focus to 0x5649148455a0:1 (OUTPUT 'WLC-1')
[main.c:50] [wlc] compositor/view.c: 574 @ wlc_view_focus(): Tried to retrieve handle of wrong type (output != view)

[log.txt](https://github.com/swaywm/sway/files/1619627/log.txt)
