### PR TITLE
Fixed missing icons bug in index.theme parsing...

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -28,7 +28,7 @@
 /* Finds all themes that the given theme inherits */
 static list_t *find_inherits(const char *theme_dir) {
 	const char inherits[] = "Inherits";
-	const char index_name[] = "index.theme";
+	const char index_name[] = "/index.theme";
 	list_t *themes = create_list();
 	FILE *index = NULL;
 	char *path = malloc(strlen(theme_dir) + sizeof(index_name));
@@ -253,6 +253,10 @@ static list_t* find_theme_subdirs(const char *theme_dir) {
 		}
 		if (strncmp(directories, buf, sizeof(directories) - 1) == 0) {
 			char *dirstr = buf + sizeof(directories);
+			int len = strlen(dirstr);
+			if (dirstr[len-1] == '\n') {
+				dirstr[len-1] = '\0';
+			}
 			dirs = split_subdirs(dirstr);
 			break;
 		}


### PR DESCRIPTION
This PR fixes the missing scalable icons issue I reported (#1624). The issue is that the directories were parsed from `index.theme` using `getline()` without chopping the newline at the end -- so the last sub-directory on the list could not be opened (`scalable/status` in the Paper icon theme).

Additionally I noticed that the `find_inherits()` function was concatenating the 'index.theme' string onto the directory without a forward-slash so I fixed that too.