### PR TITLE
focus overhaul

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -5,11 +5,11 @@
 
 void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
 #define sway_abort(FMT, ...) \
-    _sway_abort("[%s:%d] " FMT, _strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+    _sway_abort("[%s:%d] " FMT, wlr_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
 
 bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
 #define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, "[%s:%d] %s:" FMT, _strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+	_sway_assert(COND, "[%s:%d] %s:" FMT, wlr_strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 void error_handler(int sig);
 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -46,9 +46,9 @@ struct cmd_results *checkarg(int argc, const char *name,
 		enum expected_args type, int val);
 
 /**
- * Parse and handles a command.
+ * Parse and executes a command.
  */
-struct cmd_results *handle_command(char *command);
+struct cmd_results *execute_command(char *command,  struct sway_seat *seat);
 /**
  * Parse and handles a command during config file loading.
  *

--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -164,4 +164,6 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 void container_for_each_bfs(swayc_t *con, void (*f)(swayc_t *con, void *data),
 		void *data);
 
+swayc_t *swayc_change_layout(swayc_t *container, enum swayc_layouts layout);
+
 #endif

--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -163,9 +163,9 @@ swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
- * Get a list of containers that are descendents of the container in rendering
- * order
+ * Apply the function for each child of the container breadth first.
  */
-list_t *container_list_children(swayc_t *con);
+void container_for_each_bfs(swayc_t *con, void (*f)(swayc_t *con, void *data),
+		void *data);
 
 #endif

--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -162,4 +162,10 @@ void container_map(swayc_t *container,
 swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy);
 
+/**
+ * Get a list of containers that are descendents of the container in rendering
+ * order
+ */
+list_t *container_list_children(swayc_t *con);
+
 #endif

--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -106,10 +106,6 @@ struct sway_container {
 	 * The parent of this container. NULL for the root container.
 	 */
 	struct sway_container *parent;
-	/**
-	 * Which of this container's children has focus.
-	 */
-	struct sway_container *focused;
 
 	/**
 	 * Number of master views in auto layouts.

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -20,11 +20,11 @@ struct sway_input_device {
 };
 
 struct sway_input_manager {
-	struct wl_listener input_add;
-	struct wl_listener input_remove;
 	struct sway_server *server;
 	struct wl_list devices;
 	struct wl_list seats;
+
+	struct wl_listener new_input;
 };
 
 struct sway_input_manager *sway_input_manager_create(

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -16,6 +16,7 @@ struct sway_input_device {
 	struct wlr_input_device *wlr_device;
 	struct input_config *config;
 	struct wl_list link;
+	struct wl_listener device_destroy;
 };
 
 struct sway_input_manager {

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -58,6 +58,15 @@ void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container);
 
 swayc_t *sway_seat_get_focus(struct sway_seat *seat);
 
+/**
+ * Return the last container to be focused for the seat (or the most recently
+ * opened if no container has received focused) that is a child of the given
+ * container. The focus-inactive container of the root window is the focused
+ * container for the seat (if the seat does have focus). This function can be
+ * used to determine what container gets focused next if the focused container
+ * is destroyed, or focus moves to a container with children and we need to
+ * descend into the next leaf in focus order.
+ */
 swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container);
 
 swayc_t *sway_seat_get_focus_by_type(struct sway_seat *seat,

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -12,14 +12,26 @@ struct sway_seat_device {
 	struct wl_list link; // sway_seat::devices
 };
 
+struct sway_seat_container {
+	struct sway_seat *seat;
+	swayc_t *container;
+
+	struct wl_list link; // sway_seat::focus_stack
+
+	struct wl_listener destroy;
+};
+
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct seat_config *config;
 	struct sway_cursor *cursor;
 	struct sway_input_manager *input;
-	swayc_t *focus;
+
+	bool has_focus;
+	struct wl_list focus_stack; // list of containers in focus order
 
 	struct wl_listener focus_destroy;
+	struct wl_listener new_container;
 
 	struct wl_list devices; // sway_seat_device::link
 
@@ -43,6 +55,8 @@ void sway_seat_remove_device(struct sway_seat *seat,
 void sway_seat_configure_xcursor(struct sway_seat *seat);
 
 void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container);
+
+swayc_t *sway_seat_get_focus(struct sway_seat *seat, swayc_t *container);
 
 void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -56,7 +56,9 @@ void sway_seat_configure_xcursor(struct sway_seat *seat);
 
 void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container);
 
-swayc_t *sway_seat_get_focus(struct sway_seat *seat, swayc_t *container);
+swayc_t *sway_seat_get_focus(struct sway_seat *seat);
+
+swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container);
 
 void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -60,6 +60,9 @@ swayc_t *sway_seat_get_focus(struct sway_seat *seat);
 
 swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container);
 
+swayc_t *sway_seat_get_focus_by_type(struct sway_seat *seat,
+		enum swayc_types type);
+
 void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
 
 #endif

--- a/include/sway/layout.h
+++ b/include/sway/layout.h
@@ -2,6 +2,7 @@
 #define _SWAY_LAYOUT_H
 
 #include <wlr/types/wlr_output_layout.h>
+#include "sway/container.h"
 
 struct sway_container;
 
@@ -11,10 +12,15 @@ struct sway_root {
 	struct wl_listener output_layout_change;
 
 	struct wl_list unmanaged_views; // sway_view::unmanaged_view_link
+
+	struct {
+		struct wl_signal new_container;
+	} events;
 };
 
 void init_layout(void);
 void add_child(struct sway_container *parent, struct sway_container *child);
+swayc_t *add_sibling(swayc_t *parent, swayc_t *child);
 struct sway_container *remove_child(struct sway_container *child);
 enum swayc_layouts default_layout(struct sway_container *output);
 void sort_workspaces(struct sway_container *output);

--- a/include/sway/layout.h
+++ b/include/sway/layout.h
@@ -4,6 +4,18 @@
 #include <wlr/types/wlr_output_layout.h>
 #include "sway/container.h"
 
+enum movement_direction {
+	MOVE_LEFT,
+	MOVE_RIGHT,
+	MOVE_UP,
+	MOVE_DOWN,
+	MOVE_PARENT,
+	MOVE_CHILD,
+	MOVE_NEXT,
+	MOVE_PREV,
+	MOVE_FIRST
+};
+
 struct sway_container;
 
 struct sway_root {
@@ -25,5 +37,7 @@ struct sway_container *remove_child(struct sway_container *child);
 enum swayc_layouts default_layout(struct sway_container *output);
 void sort_workspaces(struct sway_container *output);
 void arrange_windows(struct sway_container *container, double width, double height);
+swayc_t *get_swayc_in_direction(swayc_t *container,
+		struct sway_seat *seat, enum movement_direction dir);
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -14,6 +14,7 @@ struct sway_output {
 	struct timespec last_frame;
 
 	struct wl_listener frame;
+	struct wl_listener output_destroy;
 };
 
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -45,7 +45,6 @@ void server_fini(struct sway_server *server);
 void server_run(struct sway_server *server);
 
 void handle_new_output(struct wl_listener *listener, void *data);
-void handle_output_destroy(struct wl_listener *listener, void *data);
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_xwayland_surface(struct wl_listener *listener, void *data);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -24,8 +24,7 @@ struct sway_server {
 
 	struct sway_input_manager *input;
 
-	struct wl_listener output_add;
-	struct wl_listener output_remove;
+	struct wl_listener new_output;
 	struct wl_listener output_frame;
 
 	struct wlr_xdg_shell_v6 *xdg_shell_v6;
@@ -45,8 +44,8 @@ bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);
 void server_run(struct sway_server *server);
 
-void output_add_notify(struct wl_listener *listener, void *data);
-void output_remove_notify(struct wl_listener *listener, void *data);
+void handle_new_output(struct wl_listener *listener, void *data);
+void handle_output_destroy(struct wl_listener *listener, void *data);
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_xwayland_surface(struct wl_listener *listener, void *data);

--- a/include/sway/workspace.h
+++ b/include/sway/workspace.h
@@ -1,7 +1,7 @@
 #ifndef _SWAY_WORKSPACE_H
 #define _SWAY_WORKSPACE_H
 
-struct sway_container;
+#include <sway/container.h>
 
 extern char *prev_workspace_name;
 
@@ -12,9 +12,9 @@ bool workspace_switch(swayc_t *workspace);
 struct sway_container *workspace_by_number(const char* name);
 swayc_t *workspace_by_name(const char*);
 
-struct sway_container *workspace_output_next(struct sway_container *current);
-struct sway_container *workspace_next(struct sway_container *current);
-struct sway_container *workspace_output_prev(struct sway_container *current);
-struct sway_container *workspace_prev(struct sway_container *current);
+struct sway_container *workspace_output_next(swayc_t *current);
+struct sway_container *workspace_next(swayc_t *current);
+struct sway_container *workspace_output_prev(swayc_t *current);
+struct sway_container *workspace_prev(swayc_t *current);
 
 #endif

--- a/include/sway/workspace.h
+++ b/include/sway/workspace.h
@@ -1,7 +1,7 @@
 #ifndef _SWAY_WORKSPACE_H
 #define _SWAY_WORKSPACE_H
 
-#include <sway/container.h>
+#include "sway/container.h"
 
 extern char *prev_workspace_name;
 

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project(
 )
 
 add_project_arguments('-Wno-unused-parameter', language: 'c')
+add_project_arguments('-Wno-unused-function', language: 'c')
 
 cc = meson.get_compiler('c')
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -281,7 +281,10 @@ struct cmd_results *handle_command(char *_exec) {
 					seat = sway_input_manager_get_default_seat(input_manager);
 				}
 				if (seat) {
-					config->handler_context.current_container = seat->focus;
+					config->handler_context.current_container =
+						(seat->has_focus ?
+						 sway_seat_get_focus(seat, &root_container) :
+						 NULL);
 					struct cmd_results *res = handler->handle(argc-1, argv+1);
 					if (res->status != CMD_SUCCESS) {
 						free_argv(argc, argv);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -136,6 +136,7 @@ static struct cmd_handler handlers[] = {
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "kill", cmd_kill },
+	{ "layout", cmd_layout },
 	{ "output", cmd_output },
 	{ "reload", cmd_reload },
 	{ "seat", cmd_seat },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -138,8 +138,15 @@ static struct cmd_handler handlers[] = {
 	{ "input", cmd_input },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },
-	{ "set", cmd_set },
 	{ "workspace", cmd_workspace },
+};
+
+/**
+ * Commands that can *only* run in the config loading context
+ * Keep alphabetized
+ */
+static struct cmd_handler config_handlers[] = {
+	{ "set", cmd_set },
 };
 
 /**
@@ -208,6 +215,16 @@ static struct cmd_handler *find_handler(char *line, enum cmd_status block) {
 	if (!config_loading) {
 		res = bsearch(&d, command_handlers,
 				sizeof(command_handlers) / sizeof(struct cmd_handler),
+				sizeof(struct cmd_handler), handler_compare);
+
+		if (res) {
+			return res;
+		}
+	}
+
+	if (config->reading) {
+		res = bsearch(&d, config_handlers,
+				sizeof(config_handlers) / sizeof(struct cmd_handler),
 				sizeof(struct cmd_handler), handler_compare);
 
 		if (res) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -132,6 +132,7 @@ static struct cmd_handler handlers[] = {
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "exit", cmd_exit },
+	{ "focus", cmd_focus },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "kill", cmd_kill },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -282,9 +282,7 @@ struct cmd_results *handle_command(char *_exec) {
 				}
 				if (seat) {
 					config->handler_context.current_container =
-						(seat->has_focus ?
-						 sway_seat_get_focus(seat, &root_container) :
-						 NULL);
+						sway_seat_get_focus(seat);
 					struct cmd_results *res = handler->handle(argc-1, argv+1);
 					if (res->status != CMD_SUCCESS) {
 						free_argv(argc, argv);

--- a/sway/commands/exit.c
+++ b/sway/commands/exit.c
@@ -6,9 +6,6 @@ void sway_terminate(int exit_code);
 
 struct cmd_results *cmd_exit(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (config->reading) {
-		return cmd_results_new(CMD_FAILURE, "exit", "Can't be used in config file.");
-	}
 	if ((error = checkarg(argc, "exit", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -33,20 +33,6 @@ static bool parse_movement_direction(const char *name, enum movement_direction *
 struct cmd_results *cmd_focus(int argc, char **argv) {
 	swayc_t *con = config->handler_context.current_container;
 	struct sway_seat *seat = config->handler_context.seat;
-
-	if (!sway_assert(seat, "'focus' command called without seat context")) {
-		return cmd_results_new(CMD_FAILURE, "focus",
-			"Command 'focus' called without seat context (this is a bug in sway)");
-	}
-
-	if (config->reading) {
-		return cmd_results_new(CMD_FAILURE, "focus",
-			"Command 'focus' cannot be used in the config file");
-	}
-	if (con == NULL) {
-		wlr_log(L_DEBUG, "no container to focus");
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
-	}
 	if (con->type < C_WORKSPACE) {
 		return cmd_results_new(CMD_FAILURE, "focus",
 			"Command 'focus' cannot be used above the workspace level");

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -1,0 +1,32 @@
+#include <wlr/util/log.h>
+#include "log.h"
+#include "sway/input/input-manager.h"
+#include "sway/input/seat.h"
+#include "sway/view.h"
+#include "sway/commands.h"
+
+struct cmd_results *cmd_focus(int argc, char **argv) {
+	swayc_t *con = config->handler_context.current_container;
+	struct sway_seat *seat = config->handler_context.seat;
+
+	if (!sway_assert(seat, "'focus' command called without seat context")) {
+		return cmd_results_new(CMD_FAILURE, "focus",
+			"Command 'focus' called without seat context (this is a bug in sway)");
+	}
+
+	if (config->reading) {
+		return cmd_results_new(CMD_FAILURE, "focus",
+			"Command 'focus' cannot be used in the config file");
+	}
+	if (con == NULL) {
+		wlr_log(L_DEBUG, "no container to focus");
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
+	if (argc == 0) {
+		sway_seat_set_focus(seat, con);
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -1,9 +1,34 @@
+#include <strings.h>
 #include <wlr/util/log.h>
 #include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/view.h"
 #include "sway/commands.h"
+
+static bool parse_movement_direction(const char *name, enum movement_direction *out) {
+	if (strcasecmp(name, "left") == 0) {
+		*out = MOVE_LEFT;
+	} else if (strcasecmp(name, "right") == 0) {
+		*out = MOVE_RIGHT;
+	} else if (strcasecmp(name, "up") == 0) {
+		*out = MOVE_UP;
+	} else if (strcasecmp(name, "down") == 0) {
+		*out = MOVE_DOWN;
+	} else if (strcasecmp(name, "parent") == 0) {
+		*out = MOVE_PARENT;
+	} else if (strcasecmp(name, "child") == 0) {
+		*out = MOVE_CHILD;
+	} else if (strcasecmp(name, "next") == 0) {
+		*out = MOVE_NEXT;
+	} else if (strcasecmp(name, "prev") == 0) {
+		*out = MOVE_PREV;
+	} else {
+		return false;
+	}
+
+	return true;
+}
 
 struct cmd_results *cmd_focus(int argc, char **argv) {
 	swayc_t *con = config->handler_context.current_container;
@@ -22,10 +47,26 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		wlr_log(L_DEBUG, "no container to focus");
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
+	if (con->type < C_WORKSPACE) {
+		return cmd_results_new(CMD_FAILURE, "focus",
+			"Command 'focus' cannot be used above the workspace level");
+	}
 
 	if (argc == 0) {
 		sway_seat_set_focus(seat, con);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
+	// TODO mode_toggle
+	enum movement_direction direction = 0;
+	if (!parse_movement_direction(argv[0], &direction)) {
+		return cmd_results_new(CMD_INVALID, "focus",
+				"Expected 'focus <direction|parent|child|mode_toggle>' or 'focus output <direction|name>'");
+	}
+
+	swayc_t *next_focus = get_swayc_in_direction(con, seat, direction);
+	if (next_focus) {
+		sway_seat_set_focus(seat, next_focus);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -10,11 +10,16 @@ struct cmd_results *cmd_kill(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "kill",
 			"Command 'kill' cannot be used in the config file");
 	}
+	if (config->handler_context.current_container == NULL) {
+		wlr_log(L_DEBUG, "no container to kill");
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
 	enum swayc_types type = config->handler_context.current_container->type;
-	if (type != C_VIEW || type != C_CONTAINER) {
+	if (type != C_VIEW && type != C_CONTAINER) {
 		return cmd_results_new(CMD_INVALID, NULL,
 				"Can only kill views and containers with this command");
 	}
+
 	// TODO close arbitrary containers without a view
 	struct sway_view *view =
 		config->handler_context.current_container->sway_view;

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -6,14 +6,6 @@
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
-	if (config->reading) {
-		return cmd_results_new(CMD_FAILURE, "kill",
-			"Command 'kill' cannot be used in the config file");
-	}
-	if (config->handler_context.current_container == NULL) {
-		wlr_log(L_DEBUG, "no container to kill");
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
-	}
 	enum swayc_types type = config->handler_context.current_container->type;
 	if (type != C_VIEW && type != C_CONTAINER) {
 		return cmd_results_new(CMD_INVALID, NULL,

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -7,19 +7,10 @@
 
 struct cmd_results *cmd_layout(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (config->reading) {
-		return cmd_results_new(CMD_FAILURE, "layout", "Can't be used in config file.");
-	}
-	if (!config->active) {
-		return cmd_results_new(CMD_FAILURE, "layout", "Can only be used when sway is running.");
-	}
 	if ((error = checkarg(argc, "layout", EXPECTED_MORE_THAN, 0))) {
 		return error;
 	}
 	swayc_t *parent = config->handler_context.current_container;
-	if (!sway_assert(parent != NULL, "command called without container context")) {
-		return NULL;
-	}
 
 	// TODO: floating
 	/*

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -1,0 +1,65 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/container.h"
+#include "sway/layout.h"
+#include "log.h"
+
+struct cmd_results *cmd_layout(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if (config->reading) {
+		return cmd_results_new(CMD_FAILURE, "layout", "Can't be used in config file.");
+	}
+	if (!config->active) {
+		return cmd_results_new(CMD_FAILURE, "layout", "Can only be used when sway is running.");
+	}
+	if ((error = checkarg(argc, "layout", EXPECTED_MORE_THAN, 0))) {
+		return error;
+	}
+	swayc_t *parent = config->handler_context.current_container;
+	if (!sway_assert(parent != NULL, "command called without container context")) {
+		return NULL;
+	}
+
+	// TODO: floating
+	/*
+	if (parent->is_floating) {
+		return cmd_results_new(CMD_FAILURE, "layout", "Unable to change layout of floating windows");
+	}
+	*/
+
+	while (parent->type == C_VIEW) {
+		parent = parent->parent;
+	}
+
+	// TODO: stacks and tabs
+
+	if (strcasecmp(argv[0], "default") == 0) {
+		swayc_change_layout(parent, parent->prev_layout);
+		if (parent->layout == L_NONE) {
+			swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
+			swayc_change_layout(parent, default_layout(output));
+		}
+	} else {
+		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
+			parent->prev_layout = parent->layout;
+		}
+
+		if (strcasecmp(argv[0], "splith") == 0) {
+			swayc_change_layout(parent, L_HORIZ);
+		} else if (strcasecmp(argv[0], "splitv") == 0) {
+			swayc_change_layout(parent, L_VERT);
+		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
+			if (parent->layout == L_HORIZ && (parent->workspace_layout == L_NONE
+					|| parent->workspace_layout == L_HORIZ)) {
+				swayc_change_layout(parent, L_VERT);
+			} else {
+				swayc_change_layout(parent, L_HORIZ);
+			}
+		}
+	}
+
+	arrange_windows(parent, parent->width, parent->height);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -4,9 +4,6 @@
 
 struct cmd_results *cmd_reload(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (config->reading) {
-		return cmd_results_new(CMD_FAILURE, "reload", "Can't be used in config file.");
-	}
 	if ((error = checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -27,7 +27,6 @@ void free_sway_variable(struct sway_variable *var) {
 struct cmd_results *cmd_set(int argc, char **argv) {
 	char *tmp;
 	struct cmd_results *error = NULL;
-	if (!config->reading) return cmd_results_new(CMD_FAILURE, "set", "Can only be used in config file.");
 	if ((error = checkarg(argc, "set", EXPECTED_AT_LEAST, 2))) {
 		return error;
 	}

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -91,7 +91,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 		workspace_switch(ws);
 		current_container =
-			sway_seat_get_focus(config->handler_context.seat, &root_container);
+			sway_seat_get_focus(config->handler_context.seat);
 		swayc_t *new_output = swayc_parent_by_type(current_container, C_OUTPUT);
 
 		if (config->mouse_warping && old_output != new_output) {

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -90,7 +90,8 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			free(name);
 		}
 		workspace_switch(ws);
-		current_container = config->handler_context.seat->focus;
+		current_container =
+			sway_seat_get_focus(config->handler_context.seat, &root_container);
 		swayc_t *new_output = swayc_parent_by_type(current_container, C_OUTPUT);
 
 		if (config->mouse_warping && old_output != new_output) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -219,23 +219,11 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 }
 
 static void handle_output_destroy(struct wl_listener *listener, void *data) {
+	struct sway_output *output = wl_container_of(listener, output, output_destroy);
 	struct wlr_output *wlr_output = data;
 	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
 
-	swayc_t *output_container = NULL;
-	for (int i = 0 ; i < root_container.children->length; ++i) {
-		swayc_t *child = root_container.children->items[i];
-		if (child->type == C_OUTPUT &&
-				child->sway_output->wlr_output == wlr_output) {
-			output_container = child;
-			break;
-		}
-	}
-	if (!output_container) {
-		return;
-	}
-
-	destroy_output(output_container);
+	destroy_output(output->swayc);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -51,7 +51,7 @@ static void render_surface(struct wlr_surface *surface,
 
 	// FIXME: view coords are inconsistently assumed to be in output or layout coords
 	struct wlr_box layout_box = {
-		.x = lx + owidth, .y = ly + oheight,
+		.x = lx + wlr_output->lx, .y = ly + wlr_output->ly,
 		.width = render_width, .height = render_height,
 	};
 	if (wlr_output_layout_intersects(layout, wlr_output, &layout_box)) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -286,6 +286,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	wl_signal_add(&wlr_output->events.destroy, &output->output_destroy);
 	output->output_destroy.notify = handle_output_destroy;
+
+	arrange_windows(&root_container, -1, -1);
 }
 
 void handle_output_destroy(struct wl_listener *listener, void *data) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -216,9 +216,10 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct sway_output *soutput = wl_container_of(listener, soutput, frame);
 	struct wlr_output *wlr_output = data;
 	struct sway_server *server = soutput->server;
-
 	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	wlr_renderer_clear(renderer, &clear_color);
+
 	wlr_renderer_clear(renderer, &clear_color);
 
 	int buffer_age = -1;
@@ -254,8 +255,8 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	soutput->last_frame = now;
 }
 
-void output_add_notify(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(listener, server, output_add);
+void handle_new_output(struct wl_listener *listener, void *data) {
+	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;
 	wlr_log(L_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
 
@@ -280,12 +281,14 @@ void output_add_notify(struct wl_listener *listener, void *data) {
 
 	sway_input_manager_configure_xcursor(input_manager);
 
-	output->frame.notify = output_frame_notify;
 	wl_signal_add(&wlr_output->events.frame, &output->frame);
+	output->frame.notify = output_frame_notify;
+
+	wl_signal_add(&wlr_output->events.destroy, &output->output_destroy);
+	output->output_destroy.notify = handle_output_destroy;
 }
 
-void output_remove_notify(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(listener, server, output_remove);
+void handle_output_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = data;
 	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -125,8 +125,9 @@ static void render_xdg_v6_popups(struct wlr_xdg_surface_v6 *surface,
 	double width = surface->surface->current->width;
 	double height = surface->surface->current->height;
 
-	struct wlr_xdg_surface_v6 *popup;
-	wl_list_for_each(popup, &surface->popups, popup_link) {
+	struct wlr_xdg_popup_v6 *popup_state;
+	wl_list_for_each(popup_state, &surface->popups, link) {
+		struct wlr_xdg_surface_v6 *popup = popup_state->base;
 		if (!popup->configured) {
 			continue;
 		}
@@ -216,7 +217,12 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = data;
 	struct sway_server *server = soutput->server;
 
-	wlr_output_make_current(wlr_output);
+	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
+	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	wlr_renderer_clear(renderer, &clear_color);
+
+	int buffer_age = -1;
+	wlr_output_make_current(wlr_output, &buffer_age);
 	wlr_renderer_begin(server->renderer, wlr_output);
 
 	swayc_t *workspace = soutput->swayc->focused;
@@ -236,7 +242,7 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_renderer_end(server->renderer);
-	wlr_output_swap_buffers(wlr_output);
+	wlr_output_swap_buffers(wlr_output, &soutput->last_frame, NULL);
 
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -225,7 +225,12 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	wlr_output_make_current(wlr_output, &buffer_age);
 	wlr_renderer_begin(server->renderer, wlr_output);
 
-	swayc_t *workspace = soutput->swayc->focused;
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, soutput->swayc);
+	swayc_t *workspace = (focus->type == C_WORKSPACE ?
+			focus :
+			swayc_parent_by_type(focus, C_WORKSPACE));
+
 	swayc_descendants_of_type(workspace, C_VIEW, output_frame_view, soutput);
 
 	// render unmanaged views on top

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -218,6 +218,26 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	soutput->last_frame = now;
 }
 
+static void handle_output_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_output *wlr_output = data;
+	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
+
+	swayc_t *output_container = NULL;
+	for (int i = 0 ; i < root_container.children->length; ++i) {
+		swayc_t *child = root_container.children->items[i];
+		if (child->type == C_OUTPUT &&
+				child->sway_output->wlr_output == wlr_output) {
+			output_container = child;
+			break;
+		}
+	}
+	if (!output_container) {
+		return;
+	}
+
+	destroy_output(output_container);
+}
+
 void handle_new_output(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;
@@ -251,24 +271,4 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->output_destroy.notify = handle_output_destroy;
 
 	arrange_windows(&root_container, -1, -1);
-}
-
-void handle_output_destroy(struct wl_listener *listener, void *data) {
-	struct wlr_output *wlr_output = data;
-	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
-
-	swayc_t *output_container = NULL;
-	for (int i = 0 ; i < root_container.children->length; ++i) {
-		swayc_t *child = root_container.children->items[i];
-		if (child->type == C_OUTPUT &&
-				child->sway_output->wlr_output == wlr_output) {
-			output_container = child;
-			break;
-		}
-	}
-	if (!output_container) {
-		return;
-	}
-
-	destroy_output(output_container);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -135,7 +135,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&xdg_surface->events.destroy, &sway_surface->destroy);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	swayc_t *cont = new_view(focus, sway_view);
 	sway_view->swayc = cont;
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -135,7 +135,8 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&xdg_surface->events.destroy, &sway_surface->destroy);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *cont = new_view(seat->focus, sway_view);
+	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	swayc_t *cont = new_view(focus, sway_view);
 	sway_view->swayc = cont;
 
 	arrange_windows(cont->parent, -1, -1);

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -160,7 +160,32 @@ static void sway_input_manager_libinput_config_pointer(struct sway_input_device 
 	}
 }
 
-static void input_add_notify(struct wl_listener *listener, void *data) {
+static void handle_device_destroy(struct wl_listener *listener, void *data) {
+	struct wlr_input_device *device = data;
+
+	struct sway_input_device *input_device =
+		input_sway_device_from_wlr(input_manager, device);
+
+	if (!sway_assert(input_device, "could not find sway device")) {
+		return;
+	}
+
+	wlr_log(L_DEBUG, "removing device: '%s'",
+		input_device->identifier);
+
+	struct sway_seat *seat = NULL;
+	wl_list_for_each(seat, &input_manager->seats, link) {
+		sway_seat_remove_device(seat, input_device);
+	}
+
+	wl_list_remove(&input_device->link);
+	wl_list_remove(&input_device->device_destroy.link);
+	free_input_config(input_device->config);
+	free(input_device->identifier);
+	free(input_device);
+}
+
+static void handle_new_input(struct wl_listener *listener, void *data) {
 	struct sway_input_manager *input =
 		wl_container_of(listener, input, input_add);
 	struct wlr_input_device *device = data;
@@ -226,32 +251,9 @@ static void input_add_notify(struct wl_listener *listener, void *data) {
 			"device '%s' is not configured on any seats",
 			input_device->identifier);
 	}
-}
 
-static void input_remove_notify(struct wl_listener *listener, void *data) {
-	struct sway_input_manager *input =
-		wl_container_of(listener, input, input_remove);
-	struct wlr_input_device *device = data;
-
-	struct sway_input_device *input_device =
-		input_sway_device_from_wlr(input, device);
-
-	if (!sway_assert(input_device, "could not find sway device")) {
-		return;
-	}
-
-	wlr_log(L_DEBUG, "removing device: '%s'",
-		input_device->identifier);
-
-	struct sway_seat *seat = NULL;
-	wl_list_for_each(seat, &input->seats, link) {
-		sway_seat_remove_device(seat, input_device);
-	}
-
-	wl_list_remove(&input_device->link);
-	free_input_config(input_device->config);
-	free(input_device->identifier);
-	free(input_device);
+	wl_signal_add(&device->events.destroy, &input_device->device_destroy);
+	input_device->device_destroy.notify = handle_device_destroy;
 }
 
 struct sway_input_manager *sway_input_manager_create(
@@ -269,11 +271,8 @@ struct sway_input_manager *sway_input_manager_create(
 	// create the default seat
 	input_manager_get_seat(input, default_seat);
 
-	input->input_add.notify = input_add_notify;
-	wl_signal_add(&server->backend->events.input_add, &input->input_add);
-
-	input->input_remove.notify = input_remove_notify;
-	wl_signal_add(&server->backend->events.input_remove, &input->input_remove);
+	input->input_add.notify = handle_new_input;
+	wl_signal_add(&server->backend->events.new_input, &input->input_add);
 
 	return input;
 }

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -282,7 +282,7 @@ bool sway_input_manager_has_focus(struct sway_input_manager *input,
 		swayc_t *container) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
-		if (seat->focus == container) {
+		if (seat->has_focus && sway_seat_get_focus(seat, &root_container) == container) {
 			return true;
 		}
 	}

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -187,7 +187,7 @@ static void handle_device_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_new_input(struct wl_listener *listener, void *data) {
 	struct sway_input_manager *input =
-		wl_container_of(listener, input, input_add);
+		wl_container_of(listener, input, new_input);
 	struct wlr_input_device *device = data;
 
 	struct sway_input_device *input_device =
@@ -271,8 +271,8 @@ struct sway_input_manager *sway_input_manager_create(
 	// create the default seat
 	input_manager_get_seat(input, default_seat);
 
-	input->input_add.notify = handle_new_input;
-	wl_signal_add(&server->backend->events.new_input, &input->input_add);
+	input->new_input.notify = handle_new_input;
+	wl_signal_add(&server->backend->events.new_input, &input->new_input);
 
 	return input;
 }

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -282,7 +282,7 @@ bool sway_input_manager_has_focus(struct sway_input_manager *input,
 		swayc_t *container) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
-		if (seat->has_focus && sway_seat_get_focus(seat, &root_container) == container) {
+		if (sway_seat_get_focus(seat) == container) {
 			return true;
 		}
 	}

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -95,7 +95,7 @@ static void keyboard_execute_command(struct sway_keyboard *keyboard,
 		binding->command);
 	config_clear_handler_context(config);
 	config->handler_context.seat = keyboard->seat_device->sway_seat;
-	struct cmd_results *results = handle_command(binding->command);
+	struct cmd_results *results = execute_command(binding->command, NULL);
 	if (results->status != CMD_SUCCESS) {
 		wlr_log(L_DEBUG, "could not run command for binding: %s",
 			binding->command);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -358,6 +358,16 @@ swayc_t *sway_seat_get_focus(struct sway_seat *seat) {
 	return sway_seat_get_focus_inactive(seat, &root_container);
 }
 
+swayc_t *sway_seat_get_focus_by_type(struct sway_seat *seat,
+		enum swayc_types type) {
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	if (focus->type == type) {
+		return focus;
+	}
+
+	return swayc_parent_by_type(focus, type);
+}
+
 void sway_seat_set_config(struct sway_seat *seat,
 		struct seat_config *seat_config) {
 	// clear configs

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -74,8 +74,8 @@ static void ipc_json_describe_output(swayc_t *container, json_object *object) {
 	json_object_object_add(object, "refresh", json_object_new_int(wlr_output->refresh));
 	json_object_object_add(object, "transform",
 		json_object_new_string(ipc_json_get_output_transform(wlr_output->transform)));
-	json_object_object_add(object, "current_workspace",
-		(container->focused) ? json_object_new_string(container->focused->name) : NULL);
+	// TODO WLR need to set "current_workspace" to the currently focused
+	// workspace in a way that makes sense with multiseat
 }
 
 static void ipc_json_describe_workspace(swayc_t *workspace, json_object *object) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -336,6 +336,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_COMMAND:
 	{
 		config_clear_handler_context(config);
+		config->handler_context.seat = input_manager_current_seat(input_manager);
 		struct cmd_results *results = handle_command(buf);
 		const char *json = cmd_results_to_json(results);
 		char reply[256];

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -336,8 +336,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_COMMAND:
 	{
 		config_clear_handler_context(config);
-		config->handler_context.seat = input_manager_current_seat(input_manager);
-		struct cmd_results *results = handle_command(buf);
+		struct cmd_results *results = execute_command(buf, NULL);
 		const char *json = cmd_results_to_json(results);
 		char reply[256];
 		int length = snprintf(reply, sizeof(reply), "%s", json);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -10,6 +10,7 @@ sway_sources = files(
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',
+	'commands/focus.c',
 	'commands/kill.c',
 	'commands/include.c',
 	'commands/input.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -14,6 +14,7 @@ sway_sources = files(
 	'commands/kill.c',
 	'commands/include.c',
 	'commands/input.c',
+	'commands/layout.c',
 	'commands/seat.c',
 	'commands/seat/attach.c',
 	'commands/seat/fallback.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -22,7 +22,7 @@ static void server_ready(struct wl_listener *listener, void *data) {
 	config->active = true;
 	while (config->cmd_queue->length) {
 		char *line = config->cmd_queue->items[0];
-		struct cmd_results *res = handle_command(line);
+		struct cmd_results *res = execute_command(line, NULL);
 		if (res->status != CMD_SUCCESS) {
 			wlr_log(L_ERROR, "Error on line '%s': %s", line, res->error);
 		}

--- a/sway/server.c
+++ b/sway/server.c
@@ -48,12 +48,8 @@ bool server_init(struct sway_server *server) {
 	server->data_device_manager =
 		wlr_data_device_manager_create(server->wl_display);
 
-	server->output_add.notify = output_add_notify;
-	wl_signal_add(&server->backend->events.output_add, &server->output_add);
-
-	server->output_remove.notify = output_remove_notify;
-	wl_signal_add(&server->backend->events.output_remove,
-			&server->output_remove);
+	server->new_output.notify = handle_new_output;
+	wl_signal_add(&server->backend->events.new_output, &server->new_output);
 
 	server->xdg_shell_v6 = wlr_xdg_shell_v6_create(server->wl_display);
 	wl_signal_add(&server->xdg_shell_v6->events.new_surface,

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -381,13 +381,13 @@ void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), voi
 	}
 }
 
-/**
- * Get a list of containers that are descendents of the container in rendering
- * order
- */
-list_t *container_list_children(swayc_t *con) {
-	list_t *list = create_list();
+void container_for_each_bfs(swayc_t *con, void (*f)(swayc_t *con, void *data),
+		void *data) {
 	list_t *queue = create_list();
+	if (queue == NULL) {
+		wlr_log(L_ERROR, "could not allocate list");
+		return;
+	}
 
 	list_add(queue, con);
 
@@ -395,11 +395,10 @@ list_t *container_list_children(swayc_t *con) {
 	while (queue->length) {
 		current = queue->items[0];
 		list_del(queue, 0);
-		list_add(list, current);
+		f(current, data);
 		// TODO floating containers
 		list_cat(queue, current->children);
 	}
 
 	list_free(queue);
-	return list;
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -400,3 +400,15 @@ void container_for_each_bfs(swayc_t *con, void (*f)(swayc_t *con, void *data),
 
 	list_free(queue);
 }
+
+swayc_t *swayc_change_layout(swayc_t *container, enum swayc_layouts layout) {
+	if (container->type == C_WORKSPACE) {
+		container->workspace_layout = layout;
+		if (layout == L_HORIZ || layout == L_VERT) {
+			container->layout = layout;
+		}
+	} else {
+		container->layout = layout;
+	}
+	return container;
+}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -152,9 +152,6 @@ swayc_t *new_output(struct sway_output *sway_output) {
 	wlr_log(L_DEBUG, "Creating default workspace %s", ws_name);
 	swayc_t *ws = new_workspace(output, ws_name);
 	// Set each seat's focus if not already set
-	// TODO FOCUS: this is probably stupid, we shouldn't define focus in two
-	// places. We should probably put the active workspace on the sway_output
-	// struct instead of trying to do focus semantics like this
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input_manager->seats, link) {
 		if (!seat->has_focus) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -151,7 +151,6 @@ swayc_t *new_output(struct sway_output *sway_output) {
 	char *ws_name = workspace_next_name(output->name);
 	wlr_log(L_DEBUG, "Creating default workspace %s", ws_name);
 	swayc_t *ws = new_workspace(output, ws_name);
-	output->focused = ws;
 	// Set each seat's focus if not already set
 	// TODO FOCUS: this is probably stupid, we shouldn't define focus in two
 	// places. We should probably put the active workspace on the sway_output

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -236,6 +236,8 @@ swayc_t *destroy_output(swayc_t *output) {
 		}
 	}
 
+	wl_list_remove(&output->sway_output->output_destroy.link);
+
 	wlr_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
 	free_swayc(output);
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -84,8 +84,6 @@ swayc_t *add_sibling(swayc_t *fixed, swayc_t *active) {
 	int i = index_child(fixed);
 	list_insert(parent->children, i + 1, active);
 	active->parent = parent;
-	// focus new child
-	parent->focused = active;
 	return active->parent;
 }
 
@@ -96,9 +94,6 @@ void add_child(swayc_t *parent, swayc_t *child) {
 	list_add(parent->children, child);
 	child->parent = parent;
 	// set focus for this container
-	if (!parent->focused) {
-		parent->focused = child;
-	}
 	/* TODO WLR
 	if (parent->type == C_WORKSPACE && child->type == C_VIEW && (parent->workspace_layout == L_TABBED || parent->workspace_layout == L_STACKED)) {
 		child = new_container(child, parent->workspace_layout);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -61,7 +61,7 @@ void init_layout(void) {
 		&root_container.sway_root->output_layout_change);
 }
 
-int index_child(const swayc_t *child) {
+static int index_child(const swayc_t *child) {
 	// TODO handle floating
 	swayc_t *parent = child->parent;
 	int i, len;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -461,6 +461,8 @@ static swayc_t *get_swayc_in_direction_under(swayc_t *container,
 		int desired;
 		int idx = index_child(container);
 		if (parent->type == C_ROOT) {
+			// TODO
+			/*
 			struct wlr_output_layout *layout = root_container.sway_root->output_layout;
 			wlr_output_layout_adjacent_output(layout, container->sway_output->wlr_output);
 			//swayc_t *output = swayc_adjacent_output(container, dir, &abs_pos, true);
@@ -469,6 +471,7 @@ static swayc_t *get_swayc_in_direction_under(swayc_t *container,
 			}
 			wlr_log(L_DEBUG, "Moving between outputs");
 			return get_swayc_in_output_direction(output, dir, seat);
+			*/
 		} else {
 			if (dir == MOVE_LEFT || dir == MOVE_RIGHT) {
 				if (parent->layout == L_HORIZ || parent->layout == L_TABBED) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -173,8 +173,8 @@ void arrange_windows(swayc_t *container, double width, double height) {
 	height = floor(height);
 
 	wlr_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", container,
-		 container->name, container->width, container->height, container->x,
-		 container->y);
+		container->name, container->width, container->height, container->x,
+		container->y);
 
 	double x = 0, y = 0;
 	switch (container->type) {
@@ -275,8 +275,8 @@ static void apply_horiz_layout(swayc_t *container,
 		for (int i = start; i < end; ++i) {
 			swayc_t *child = container->children->items[i];
 			wlr_log(L_DEBUG,
-				 "Calculating arrangement for %p:%d (will scale %f by %f)",
-				 child, child->type, width, scale);
+				"Calculating arrangement for %p:%d (will scale %f by %f)",
+				child, child->type, width, scale);
 			view_set_position(child->sway_view, child_x, y);
 
 			if (i == end - 1) {
@@ -325,8 +325,8 @@ void apply_vert_layout(swayc_t *container,
 		for (i = start; i < end; ++i) {
 			swayc_t *child = container->children->items[i];
 			wlr_log(L_DEBUG,
-				 "Calculating arrangement for %p:%d (will scale %f by %f)",
-				 child, child->type, height, scale);
+				"Calculating arrangement for %p:%d (will scale %f by %f)",
+				child, child->type, height, scale);
 			view_set_position(child->sway_view, x, child_y);
 
 			if (i == end - 1) {
@@ -373,24 +373,23 @@ static swayc_t *get_swayc_in_output_direction(swayc_t *output,
 			// get most left child of new output
 			return ws->children->items[0];
 		case MOVE_UP:
-		case MOVE_DOWN:
-			{
-				swayc_t *focused = sway_seat_get_focus_inactive(seat, ws);
-				if (focused && focused->parent) {
-					swayc_t *parent = focused->parent;
-					if (parent->layout == L_VERT) {
-						if (dir == MOVE_UP) {
-							// get child furthest down on new output
-							return parent->children->items[parent->children->length-1];
-						} else if (dir == MOVE_DOWN) {
-							// get child furthest up on new output
-							return parent->children->items[0];
-						}
+		case MOVE_DOWN: {
+			swayc_t *focused = sway_seat_get_focus_inactive(seat, ws);
+			if (focused && focused->parent) {
+				swayc_t *parent = focused->parent;
+				if (parent->layout == L_VERT) {
+					if (dir == MOVE_UP) {
+						// get child furthest down on new output
+						return parent->children->items[parent->children->length-1];
+					} else if (dir == MOVE_DOWN) {
+						// get child furthest up on new output
+						return parent->children->items[0];
 					}
-					return focused;
 				}
-				break;
+				return focused;
 			}
+			break;
+		}
 		default:
 			break;
 		}

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -531,7 +531,10 @@ static swayc_t *get_swayc_in_direction_under(swayc_t *container,
 				return wrap_candidate;
 			}
 			swayc_t *next = get_swayc_in_output_direction(adjacent, dir, seat);
-			if (next->children->length) {
+			if (next == NULL) {
+				return NULL;
+			}
+			if (next->children && next->children->length) {
 				// TODO consider floating children as well
 				return sway_seat_get_focus_inactive(seat, next);
 			} else {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -421,7 +421,6 @@ static void get_layout_center_position(swayc_t *container, int *x, int *y) {
 }
 
 static bool sway_dir_to_wlr(enum movement_direction dir, enum wlr_direction *out) {
-	*out = 0;
 	switch (dir) {
 	case MOVE_UP:
 		*out = WLR_DIRECTION_UP;
@@ -436,10 +435,10 @@ static bool sway_dir_to_wlr(enum movement_direction dir, enum wlr_direction *out
 		*out = WLR_DIRECTION_RIGHT;
 		break;
 	default:
-		break;
+		return false;
 	}
 
-	return *out != 0;
+	return true;
 }
 
 static swayc_t *sway_output_from_wlr(struct wlr_output *output) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -353,8 +353,6 @@ void apply_vert_layout(swayc_t *container,
  */
 static swayc_t *get_swayc_in_output_direction(swayc_t *output,
 		enum movement_direction dir, struct sway_seat *seat) {
-	// XXX is this really a seat function or can we do it with the default
-	// seat?
 	if (!output) {
 		return NULL;
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -63,8 +63,8 @@ static bool _workspace_by_name(swayc_t *view, void *data) {
 swayc_t *workspace_by_name(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	swayc_t *current_workspace = NULL, *current_output = NULL;
-	if (seat->has_focus) {
-		swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	swayc_t *focus = sway_seat_get_focus(seat);
+	if (focus) {
 		current_workspace = swayc_parent_by_type(focus, C_WORKSPACE);
 		current_output = swayc_parent_by_type(focus, C_OUTPUT);
 	}
@@ -103,7 +103,7 @@ swayc_t *workspace_create(const char *name) {
 	}
 	// Otherwise create a new one
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	parent = focus;
 	parent = swayc_parent_by_type(parent, C_OUTPUT);
 	return new_workspace(parent, name);
@@ -195,7 +195,7 @@ bool workspace_switch(swayc_t *workspace) {
 		return false;
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	if (!seat || !focus) {
 		return false;
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -63,9 +63,10 @@ static bool _workspace_by_name(swayc_t *view, void *data) {
 swayc_t *workspace_by_name(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	swayc_t *current_workspace = NULL, *current_output = NULL;
-	if (seat->focus) {
-		current_workspace = swayc_parent_by_type(seat->focus, C_WORKSPACE);
-		current_output = swayc_parent_by_type(seat->focus, C_OUTPUT);
+	if (seat->has_focus) {
+		swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+		current_workspace = swayc_parent_by_type(focus, C_WORKSPACE);
+		current_output = swayc_parent_by_type(focus, C_OUTPUT);
 	}
 	if (strcmp(name, "prev") == 0) {
 		return workspace_prev(current_workspace);
@@ -102,7 +103,8 @@ swayc_t *workspace_create(const char *name) {
 	}
 	// Otherwise create a new one
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	parent = seat->focus;
+	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	parent = focus;
 	parent = swayc_parent_by_type(parent, C_OUTPUT);
 	return new_workspace(parent, name);
 }
@@ -193,12 +195,13 @@ bool workspace_switch(swayc_t *workspace) {
 		return false;
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	if (!seat || !seat->focus) {
+	swayc_t *focus = sway_seat_get_focus(seat, &root_container);
+	if (!seat || !focus) {
 		return false;
 	}
-	swayc_t *active_ws = seat->focus;
+	swayc_t *active_ws = focus;
 	if (active_ws->type != C_WORKSPACE) {
-		swayc_parent_by_type(seat->focus, C_WORKSPACE);
+		swayc_parent_by_type(focus, C_WORKSPACE);
 	}
 
 	if (config->auto_back_and_forth

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -120,9 +120,15 @@ swayc_t *workspace_output_prev_next_impl(swayc_t *output, bool next) {
 		return NULL;
 	}
 
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	swayc_t *focus = sway_seat_get_focus_inactive(seat, output);
+	swayc_t *workspace = (focus->type == C_WORKSPACE ?
+			focus :
+			swayc_parent_by_type(focus, C_WORKSPACE));
+
 	int i;
 	for (i = 0; i < output->children->length; i++) {
-		if (output->children->items[i] == output->focused) {
+		if (output->children->items[i] == workspace) {
 			return output->children->items[
 				wrap(i + (next ? 1 : -1), output->children->length)];
 		}
@@ -225,16 +231,12 @@ bool workspace_switch(swayc_t *workspace) {
 	// TODO: Deal with sticky containers
 
 	wlr_log(L_DEBUG, "Switching to workspace %p:%s", workspace, workspace->name);
-	// TODO FOCUS: Focus the last view this seat had focused on this workspace
-	if (workspace->children->length) {
-		// TODO FOCUS: This is really fucking stupid
-		sway_seat_set_focus(seat, workspace->children->items[0]);
-	} else {
-		sway_seat_set_focus(seat, workspace);
+	swayc_t *next = sway_seat_get_focus_inactive(seat, workspace);
+	if (next == NULL) {
+		next = workspace;
 	}
+	sway_seat_set_focus(seat, next);
 	swayc_t *output = swayc_parent_by_type(workspace, C_OUTPUT);
-	// TODO FOCUS: take a look at this
-	output->focused = workspace;
 	arrange_windows(output, -1, -1);
 	return true;
 }


### PR DESCRIPTION
Changes:

No new features added or bugs fixed, just refactoring changes.

* Keep an up-to-date list of all the containers of the seat in focus order
* Add `sway_seat_get_focus` to get the "focus inactive" of the container (returns true focus if the seat has focus and container is the root)
* Add `sway_seat_container` to store seat-specific data about a container (here, the focus stack list link and destroy handler).

Features:

* [x] static bfs queue
* [x] separate config/command command handlers

Tests:

* [x] open several windows and close one and focus should revert to the last container you focused
* [x] move focus with swaymsg/binding in the basic directions (left, right, up, down).
* [x] move focus across outputs
* [x] test on vertical layouts
* [ ] bug: focused popups don't render on top when in the middle of the children list.

Hard problems:

* [ ] are view coordinates in the output coordinate system or the layout coordinate system?
* [ ] how do I iterate a list of containers in rendering order? (BFS, DFS, or something else?)
* [ ] how do I iterate a list of containers in input order? (reverse of rendering order)
* [ ] are there any use cases where the focus-inactive algorithm gives the wrong answer or is inefficient?

Test config:

```
bindsym Alt+h focus left
bindsym Alt+j focus down
bindsym Alt+k focus up
bindsym Alt+l focus right

bindsym Alt+z layout splith
bindsym Alt+x layout splitv
bindsym Alt+c layout toggle split
```

Feedback on the approach is welcome.