### PR TITLE
meson: allow wlroots to be a subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .lvimrc
 config-debug
 wayland-*-protocol.*
+/subprojects/wlroots

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ prefix = get_option('prefix')
 
 jsonc          = dependency('json-c', version: '>=0.13')
 pcre           = dependency('libpcre')
-wlroots        = dependency('wlroots')
+wlroots        = dependency('wlroots', fallback: ['wlroots', 'wlroots'])
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
 wayland_egl    = dependency('wayland-egl')


### PR DESCRIPTION
Usage: make `subprojects/wlroots` a symbolic link to wlroots.

This allows to edit and build sway and wlroots at the same time. This can be useful for features like multibackend.