### PR TITLE
Enable docker service in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 
+services:
+- docker
+
 language: c
 
 compiler:


### PR DESCRIPTION
Adds the docker service in travis which is now required by arch-travis.

See: https://github.com/mikkeloscar/arch-travis/pull/40