### PR TITLE
save errno to avoid issues with it being overwritten in sway_log_errno

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -153,6 +153,7 @@ void sway_log_errno(log_importance_t verbosity, char* format, ...) {
 		}
 		fprintf(stderr, "\n");
 	}
+	errno = errsv;
 }
 
 bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) {

--- a/common/log.c
+++ b/common/log.c
@@ -127,6 +127,7 @@ void _sway_abort(const char *filename, int line, const char* format, ...) {
 }
 
 void sway_log_errno(log_importance_t verbosity, char* format, ...) {
+	int errsv = errno;
 	if (verbosity <= v) {
 		unsigned int c = verbosity;
 		if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
@@ -145,7 +146,7 @@ void sway_log_errno(log_importance_t verbosity, char* format, ...) {
 		va_end(args);
 
 		fprintf(stderr, ": ");
-		fprintf(stderr, "%s", strerror(errno));
+		fprintf(stderr, "%s", strerror(errsv));
 
 		if (colored && isatty(STDERR_FILENO)) {
 			fprintf(stderr, "\x1B[0m");


### PR DESCRIPTION
was fiddling around with the logging to make it a bit more convenient to debug
and noticed a small mistake with `sway_log_errno`, as `errno` can get overwritten before we use it.

its been a while since i contributed, but i assume 0.15 is where development is going for now