### PR TITLE
swaybar: correctly render min_width for strings

### DIFF
--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -17,7 +17,7 @@ struct status_line {
 };
 
 struct status_block {
-	char *full_text, *short_text, *align;
+	char *full_text, *short_text, *align, *min_width_str;
 	bool urgent;
 	uint32_t color;
 	int min_width;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -61,6 +61,13 @@ static void render_block(struct window *window, struct config *config, struct st
 	int textwidth = width;
 	double block_width = width;
 
+	if (block->min_width_str) {
+		int w, h;
+		get_text_size(window->cairo, window->font, &w, &h,
+				window->scale, block->markup, "%s", block->min_width_str);
+		block->min_width = w;
+	}
+
 	if (width < block->min_width) {
 		width = block->min_width;
 	}

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -121,7 +121,7 @@ static void parse_json(struct bar *bar, const char *text) {
 				new->min_width = json_object_get_int(min_width);
 			} else if (type == json_type_string) {
 				/* the width will be calculated when rendering */
-				new->min_width = 0;
+				new->min_width_str = strdup(json_object_get_string(min_width));
 			}
 		}
 


### PR DESCRIPTION
fixes #1635