### PR TITLE
xwayland: do not send surface configure when no width/height

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -67,6 +67,10 @@ static void set_position(struct sway_view *view, double ox, double oy) {
 	view->swayc->x = ox;
 	view->swayc->y = oy;
 
+	if (view->width == 0 || view->height == 0) {
+		return;
+	}
+
 	wlr_xwayland_surface_configure(view->wlr_xwayland_surface,
 		ox + loutput->x, oy + loutput->y,
 		view->width, view->height);


### PR DESCRIPTION
The code in `apply_horiz_layout` systematically does `set_position`
then `set_size`, so for new windows there is an invalid call.

For old windows there are two calls when only one is needed,
with the current code set_position could not send any surface
configure without impact, but in the future it might be needed?
Native wayland surfaces do not need to know where they are (the
set_position handled only updates the sway internal view variable),
why does X11 window need that?