### PR TITLE
Fix memory errors

### DIFF
--- a/common/readline.c
+++ b/common/readline.c
@@ -36,7 +36,7 @@ char *read_line(FILE *file) {
 		}
 		string[length++] = c;
 	}
-	if (length + 1 == size) {
+	if (length + 1 >= size) {
 		char *new_string = realloc(string, length + 1);
 		if (!new_string) {
 			free(string);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -484,6 +484,8 @@ static bool handle_view_created(wlc_handle handle) {
 			// refocus in-between command lists
 			set_focused_container(newview);
 		}
+		// Make sure to free the list_t returned by criteria_for.
+		list_free(criteria);
 		swayc_t *workspace = swayc_parent_by_type(focused, C_WORKSPACE);
 		if (workspace && workspace->fullscreen) {
 			set_focused_container(workspace->fullscreen);


### PR DESCRIPTION
 - `read_line`: OOB write when a line in `/proc/modules` contains a
   terminating character at `size` position.
 - `handle_view_created`: Ensure that the `list_t` returned by `criteria_for`
   is `free`'d after use
 - `ipc_event_binding_keyboard`/`ipc_event_binding`: Properly handle
   `json_object` reference counting and ownership.