### PR TITLE
Command criteria

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -354,6 +354,7 @@ struct sway_config {
 	// Context for command handlers
 	struct {
 		struct input_config *input_config;
+		struct seat_config *seat_config;
 	} handler_context;
 };
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -350,6 +350,11 @@ struct sway_config {
 	list_t *command_policies;
 	list_t *feature_policies;
 	list_t *ipc_policies;
+
+	// Context for command handlers
+	struct {
+		struct input_config *input_config;
+	} handler_context;
 };
 
 void pid_workspace_add(struct pid_workspace *pw);
@@ -375,6 +380,9 @@ bool read_config(FILE *file, struct sway_config *config);
  * Free config struct
  */
 void free_config(struct sway_config *config);
+
+void config_clear_handler_context(struct sway_config *config);
+
 void free_sway_variable(struct sway_variable *var);
 /**
  * Does variable replacement for a string based on the config's currently loaded variables.

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -356,6 +356,7 @@ struct sway_config {
 		struct input_config *input_config;
 		struct seat_config *seat_config;
 		struct sway_seat *seat;
+		swayc_t *current_container;
 	} handler_context;
 };
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -355,6 +355,7 @@ struct sway_config {
 	struct {
 		struct input_config *input_config;
 		struct seat_config *seat_config;
+		struct sway_seat *seat;
 	} handler_context;
 };
 

--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -145,4 +145,6 @@ swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types type);
 swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy);
 
+void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data);
+
 #endif

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -1,0 +1,42 @@
+#ifndef _SWAY_CRITERIA_H
+#define _SWAY_CRITERIA_H
+
+#include "container.h"
+#include "list.h"
+
+/**
+ * Maps criteria (as a list of criteria tokens) to a command list.
+ *
+ * A list of tokens together represent a single criteria string (e.g.
+ * '[class="abc" title="xyz"]' becomes two criteria tokens).
+ *
+ * for_window: Views matching all criteria will have the bound command list
+ * executed on them.
+ *
+ * Set via `for_window <criteria> <cmd list>`.
+ */
+struct criteria {
+	list_t *tokens; // struct crit_token, contains compiled regex.
+	char *crit_raw; // entire criteria string (for logging)
+
+	char *cmdlist;
+};
+
+int criteria_cmp(const void *item, const void *data);
+void free_criteria(struct criteria *crit);
+
+// Pouplate list with crit_tokens extracted from criteria string, returns error
+// string or NULL if successful.
+char *extract_crit_tokens(list_t *tokens, const char *criteria);
+
+// Returns list of criteria that match given container. These criteria have
+// been set with `for_window` commands and have an associated cmdlist.
+list_t *criteria_for(swayc_t *cont);
+
+// Returns a list of all containers that match the given list of tokens.
+list_t *container_for(list_t *tokens);
+
+// Returns true if any criteria in the given list matches this container
+bool criteria_any(swayc_t *cont, list_t *criteria);
+
+#endif

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -34,7 +34,7 @@ char *extract_crit_tokens(list_t *tokens, const char *criteria);
 list_t *criteria_for(swayc_t *cont);
 
 // Returns a list of all containers that match the given list of tokens.
-list_t *container_for(list_t *tokens);
+list_t *container_for_crit_tokens(list_t *tokens);
 
 // Returns true if any criteria in the given list matches this container
 bool criteria_any(swayc_t *cont, list_t *criteria);

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -5,8 +5,6 @@
 #include "sway/config.h"
 #include "list.h"
 
-extern struct seat_config *current_seat_config;
-
 /**
  * The global singleton input manager
  * TODO: make me not a global

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -43,4 +43,7 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 		struct seat_config *seat_config);
 
+struct sway_seat *sway_input_manager_get_default_seat(
+		struct sway_input_manager *input);
+
 #endif

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -5,7 +5,6 @@
 #include "sway/config.h"
 #include "list.h"
 
-extern struct input_config *current_input_config;
 extern struct seat_config *current_seat_config;
 
 /**

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -92,6 +92,7 @@ struct sway_view {
 		void (*set_position)(struct sway_view *view,
 				double ox, double oy);
 		void (*set_activated)(struct sway_view *view, bool activated);
+		void (*close)(struct sway_view *view);
 	} iface;
 
 	// only used for unmanaged views (shell specific)

--- a/include/sway/view.h
+++ b/include/sway/view.h
@@ -99,4 +99,20 @@ struct sway_view {
 	struct wl_list unmanaged_view_link; // sway_root::unmanaged views
 };
 
+const char *view_get_title(struct sway_view *view);
+
+const char *view_get_app_id(struct sway_view *view);
+
+const char *view_get_class(struct sway_view *view);
+
+const char *view_get_instance(struct sway_view *view);
+
+void view_set_size(struct sway_view *view, int width, int height);
+
+void view_set_position(struct sway_view *view, double ox, double oy);
+
+void view_set_activated(struct sway_view *view, bool activated);
+
+void view_close(struct sway_view *view);
+
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -86,7 +86,6 @@ void apply_seat_config(struct seat_config *seat) {
 		list_add(config->seat_configs, seat);
 	}
 
-	current_seat_config = seat;
 	sway_input_manager_apply_seat_config(input_manager, seat);
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -132,6 +132,7 @@ static struct cmd_handler handlers[] = {
 	{ "exit", cmd_exit },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
+	{ "kill", cmd_kill },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -226,7 +226,7 @@ struct cmd_results *handle_command(char *_exec) {
 					free(tokens);
 					goto cleanup;
 				}
-				containers = container_for(tokens);
+				containers = container_for_crit_tokens(tokens);
 
 				free(tokens);
 			} else {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -70,10 +70,7 @@ void apply_input_config(struct input_config *input) {
 		list_add(config->input_configs, input);
 	}
 
-	struct input_config *old_input_config = current_input_config;
-	current_input_config = input;
 	sway_input_manager_apply_input_config(input_manager, input);
-	current_input_config = old_input_config;
 }
 
 void apply_seat_config(struct seat_config *seat) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -8,6 +8,7 @@
 #include <json-c/json.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/criteria.h"
 #include "sway/security.h"
 #include "sway/input/input-manager.h"
 #include "stringop.h"
@@ -201,9 +202,41 @@ struct cmd_results *handle_command(char *_exec) {
 	char *head = exec;
 	char *cmdlist;
 	char *cmd;
+	list_t *containers = NULL;
 
 	head = exec;
 	do {
+		// Extract criteria (valid for this command list only).
+		bool has_criteria = false;
+		if (*head == '[') {
+			has_criteria = true;
+			++head;
+			char *criteria_string = argsep(&head, "]");
+			if (head) {
+				++head;
+				list_t *tokens = create_list();
+				char *error;
+
+				if ((error = extract_crit_tokens(tokens, criteria_string))) {
+					wlr_log(L_DEBUG, "criteria string parse error: %s", error);
+					results = cmd_results_new(CMD_INVALID, criteria_string,
+						"Can't parse criteria string: %s", error);
+					free(error);
+					free(tokens);
+					goto cleanup;
+				}
+				containers = container_for(tokens);
+
+				free(tokens);
+			} else {
+				if (!results) {
+					results = cmd_results_new(CMD_INVALID, criteria_string, "Unmatched [");
+				}
+				goto cleanup;
+			}
+			// Skip leading whitespace
+			head += strspn(head, whitespace);
+		}
 		// Split command list
 		cmdlist = argsep(&head, ";");
 		cmdlist += strspn(cmdlist, whitespace);
@@ -236,16 +269,35 @@ struct cmd_results *handle_command(char *_exec) {
 				free_argv(argc, argv);
 				goto cleanup;
 			}
-			struct cmd_results *res = handler->handle(argc-1, argv+1);
-			if (res->status != CMD_SUCCESS) {
-				free_argv(argc, argv);
-				if (results) {
-					free_cmd_results(results);
+
+			if (!has_criteria) {
+				config->handler_context.current_container = NULL;
+				struct cmd_results *res = handler->handle(argc-1, argv+1);
+				if (res->status != CMD_SUCCESS) {
+					free_argv(argc, argv);
+					if (results) {
+						free_cmd_results(results);
+					}
+					results = res;
+					goto cleanup;
 				}
-				results = res;
-				goto cleanup;
+				free_cmd_results(res);
+			} else {
+				wlr_log(L_DEBUG, "@@ running command on containers");
+				for (int i = 0; i < containers->length; ++i) {
+					config->handler_context.current_container = containers->items[i];
+					struct cmd_results *res = handler->handle(argc-1, argv+1);
+					if (res->status != CMD_SUCCESS) {
+						free_argv(argc, argv);
+						if (results) {
+							free_cmd_results(results);
+						}
+						results = res;
+						goto cleanup;
+					}
+					free_cmd_results(res);
+				}
 			}
-			free_cmd_results(res);
 			free_argv(argc, argv);
 		} while(cmdlist);
 	} while(head);

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -28,6 +28,9 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 	if (!has_context) {
 		// caller did not give a context so create one just for this command
 		config->handler_context.input_config = new_input_config(argv[0]);
+		if (!config->handler_context.input_config) {
+			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+		}
 	}
 
 	int argc_new = argc-2;

--- a/sway/commands/input/accel_profile.c
+++ b/sway/commands/input/accel_profile.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
 	if ((error = checkarg(argc, "accel_profile", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "accel_profile",
 				"No input device defined.");

--- a/sway/commands/input/click_method.c
+++ b/sway/commands/input/click_method.c
@@ -6,12 +6,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_click_method(int argc, char **argv) {
-	wlr_log(L_DEBUG, "click_method for device:  %d %s",
-		current_input_config==NULL, current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "click_method", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "click_method",
 			"No input device defined.");

--- a/sway/commands/input/drag_lock.c
+++ b/sway/commands/input/drag_lock.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 	if ((error = checkarg(argc, "drag_lock", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE,
 			"drag_lock", "No input device defined.");

--- a/sway/commands/input/dwt.c
+++ b/sway/commands/input/dwt.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 	if ((error = checkarg(argc, "dwt", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "dwt", "No input device defined.");
 	}

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -6,16 +6,18 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_events(int argc, char **argv) {
-	wlr_log(L_DEBUG, "events for device: %s",
-		current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "events", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "events",
 			"No input device defined.");
 	}
+	wlr_log(L_DEBUG, "events for device: %s",
+		current_input_config->identifier);
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
 	if ((error = checkarg(argc, "left_handed", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "left_handed",
 			"No input device defined.");

--- a/sway/commands/input/middle_emulation.c
+++ b/sway/commands/input/middle_emulation.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 	if ((error = checkarg(argc, "middle_emulation", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "middle_emulation",
 			"No input device defined.");

--- a/sway/commands/input/natural_scroll.c
+++ b/sway/commands/input/natural_scroll.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
 	if ((error = checkarg(argc, "natural_scroll", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "natural_scoll",
 			"No input device defined.");

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 	if ((error = checkarg(argc, "pointer_accel", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE,
 			"pointer_accel", "No input device defined.");

--- a/sway/commands/input/scroll_method.c
+++ b/sway/commands/input/scroll_method.c
@@ -9,6 +9,8 @@ struct cmd_results *input_cmd_scroll_method(int argc, char **argv) {
 	if ((error = checkarg(argc, "scroll_method", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "scroll_method",
 			"No input device defined.");

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -6,11 +6,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_tap(int argc, char **argv) {
-	wlr_log(L_DEBUG, "tap for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "tap", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "tap", "No input device defined.");
 	}

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -5,11 +5,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
-	wlr_log(L_DEBUG, "xkb layout for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_layout", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "xkb_layout", "No input device defined.");
 	}

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -5,11 +5,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
-	wlr_log(L_DEBUG, "xkb model for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_model", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "xkb_model", "No input device defined.");
 	}

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -5,11 +5,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
-	wlr_log(L_DEBUG, "xkb options for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_options", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "xkb_options", "No input device defined.");
 	}

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -5,11 +5,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
-	wlr_log(L_DEBUG, "xkb rules for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_rules", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "xkb_rules", "No input device defined.");
 	}

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -5,11 +5,12 @@
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
-	wlr_log(L_DEBUG, "xkb variant for device: %s", current_input_config->identifier);
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "xkb_variant", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
 	if (!current_input_config) {
 		return cmd_results_new(CMD_FAILURE, "xkb_variant", "No input device defined.");
 	}

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -15,7 +15,13 @@ struct cmd_results *cmd_kill(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, NULL, "no seat context given");
 	}
 
-	struct sway_view *view = seat->focus->sway_view;
+	struct sway_view *view = NULL;
+
+	if (config->handler_context.current_container) {
+		view = config->handler_context.current_container->sway_view;
+	} else {
+		view = seat->focus->sway_view;
+	}
 
 	if (view->iface.close) {
 		view->iface.close(view);

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -1,29 +1,21 @@
+#include <wlr/util/log.h>
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/view.h"
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
-	struct sway_seat *seat = config->handler_context.seat;
-	if (!seat) {
-		seat = sway_input_manager_get_default_seat(input_manager);
+	if (!config->handler_context.current_container) {
+		wlr_log(L_ERROR, "cmd_kill called without container context");
+		return cmd_results_new(CMD_INVALID, NULL,
+				"cmd_kill called without container context "
+				"(this is a bug in sway)");
 	}
+	// TODO close arbitrary containers without a view
+	struct sway_view *view =
+		config->handler_context.current_container->sway_view;
 
-	// TODO context for arbitrary sway containers (when we get criteria
-	// working) will make seat context not explicitly required
-	if (!seat) {
-		return cmd_results_new(CMD_FAILURE, NULL, "no seat context given");
-	}
-
-	struct sway_view *view = NULL;
-
-	if (config->handler_context.current_container) {
-		view = config->handler_context.current_container->sway_view;
-	} else {
-		view = seat->focus->sway_view;
-	}
-
-	if (view->iface.close) {
+	if (view && view->iface.close) {
 		view->iface.close(view);
 	}
 

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -1,12 +1,13 @@
 #include <wlr/util/log.h>
+#include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/view.h"
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
-	if (!config->handler_context.current_container) {
-		wlr_log(L_ERROR, "cmd_kill called without container context");
+	if (!sway_assert(config->handler_context.current_container,
+				"cmd_kill called without container context")) {
 		return cmd_results_new(CMD_INVALID, NULL,
 				"cmd_kill called without container context "
 				"(this is a bug in sway)");

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -1,0 +1,25 @@
+#include "sway/input/input-manager.h"
+#include "sway/input/seat.h"
+#include "sway/view.h"
+#include "sway/commands.h"
+
+struct cmd_results *cmd_kill(int argc, char **argv) {
+	struct sway_seat *seat = config->handler_context.seat;
+	if (!seat) {
+		seat = sway_input_manager_get_default_seat(input_manager);
+	}
+
+	// TODO context for arbitrary sway containers (when we get criteria
+	// working) will make seat context not explicitly required
+	if (!seat) {
+		return cmd_results_new(CMD_FAILURE, NULL, "no seat context given");
+	}
+
+	struct sway_view *view = seat->focus->sway_view;
+
+	if (view->iface.close) {
+		view->iface.close(view);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -15,8 +15,8 @@ struct cmd_results *cmd_kill(int argc, char **argv) {
 	struct sway_view *view =
 		config->handler_context.current_container->sway_view;
 
-	if (view && view->iface.close) {
-		view->iface.close(view);
+	if (view) {
+		view_close(view);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -6,6 +6,10 @@
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
+	if (config->reading) {
+		return cmd_results_new(CMD_FAILURE, "kill",
+			"Command 'kill' cannot be used in the config file");
+	}
 	if (!sway_assert(config->handler_context.current_container,
 				"cmd_kill called without container context")) {
 		return cmd_results_new(CMD_INVALID, NULL,

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -11,8 +11,12 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	}
 
 	if (config->reading && strcmp("{", argv[1]) == 0) {
-		current_seat_config = new_seat_config(argv[0]);
-		wlr_log(L_DEBUG, "entering seat block: %s", current_seat_config->name);
+		free_seat_config(config->handler_context.seat_config);
+		config->handler_context.seat_config = new_seat_config(argv[0]);
+		if (!config->handler_context.seat_config) {
+			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+		}
+		wlr_log(L_DEBUG, "entering seat block: %s", argv[0]);
 		return cmd_results_new(CMD_BLOCK_SEAT, NULL, NULL);
 	}
 
@@ -20,11 +24,18 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 		return error;
 	}
 
+	bool has_context = (config->handler_context.seat_config != NULL);
+	if (!has_context) {
+		config->handler_context.seat_config = new_seat_config(argv[0]);
+		if (!config->handler_context.seat_config) {
+			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+		}
+	}
+
 	int argc_new = argc-2;
 	char **argv_new = argv+2;
 
 	struct cmd_results *res;
-	current_seat_config = new_seat_config(argv[0]);
 	if (strcasecmp("attach", argv[1]) == 0) {
 		res = seat_cmd_attach(argc_new, argv_new);
 	} else if (strcasecmp("fallback", argv[1]) == 0) {
@@ -32,6 +43,12 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	} else {
 		res = cmd_results_new(CMD_INVALID, "seat <name>", "Unknown command %s", argv[1]);
 	}
-	current_seat_config = NULL;
+
+	if (!has_context) {
+		// clean up the context we created earlier
+		free_seat_config(config->handler_context.seat_config);
+		config->handler_context.seat_config = NULL;
+	}
+
 	return res;
 }

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -12,6 +12,8 @@ struct cmd_results *seat_cmd_attach(int argc, char **argv) {
 	if ((error = checkarg(argc, "attach", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct seat_config *current_seat_config =
+		config->handler_context.seat_config;
 	if (!current_seat_config) {
 		return cmd_results_new(CMD_FAILURE, "attach", "No seat defined");
 	}

--- a/sway/commands/seat/fallback.c
+++ b/sway/commands/seat/fallback.c
@@ -9,6 +9,8 @@ struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
 	if ((error = checkarg(argc, "fallback", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	struct seat_config *current_seat_config =
+		config->handler_context.seat_config;
 	if (!current_seat_config) {
 		return cmd_results_new(CMD_FAILURE, "fallback", "No seat defined");
 	}
@@ -20,6 +22,7 @@ struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "false") == 0) {
 		new_config->fallback = 0;
 	} else {
+		free_seat_config(new_config);
 		return cmd_results_new(CMD_INVALID, "fallback",
 			"Expected 'fallback <true|false>'");
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -484,6 +484,7 @@ bool load_include_configs(const char *path, struct sway_config *config) {
 
 void config_clear_handler_context(struct sway_config *config) {
 	free_input_config(config->handler_context.input_config);
+	free_seat_config(config->handler_context.seat_config);
 
 	memset(&config->handler_context, 0, sizeof(config->handler_context));
 }
@@ -604,7 +605,6 @@ bool read_config(FILE *file, struct sway_config *config) {
 
 			case CMD_BLOCK_SEAT:
 				wlr_log(L_DEBUG, "End of seat block");
-				current_seat_config = NULL;
 				block = CMD_BLOCK_END;
 				break;
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -54,6 +54,8 @@ static void free_mode(struct sway_mode *mode) {
 }
 
 void free_config(struct sway_config *config) {
+	config_clear_handler_context(config);
+
 	int i;
 
 	if (!config) {
@@ -480,6 +482,11 @@ bool load_include_configs(const char *path, struct sway_config *config) {
 	return true;
 }
 
+void config_clear_handler_context(struct sway_config *config) {
+	free_input_config(config->handler_context.input_config);
+
+	memset(&config->handler_context, 0, sizeof(config->handler_context));
+}
 
 bool read_config(FILE *file, struct sway_config *config) {
 	bool success = true;
@@ -592,8 +599,6 @@ bool read_config(FILE *file, struct sway_config *config) {
 
 			case CMD_BLOCK_INPUT:
 				wlr_log(L_DEBUG, "End of input block");
-				free_input_config(current_input_config);
-				current_input_config = NULL;
 				block = CMD_BLOCK_END;
 				break;
 
@@ -635,6 +640,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 
 			default:;
 			}
+			config_clear_handler_context(config);
 		default:;
 		}
 		free(line);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -299,21 +299,17 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 		case CRIT_ID: // TODO
 			break;
 		case CRIT_APP_ID:
-			if (!view->iface.get_prop) {
+			{
+				const char *app_id = view_get_app_id(cont->sway_view);
+				if (!app_id) {
+					break;
+				}
+
+				if (crit->regex && regex_cmp(app_id, crit->regex) == 0) {
+					matches++;
+				}
 				break;
 			}
-
-			const char *app_id =
-				cont->sway_view->iface.get_prop(view, VIEW_PROP_APP_ID);
-
-			if (!app_id) {
-				break;
-			}
-			
-			if (crit->regex && regex_cmp(app_id, crit->regex) == 0) {
-				matches++;
-			}
-			break;
 		case CRIT_INSTANCE: // TODO
 			break;
 		case CRIT_TILING: // TODO

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -1,0 +1,413 @@
+#define _XOPEN_SOURCE 700
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <pcre.h>
+#include "sway/criteria.h"
+#include "sway/container.h"
+#include "sway/config.h"
+#include "sway/view.h"
+#include "stringop.h"
+#include "list.h"
+#include "log.h"
+
+enum criteria_type { // *must* keep in sync with criteria_strings[]
+	CRIT_APP_ID,
+	CRIT_CLASS,
+	CRIT_CON_ID,
+	CRIT_CON_MARK,
+	CRIT_FLOATING,
+	CRIT_ID,
+	CRIT_INSTANCE,
+	CRIT_TILING,
+	CRIT_TITLE,
+	CRIT_URGENT,
+	CRIT_WINDOW_ROLE,
+	CRIT_WINDOW_TYPE,
+	CRIT_WORKSPACE,
+	CRIT_LAST
+};
+
+static const char * const criteria_strings[CRIT_LAST] = {
+	[CRIT_APP_ID] = "app_id",
+	[CRIT_CLASS] = "class",
+	[CRIT_CON_ID] = "con_id",
+	[CRIT_CON_MARK] = "con_mark",
+	[CRIT_FLOATING] = "floating",
+	[CRIT_ID] = "id",
+	[CRIT_INSTANCE] = "instance",
+	[CRIT_TILING] = "tiling",
+	[CRIT_TITLE] = "title",
+	[CRIT_URGENT] = "urgent", // either "latest" or "oldest" ...
+	[CRIT_WINDOW_ROLE] = "window_role",
+	[CRIT_WINDOW_TYPE] = "window_type",
+	[CRIT_WORKSPACE] = "workspace"
+};
+
+/**
+ * A single criteria token (ie. value/regex pair),
+ * e.g. 'class="some class regex"'.
+ */
+struct crit_token {
+	enum criteria_type type;
+	pcre *regex;
+	char *raw;
+};
+
+static void free_crit_token(struct crit_token *crit) {
+	pcre_free(crit->regex);
+	free(crit->raw);
+	free(crit);
+}
+
+static void free_crit_tokens(list_t *crit_tokens) {
+	for (int i = 0; i < crit_tokens->length; i++) {
+		free_crit_token(crit_tokens->items[i]);
+	}
+	list_free(crit_tokens);
+}
+
+// Extracts criteria string from its brackets. Returns new (duplicate)
+// substring.
+static char *criteria_from(const char *arg) {
+	char *criteria = NULL;
+	if (*arg == '[') {
+		criteria = strdup(arg + 1);
+	} else {
+		criteria = strdup(arg);
+	}
+
+	int last = strlen(criteria) - 1;
+	if (criteria[last] == ']') {
+		criteria[last] = '\0';
+	}
+	return criteria;
+}
+
+// Return instances of c found in str.
+static int countchr(char *str, char c) {
+	int found = 0;
+	for (int i = 0; str[i]; i++) {
+		if (str[i] == c) {
+			++found;
+		}
+	}
+	return found;
+}
+
+// criteria_str is e.g. '[class="some class regex" instance="instance name"]'.
+//
+// Will create array of pointers in buf, where first is duplicate of given
+// string (must be freed) and the rest are pointers to names and values in the
+// base string (every other, naturally). argc will be populated with the length
+// of buf.
+//
+// Returns error string or NULL if successful.
+static char *crit_tokens(int *argc, char ***buf, const char * const criteria_str) {
+	wlr_log(L_DEBUG, "Parsing criteria: '%s'", criteria_str);
+	char *base = criteria_from(criteria_str);
+	char *head = base;
+	char *namep = head; // start of criteria name
+	char *valp = NULL; // start of value
+
+	// We're going to place EOS markers where we need to and fill up an array
+	// of pointers to the start of each token (either name or value).
+	int pairs = countchr(base, '=');
+	int max_tokens = pairs * 2 + 1; // this gives us at least enough slots
+
+	char **argv = *buf = calloc(max_tokens, sizeof(char*));
+	argv[0] = base; // this needs to be freed by caller
+	bool quoted = true;
+
+	*argc = 1; // uneven = name, even = value
+	while (*head && *argc < max_tokens) {
+		if (namep != head && *(head - 1) == '\\') {
+			// escaped character: don't try to parse this
+		} else if (*head == '=' && namep != head) {
+			if (*argc % 2 != 1) {
+				// we're not expecting a name
+				return strdup("Unable to parse criteria: "
+					"Found out of place equal sign");
+			} else {
+				// name ends here
+				char *end = head; // don't want to rewind the head
+				while (*(end - 1) == ' ') {
+					--end;
+				}
+				*end = '\0';
+				if (*(namep) == ' ') {
+					namep = strrchr(namep, ' ') + 1;
+				}
+				argv[*argc] = namep;
+				*argc += 1;
+			}
+		} else if (*head == '"') {
+			if (*argc % 2 != 0) {
+				// we're not expecting a value
+				return strdup("Unable to parse criteria: "
+					"Found quoted value where it was not expected");
+			} else if (!valp) { // value starts here
+				valp = head + 1;
+				quoted = true;
+			} else {
+				// value ends here
+				argv[*argc] = valp;
+				*argc += 1;
+				*head = '\0';
+				valp = NULL;
+				namep = head + 1;
+			}
+		} else if (*argc % 2 == 0 && *head != ' ') {
+			// parse unquoted values
+			if (!valp) {
+				quoted = false;
+				valp = head;  // value starts here
+			}
+		} else if (valp && !quoted && *head == ' ') {
+			// value ends here
+			argv[*argc] = valp;
+			*argc += 1;
+			*head = '\0';
+			valp = NULL;
+			namep = head + 1;
+		}
+		head++;
+	}
+
+	// catch last unquoted value if needed
+	if (valp && !quoted && !*head) {
+		argv[*argc] = valp;
+		*argc += 1;
+	}
+
+	return NULL;
+}
+
+// Returns error string on failure or NULL otherwise.
+static char *parse_criteria_name(enum criteria_type *type, char *name) {
+	*type = CRIT_LAST;
+	for (int i = 0; i < CRIT_LAST; i++) {
+		if (strcmp(criteria_strings[i], name) == 0) {
+			*type = (enum criteria_type) i;
+			break;
+		}
+	}
+	if (*type == CRIT_LAST) {
+		const char *fmt = "Criteria type '%s' is invalid or unsupported.";
+		int len = strlen(name) + strlen(fmt) - 1;
+		char *error = malloc(len);
+		snprintf(error, len, fmt, name);
+		return error;
+	} else if (*type == CRIT_URGENT || *type == CRIT_WINDOW_ROLE ||
+			*type == CRIT_WINDOW_TYPE) {
+		// (we're just being helpful here)
+		const char *fmt = "\"%s\" criteria currently unsupported, "
+			"no window will match this";
+		int len = strlen(fmt) + strlen(name) - 1;
+		char *error = malloc(len);
+		snprintf(error, len, fmt, name);
+		return error;
+	}
+	return NULL;
+}
+
+// Returns error string on failure or NULL otherwise.
+static char *generate_regex(pcre **regex, char *value) {
+	const char *reg_err;
+	int offset;
+
+	*regex = pcre_compile(value, PCRE_UTF8 | PCRE_UCP, &reg_err, &offset, NULL);
+
+	if (!*regex) {
+		const char *fmt = "Regex compilation (for '%s') failed: %s";
+		int len = strlen(fmt) + strlen(value) + strlen(reg_err) - 3;
+		char *error = malloc(len);
+		snprintf(error, len, fmt, value, reg_err);
+		return error;
+	}
+	return NULL;
+}
+
+// Test whether the criterion corresponds to the currently focused window
+static bool crit_is_focused(const char *value) {
+	return !strcmp(value, "focused") || !strcmp(value, "__focused__");
+}
+
+// Populate list with crit_tokens extracted from criteria string, returns error
+// string or NULL if successful.
+char *extract_crit_tokens(list_t *tokens, const char * const criteria) {
+	int argc;
+	char **argv = NULL, *error = NULL;
+	if ((error = crit_tokens(&argc, &argv, criteria))) {
+		goto ect_cleanup;
+	}
+	for (int i = 1; i + 1 < argc; i += 2) {
+		char* name = argv[i], *value = argv[i + 1];
+		struct crit_token *token = calloc(1, sizeof(struct crit_token));
+		token->raw = strdup(value);
+
+		if ((error = parse_criteria_name(&token->type, name))) {
+			free_crit_token(token);
+			goto ect_cleanup;
+		} else if (token->type == CRIT_URGENT || crit_is_focused(value)) {
+			wlr_log(L_DEBUG, "%s -> \"%s\"", name, value);
+			list_add(tokens, token);
+		} else if((error = generate_regex(&token->regex, value))) {
+			free_crit_token(token);
+			goto ect_cleanup;
+		} else {
+			wlr_log(L_DEBUG, "%s -> /%s/", name, value);
+			list_add(tokens, token);
+		}
+	}
+ect_cleanup:
+	free(argv[0]); // base string
+	free(argv);
+	return error;
+}
+
+static int regex_cmp(const char *item, const pcre *regex) {
+	return pcre_exec(regex, NULL, item, strlen(item), 0, 0, NULL, 0);
+}
+
+// test a single view if it matches list of criteria tokens (all of them).
+static bool criteria_test(swayc_t *cont, list_t *tokens) {
+	if (cont->type != C_VIEW) {
+		return false;
+	}
+	struct sway_view *view = cont->sway_view;
+
+	int matches = 0;
+	for (int i = 0; i < tokens->length; i++) {
+		struct crit_token *crit = tokens->items[i];
+		switch (crit->type) {
+		case CRIT_CLASS: // TODO
+			break;
+		case CRIT_CON_ID: {
+			char *endptr;
+			size_t crit_id = strtoul(crit->raw, &endptr, 10);
+
+			if (*endptr == 0 && cont->id == crit_id) {
+				++matches;
+			}
+			break;
+		}
+		case CRIT_CON_MARK: // TODO
+			break;
+		case CRIT_FLOATING: // TODO
+			break;
+		case CRIT_ID: // TODO
+			break;
+		case CRIT_APP_ID:
+			if (!view->iface.get_prop) {
+				break;
+			}
+
+			const char *app_id =
+				cont->sway_view->iface.get_prop(view, VIEW_PROP_APP_ID);
+
+			if (!app_id) {
+				break;
+			}
+			
+			if (crit->regex && regex_cmp(app_id, crit->regex) == 0) {
+				matches++;
+			}
+			break;
+		case CRIT_INSTANCE: // TODO
+			break;
+		case CRIT_TILING: // TODO
+			break;
+		case CRIT_TITLE:
+			if (!cont->name) {
+				// ignore
+			} else if (crit->regex && regex_cmp(cont->name, crit->regex) == 0) {
+				matches++;
+			}
+			break;
+		case CRIT_URGENT: // "latest" or "oldest"
+			break;
+		case CRIT_WINDOW_ROLE:
+			break;
+		case CRIT_WINDOW_TYPE:
+			break;
+		case CRIT_WORKSPACE: // TODO
+			break;
+		default:
+			sway_abort("Invalid criteria type (%i)", crit->type);
+			break;
+		}
+	}
+	return matches == tokens->length;
+}
+
+int criteria_cmp(const void *a, const void *b) {
+	if (a == b) {
+		return 0;
+	} else if (!a) {
+		return -1;
+	} else if (!b) {
+		return 1;
+	}
+	const struct criteria *crit_a = a, *crit_b = b;
+	int cmp = lenient_strcmp(crit_a->cmdlist, crit_b->cmdlist);
+	if (cmp != 0) {
+		return cmp;
+	}
+	return lenient_strcmp(crit_a->crit_raw, crit_b->crit_raw);
+}
+
+void free_criteria(struct criteria *crit) {
+	if (crit->tokens) {
+		free_crit_tokens(crit->tokens);
+	}
+	if (crit->cmdlist) {
+		free(crit->cmdlist);
+	}
+	if (crit->crit_raw) {
+		free(crit->crit_raw);
+	}
+	free(crit);
+}
+
+bool criteria_any(swayc_t *cont, list_t *criteria) {
+	for (int i = 0; i < criteria->length; i++) {
+		struct criteria *bc = criteria->items[i];
+		if (criteria_test(cont, bc->tokens)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+list_t *criteria_for(swayc_t *cont) {
+	list_t *criteria = config->criteria, *matches = create_list();
+	for (int i = 0; i < criteria->length; i++) {
+		struct criteria *bc = criteria->items[i];
+		if (criteria_test(cont, bc->tokens)) {
+			list_add(matches, bc);
+		}
+	}
+	return matches;
+}
+
+struct list_tokens {
+	list_t *list;
+	list_t *tokens;
+};
+
+static void container_match_add(swayc_t *container, struct list_tokens *list_tokens) {
+	if (criteria_test(container, list_tokens->tokens)) {
+		list_add(list_tokens->list, container);
+	}
+}
+
+list_t *container_for(list_t *tokens) {
+	struct list_tokens list_tokens = (struct list_tokens){create_list(), tokens};
+
+	container_map(&root_container, (void (*)(swayc_t *, void *))container_match_add, &list_tokens);
+
+	// TODO look in the scratchpad
+	
+	return list_tokens.list;
+}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -103,7 +103,8 @@ static int countchr(char *str, char c) {
 // of buf.
 //
 // Returns error string or NULL if successful.
-static char *crit_tokens(int *argc, char ***buf, const char * const criteria_str) {
+static char *crit_tokens(int *argc, char ***buf,
+		const char * const criteria_str) {
 	wlr_log(L_DEBUG, "Parsing criteria: '%s'", criteria_str);
 	char *base = criteria_from(criteria_str);
 	char *head = base;
@@ -423,16 +424,20 @@ struct list_tokens {
 	list_t *tokens;
 };
 
-static void container_match_add(swayc_t *container, struct list_tokens *list_tokens) {
+static void container_match_add(swayc_t *container,
+		struct list_tokens *list_tokens) {
 	if (criteria_test(container, list_tokens->tokens)) {
 		list_add(list_tokens->list, container);
 	}
 }
 
-list_t *container_for(list_t *tokens) {
-	struct list_tokens list_tokens = (struct list_tokens){create_list(), tokens};
+list_t *container_for_crit_tokens(list_t *tokens) {
+	struct list_tokens list_tokens =
+		(struct list_tokens){create_list(), tokens};
 
-	container_map(&root_container, (void (*)(swayc_t *, void *))container_match_add, &list_tokens);
+	container_map(&root_container,
+		(void (*)(swayc_t *, void *))container_match_add,
+		&list_tokens);
 
 	// TODO look in the scratchpad
 	

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -275,28 +275,39 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 	if (cont->type != C_VIEW) {
 		return false;
 	}
-	struct sway_view *view = cont->sway_view;
-
 	int matches = 0;
 	for (int i = 0; i < tokens->length; i++) {
 		struct crit_token *crit = tokens->items[i];
 		switch (crit->type) {
-		case CRIT_CLASS: // TODO
-			break;
-		case CRIT_CON_ID: {
-			char *endptr;
-			size_t crit_id = strtoul(crit->raw, &endptr, 10);
-
-			if (*endptr == 0 && cont->id == crit_id) {
-				++matches;
+		case CRIT_CLASS:
+			{
+				const char *class = view_get_class(cont->sway_view);
+				if (!class) {
+					break;
+				}
+				if (crit->regex && regex_cmp(class, crit->regex) == 0) {
+					matches++;
+				}
+				break;
 			}
+		case CRIT_CON_ID:
+			{
+				char *endptr;
+				size_t crit_id = strtoul(crit->raw, &endptr, 10);
+
+				if (*endptr == 0 && cont->id == crit_id) {
+					++matches;
+				}
+				break;
+			}
+		case CRIT_CON_MARK:
+			// TODO
 			break;
-		}
-		case CRIT_CON_MARK: // TODO
+		case CRIT_FLOATING:
+			// TODO
 			break;
-		case CRIT_FLOATING: // TODO
-			break;
-		case CRIT_ID: // TODO
+		case CRIT_ID:
+			// TODO
 			break;
 		case CRIT_APP_ID:
 			{
@@ -310,24 +321,44 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 				}
 				break;
 			}
-		case CRIT_INSTANCE: // TODO
-			break;
-		case CRIT_TILING: // TODO
+		case CRIT_INSTANCE:
+			{
+				const char *instance = view_get_instance(cont->sway_view);
+				if (!instance) {
+					break;
+				}
+
+				if (crit->regex && regex_cmp(instance, crit->regex) == 0) {
+					matches++;
+				}
+				break;
+			}
+		case CRIT_TILING:
+			// TODO
 			break;
 		case CRIT_TITLE:
-			if (!cont->name) {
-				// ignore
-			} else if (crit->regex && regex_cmp(cont->name, crit->regex) == 0) {
-				matches++;
+			{
+				const char *title = view_get_title(cont->sway_view);
+				if (!title) {
+					break;
+				}
+
+				if (crit->regex && regex_cmp(title, crit->regex) == 0) {
+					matches++;
+				}
+				break;
 			}
-			break;
-		case CRIT_URGENT: // "latest" or "oldest"
+		case CRIT_URGENT:
+			// TODO "latest" or "oldest"
 			break;
 		case CRIT_WINDOW_ROLE:
+			// TODO
 			break;
 		case CRIT_WINDOW_TYPE:
+			// TODO
 			break;
-		case CRIT_WORKSPACE: // TODO
+		case CRIT_WORKSPACE:
+			// TODO
 			break;
 		default:
 			sway_abort("Invalid criteria type (%i)", crit->type);

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -51,6 +51,14 @@ static void set_activated(struct sway_view *view, bool activated) {
 	// no way to activate wl_shell
 }
 
+static void close(struct sway_view *view) {
+	if (!assert_wl_shell(view)) {
+		return;
+	}
+
+	wl_client_destroy(view->wlr_wl_shell_surface->client);
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_wl_shell_surface *sway_surface =
 		wl_container_of(listener, sway_surface, commit);
@@ -103,6 +111,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	sway_view->iface.set_size = set_size;
 	sway_view->iface.set_position = set_position;
 	sway_view->iface.set_activated = set_activated;
+	sway_view->iface.close = close;
 	sway_view->wlr_wl_shell_surface = shell_surface;
 	sway_view->sway_wl_shell_surface = sway_surface;
 	sway_view->surface = shell_surface->surface;

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -57,6 +57,16 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
+static void close(struct sway_view *view) {
+	if (!assert_xdg(view)) {
+		return;
+	}
+	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
+	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		wlr_xdg_toplevel_v6_send_close(surface);
+	}
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_surface_v6 *sway_surface =
 		wl_container_of(listener, sway_surface, commit);
@@ -107,6 +117,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	sway_view->iface.set_size = set_size;
 	sway_view->iface.set_position = set_position;
 	sway_view->iface.set_activated = set_activated;
+	sway_view->iface.close = close;
 	sway_view->wlr_xdg_surface_v6 = xdg_surface;
 	sway_view->sway_xdg_surface_v6 = sway_surface;
 	sway_view->surface = xdg_surface->surface;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -80,6 +80,13 @@ static void set_activated(struct sway_view *view, bool activated) {
 	wlr_xwayland_surface_activate(surface, activated);
 }
 
+static void close(struct sway_view *view) {
+	if (!assert_xwayland(view)) {
+		return;
+	}
+	wlr_xwayland_surface_close(view->wlr_xwayland_surface);
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_surface *sway_surface =
 		wl_container_of(listener, sway_surface, commit);
@@ -192,6 +199,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	sway_view->iface.set_size = set_size;
 	sway_view->iface.set_position = set_position;
 	sway_view->iface.set_activated = set_activated;
+	sway_view->iface.close = close;
 	sway_view->wlr_xwayland_surface = xsurface;
 	sway_view->sway_xwayland_surface = sway_surface;
 	sway_view->surface = xsurface->surface;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -369,3 +369,14 @@ void sway_input_manager_configure_xcursor(struct sway_input_manager *input) {
 		sway_seat_configure_xcursor(seat);
 	}
 }
+
+struct sway_seat *sway_input_manager_get_default_seat(
+		struct sway_input_manager *input) {
+	struct sway_seat *seat = NULL;
+	wl_list_for_each(seat, &input->seats, link) {
+		if (strcmp(seat->wlr_seat->name, "seat0") == 0) {
+			return seat;
+		}
+	}
+	return seat;
+}

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -89,9 +89,12 @@ static bool binding_matches_key_state(struct sway_binding *binding,
 	return false;
 }
 
-static void binding_execute_command(struct sway_binding *binding) {
+static void keyboard_execute_command(struct sway_keyboard *keyboard,
+		struct sway_binding *binding) {
 	wlr_log(L_DEBUG, "running command for binding: %s",
 		binding->command);
+	config_clear_handler_context(config);
+	config->handler_context.seat = keyboard->seat_device->sway_seat;
 	struct cmd_results *results = handle_command(binding->command);
 	if (results->status != CMD_SUCCESS) {
 		wlr_log(L_DEBUG, "could not run command for binding: %s",
@@ -160,7 +163,7 @@ static bool keyboard_execute_bindsym(struct sway_keyboard *keyboard,
 		}
 
 		if (match) {
-			binding_execute_command(binding);
+			keyboard_execute_command(keyboard, binding);
 			return true;
 		}
 	}
@@ -267,7 +270,7 @@ static bool keyboard_execute_bindcode(struct sway_keyboard *keyboard,
 	for (int i = 0; i < keycode_bindings->length; ++i) {
 		struct sway_binding *binding = keycode_bindings->items[i];
 		if (binding_matches_keycodes(wlr_keyboard, binding, event)) {
-			binding_execute_command(binding);
+			keyboard_execute_command(keyboard, binding);
 			return true;
 		}
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -214,7 +214,7 @@ void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container) {
 
 	if (container) {
 		struct sway_view *view = container->sway_view;
-		view->iface.set_activated(view, true);
+		view_set_activated(view, true);
 		wl_signal_add(&container->events.destroy, &seat->focus_destroy);
 		seat->focus_destroy.notify = handle_focus_destroy;
 
@@ -234,8 +234,7 @@ void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container) {
 	if (last_focus &&
 			!sway_input_manager_has_focus(seat->input, last_focus)) {
 		struct sway_view *view = last_focus->sway_view;
-		view->iface.set_activated(view, false);
-
+		view_set_activated(view, false);
 	}
 }
 

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -335,6 +335,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	switch (client->current_command) {
 	case IPC_COMMAND:
 	{
+		config_clear_handler_context(config);
 		struct cmd_results *results = handle_command(buf);
 		const char *json = cmd_results_to_json(results);
 		char reply[256];

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -10,6 +10,7 @@ sway_sources = files(
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',
+	'commands/kill.c',
 	'commands/include.c',
 	'commands/input.c',
 	'commands/seat.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -48,6 +48,7 @@ sway_sources = files(
 	'security.c',
 	'tree/container.c',
 	'tree/layout.c',
+	'tree/view.c',
 	'tree/workspace.c',
 )
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -38,6 +38,7 @@ sway_sources = files(
 	'config/output.c',
 	'config/seat.c',
 	'config/input.c',
+	'criteria.c',
 	'ipc-json.c',
 	'ipc-server.c',
 	'desktop/output.c',
@@ -51,6 +52,7 @@ sway_sources = files(
 )
 
 sway_deps = [
+	pcre,
 	pixman,
 	wayland_server,
 	jsonc,

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -157,7 +157,7 @@ swayc_t *new_view(swayc_t *sibling, struct sway_view *sway_view) {
 	if (!sway_assert(sibling, "new_view called with NULL sibling/parent")) {
 		return NULL;
 	}
-	const char *title = sway_view->iface.get_prop(sway_view, VIEW_PROP_TITLE);
+	const char *title = view_get_title(sway_view);
 	swayc_t *swayc = new_swayc(C_VIEW);
 	wlr_log(L_DEBUG, "Adding new view %p:%s to container %p %d",
 		swayc, title, sibling, sibling ? sibling->type : 0);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -321,3 +321,25 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 
 	return NULL;
 }
+
+void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data) {
+	if (container) {
+		int i;
+		if (container->children)  {
+			for (i = 0; i < container->children->length; ++i) {
+				swayc_t *child = container->children->items[i];
+				container_map(child, f, data);
+			}
+		}
+		// TODO
+		/*
+		if (container->floating) {
+			for (i = 0; i < container->floating->length; ++i) {
+				swayc_t *child = container->floating->items[i];
+				container_map(child, f, data);
+			}
+		}
+		*/
+		f(container, data);
+	}
+}

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -191,8 +191,8 @@ void arrange_windows(swayc_t *container, double width, double height) {
 		{
 			container->width = width;
 			container->height = height;
-			container->sway_view->iface.set_size(container->sway_view,
-					container->width, container->height);
+			view_set_size(container->sway_view,
+				container->width, container->height);
 			wlr_log(L_DEBUG, "Set view to %.f x %.f @ %.f, %.f",
 					container->width, container->height,
 					container->x, container->y);
@@ -251,7 +251,7 @@ static void apply_horiz_layout(swayc_t *container,
 			wlr_log(L_DEBUG,
 				 "Calculating arrangement for %p:%d (will scale %f by %f)",
 				 child, child->type, width, scale);
-			child->sway_view->iface.set_position(child->sway_view, child_x, y);
+			view_set_position(child->sway_view, child_x, y);
 
 			if (i == end - 1) {
 				double remaining_width = x + width - child_x;
@@ -301,7 +301,7 @@ void apply_vert_layout(swayc_t *container,
 			wlr_log(L_DEBUG,
 				 "Calculating arrangement for %p:%d (will scale %f by %f)",
 				 child, child->type, height, scale);
-			child->sway_view->iface.set_position(child->sway_view, x, child_y);
+			view_set_position(child->sway_view, x, child_y);
 
 			if (i == end - 1) {
 				double remaining_height = y + height - child_y;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,0 +1,53 @@
+#include "sway/view.h"
+
+const char *view_get_title(struct sway_view *view) {
+	if (view->iface.get_prop) {
+		return view->iface.get_prop(view, VIEW_PROP_TITLE);
+	}
+	return NULL;
+}
+
+const char *view_get_app_id(struct sway_view *view) {
+	if (view->iface.get_prop) {
+		return view->iface.get_prop(view, VIEW_PROP_APP_ID);
+	}
+	return NULL;
+}
+
+const char *view_get_class(struct sway_view *view) {
+	if (view->iface.get_prop) {
+		return view->iface.get_prop(view, VIEW_PROP_CLASS);
+	}
+	return NULL;
+}
+
+const char *view_get_instance(struct sway_view *view) {
+	if (view->iface.get_prop) {
+		return view->iface.get_prop(view, VIEW_PROP_INSTANCE);
+	}
+	return NULL;
+}
+
+void view_set_size(struct sway_view *view, int width, int height) {
+	if (view->iface.set_size) {
+		view->iface.set_size(view, width, height);
+	}
+}
+
+void view_set_position(struct sway_view *view, double ox, double oy) {
+	if (view->iface.set_position) {
+		view->iface.set_position(view, ox, oy);
+	}
+}
+
+void view_set_activated(struct sway_view *view, bool activated) {
+	if (view->iface.set_activated) {
+		view->iface.set_activated(view, activated);
+	}
+}
+
+void view_close(struct sway_view *view) {
+	if (view->iface.close) {
+		view->iface.close(view);
+	}
+}


### PR DESCRIPTION
Make command criteria work.

Add a `kill` command, demonstrates new conventions for running bindings and includes general config refactoring.

Config refactor:

* Remove globals `current_input_config` and `current_seat_config` and be more careful about how these are managed.
* Set config handler context for the seat of the keyboard that executes the command
* When criteria matches, run each command with `current_container` config context for each container that matches.

Implemented criteria:

* class
* con_id
* app_id
* instance
* title

Test:

Kill the currently focused window.

```
bindsym Alt+w kill
```

Kill *only* the gnome-terminals.

```
bindsym Alt+w [app_id="gnome-terminal-server"] kill
```

Test the other criteria listed above similarly.