### PR TITLE
Fix segfault if swaybg is run without Wayland

### DIFF
--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -31,7 +31,9 @@ void sway_terminate(int exit_code) {
 		window_teardown(window);
 	}
 	list_free(surfaces);
-	registry_teardown(registry);
+	if (registry) {
+		registry_teardown(registry);
+	}
 	exit(exit_code);
 }
 


### PR DESCRIPTION
Mirrors a similar check in `swaylock/main.c`