### PR TITLE
Fix more leaks

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -96,6 +96,7 @@ pid_t get_parent_pid(pid_t child) {
 			parent = strtol(token, NULL, 10);
 		}
 
+		free(buffer);
 		fclose(stat);
 	}
 

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -62,22 +62,21 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 		return error;
 	}
 	if (strcasecmp(argv[0], "v") == 0 || strcasecmp(argv[0], "vertical") == 0) {
-		_do_split(argc - 1, argv + 1, L_VERT);
+		return _do_split(argc - 1, argv + 1, L_VERT);
 	} else if (strcasecmp(argv[0], "h") == 0 || strcasecmp(argv[0], "horizontal") == 0) {
-		_do_split(argc - 1, argv + 1, L_HORIZ);
+		return _do_split(argc - 1, argv + 1, L_HORIZ);
 	} else if (strcasecmp(argv[0], "t") == 0 || strcasecmp(argv[0], "toggle") == 0) {
 		swayc_t *focused = current_container;
 		if (focused->parent->layout == L_VERT) {
-			_do_split(argc - 1, argv + 1, L_HORIZ);
+			return _do_split(argc - 1, argv + 1, L_HORIZ);
 		} else {
-			_do_split(argc - 1, argv + 1, L_VERT);
+			return _do_split(argc - 1, argv + 1, L_VERT);
 		}
 	} else {
 		error = cmd_results_new(CMD_FAILURE, "split",
 			"Invalid split command (expected either horizontal or vertical).");
 		return error;
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
 struct cmd_results *cmd_splitv(int argc, char **argv) {

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -368,6 +368,7 @@ swayc_t *workspace_for_pid(pid_t pid) {
 			ws = workspace_create(pw->workspace);
 		}
 
+		free_pid_workspace(pw);
 		list_del(config->pid_workspaces, i);
 	}
 


### PR DESCRIPTION
 - `get_parent_pid`: free buffer returned from `read_line` after use.
 - `workspace_for_pid`: ensure `free_pid_workspace` is called when
   `pid_workspace`s are removed from `config->pid_workspaces`.
 - `cmd_split`: return the `cmd_results` from `_do_split`, so that the
   parent function may free it.