### PR TITLE
Copy input config references

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -386,12 +386,14 @@ struct cmd_results *check_security_config();
 int input_identifier_cmp(const void *item, const void *data);
 struct input_config *new_input_config(const char* identifier);
 void merge_input_config(struct input_config *dst, struct input_config *src);
+struct input_config *copy_input_config(struct input_config *ic);
 void free_input_config(struct input_config *ic);
 void apply_input_config(struct input_config *input);
 
 int seat_name_cmp(const void *item, const void *data);
 struct seat_config *new_seat_config(const char* name);
 void merge_seat_config(struct seat_config *dst, struct seat_config *src);
+struct seat_config *copy_seat_config(struct seat_config *seat);
 void free_seat_config(struct seat_config *ic);
 struct seat_attachment_config *seat_attachment_config_new();
 struct seat_attachment_config *seat_config_get_attachment(

--- a/sway/config.c
+++ b/sway/config.c
@@ -84,7 +84,12 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->input_configs);
 	}
-	list_free(config->seat_configs);
+	if (config->seat_configs) {
+		for (i = 0; i < config->seat_configs->length; i++) {
+			free_seat_config(config->seat_configs->items[i]);
+		}
+		list_free(config->seat_configs);
+	}
 	list_free(config->criteria);
 	list_free(config->no_focus);
 	list_free(config->active_bar_modifiers);

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -90,6 +90,16 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 }
 
+struct input_config *copy_input_config(struct input_config *ic) {
+	struct input_config *copy = calloc(1, sizeof(struct input_config));
+	if (copy == NULL) {
+		wlr_log(L_ERROR, "could not allocate input config");
+		return NULL;
+	}
+	merge_input_config(copy, ic);
+	return copy;
+}
+
 void free_input_config(struct input_config *ic) {
 	if (!ic) {
 		return;

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -99,6 +99,17 @@ void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 	}
 }
 
+struct seat_config *copy_seat_config(struct seat_config *seat) {
+	struct seat_config *copy = new_seat_config(seat->name);
+	if (copy == NULL) {
+		return NULL;
+	}
+
+	merge_seat_config(copy, seat);
+
+	return copy;
+}
+
 void free_seat_config(struct seat_config *seat) {
 	if (!seat) {
 		return;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -174,7 +174,8 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 	for (int i = 0; i < config->input_configs->length; ++i) {
 		struct input_config *input_config = config->input_configs->items[i];
 		if (strcmp(input_config->identifier, input_device->identifier) == 0) {
-			input_device->config = input_config;
+			free_input_config(input_device->config);
+			input_device->config = copy_input_config(input_config);
 			break;
 		}
 	}
@@ -240,6 +241,7 @@ static void input_remove_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wl_list_remove(&input_device->link);
+	free_input_config(input_device->config);
 	free(input_device->identifier);
 	free(input_device);
 }
@@ -293,7 +295,8 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &input->devices, link) {
 		if (strcmp(input_device->identifier, input_config->identifier) == 0) {
-			input_device->config = input_config;
+			free_input_config(input_device->config);
+			input_device->config = copy_input_config(input_config);
 
 			if (input_device->wlr_device->type == WLR_INPUT_DEVICE_POINTER) {
 				sway_input_manager_libinput_config_pointer(input_device);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -230,6 +230,7 @@ void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container) {
 void sway_seat_set_config(struct sway_seat *seat,
 		struct seat_config *seat_config) {
 	// clear configs
+	free_seat_config(seat->config);
 	seat->config = NULL;
 
 	struct sway_seat_device *seat_device = NULL;
@@ -242,11 +243,9 @@ void sway_seat_set_config(struct sway_seat *seat,
 	}
 
 	// add configs
-	seat->config = seat_config;
+	seat->config = copy_seat_config(seat_config);
 
 	wl_list_for_each(seat_device, &seat->devices, link) {
-		seat_device->attachment_config =
-			seat_config_get_attachment(seat_config,
-				seat_device->input_device->identifier);
+		sway_seat_configure_device(seat, seat_device->input_device);
 	}
 }


### PR DESCRIPTION
Don't hang onto copies of config pointers in the input manager or the seat.

For #1555.