### PR TITLE
Subsurfaces and popups

### DIFF
--- a/include/sway/layout.h
+++ b/include/sway/layout.h
@@ -9,6 +9,8 @@ struct sway_root {
 	struct wlr_output_layout *output_layout;
 
 	struct wl_listener output_layout_change;
+
+	struct wl_list unmanaged_views; // sway_view::unmanaged_view_link
 };
 
 void init_layout(void);

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -28,6 +28,8 @@ struct sway_xwayland_surface {
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_configure;
+	struct wl_listener unmap_notify;
+	struct wl_listener map_notify;
 	struct wl_listener destroy;
 
 	int pending_width, pending_height;
@@ -91,6 +93,9 @@ struct sway_view {
 				double ox, double oy);
 		void (*set_activated)(struct sway_view *view, bool activated);
 	} iface;
+
+	// only used for unmanaged views (shell specific)
+	struct wl_list unmanaged_view_link; // sway_root::unmanaged views
 };
 
 #endif

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -218,6 +218,19 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	swayc_descendants_of_type(
 			&root_container, C_VIEW, output_frame_view, soutput);
 
+	// render unmanaged views on top
+	struct sway_view *view;
+	wl_list_for_each(view, &root_container.sway_root->unmanaged_views,
+			unmanaged_view_link) {
+		if (view->type == SWAY_XWAYLAND_VIEW) {
+			// the only kind of unamanged view right now is xwayland override redirect
+			int view_x = view->wlr_xwayland_surface->x;
+			int view_y = view->wlr_xwayland_surface->y;
+			render_surface(view->surface, wlr_output, &soutput->last_frame,
+					view_x, view_y, 0);
+		}
+	}
+
 	wlr_renderer_end(server->renderer);
 	wlr_output_swap_buffers(wlr_output);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -180,6 +180,10 @@ static void output_frame_view(swayc_t *view, void *data) {
 	struct sway_view *sway_view = view->sway_view;
 	struct wlr_surface *surface = sway_view->surface;
 
+	if (!surface) {
+		return;
+	}
+
 	switch (sway_view->type) {
 	case SWAY_XDG_SHELL_V6_VIEW: {
 		int window_offset_x = view->sway_view->wlr_xdg_surface_v6->geometry->x;

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -77,10 +77,12 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 			listener, server, wl_shell_surface);
 	struct wlr_wl_shell_surface *shell_surface = data;
 
-	if (shell_surface->state != WLR_WL_SHELL_SURFACE_STATE_TOPLEVEL) {
-		// TODO: transient and popups should be floating
+	if (shell_surface->state == WLR_WL_SHELL_SURFACE_STATE_POPUP) {
+		// popups don't get views
 		return;
 	}
+
+	// TODO make transient windows floating
 
 	wlr_log(L_DEBUG, "New wl_shell toplevel title='%s' app_id='%s'",
 			shell_surface->title, shell_surface->class);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -259,7 +259,6 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 			int width = swayc->sway_view->surface->current->width;
 			int height = swayc->sway_view->surface->current->height;
 
-			// TODO popups and subsurfaces
 			switch (sview->type) {
 				case SWAY_WL_SHELL_VIEW:
 					break;
@@ -268,6 +267,20 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 					// coordinate of the top left corner of the window geometry
 					view_sx += sview->wlr_xdg_surface_v6->geometry->x;
 					view_sy += sview->wlr_xdg_surface_v6->geometry->y;
+
+					// check for popups
+					double popup_sx, popup_sy;
+					struct wlr_xdg_surface_v6 *popup =
+						wlr_xdg_surface_v6_popup_at(sview->wlr_xdg_surface_v6,
+								view_sx, view_sy, &popup_sx, &popup_sy);
+
+					if (popup) {
+						*sx = view_sx - popup_sx;
+						*sy = view_sy - popup_sy;
+						*surface = popup->surface;
+						list_free(queue);
+						return swayc;
+					}
 					break;
 				case SWAY_XWAYLAND_VIEW:
 					break;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -288,6 +288,19 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 					break;
 			}
 
+			// check for subsurfaces
+			double sub_x, sub_y;
+			struct wlr_subsurface *subsurface =
+				wlr_surface_subsurface_at(sview->surface,
+						view_sx, view_sy, &sub_x, &sub_y);
+			if (subsurface) {
+				*sx = view_sx - sub_x;
+				*sy = view_sy - sub_y;
+				*surface = subsurface->surface;
+				list_free(queue);
+				return swayc;
+			}
+
 			if (view_sx > 0 && view_sx < width &&
 					view_sy > 0 && view_sy < height &&
 					pixman_region32_contains_point(

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -207,7 +207,7 @@ swayc_t *destroy_output(swayc_t *output) {
 }
 
 swayc_t *destroy_view(swayc_t *view) {
-	if (!sway_assert(view, "null view passed to destroy_view")) {
+	if (!view) {
 		return NULL;
 	}
 	wlr_log(L_DEBUG, "Destroying view '%s'", view->name);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -51,6 +51,7 @@ void init_layout(void) {
 
 	root_container.sway_root = calloc(1, sizeof(*root_container.sway_root));
 	root_container.sway_root->output_layout = wlr_output_layout_create();
+	wl_list_init(&root_container.sway_root->unmanaged_views);
 
 	root_container.sway_root->output_layout_change.notify =
 		output_layout_change_notify;


### PR DESCRIPTION
Render subsurfaces and popups.

* [x] render xdg-popups
* [x] xdg-popups input
* [x] render subsurfaces
* [x] subsurfaces input
* [x] render wl-shell popups
* [x] wl-shell popups input
* [x] render xwayland override redirect
* [x] xwayland override redirect input

Further work:

* make wl-shell transient windows floating