### PR TITLE
Fix memory errors

### DIFF
--- a/common/readline.c
+++ b/common/readline.c
@@ -36,7 +36,7 @@ char *read_line(FILE *file) {
 		}
 		string[length++] = c;
 	}
-	if (length + 1 == size) {
+	if (length + 1 >= size) {
 		char *new_string = realloc(string, length + 1);
 		if (!new_string) {
 			free(string);

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -172,6 +172,7 @@ void notify_key(enum wl_keyboard_key_state state, xkb_keysym_t sym, uint32_t cod
 			redraw_screen = 1;
 
 			password_size = 1024;
+			free(password);
 			password = malloc(password_size);
 			password[0] = '\0';
 			break;


### PR DESCRIPTION
 - `swaylock` does not free the password buffer on ENTER
 - `read_line`: OOB write when a line in /proc/modules contains a
   terminating character at `size` position.

Some errors noted on a sanitized build.