### PR TITLE
fix remove_view_from_scratchpad

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -141,12 +141,12 @@ void remove_view_from_scratchpad(swayc_t *view) {
 	int i;
 	for (i = 0; i < scratchpad->length; i++) {
 		if (scratchpad->items[i] == view) {
+			list_del(scratchpad, sp_index);
 			if (sp_index == 0) {
 				sp_index = scratchpad->length - 1;
 			} else {
 				sp_index--;
 			}
-			list_del(scratchpad, sp_index);
 			sp_view = NULL;
 		}
 	}

--- a/sway/container.c
+++ b/sway/container.c
@@ -869,6 +869,9 @@ void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), voi
 void update_visibility_output(swayc_t *container, wlc_handle output) {
 	// Inherit visibility
 	swayc_t *parent = container->parent;
+	if (parent == NULL) {
+		return;
+	}
 	container->visible = parent->visible;
 	// special cases where visibility depends on focus
 	if (parent->type == C_OUTPUT || parent->layout == L_TABBED ||

--- a/sway/debug_log.c
+++ b/sway/debug_log.c
@@ -71,11 +71,11 @@ void layout_log(const swayc_t *c, int depth) {
 				layout_log(c->floating->items[i], depth + 1);
 			}
 		}
-	}
-	if (c->type == C_ROOT) {
-		fprintf(stderr,"ScratchPad\n");
-		for (int i = 0; i < scratchpad->length; ++i)
+	} else if (c->type == C_ROOT && scratchpad->length > 0) {
+		fprintf(stderr, "ScratchPad\n");
+		for (i = 0; i < scratchpad->length; ++i) {
 			container_log(scratchpad->items[i], 0);
+		}
 	}
 }
 

--- a/sway/debug_log.c
+++ b/sway/debug_log.c
@@ -72,6 +72,11 @@ void layout_log(const swayc_t *c, int depth) {
 			}
 		}
 	}
+	if (c->type == C_ROOT) {
+		fprintf(stderr,"ScratchPad\n");
+		for (int i = 0; i < scratchpad->length; ++i)
+			container_log(scratchpad->items[i], 0);
+	}
 }
 
 const char *swayc_type_string(enum swayc_types type) {


### PR DESCRIPTION
Fixes #1468 `Scratchpad show then floating toggle crashes sway.`
Could not reproduce with original instructions,
but can reproduce with instructions provided by nickbatsaras

1. Move a window to scratchpad
2. Move another window to scratchpad
3. Scratchpad show
4. Floating toggle
5. Scratchpad show
6. Scratchpad show

The first sign of the issue starts at step 4.
Given a scratchpad with 2 windows (1,2), with window 1 being a visible container,
turning off floating via `toggle floating` will call `remove_view_from_scratchpad`.
this function was incorrect and resulted in removing window 2,
leaving window 1 in the scratchpad when it shouldnt be and losing window 2 permanently.
the segfault was later caused in update_visibility_output due to window 1 having a NULL parent and dereferencing it.

this fix correctly removes the right container from the scratchpad list,
and  checks for null parent just in case,
also added printing out of scratchpad to layout_log

there might be something more to this that i missed, but for now it seems to work