### PR TITLE
Refactor tree

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -356,7 +356,7 @@ struct sway_config {
 		struct input_config *input_config;
 		struct seat_config *seat_config;
 		struct sway_seat *seat;
-		swayc_t *current_container;
+		struct sway_container *current_container;
 	} handler_context;
 };
 
@@ -416,7 +416,8 @@ void output_get_identifier(char *identifier, size_t len,
 	struct sway_output *output);
 struct output_config *new_output_config(const char *name);
 void merge_output_config(struct output_config *dst, struct output_config *src);
-void apply_output_config(struct output_config *oc, swayc_t *output);
+void apply_output_config(struct output_config *oc,
+		struct sway_container *output);
 void free_output_config(struct output_config *oc);
 
 /**

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -299,8 +299,8 @@ struct sway_config {
 	char *floating_scroll_down_cmd;
 	char *floating_scroll_left_cmd;
 	char *floating_scroll_right_cmd;
-	enum swayc_layouts default_orientation;
-	enum swayc_layouts default_layout;
+	enum sway_container_layout default_orientation;
+	enum sway_container_layout default_layout;
 	char *font;
 	int font_height;
 
@@ -324,8 +324,8 @@ struct sway_config {
 	list_t *config_chain;
 	const char *current_config;
 
-	enum swayc_border_types border;
-	enum swayc_border_types floating_border;
+	enum sway_container_border border;
+	enum sway_container_border floating_border;
 	int border_thickness;
 	int floating_border_thickness;
 	enum edge_border_types hide_edge_borders;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -10,8 +10,8 @@
 #include <xkbcommon/xkbcommon.h>
 #include <time.h>
 #include "list.h"
-#include "layout.h"
-#include "container.h"
+#include "tree/layout.h"
+#include "tree/container.h"
 
 /**
  * Describes a variable created via the `set` command.

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -31,12 +31,12 @@ char *extract_crit_tokens(list_t *tokens, const char *criteria);
 
 // Returns list of criteria that match given container. These criteria have
 // been set with `for_window` commands and have an associated cmdlist.
-list_t *criteria_for(swayc_t *cont);
+list_t *criteria_for(struct sway_container *cont);
 
 // Returns a list of all containers that match the given list of tokens.
 list_t *container_for_crit_tokens(list_t *tokens);
 
 // Returns true if any criteria in the given list matches this container
-bool criteria_any(swayc_t *cont, list_t *criteria);
+bool criteria_any(struct sway_container *cont, list_t *criteria);
 
 #endif

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -1,7 +1,7 @@
 #ifndef _SWAY_CRITERIA_H
 #define _SWAY_CRITERIA_H
 
-#include "container.h"
+#include "tree/container.h"
 #include "list.h"
 
 /**

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -31,10 +31,10 @@ struct sway_input_manager *sway_input_manager_create(
 		struct sway_server *server);
 
 bool sway_input_manager_has_focus(struct sway_input_manager *input,
-		swayc_t *container);
+		struct sway_container *container);
 
 void sway_input_manager_set_focus(struct sway_input_manager *input,
-		swayc_t *container);
+		struct sway_container *container);
 
 void sway_input_manager_configure_xcursor(struct sway_input_manager *input);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -14,7 +14,7 @@ struct sway_seat_device {
 
 struct sway_seat_container {
 	struct sway_seat *seat;
-	swayc_t *container;
+	struct sway_container *container;
 
 	struct wl_list link; // sway_seat::focus_stack
 
@@ -54,9 +54,9 @@ void sway_seat_remove_device(struct sway_seat *seat,
 
 void sway_seat_configure_xcursor(struct sway_seat *seat);
 
-void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container);
+void sway_seat_set_focus(struct sway_seat *seat, struct sway_container *container);
 
-swayc_t *sway_seat_get_focus(struct sway_seat *seat);
+struct sway_container *sway_seat_get_focus(struct sway_seat *seat);
 
 /**
  * Return the last container to be focused for the seat (or the most recently
@@ -67,9 +67,10 @@ swayc_t *sway_seat_get_focus(struct sway_seat *seat);
  * is destroyed, or focus moves to a container with children and we need to
  * descend into the next leaf in focus order.
  */
-swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container);
+struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat,
+		struct sway_container *container);
 
-swayc_t *sway_seat_get_focus_by_type(struct sway_seat *seat,
+struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
 		enum swayc_types type);
 
 void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -71,7 +71,7 @@ struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat,
 		struct sway_container *container);
 
 struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
-		enum swayc_types type);
+		enum sway_container_type type);
 
 void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
 

--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -1,7 +1,7 @@
 #ifndef _SWAY_IPC_JSON_H
 #define _SWAY_IPC_JSON_H
 #include <json-c/json.h>
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/input/input-manager.h"
 
 json_object *ipc_json_get_version();

--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -6,8 +6,8 @@
 
 json_object *ipc_json_get_version();
 
-json_object *ipc_json_describe_container(swayc_t *c);
-json_object *ipc_json_describe_container_recursive(swayc_t *c);
+json_object *ipc_json_describe_container(struct sway_container *c);
+json_object *ipc_json_describe_container_recursive(struct sway_container *c);
 json_object *ipc_json_describe_input(struct sway_input_device *device);
 
 #endif

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -1,13 +1,15 @@
 #ifndef _SWAY_IPC_SERVER_H
 #define _SWAY_IPC_SERVER_H
 #include <sys/socket.h>
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "ipc.h"
 
 struct sway_server;
 
 void ipc_init(struct sway_server *server);
+
 void ipc_terminate(void);
+
 struct sockaddr_un *ipc_user_sockaddr(void);
 
 void ipc_event_window(swayc_t *window, const char *change);

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -12,6 +12,6 @@ void ipc_terminate(void);
 
 struct sockaddr_un *ipc_user_sockaddr(void);
 
-void ipc_event_window(swayc_t *window, const char *change);
+void ipc_event_window(struct sway_container *window, const char *change);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -88,41 +88,38 @@ struct sway_container {
 };
 
 // TODO only one container create function and pass the type?
-struct sway_container *sway_container_output_create(
+struct sway_container *container_output_create(
 		struct sway_output *sway_output);
 
-struct sway_container *sway_container_workspace_create(
+struct sway_container *container_workspace_create(
 		struct sway_container *output, const char *name);
 
-struct sway_container *sway_container_view_create(
+struct sway_container *container_view_create(
 		struct sway_container *sibling, struct sway_view *sway_view);
 
-struct sway_container *sway_container_output_destroy(
+struct sway_container *container_output_destroy(
 		struct sway_container *output);
 
-struct sway_container *sway_container_view_destroy(struct sway_container *view);
+struct sway_container *container_view_destroy(struct sway_container *view);
 
-struct sway_container *sway_container_set_layout(
+struct sway_container *container_set_layout(
 		struct sway_container *container, enum sway_container_layout layout);
 
-void sway_container_descendents(struct sway_container *root,
+void container_descendents(struct sway_container *root,
 		enum sway_container_type type,
 		void (*func)(struct sway_container *item, void *data), void *data);
-
-// XXX: what is this?
-struct sway_container *next_view_sibling(struct sway_seat *seat);
 
 /**
  * Finds a container based on test criteria. Returns the first container that
  * passes the test.
  */
-struct sway_container *sway_container_find(struct sway_container *container,
+struct sway_container *container_find(struct sway_container *container,
 		bool (*test)(struct sway_container *view, void *data), void *data);
 
 /**
  * Finds a parent container with the given struct sway_containerype.
  */
-struct sway_container *sway_container_parent(struct sway_container *container,
+struct sway_container *container_parent(struct sway_container *container,
 		enum sway_container_type type);
 
 /**

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -20,60 +20,43 @@ struct sway_seat;
  * it on this list.
  */
 enum swayc_types {
-	C_ROOT,      /**< The root container. Only one of these ever exists. */
-	C_OUTPUT,    /**< An output (aka monitor, head, etc). */
-	C_WORKSPACE, /**< A workspace. */
-	C_CONTAINER, /**< A manually created container. */
-	C_VIEW,      /**< A view (aka window). */
+	C_ROOT,
+	C_OUTPUT,
+	C_WORKSPACE,
+	C_CONTAINER,
+	C_VIEW,
 
 	C_TYPES,
 };
 
-/**
- * Different ways to arrange a container.
- */
 enum swayc_layouts {
-	L_NONE,     /**< Used for containers that have no layout (views, root) */
+	L_NONE,
 	L_HORIZ,
 	L_VERT,
 	L_STACKED,
 	L_TABBED,
-	L_FLOATING, /**< A psuedo-container, removed from the tree, to hold floating windows */
-
-	/* Awesome/Monad style auto layouts */
-	L_AUTO_LEFT,
-	L_AUTO_RIGHT,
-	L_AUTO_TOP,
-	L_AUTO_BOTTOM,
-
-	L_AUTO_FIRST = L_AUTO_LEFT,
-	L_AUTO_LAST = L_AUTO_BOTTOM,
+	L_FLOATING,
 
 	// Keep last
 	L_LAYOUTS,
 };
 
 enum swayc_border_types {
-	B_NONE,   /**< No border */
-	B_PIXEL,  /**< 1px border */
-	B_NORMAL, /**< Normal border with title bar */
+	B_NONE,
+	B_PIXEL,
+	B_NORMAL,
 };
 
 struct sway_root;
 struct sway_output;
 struct sway_view;
 
-/**
- * Stores information about a container.
- *
- * The tree is made of these. Views are containers that cannot have children.
- */
 struct sway_container {
 	union {
 		// TODO: Encapsulate state for other node types as well like C_CONTAINER
-		struct sway_root *sway_root;             // C_ROOT
-		struct sway_output *sway_output;         // C_OUTPUT
-		struct sway_view *sway_view;             // C_VIEW
+		struct sway_root *sway_root;
+		struct sway_output *sway_output;
+		struct sway_view *sway_view;
 	};
 
 	/**
@@ -89,38 +72,17 @@ struct sway_container {
 	enum swayc_layouts prev_layout;
 	enum swayc_layouts workspace_layout;
 
-	/**
-	 * The coordinates that this view appear at, relative to the output they
-	 * are located on (output containers have absolute coordinates).
-	 */
+    // TODO convert to layout coordinates
 	double x, y;
 
-	/**
-	 * Width and height of this container, without borders or gaps.
-	 */
+    // does not include borders or gaps.
 	double width, height;
 
 	list_t *children;
 
-	/**
-	 * The parent of this container. NULL for the root container.
-	 */
 	struct sway_container *parent;
 
-	/**
-	 * Number of master views in auto layouts.
-	 */
-	size_t nb_master;
-
-	/**
-	 * Number of slave groups (e.g. columns) in auto layouts.
-	 */
-	size_t nb_slave_groups;
-
-	/**
-	 * Marks applied to the container, list_t of char*.
-	 */
-	list_t *marks;
+	list_t *marks; // list of char*
 
 	struct {
 		struct wl_signal destroy;
@@ -130,8 +92,11 @@ struct sway_container {
 void swayc_descendants_of_type(swayc_t *root, enum swayc_types type,
 		void (*func)(swayc_t *item, void *data), void *data);
 
+// TODO only one container create function and pass the type?
 swayc_t *new_output(struct sway_output *sway_output);
+
 swayc_t *new_workspace(swayc_t *output, const char *name);
+
 swayc_t *new_view(swayc_t *sibling, struct sway_view *sway_view);
 
 swayc_t *destroy_output(swayc_t *output);
@@ -145,10 +110,12 @@ swayc_t *next_view_sibling(struct sway_seat *seat);
  */
 swayc_t *swayc_by_test(swayc_t *container,
 		bool (*test)(swayc_t *view, void *data), void *data);
+
 /**
  * Finds a parent container with the given swayc_type.
  */
 swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types type);
+
 /**
  * Maps a container's children over a function.
  */

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -17,7 +17,7 @@ struct sway_seat;
  * This enum is in order. A container will never be inside of a container below
  * it on this list.
  */
-enum swayc_types {
+enum sway_container_type {
 	C_ROOT,
 	C_OUTPUT,
 	C_WORKSPACE,
@@ -27,7 +27,7 @@ enum swayc_types {
 	C_TYPES,
 };
 
-enum swayc_layouts {
+enum sway_container_layout {
 	L_NONE,
 	L_HORIZ,
 	L_VERT,
@@ -39,7 +39,7 @@ enum swayc_layouts {
 	L_LAYOUTS,
 };
 
-enum swayc_border_types {
+enum sway_container_border {
 	B_NONE,
 	B_PIXEL,
 	B_NORMAL,
@@ -65,10 +65,10 @@ struct sway_container {
 
 	char *name;
 
-	enum swayc_types type;
-	enum swayc_layouts layout;
-	enum swayc_layouts prev_layout;
-	enum swayc_layouts workspace_layout;
+	enum sway_container_type type;
+	enum sway_container_layout layout;
+	enum sway_container_layout prev_layout;
+	enum sway_container_layout workspace_layout;
 
     // TODO convert to layout coordinates
 	double x, y;
@@ -87,53 +87,61 @@ struct sway_container {
 	} events;
 };
 
-void swayc_descendants_of_type(struct sway_container *root,
-		enum swayc_types type,
+// TODO only one container create function and pass the type?
+struct sway_container *sway_container_output_create(
+		struct sway_output *sway_output);
+
+struct sway_container *sway_container_workspace_create(
+		struct sway_container *output, const char *name);
+
+struct sway_container *sway_container_view_create(
+		struct sway_container *sibling, struct sway_view *sway_view);
+
+struct sway_container *sway_container_output_destroy(
+		struct sway_container *output);
+
+struct sway_container *sway_container_view_destroy(struct sway_container *view);
+
+struct sway_container *sway_container_set_layout(
+		struct sway_container *container, enum sway_container_layout layout);
+
+void sway_container_descendents(struct sway_container *root,
+		enum sway_container_type type,
 		void (*func)(struct sway_container *item, void *data), void *data);
 
-// TODO only one container create function and pass the type?
-struct sway_container *new_output(struct sway_output *sway_output);
-
-struct sway_container *new_workspace(struct sway_container *output,
-		const char *name);
-
-struct sway_container *new_view(struct sway_container *sibling,
-		struct sway_view *sway_view);
-
-struct sway_container *destroy_output(struct sway_container *output);
-struct sway_container *destroy_view(struct sway_container *view);
-
+// XXX: what is this?
 struct sway_container *next_view_sibling(struct sway_seat *seat);
 
 /**
  * Finds a container based on test criteria. Returns the first container that
  * passes the test.
  */
-struct sway_container *swayc_by_test(struct sway_container *container,
+struct sway_container *sway_container_find(struct sway_container *container,
 		bool (*test)(struct sway_container *view, void *data), void *data);
 
 /**
- * Finds a parent container with the given swayc_type.
+ * Finds a parent container with the given struct sway_containerype.
  */
-struct sway_container *swayc_parent_by_type(struct sway_container *container,
-		enum swayc_types type);
+struct sway_container *sway_container_parent(struct sway_container *container,
+		enum sway_container_type type);
 
 /**
- * Maps a container's children over a function.
+ * Run a function for each child.
  */
-void container_map(struct sway_container *container,
+void sway_container_for_each(struct sway_container *container,
 		void (*f)(struct sway_container *view, void *data), void *data);
 
-struct sway_container *swayc_at(struct sway_container *parent, double lx,
-		double ly, struct wlr_surface **surface, double *sx, double *sy);
+/**
+ * Find a container at the given coordinates.
+ */
+struct sway_container *sway_container_at(struct sway_container *parent,
+		double lx, double ly, struct wlr_surface **surface,
+		double *sx, double *sy);
 
 /**
  * Apply the function for each child of the container breadth first.
  */
-void container_for_each_bfs(struct sway_container *con, void (*f)(struct
-			sway_container *con, void *data), void *data);
-
-struct sway_container *swayc_change_layout(struct sway_container *container,
-		enum swayc_layouts layout);
+void sway_container_for_each_bfs(struct sway_container *container,
+		void (*f)(struct sway_container *container, void *data), void *data);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -131,7 +131,7 @@ struct sway_container *container_at(struct sway_container *parent,
 /**
  * Apply the function for each child of the container breadth first.
  */
-void container_for_each(struct sway_container *container,
+void container_for_each_descendent(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data), void *data);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -70,10 +70,10 @@ struct sway_container {
 	enum sway_container_layout prev_layout;
 	enum sway_container_layout workspace_layout;
 
-    // TODO convert to layout coordinates
+	// TODO convert to layout coordinates
 	double x, y;
 
-    // does not include borders or gaps.
+	// does not include borders or gaps.
 	double width, height;
 
 	list_t *children;
@@ -122,22 +122,16 @@ struct sway_container *container_parent(struct sway_container *container,
 		enum sway_container_type type);
 
 /**
- * Run a function for each child.
- */
-void sway_container_for_each(struct sway_container *container,
-		void (*f)(struct sway_container *view, void *data), void *data);
-
-/**
  * Find a container at the given coordinates.
  */
-struct sway_container *sway_container_at(struct sway_container *parent,
+struct sway_container *container_at(struct sway_container *parent,
 		double lx, double ly, struct wlr_surface **surface,
 		double *sx, double *sy);
 
 /**
  * Apply the function for each child of the container breadth first.
  */
-void sway_container_for_each_bfs(struct sway_container *container,
+void container_for_each(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data), void *data);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -97,13 +97,12 @@ struct sway_container *container_workspace_create(
 struct sway_container *container_view_create(
 		struct sway_container *sibling, struct sway_view *sway_view);
 
-struct sway_container *container_output_destroy(
-		struct sway_container *output);
+struct sway_container *container_output_destroy(struct sway_container *output);
 
 struct sway_container *container_view_destroy(struct sway_container *view);
 
-struct sway_container *container_set_layout(
-		struct sway_container *container, enum sway_container_layout layout);
+struct sway_container *container_set_layout(struct sway_container *container,
+		enum sway_container_layout layout);
 
 void container_descendents(struct sway_container *root,
 		enum sway_container_type type,

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -6,9 +6,7 @@
 #include <wlr/types/wlr_surface.h>
 #include "list.h"
 
-typedef struct sway_container swayc_t;
-
-extern swayc_t root_container;
+extern struct sway_container root_container;
 
 struct sway_view;
 struct sway_seat;
@@ -89,48 +87,53 @@ struct sway_container {
 	} events;
 };
 
-void swayc_descendants_of_type(swayc_t *root, enum swayc_types type,
-		void (*func)(swayc_t *item, void *data), void *data);
+void swayc_descendants_of_type(struct sway_container *root,
+		enum swayc_types type,
+		void (*func)(struct sway_container *item, void *data), void *data);
 
 // TODO only one container create function and pass the type?
-swayc_t *new_output(struct sway_output *sway_output);
+struct sway_container *new_output(struct sway_output *sway_output);
 
-swayc_t *new_workspace(swayc_t *output, const char *name);
+struct sway_container *new_workspace(struct sway_container *output,
+		const char *name);
 
-swayc_t *new_view(swayc_t *sibling, struct sway_view *sway_view);
+struct sway_container *new_view(struct sway_container *sibling,
+		struct sway_view *sway_view);
 
-swayc_t *destroy_output(swayc_t *output);
-swayc_t *destroy_view(swayc_t *view);
+struct sway_container *destroy_output(struct sway_container *output);
+struct sway_container *destroy_view(struct sway_container *view);
 
-swayc_t *next_view_sibling(struct sway_seat *seat);
+struct sway_container *next_view_sibling(struct sway_seat *seat);
 
 /**
  * Finds a container based on test criteria. Returns the first container that
  * passes the test.
  */
-swayc_t *swayc_by_test(swayc_t *container,
-		bool (*test)(swayc_t *view, void *data), void *data);
+struct sway_container *swayc_by_test(struct sway_container *container,
+		bool (*test)(struct sway_container *view, void *data), void *data);
 
 /**
  * Finds a parent container with the given swayc_type.
  */
-swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types type);
+struct sway_container *swayc_parent_by_type(struct sway_container *container,
+		enum swayc_types type);
 
 /**
  * Maps a container's children over a function.
  */
-void container_map(swayc_t *container,
-		void (*f)(swayc_t *view, void *data), void *data);
+void container_map(struct sway_container *container,
+		void (*f)(struct sway_container *view, void *data), void *data);
 
-swayc_t *swayc_at(swayc_t *parent, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
+struct sway_container *swayc_at(struct sway_container *parent, double lx,
+		double ly, struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * Apply the function for each child of the container breadth first.
  */
-void container_for_each_bfs(swayc_t *con, void (*f)(swayc_t *con, void *data),
-		void *data);
+void container_for_each_bfs(struct sway_container *con, void (*f)(struct
+			sway_container *con, void *data), void *data);
 
-swayc_t *swayc_change_layout(swayc_t *container, enum swayc_layouts layout);
+struct sway_container *swayc_change_layout(struct sway_container *container,
+		enum swayc_layouts layout);
 
 #endif

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -34,7 +34,8 @@ void init_layout(void);
 
 void add_child(struct sway_container *parent, struct sway_container *child);
 
-swayc_t *add_sibling(swayc_t *parent, swayc_t *child);
+struct sway_container *add_sibling(struct sway_container *parent,
+		struct sway_container *child);
 
 struct sway_container *remove_child(struct sway_container *child);
 
@@ -45,7 +46,7 @@ void sort_workspaces(struct sway_container *output);
 void arrange_windows(struct sway_container *container,
 		double width, double height);
 
-swayc_t *get_swayc_in_direction(swayc_t *container,
-		struct sway_seat *seat, enum movement_direction dir);
+struct sway_container *get_swayc_in_direction(struct sway_container
+		*container, struct sway_seat *seat, enum movement_direction dir);
 
 #endif

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -43,7 +43,7 @@ enum sway_container_layout container_get_default_layout(struct sway_container *o
 
 void container_sort_workspaces(struct sway_container *output);
 
-void container_arrange_windows(struct sway_container *container,
+void arrange_windows(struct sway_container *container,
 		double width, double height);
 
 struct sway_container *container_get_in_direction(struct sway_container

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -30,23 +30,23 @@ struct sway_root {
 	} events;
 };
 
-void init_layout(void);
+void layout_init(void);
 
-void add_child(struct sway_container *parent, struct sway_container *child);
+void container_add_child(struct sway_container *parent, struct sway_container *child);
 
-struct sway_container *add_sibling(struct sway_container *parent,
+struct sway_container *container_add_sibling(struct sway_container *parent,
 		struct sway_container *child);
 
-struct sway_container *remove_child(struct sway_container *child);
+struct sway_container *container_remove_child(struct sway_container *child);
 
-enum sway_container_layout default_layout(struct sway_container *output);
+enum sway_container_layout container_get_default_layout(struct sway_container *output);
 
-void sort_workspaces(struct sway_container *output);
+void container_sort_workspaces(struct sway_container *output);
 
-void arrange_windows(struct sway_container *container,
+void container_arrange_windows(struct sway_container *container,
 		double width, double height);
 
-struct sway_container *get_swayc_in_direction(struct sway_container
+struct sway_container *container_get_in_direction(struct sway_container
 		*container, struct sway_seat *seat, enum movement_direction dir);
 
 #endif

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -2,7 +2,7 @@
 #define _SWAY_LAYOUT_H
 
 #include <wlr/types/wlr_output_layout.h>
-#include "sway/container.h"
+#include "sway/tree/container.h"
 
 enum movement_direction {
 	MOVE_LEFT,
@@ -31,12 +31,20 @@ struct sway_root {
 };
 
 void init_layout(void);
+
 void add_child(struct sway_container *parent, struct sway_container *child);
+
 swayc_t *add_sibling(swayc_t *parent, swayc_t *child);
+
 struct sway_container *remove_child(struct sway_container *child);
+
 enum swayc_layouts default_layout(struct sway_container *output);
+
 void sort_workspaces(struct sway_container *output);
-void arrange_windows(struct sway_container *container, double width, double height);
+
+void arrange_windows(struct sway_container *container,
+		double width, double height);
+
 swayc_t *get_swayc_in_direction(swayc_t *container,
 		struct sway_seat *seat, enum movement_direction dir);
 

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -39,7 +39,7 @@ struct sway_container *add_sibling(struct sway_container *parent,
 
 struct sway_container *remove_child(struct sway_container *child);
 
-enum swayc_layouts default_layout(struct sway_container *output);
+enum sway_container_layout default_layout(struct sway_container *output);
 
 void sort_workspaces(struct sway_container *output);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -62,10 +62,6 @@ enum sway_view_prop {
 	VIEW_PROP_INSTANCE,
 };
 
-/**
- * sway_view is a state container for surfaces that are arranged in the sway
- * tree (shell surfaces).
- */
 struct sway_view {
 	enum sway_view_type type;
 	struct sway_container *swayc;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -7,20 +7,20 @@ extern char *prev_workspace_name;
 
 char *workspace_next_name(const char *output_name);
 
-swayc_t *workspace_create(const char *name);
+struct sway_container *workspace_create(const char *name);
 
-bool workspace_switch(swayc_t *workspace);
+bool workspace_switch(struct sway_container *workspace);
 
 struct sway_container *workspace_by_number(const char* name);
 
-swayc_t *workspace_by_name(const char*);
+struct sway_container *workspace_by_name(const char*);
 
-struct sway_container *workspace_output_next(swayc_t *current);
+struct sway_container *workspace_output_next(struct sway_container *current);
 
-struct sway_container *workspace_next(swayc_t *current);
+struct sway_container *workspace_next(struct sway_container *current);
 
-struct sway_container *workspace_output_prev(swayc_t *current);
+struct sway_container *workspace_output_prev(struct sway_container *current);
 
-struct sway_container *workspace_prev(swayc_t *current);
+struct sway_container *workspace_prev(struct sway_container *current);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -1,20 +1,26 @@
 #ifndef _SWAY_WORKSPACE_H
 #define _SWAY_WORKSPACE_H
 
-#include "sway/container.h"
+#include "sway/tree/container.h"
 
 extern char *prev_workspace_name;
 
 char *workspace_next_name(const char *output_name);
+
 swayc_t *workspace_create(const char *name);
+
 bool workspace_switch(swayc_t *workspace);
 
 struct sway_container *workspace_by_number(const char* name);
+
 swayc_t *workspace_by_name(const char*);
 
 struct sway_container *workspace_output_next(swayc_t *current);
+
 struct sway_container *workspace_next(swayc_t *current);
+
 struct sway_container *workspace_output_prev(swayc_t *current);
+
 struct sway_container *workspace_prev(swayc_t *current);
 
 #endif

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -6,8 +6,8 @@
 #include <unistd.h>
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/container.h"
-#include "sway/workspace.h"
+#include "sway/tree/container.h"
+#include "sway/tree/workspace.h"
 #include "log.h"
 #include "stringop.h"
 

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -51,7 +51,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 				"Expected 'focus <direction|parent|child|mode_toggle>' or 'focus output <direction|name>'");
 	}
 
-	struct sway_container *next_focus = get_swayc_in_direction(con, seat, direction);
+	struct sway_container *next_focus = container_get_in_direction(con, seat, direction);
 	if (next_focus) {
 		sway_seat_set_focus(seat, next_focus);
 	}

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -3,10 +3,11 @@
 #include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/commands.h"
 
-static bool parse_movement_direction(const char *name, enum movement_direction *out) {
+static bool parse_movement_direction(const char *name,
+		enum movement_direction *out) {
 	if (strcasecmp(name, "left") == 0) {
 		*out = MOVE_LEFT;
 	} else if (strcasecmp(name, "right") == 0) {

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -32,7 +32,7 @@ static bool parse_movement_direction(const char *name,
 }
 
 struct cmd_results *cmd_focus(int argc, char **argv) {
-	swayc_t *con = config->handler_context.current_container;
+	struct sway_container *con = config->handler_context.current_container;
 	struct sway_seat *seat = config->handler_context.seat;
 	if (con->type < C_WORKSPACE) {
 		return cmd_results_new(CMD_FAILURE, "focus",
@@ -51,7 +51,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 				"Expected 'focus <direction|parent|child|mode_toggle>' or 'focus output <direction|name>'");
 	}
 
-	swayc_t *next_focus = get_swayc_in_direction(con, seat, direction);
+	struct sway_container *next_focus = get_swayc_in_direction(con, seat, direction);
 	if (next_focus) {
 		sway_seat_set_focus(seat, next_focus);
 	}

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -6,7 +6,7 @@
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
-	enum swayc_types type = config->handler_context.current_container->type;
+	enum sway_container_type type = config->handler_context.current_container->type;
 	if (type != C_VIEW && type != C_CONTAINER) {
 		return cmd_results_new(CMD_INVALID, NULL,
 				"Can only kill views and containers with this command");

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -2,7 +2,7 @@
 #include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/commands.h"
 
 struct cmd_results *cmd_kill(int argc, char **argv) {

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -10,7 +10,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	if ((error = checkarg(argc, "layout", EXPECTED_MORE_THAN, 0))) {
 		return error;
 	}
-	swayc_t *parent = config->handler_context.current_container;
+	struct sway_container *parent = config->handler_context.current_container;
 
 	// TODO: floating
 	/*
@@ -28,7 +28,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	if (strcasecmp(argv[0], "default") == 0) {
 		swayc_change_layout(parent, parent->prev_layout);
 		if (parent->layout == L_NONE) {
-			swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
+			struct sway_container *output = sway_container_parent(parent, C_OUTPUT);
 			swayc_change_layout(parent, default_layout(output));
 		}
 	} else {

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
-#include "sway/container.h"
-#include "sway/layout.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
 #include "log.h"
 
 struct cmd_results *cmd_layout(int argc, char **argv) {

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -50,7 +50,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 	}
 
-	container_arrange_windows(parent, parent->width, parent->height);
+	arrange_windows(parent, parent->width, parent->height);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -26,10 +26,10 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	// TODO: stacks and tabs
 
 	if (strcasecmp(argv[0], "default") == 0) {
-		swayc_change_layout(parent, parent->prev_layout);
+		container_set_layout(parent, parent->prev_layout);
 		if (parent->layout == L_NONE) {
-			struct sway_container *output = sway_container_parent(parent, C_OUTPUT);
-			swayc_change_layout(parent, default_layout(output));
+			struct sway_container *output = container_parent(parent, C_OUTPUT);
+			container_set_layout(parent, container_get_default_layout(output));
 		}
 	} else {
 		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
@@ -37,20 +37,20 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 
 		if (strcasecmp(argv[0], "splith") == 0) {
-			swayc_change_layout(parent, L_HORIZ);
+			container_set_layout(parent, L_HORIZ);
 		} else if (strcasecmp(argv[0], "splitv") == 0) {
-			swayc_change_layout(parent, L_VERT);
+			container_set_layout(parent, L_VERT);
 		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
 			if (parent->layout == L_HORIZ && (parent->workspace_layout == L_NONE
 					|| parent->workspace_layout == L_HORIZ)) {
-				swayc_change_layout(parent, L_VERT);
+				container_set_layout(parent, L_VERT);
 			} else {
-				swayc_change_layout(parent, L_HORIZ);
+				container_set_layout(parent, L_HORIZ);
 			}
 		}
 	}
 
-	arrange_windows(parent, parent->width, parent->height);
+	container_arrange_windows(parent, parent->width, parent->height);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -296,7 +296,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	char identifier[128];
 	bool all = strcmp(output->name, "*") == 0;
 	for (int i = 0; i < root_container.children->length; ++i) {
-		swayc_t *cont = root_container.children->items[i];
+		struct sway_container *cont = root_container.children->items[i];
 		if (cont->type != C_OUTPUT) {
 			continue;
 		}

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -13,6 +13,6 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 
 	/* load_swaybars(); -- for when it's implemented */
 
-	arrange_windows(&root_container, -1, -1);
+	container_arrange_windows(&root_container, -1, -1);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -1,6 +1,6 @@
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 
 struct cmd_results *cmd_reload(int argc, char **argv) {
 	struct cmd_results *error = NULL;

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -13,6 +13,6 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 
 	/* load_swaybars(); -- for when it's implemented */
 
-	container_arrange_windows(&root_container, -1, -1);
+	arrange_windows(&root_container, -1, -1);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -4,7 +4,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/input/seat.h"
-#include "sway/workspace.h"
+#include "sway/tree/workspace.h"
 #include "list.h"
 #include "log.h"
 #include "stringop.h"

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -17,15 +17,15 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 
 	int output_location = -1;
 
-	swayc_t *current_container = config->handler_context.current_container;
-	swayc_t *old_workspace = NULL, *old_output = NULL;
+	struct sway_container *current_container = config->handler_context.current_container;
+	struct sway_container *old_workspace = NULL, *old_output = NULL;
 	if (current_container) {
 		if (current_container->type == C_WORKSPACE) {
 			old_workspace = current_container;
 		} else {
-			old_workspace = swayc_parent_by_type(current_container, C_WORKSPACE);
+			old_workspace = sway_container_parent(current_container, C_WORKSPACE);
 		}
-		old_output = swayc_parent_by_type(current_container, C_OUTPUT);
+		old_output = sway_container_parent(current_container, C_OUTPUT);
 	}
 
 	for (int i = 0; i < argc; ++i) {
@@ -57,7 +57,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, "workspace", NULL);
 		}
-		swayc_t *ws = NULL;
+		struct sway_container *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
 			if (!(ws = workspace_by_number(argv[1]))) {
 				char *name = join_args(argv + 1, argc - 1);
@@ -92,7 +92,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		workspace_switch(ws);
 		current_container =
 			sway_seat_get_focus(config->handler_context.seat);
-		swayc_t *new_output = swayc_parent_by_type(current_container, C_OUTPUT);
+		struct sway_container *new_output = sway_container_parent(current_container, C_OUTPUT);
 
 		if (config->mouse_warping && old_output != new_output) {
 			// TODO: Warp mouse

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -23,9 +23,9 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		if (current_container->type == C_WORKSPACE) {
 			old_workspace = current_container;
 		} else {
-			old_workspace = sway_container_parent(current_container, C_WORKSPACE);
+			old_workspace = container_parent(current_container, C_WORKSPACE);
 		}
-		old_output = sway_container_parent(current_container, C_OUTPUT);
+		old_output = container_parent(current_container, C_OUTPUT);
 	}
 
 	for (int i = 0; i < argc; ++i) {
@@ -92,7 +92,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		workspace_switch(ws);
 		current_container =
 			sway_seat_get_focus(config->handler_context.seat);
-		struct sway_container *new_output = sway_container_parent(current_container, C_OUTPUT);
+		struct sway_container *new_output = container_parent(current_container, C_OUTPUT);
 
 		if (config->mouse_warping && old_output != new_output) {
 			// TODO: Warp mouse

--- a/sway/config.c
+++ b/sway/config.c
@@ -24,7 +24,7 @@
 #include "sway/input/seat.h"
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 #include "readline.h"
 #include "stringop.h"
 #include "list.h"

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -127,7 +127,7 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 	if (oc && oc->enabled == 0) {
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);
-		sway_container_output_destroy(output);
+		container_output_destroy(output);
 		return;
 	}
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -120,14 +120,14 @@ void terminate_swaybg(pid_t pid) {
 	}
 }
 
-void apply_output_config(struct output_config *oc, swayc_t *output) {
+void apply_output_config(struct output_config *oc, struct sway_container *output) {
 	assert(output->type == C_OUTPUT);
 
 	struct wlr_output *wlr_output = output->sway_output->wlr_output;
 	if (oc && oc->enabled == 0) {
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);
-		destroy_output(output);
+		sway_container_output_destroy(output);
 		return;
 	}
 

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -272,7 +272,7 @@ static int regex_cmp(const char *item, const pcre *regex) {
 }
 
 // test a single view if it matches list of criteria tokens (all of them).
-static bool criteria_test(swayc_t *cont, list_t *tokens) {
+static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 	if (cont->type != C_VIEW) {
 		return false;
 	}
@@ -398,7 +398,7 @@ void free_criteria(struct criteria *crit) {
 	free(crit);
 }
 
-bool criteria_any(swayc_t *cont, list_t *criteria) {
+bool criteria_any(struct sway_container *cont, list_t *criteria) {
 	for (int i = 0; i < criteria->length; i++) {
 		struct criteria *bc = criteria->items[i];
 		if (criteria_test(cont, bc->tokens)) {
@@ -408,7 +408,7 @@ bool criteria_any(swayc_t *cont, list_t *criteria) {
 	return false;
 }
 
-list_t *criteria_for(swayc_t *cont) {
+list_t *criteria_for(struct sway_container *cont) {
 	list_t *criteria = config->criteria, *matches = create_list();
 	for (int i = 0; i < criteria->length; i++) {
 		struct criteria *bc = criteria->items[i];
@@ -424,7 +424,7 @@ struct list_tokens {
 	list_t *tokens;
 };
 
-static void container_match_add(swayc_t *container,
+static void container_match_add(struct sway_container *container,
 		struct list_tokens *list_tokens) {
 	if (criteria_test(container, list_tokens->tokens)) {
 		list_add(list_tokens->list, container);
@@ -435,8 +435,8 @@ list_t *container_for_crit_tokens(list_t *tokens) {
 	struct list_tokens list_tokens =
 		(struct list_tokens){create_list(), tokens};
 
-	container_map(&root_container,
-		(void (*)(swayc_t *, void *))container_match_add,
+	sway_container_for_each(&root_container,
+		(void (*)(struct sway_container *, void *))container_match_add,
 		&list_tokens);
 
 	// TODO look in the scratchpad

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -4,9 +4,9 @@
 #include <stdbool.h>
 #include <pcre.h>
 #include "sway/criteria.h"
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/config.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "stringop.h"
 #include "list.h"
 #include "log.h"

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -435,7 +435,7 @@ list_t *container_for_crit_tokens(list_t *tokens) {
 	struct list_tokens list_tokens =
 		(struct list_tokens){create_list(), tokens};
 
-	sway_container_for_each(&root_container,
+	container_for_each(&root_container,
 		(void (*)(struct sway_container *, void *))container_match_add,
 		&list_tokens);
 

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -435,7 +435,7 @@ list_t *container_for_crit_tokens(list_t *tokens) {
 	struct list_tokens list_tokens =
 		(struct list_tokens){create_list(), tokens};
 
-	container_for_each(&root_container,
+	container_for_each_descendent(&root_container,
 		(void (*)(struct sway_container *, void *))container_match_add,
 		&list_tokens);
 

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -172,7 +172,7 @@ void arrange_layers(struct sway_output *output) {
 	if (memcmp(&usable_area_before,
 			&usable_area, sizeof(struct wlr_box)) != 0) {
 		wlr_log(L_DEBUG, "arrange");
-		arrange_windows(output->swayc, -1, -1);
+		container_arrange_windows(output->swayc, -1, -1);
 	}
 
 	// Arrange non-exlusive surfaces from top->bottom

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -7,7 +7,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 #include "sway/layers.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 #include "sway/output.h"
 #include "sway/server.h"
 

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -172,7 +172,7 @@ void arrange_layers(struct sway_output *output) {
 	if (memcmp(&usable_area_before,
 			&usable_area, sizeof(struct wlr_box)) != 0) {
 		wlr_log(L_DEBUG, "arrange");
-		container_arrange_windows(output->swayc, -1, -1);
+		arrange_windows(output->swayc, -1, -1);
 	}
 
 	// Arrange non-exlusive surfaces from top->bottom

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -11,14 +11,14 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_wl_shell.h>
 #include "log.h"
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/layers.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 #include "sway/output.h"
 #include "sway/server.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 
 /**
  * Rotate a child's position relative to a parent. The parent size is (pw, ph),

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -264,7 +264,7 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 static void handle_output_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
 	arrange_layers(output);
-	container_arrange_windows(output->swayc, -1, -1);
+	arrange_windows(output->swayc, -1, -1);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {
@@ -307,5 +307,5 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->mode.notify = handle_output_mode;
 
 	arrange_layers(output);
-	container_arrange_windows(&root_container, -1, -1);
+	arrange_windows(&root_container, -1, -1);
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -221,13 +221,13 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, soutput->swayc);
 	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
-			sway_container_parent(focus, C_WORKSPACE));
+			container_parent(focus, C_WORKSPACE));
 
 	struct render_data rdata = {
 		.output = soutput,
 		.now = &now,
 	};
-	sway_container_descendents(workspace, C_VIEW, output_frame_view, &rdata);
+	container_descendents(workspace, C_VIEW, output_frame_view, &rdata);
 
 	// render unmanaged views on top
 	struct sway_view *view;
@@ -258,13 +258,13 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = data;
 	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
 
-	sway_container_output_destroy(output->swayc);
+	container_output_destroy(output->swayc);
 }
 
 static void handle_output_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
 	arrange_layers(output);
-	arrange_windows(output->swayc, -1, -1);
+	container_arrange_windows(output->swayc, -1, -1);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {
@@ -286,7 +286,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		wlr_output_set_mode(wlr_output, mode);
 	}
 
-	output->swayc = sway_container_output_create(output);
+	output->swayc = container_output_create(output);
 	if (!output->swayc) {
 		free(output);
 		return;
@@ -307,5 +307,5 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->mode.notify = handle_output_mode;
 
 	arrange_layers(output);
-	arrange_windows(&root_container, -1, -1);
+	container_arrange_windows(&root_container, -1, -1);
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -145,7 +145,7 @@ struct render_data {
 	struct timespec *now;
 };
 
-static void output_frame_view(swayc_t *view, void *data) {
+static void output_frame_view(struct sway_container *view, void *data) {
 	struct render_data *rdata = data;
 	struct sway_output *output = rdata->output;
 	struct timespec *now = rdata->now;
@@ -218,16 +218,16 @@ static void output_frame_notify(struct wl_listener *listener, void *data) {
 			&soutput->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, soutput->swayc);
-	swayc_t *workspace = (focus->type == C_WORKSPACE ?
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, soutput->swayc);
+	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
-			swayc_parent_by_type(focus, C_WORKSPACE));
+			sway_container_parent(focus, C_WORKSPACE));
 
 	struct render_data rdata = {
 		.output = soutput,
 		.now = &now,
 	};
-	swayc_descendants_of_type(workspace, C_VIEW, output_frame_view, &rdata);
+	sway_container_descendents(workspace, C_VIEW, output_frame_view, &rdata);
 
 	// render unmanaged views on top
 	struct sway_view *view;
@@ -258,7 +258,7 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = data;
 	wlr_log(L_DEBUG, "Output %p %s removed", wlr_output, wlr_output->name);
 
-	destroy_output(output->swayc);
+	sway_container_output_destroy(output->swayc);
 }
 
 static void handle_output_mode(struct wl_listener *listener, void *data) {
@@ -286,7 +286,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		wlr_output_set_mode(wlr_output, mode);
 	}
 
-	output->swayc = new_output(output);
+	output->swayc = sway_container_output_create(output);
 	if (!output->swayc) {
 		free(output);
 		return;

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -74,7 +74,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, sway_surface, destroy);
 	wl_list_remove(&sway_surface->commit.link);
 	wl_list_remove(&sway_surface->destroy.link);
-	swayc_t *parent = destroy_view(sway_surface->view->swayc);
+	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
 	free(sway_surface->view);
 	free(sway_surface);
 	arrange_windows(parent, -1, -1);
@@ -132,8 +132,8 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&shell_surface->events.destroy, &sway_surface->destroy);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	swayc_t *cont = new_view(focus, sway_view);
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *cont = sway_container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
 	arrange_windows(cont->parent, -1, -1);

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -74,10 +74,10 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, sway_surface, destroy);
 	wl_list_remove(&sway_surface->commit.link);
 	wl_list_remove(&sway_surface->destroy.link);
-	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
+	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	free(sway_surface->view);
 	free(sway_surface);
-	arrange_windows(parent, -1, -1);
+	container_arrange_windows(parent, -1, -1);
 }
 
 void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
@@ -133,9 +133,9 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	struct sway_container *cont = sway_container_view_create(focus, sway_view);
+	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	arrange_windows(cont->parent, -1, -1);
+	container_arrange_windows(cont->parent, -1, -1);
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -3,10 +3,10 @@
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_wl_shell.h>
-#include "sway/container.h"
-#include "sway/layout.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
 #include "sway/server.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/input/seat.h"
 #include "sway/input/input-manager.h"
 #include "log.h"

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -77,7 +77,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	free(sway_surface->view);
 	free(sway_surface);
-	container_arrange_windows(parent, -1, -1);
+	arrange_windows(parent, -1, -1);
 }
 
 void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
@@ -136,6 +136,6 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	container_arrange_windows(cont->parent, -1, -1);
+	arrange_windows(cont->parent, -1, -1);
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -83,7 +83,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, sway_xdg_surface, destroy);
 	wl_list_remove(&sway_xdg_surface->commit.link);
 	wl_list_remove(&sway_xdg_surface->destroy.link);
-	swayc_t *parent = destroy_view(sway_xdg_surface->view->swayc);
+	struct sway_container *parent = sway_container_view_destroy(sway_xdg_surface->view->swayc);
 	free(sway_xdg_surface->view);
 	free(sway_xdg_surface);
 	arrange_windows(parent, -1, -1);
@@ -136,8 +136,8 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&xdg_surface->events.destroy, &sway_surface->destroy);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	swayc_t *cont = new_view(focus, sway_view);
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *cont = sway_container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
 	arrange_windows(cont->parent, -1, -1);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -3,10 +3,10 @@
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
-#include "sway/container.h"
-#include "sway/layout.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
 #include "sway/server.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/input/seat.h"
 #include "sway/input/input-manager.h"
 #include "log.h"

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -86,7 +86,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_container *parent = container_view_destroy(sway_xdg_surface->view->swayc);
 	free(sway_xdg_surface->view);
 	free(sway_xdg_surface);
-	container_arrange_windows(parent, -1, -1);
+	arrange_windows(parent, -1, -1);
 }
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
@@ -140,7 +140,7 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	container_arrange_windows(cont->parent, -1, -1);
+	arrange_windows(cont->parent, -1, -1);
 
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -83,10 +83,10 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, sway_xdg_surface, destroy);
 	wl_list_remove(&sway_xdg_surface->commit.link);
 	wl_list_remove(&sway_xdg_surface->destroy.link);
-	struct sway_container *parent = sway_container_view_destroy(sway_xdg_surface->view->swayc);
+	struct sway_container *parent = container_view_destroy(sway_xdg_surface->view->swayc);
 	free(sway_xdg_surface->view);
 	free(sway_xdg_surface);
-	arrange_windows(parent, -1, -1);
+	container_arrange_windows(parent, -1, -1);
 }
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
@@ -137,10 +137,10 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	struct sway_container *cont = sway_container_view_create(focus, sway_view);
+	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	arrange_windows(cont->parent, -1, -1);
+	container_arrange_windows(cont->parent, -1, -1);
 
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -49,11 +49,11 @@ static void set_position(struct sway_view *view, double ox, double oy) {
 	if (!assert_xwayland(view)) {
 		return;
 	}
-	struct sway_container *output = sway_container_parent(view->swayc, C_OUTPUT);
+	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
 	if (!sway_assert(output, "view must be within tree to set position")) {
 		return;
 	}
-	struct sway_container *root = sway_container_parent(output, C_ROOT);
+	struct sway_container *root = container_parent(output, C_ROOT);
 	if (!sway_assert(root, "output must be within tree to set position")) {
 		return;
 	}
@@ -114,9 +114,9 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		}
 	}
 
-	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
+	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
-		arrange_windows(parent, -1, -1);
+		container_arrange_windows(parent, -1, -1);
 	}
 
 	free(sway_surface->view);
@@ -132,9 +132,9 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	}
 
 	// take it out of the tree
-	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
+	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
-		arrange_windows(parent, -1, -1);
+		container_arrange_windows(parent, -1, -1);
 	}
 
 	sway_surface->view->swayc = NULL;
@@ -155,15 +155,15 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 			&sway_surface->view->unmanaged_view_link);
 	} else {
 		struct sway_view *view = sway_surface->view;
-		sway_container_view_destroy(view->swayc);
+		container_view_destroy(view->swayc);
 
 		struct sway_container *parent = root_container.children->items[0];
 		parent = parent->children->items[0]; // workspace
 
-		struct sway_container *cont = sway_container_view_create(parent, view);
+		struct sway_container *cont = container_view_create(parent, view);
 		view->swayc = cont;
 
-		arrange_windows(cont->parent, -1, -1);
+		container_arrange_windows(cont->parent, -1, -1);
 		sway_input_manager_set_focus(input_manager, cont);
 	}
 }
@@ -239,9 +239,9 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	struct sway_container *cont = sway_container_view_create(focus, sway_view);
+	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	arrange_windows(cont->parent, -1, -1);
+	container_arrange_windows(cont->parent, -1, -1);
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -49,11 +49,11 @@ static void set_position(struct sway_view *view, double ox, double oy) {
 	if (!assert_xwayland(view)) {
 		return;
 	}
-	swayc_t *output = swayc_parent_by_type(view->swayc, C_OUTPUT);
+	struct sway_container *output = sway_container_parent(view->swayc, C_OUTPUT);
 	if (!sway_assert(output, "view must be within tree to set position")) {
 		return;
 	}
-	swayc_t *root = swayc_parent_by_type(output, C_ROOT);
+	struct sway_container *root = sway_container_parent(output, C_ROOT);
 	if (!sway_assert(root, "output must be within tree to set position")) {
 		return;
 	}
@@ -114,7 +114,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		}
 	}
 
-	swayc_t *parent = destroy_view(sway_surface->view->swayc);
+	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
 		arrange_windows(parent, -1, -1);
 	}
@@ -132,7 +132,7 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	}
 
 	// take it out of the tree
-	swayc_t *parent = destroy_view(sway_surface->view->swayc);
+	struct sway_container *parent = sway_container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
 		arrange_windows(parent, -1, -1);
 	}
@@ -155,12 +155,12 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 			&sway_surface->view->unmanaged_view_link);
 	} else {
 		struct sway_view *view = sway_surface->view;
-		destroy_view(view->swayc);
+		sway_container_view_destroy(view->swayc);
 
-		swayc_t *parent = root_container.children->items[0];
+		struct sway_container *parent = root_container.children->items[0];
 		parent = parent->children->items[0]; // workspace
 
-		swayc_t *cont = new_view(parent, view);
+		struct sway_container *cont = sway_container_view_create(parent, view);
 		view->swayc = cont;
 
 		arrange_windows(cont->parent, -1, -1);
@@ -238,8 +238,8 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	}
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
-	swayc_t *cont = new_view(focus, sway_view);
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *cont = sway_container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
 	arrange_windows(cont->parent, -1, -1);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -5,10 +5,10 @@
 #include <wlr/xwayland.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
-#include "sway/container.h"
-#include "sway/layout.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
 #include "sway/server.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/output.h"
 #include "sway/input/seat.h"
 #include "sway/input/input-manager.h"

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -116,7 +116,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
-		container_arrange_windows(parent, -1, -1);
+		arrange_windows(parent, -1, -1);
 	}
 
 	free(sway_surface->view);
@@ -134,7 +134,7 @@ static void handle_unmap_notify(struct wl_listener *listener, void *data) {
 	// take it out of the tree
 	struct sway_container *parent = container_view_destroy(sway_surface->view->swayc);
 	if (parent) {
-		container_arrange_windows(parent, -1, -1);
+		arrange_windows(parent, -1, -1);
 	}
 
 	sway_surface->view->swayc = NULL;
@@ -163,7 +163,7 @@ static void handle_map_notify(struct wl_listener *listener, void *data) {
 		struct sway_container *cont = container_view_create(parent, view);
 		view->swayc = cont;
 
-		container_arrange_windows(cont->parent, -1, -1);
+		arrange_windows(cont->parent, -1, -1);
 		sway_input_manager_set_focus(input_manager, cont);
 	}
 }
@@ -242,6 +242,6 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 
-	container_arrange_windows(cont->parent, -1, -1);
+	arrange_windows(cont->parent, -1, -1);
 	sway_input_manager_set_focus(input_manager, cont);
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -7,7 +7,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include "sway/input/cursor.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "list.h"
 #include "log.h"
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -49,8 +49,8 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 		}
 	}
 
-	swayc_t *swayc =
-		swayc_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
+	struct sway_container *swayc =
+		sway_container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
 	if (swayc) {
 		wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
 		wlr_seat_pointer_notify_motion(seat, time, sx, sy);
@@ -87,8 +87,8 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	if (event->button == BTN_LEFT) {
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
-		swayc_t *swayc =
-			swayc_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
+		struct sway_container *swayc =
+			sway_container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
 
 		sway_seat_set_focus(cursor->seat, swayc);
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -50,7 +50,7 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	}
 
 	struct sway_container *swayc =
-		sway_container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
+		container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
 	if (swayc) {
 		wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
 		wlr_seat_pointer_notify_motion(seat, time, sx, sy);
@@ -88,7 +88,7 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
 		struct sway_container *swayc =
-			sway_container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
+			container_at(&root_container, cursor->x, cursor->y, &surface, &sx, &sy);
 
 		sway_seat_set_focus(cursor->seat, swayc);
 	}

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -278,7 +278,7 @@ struct sway_input_manager *sway_input_manager_create(
 }
 
 bool sway_input_manager_has_focus(struct sway_input_manager *input,
-		swayc_t *container) {
+		struct sway_container *container) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
 		if (sway_seat_get_focus(seat) == container) {
@@ -290,7 +290,7 @@ bool sway_input_manager_has_focus(struct sway_input_manager *input,
 }
 
 void sway_input_manager_set_focus(struct sway_input_manager *input,
-		swayc_t *container) {
+		struct sway_container *container) {
 	struct sway_seat *seat ;
 	wl_list_for_each(seat, &input->seats, link) {
 		sway_seat_set_focus(seat, container);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1,13 +1,13 @@
 #define _XOPEN_SOURCE 700
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/input/seat.h"
 #include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/keyboard.h"
 #include "sway/output.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "log.h"
 
 static void seat_device_destroy(struct sway_seat_device *seat_device) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -37,7 +37,7 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 	struct sway_seat_container *seat_con =
 		wl_container_of(listener, seat_con, destroy);
 	struct sway_seat *seat = seat_con->seat;
-	swayc_t *con = seat_con->container;
+	struct sway_container *con = seat_con->container;
 
 	bool is_focus = (sway_seat_get_focus(seat) == con);
 
@@ -46,7 +46,7 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 	if  (is_focus) {
 		// pick next focus
 		sway_seat_set_focus(seat, NULL);
-		swayc_t *next = sway_seat_get_focus_inactive(seat, con->parent);
+		struct sway_container *next = sway_seat_get_focus_inactive(seat, con->parent);
 		if (next == NULL) {
 			next = con->parent;
 		}
@@ -59,7 +59,7 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 }
 
 static struct sway_seat_container *seat_container_from_container(
-		struct sway_seat *seat, swayc_t *con) {
+		struct sway_seat *seat, struct sway_container *con) {
 	if (con->type < C_WORKSPACE) {
 		// these don't get seat containers ever
 		return NULL;
@@ -89,11 +89,11 @@ static struct sway_seat_container *seat_container_from_container(
 
 static void handle_new_container(struct wl_listener *listener, void *data) {
 	struct sway_seat *seat = wl_container_of(listener, seat, new_container);
-	swayc_t *con = data;
+	struct sway_container *con = data;
 	seat_container_from_container(seat, con);
 }
 
-static void collect_focus_iter(swayc_t *con, void *data) {
+static void collect_focus_iter(struct sway_container *con, void *data) {
 	struct sway_seat *seat = data;
 	if (con->type > C_WORKSPACE) {
 		return;
@@ -130,7 +130,7 @@ struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	container_for_each_bfs(&root_container, collect_focus_iter, seat);
+	sway_container_for_each_bfs(&root_container, collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);
@@ -166,7 +166,7 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	sway_keyboard_configure(seat_device->keyboard);
 	wlr_seat_set_keyboard(seat->wlr_seat,
 			seat_device->input_device->wlr_device);
-	swayc_t *focus = sway_seat_get_focus(seat);
+	struct sway_container *focus = sway_seat_get_focus(seat);
 	if (focus && focus->type == C_VIEW) {
 		// force notify reenter to pick up the new configuration
 		wlr_seat_keyboard_clear_focus(seat->wlr_seat);
@@ -270,7 +270,7 @@ void sway_seat_configure_xcursor(struct sway_seat *seat) {
 	}
 
 	for (int i = 0; i < root_container.children->length; ++i) {
-		swayc_t *output_container = root_container.children->items[i];
+		struct sway_container *output_container = root_container.children->items[i];
 		struct wlr_output *output =
 			output_container->sway_output->wlr_output;
 		bool result =
@@ -289,8 +289,8 @@ void sway_seat_configure_xcursor(struct sway_seat *seat) {
 		seat->cursor->cursor->y);
 }
 
-void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container) {
-	swayc_t *last_focus = sway_seat_get_focus(seat);
+void sway_seat_set_focus(struct sway_seat *seat, struct sway_container *container) {
+	struct sway_container *last_focus = sway_seat_get_focus(seat);
 
 	if (container && last_focus == container) {
 		return;
@@ -330,9 +330,9 @@ void sway_seat_set_focus(struct sway_seat *seat, swayc_t *container) {
 	seat->has_focus = (container != NULL);
 }
 
-swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container) {
+struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat, struct sway_container *container) {
 	struct sway_seat_container *current = NULL;
-	swayc_t *parent = NULL;
+	struct sway_container *parent = NULL;
 	wl_list_for_each(current, &seat->focus_stack, link) {
 		parent = current->container->parent;
 
@@ -351,21 +351,21 @@ swayc_t *sway_seat_get_focus_inactive(struct sway_seat *seat, swayc_t *container
 	return NULL;
 }
 
-swayc_t *sway_seat_get_focus(struct sway_seat *seat) {
+struct sway_container *sway_seat_get_focus(struct sway_seat *seat) {
 	if (!seat->has_focus) {
 		return NULL;
 	}
 	return sway_seat_get_focus_inactive(seat, &root_container);
 }
 
-swayc_t *sway_seat_get_focus_by_type(struct sway_seat *seat,
-		enum swayc_types type) {
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
+struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
+		enum sway_container_type type) {
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	if (focus->type == type) {
 		return focus;
 	}
 
-	return swayc_parent_by_type(focus, type);
+	return sway_container_parent(focus, type);
 }
 
 void sway_seat_set_config(struct sway_seat *seat,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -130,7 +130,7 @@ struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	sway_container_for_each_bfs(&root_container, collect_focus_iter, seat);
+	container_for_each(&root_container, collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -130,7 +130,7 @@ struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	container_for_each(&root_container, collect_focus_iter, seat);
+	container_for_each_descendent(&root_container, collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -365,7 +365,7 @@ struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
 		return focus;
 	}
 
-	return sway_container_parent(focus, type);
+	return container_parent(focus, type);
 }
 
 void sway_seat_set_config(struct sway_seat *seat,

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -25,7 +25,7 @@ json_object *ipc_json_get_version() {
 	return version;
 }
 
-static json_object *ipc_json_create_rect(swayc_t *c) {
+static json_object *ipc_json_create_rect(struct sway_container *c) {
 	json_object *rect = json_object_new_object();
 
 	json_object_object_add(rect, "x", json_object_new_int((int32_t)c->x));
@@ -36,7 +36,7 @@ static json_object *ipc_json_create_rect(swayc_t *c) {
 	return rect;
 }
 
-static void ipc_json_describe_root(swayc_t *root, json_object *object) {
+static void ipc_json_describe_root(struct sway_container *root, json_object *object) {
 	json_object_object_add(object, "type", json_object_new_string("root"));
 	json_object_object_add(object, "layout", json_object_new_string("splith"));
 }
@@ -63,7 +63,7 @@ static const char *ipc_json_get_output_transform(enum wl_output_transform transf
 	return NULL;
 }
 
-static void ipc_json_describe_output(swayc_t *container, json_object *object) {
+static void ipc_json_describe_output(struct sway_container *container, json_object *object) {
 	struct wlr_output *wlr_output = container->sway_output->wlr_output;
 	json_object_object_add(object, "type", json_object_new_string("output"));
 	json_object_object_add(object, "active", json_object_new_boolean(true));
@@ -94,7 +94,7 @@ static void ipc_json_describe_output(swayc_t *container, json_object *object) {
 	json_object_object_add(object, "modes", modes_array);
 }
 
-static void ipc_json_describe_workspace(swayc_t *workspace, json_object *object) {
+static void ipc_json_describe_workspace(struct sway_container *workspace, json_object *object) {
 	int num = (isdigit(workspace->name[0])) ? atoi(workspace->name) : -1;
 
 	json_object_object_add(object, "num", json_object_new_int(num));
@@ -102,11 +102,11 @@ static void ipc_json_describe_workspace(swayc_t *workspace, json_object *object)
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
 }
 
-static void ipc_json_describe_view(swayc_t *c, json_object *object) {
+static void ipc_json_describe_view(struct sway_container *c, json_object *object) {
 	json_object_object_add(object, "name", (c->name) ? json_object_new_string(c->name) : NULL);
 }
 
-json_object *ipc_json_describe_container(swayc_t *c) {
+json_object *ipc_json_describe_container(struct sway_container *c) {
 	if (!(sway_assert(c, "Container must not be null."))) {
 		return NULL;
 	}
@@ -147,7 +147,7 @@ json_object *ipc_json_describe_container(swayc_t *c) {
 	return object;
 }
 
-json_object *ipc_json_describe_container_recursive(swayc_t *c) {
+json_object *ipc_json_describe_container_recursive(struct sway_container *c) {
 	json_object *object = ipc_json_describe_container(c);
 	int i;
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -3,7 +3,7 @@
 #include <ctype.h>
 #include "log.h"
 #include "sway/ipc-json.h"
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/output.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -279,7 +279,7 @@ static void ipc_send_event(const char *json_string, enum ipc_command_type event)
 	}
 }
 
-void ipc_event_window(swayc_t *window, const char *change) {
+void ipc_event_window(struct sway_container *window, const char *change) {
 	wlr_log(L_DEBUG, "Sending window::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
@@ -400,7 +400,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	{
 		json_object *outputs = json_object_new_array();
 		for (int i = 0; i < root_container.children->length; ++i) {
-			swayc_t *container = root_container.children->items[i];
+			struct sway_container *container = root_container.children->items[i];
 			if (container->type == C_OUTPUT) {
 				json_object_array_add(outputs,
 					ipc_json_describe_container(container));

--- a/sway/main.c
+++ b/sway/main.c
@@ -18,7 +18,7 @@
 #include <wlr/util/log.h>
 #include "sway/config.h"
 #include "sway/server.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 #include "sway/ipc-server.h"
 #include "ipc-client.h"
 #include "readline.h"

--- a/sway/main.c
+++ b/sway/main.c
@@ -382,7 +382,7 @@ int main(int argc, char **argv) {
 
 	wlr_log(L_INFO, "Starting sway version " SWAY_VERSION);
 
-	init_layout();
+	layout_init();
 
 	if (!server_init(&server)) {
 		return 1;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -7,14 +7,14 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_wl_shell.h>
 #include "sway/config.h"
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
-#include "sway/layout.h"
+#include "sway/tree/layout.h"
 #include "sway/output.h"
 #include "sway/server.h"
-#include "sway/view.h"
-#include "sway/workspace.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "sway/ipc-server.h"
 #include "log.h"
 
@@ -82,8 +82,6 @@ static swayc_t *new_swayc(enum swayc_types type) {
 	c->layout = L_NONE;
 	c->workspace_layout = L_NONE;
 	c->type = type;
-	c->nb_master = 1;
-	c->nb_slave_groups = 1;
 	if (type != C_VIEW) {
 		c->children = create_list();
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -221,7 +221,7 @@ struct sway_container *container_output_destroy(struct sway_container *output) {
 				container_add_child(root_container.children->items[p], child);
 			}
 			container_sort_workspaces(root_container.children->items[p]);
-			container_arrange_windows(root_container.children->items[p],
+			arrange_windows(root_container.children->items[p],
 				-1, -1);
 		}
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -38,7 +38,7 @@ static void notify_new_container(struct sway_container *container) {
 	ipc_event_window(container, "new");
 }
 
-static struct sway_container *new_swayc(enum sway_container_type type) {
+static struct sway_container *container_create(enum sway_container_type type) {
 	// next id starts at 1 because 0 is assigned to root_container in layout.c
 	static size_t next_id = 1;
 	struct sway_container *c = calloc(1, sizeof(struct sway_container));
@@ -122,7 +122,7 @@ struct sway_container *container_output_create(
 		return NULL;
 	}
 
-	struct sway_container *output = new_swayc(C_OUTPUT);
+	struct sway_container *output = container_create(C_OUTPUT);
 	output->sway_output = sway_output;
 	output->name = strdup(name);
 	if (output->name == NULL) {
@@ -151,14 +151,14 @@ struct sway_container *container_output_create(
 	return output;
 }
 
-struct sway_container *container_workspace_create(struct sway_container
-		*output, const char *name) {
+struct sway_container *container_workspace_create(
+		struct sway_container *output, const char *name) {
 	if (!sway_assert(output,
 				"container_workspace_create called with null output")) {
 		return NULL;
 	}
 	wlr_log(L_DEBUG, "Added workspace %s for output %s", name, output->name);
-	struct sway_container *workspace = new_swayc(C_WORKSPACE);
+	struct sway_container *workspace = container_create(C_WORKSPACE);
 
 	workspace->x = output->x;
 	workspace->y = output->y;
@@ -182,7 +182,7 @@ struct sway_container *container_view_create(struct sway_container *sibling,
 		return NULL;
 	}
 	const char *title = view_get_title(sway_view);
-	struct sway_container *swayc = new_swayc(C_VIEW);
+	struct sway_container *swayc = container_create(C_VIEW);
 	wlr_log(L_DEBUG, "Adding new view %p:%s to container %p %d %s",
 		swayc, title, sibling, sibling ? sibling->type : 0, sibling->name);
 	// Setup values
@@ -314,30 +314,7 @@ struct sway_container *container_parent(struct sway_container *container,
 	return container;
 }
 
-void sway_container_for_each(struct sway_container *container,
-		void (*f)(struct sway_container *view, void *data), void *data) {
-	if (container) {
-		int i;
-		if (container->children)  {
-			for (i = 0; i < container->children->length; ++i) {
-				struct sway_container *child = container->children->items[i];
-				sway_container_for_each(child, f, data);
-			}
-		}
-		// TODO
-		/*
-		if (container->floating) {
-			for (i = 0; i < container->floating->length; ++i) {
-				struct sway_container *child = container->floating->items[i];
-				container_map(child, f, data);
-			}
-		}
-		*/
-		f(container, data);
-	}
-}
-
-struct sway_container *sway_container_at(struct sway_container *parent,
+struct sway_container *container_at(struct sway_container *parent,
 		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	list_t *queue = get_bfs_queue();
@@ -423,7 +400,7 @@ struct sway_container *sway_container_at(struct sway_container *parent,
 	return NULL;
 }
 
-void sway_container_for_each_bfs(struct sway_container *con,
+void container_for_each(struct sway_container *con,
 		void (*f)(struct sway_container *con, void *data), void *data) {
 	list_t *queue = get_bfs_queue();
 	if (!queue) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -154,7 +154,7 @@ struct sway_container *container_output_create(
 struct sway_container *container_workspace_create(
 		struct sway_container *output, const char *name) {
 	if (!sway_assert(output,
-				"container_workspace_create called with null output")) {
+			"container_workspace_create called with null output")) {
 		return NULL;
 	}
 	wlr_log(L_DEBUG, "Added workspace %s for output %s", name, output->name);
@@ -178,7 +178,7 @@ struct sway_container *container_workspace_create(
 struct sway_container *container_view_create(struct sway_container *sibling,
 		struct sway_view *sway_view) {
 	if (!sway_assert(sibling,
-				"container_view_create called with NULL sibling/parent")) {
+			"container_view_create called with NULL sibling/parent")) {
 		return NULL;
 	}
 	const char *title = view_get_title(sway_view);
@@ -400,7 +400,7 @@ struct sway_container *container_at(struct sway_container *parent,
 	return NULL;
 }
 
-void container_for_each(struct sway_container *con,
+void container_for_each_descendent(struct sway_container *con,
 		void (*f)(struct sway_container *con, void *data), void *data) {
 	list_t *queue = get_bfs_queue();
 	if (!queue) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -86,7 +86,8 @@ static void container_destroy(struct sway_container *cont) {
 	free(cont);
 }
 
-struct sway_container *container_output_create(struct sway_output *sway_output) {
+struct sway_container *container_output_create(
+		struct sway_output *sway_output) {
 	struct wlr_box size;
 	wlr_output_effective_resolution(sway_output->wlr_output, &size.width,
 		&size.height);
@@ -150,8 +151,10 @@ struct sway_container *container_output_create(struct sway_output *sway_output) 
 	return output;
 }
 
-struct sway_container *container_workspace_create(struct sway_container *output, const char *name) {
-	if (!sway_assert(output, "container_workspace_create called with null output")) {
+struct sway_container *container_workspace_create(struct sway_container
+		*output, const char *name) {
+	if (!sway_assert(output,
+				"container_workspace_create called with null output")) {
 		return NULL;
 	}
 	wlr_log(L_DEBUG, "Added workspace %s for output %s", name, output->name);
@@ -172,8 +175,10 @@ struct sway_container *container_workspace_create(struct sway_container *output,
 	return workspace;
 }
 
-struct sway_container *container_view_create(struct sway_container *sibling, struct sway_view *sway_view) {
-	if (!sway_assert(sibling, "container_view_create called with NULL sibling/parent")) {
+struct sway_container *container_view_create(struct sway_container *sibling,
+		struct sway_view *sway_view) {
+	if (!sway_assert(sibling,
+				"container_view_create called with NULL sibling/parent")) {
 		return NULL;
 	}
 	const char *title = view_get_title(sway_view);
@@ -198,7 +203,8 @@ struct sway_container *container_view_create(struct sway_container *sibling, str
 }
 
 struct sway_container *container_output_destroy(struct sway_container *output) {
-	if (!sway_assert(output, "null output passed to container_output_destroy")) {
+	if (!sway_assert(output,
+				"null output passed to container_output_destroy")) {
 		return NULL;
 	}
 
@@ -215,7 +221,8 @@ struct sway_container *container_output_destroy(struct sway_container *output) {
 				container_add_child(root_container.children->items[p], child);
 			}
 			container_sort_workspaces(root_container.children->items[p]);
-			container_arrange_windows(root_container.children->items[p], -1, -1);
+			container_arrange_windows(root_container.children->items[p],
+				-1, -1);
 		}
 	}
 
@@ -246,7 +253,8 @@ struct sway_container *container_view_destroy(struct sway_container *view) {
 	return parent;
 }
 
-struct sway_container *container_set_layout(struct sway_container *container, enum sway_container_layout layout) {
+struct sway_container *container_set_layout(struct sway_container *container,
+		enum sway_container_layout layout) {
 	if (container->type == C_WORKSPACE) {
 		container->workspace_layout = layout;
 		if (layout == L_HORIZ || layout == L_VERT) {
@@ -258,7 +266,8 @@ struct sway_container *container_set_layout(struct sway_container *container, en
 	return container;
 }
 
-void container_descendents(struct sway_container *root, enum sway_container_type type,
+void container_descendents(struct sway_container *root,
+		enum sway_container_type type,
 		void (*func)(struct sway_container *item, void *data), void *data) {
 	for (int i = 0; i < root->children->length; ++i) {
 		struct sway_container *item = root->children->items[i];
@@ -291,7 +300,8 @@ struct sway_container *container_find(struct sway_container *container,
 	return NULL;
 }
 
-struct sway_container *container_parent(struct sway_container *container, enum sway_container_type type) {
+struct sway_container *container_parent(struct sway_container *container,
+		enum sway_container_type type) {
 	if (!sway_assert(container, "container is NULL")) {
 		return NULL;
 	}
@@ -304,7 +314,8 @@ struct sway_container *container_parent(struct sway_container *container, enum s
 	return container;
 }
 
-void sway_container_for_each(struct sway_container *container, void (*f)(struct sway_container *view, void *data), void *data) {
+void sway_container_for_each(struct sway_container *container,
+		void (*f)(struct sway_container *view, void *data), void *data) {
 	if (container) {
 		int i;
 		if (container->children)  {
@@ -326,7 +337,8 @@ void sway_container_for_each(struct sway_container *container, void (*f)(struct 
 	}
 }
 
-struct sway_container *sway_container_at(struct sway_container *parent, double lx, double ly,
+struct sway_container *sway_container_at(struct sway_container *parent,
+		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	list_t *queue = get_bfs_queue();
 	if (!queue) {
@@ -411,8 +423,8 @@ struct sway_container *sway_container_at(struct sway_container *parent, double l
 	return NULL;
 }
 
-void sway_container_for_each_bfs(struct sway_container *con, void (*f)(struct sway_container *con, void *data),
-		void *data) {
+void sway_container_for_each_bfs(struct sway_container *con,
+		void (*f)(struct sway_container *con, void *data), void *data) {
 	list_t *queue = get_bfs_queue();
 	if (!queue) {
 		return;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -43,7 +43,7 @@ static void output_layout_change_notify(struct wl_listener *listener, void *data
 	container_arrange_windows(&root_container, -1, -1);
 }
 
-void init_layout(void) {
+void layout_init(void) {
 	root_container.id = 0; // normally assigned in new_swayc()
 	root_container.type = C_ROOT;
 	root_container.layout = L_NONE;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -6,10 +6,10 @@
 #include <string.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
-#include "sway/container.h"
-#include "sway/layout.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
 #include "sway/output.h"
-#include "sway/view.h"
+#include "sway/tree/view.h"
 #include "sway/input/seat.h"
 #include "list.h"
 #include "log.h"

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -16,14 +16,16 @@
 
 struct sway_container root_container;
 
-static void output_layout_change_notify(struct wl_listener *listener, void *data) {
+static void output_layout_change_notify(struct wl_listener *listener,
+		void *data) {
 	struct wlr_box *layout_box = wlr_output_layout_get_box(
 		root_container.sway_root->output_layout, NULL);
 	root_container.width = layout_box->width;
 	root_container.height = layout_box->height;
 
 	for (int i = 0 ; i < root_container.children->length; ++i) {
-		struct sway_container *output_container = root_container.children->items[i];
+		struct sway_container *output_container =
+			root_container.children->items[i];
 		if (output_container->type != C_OUTPUT) {
 			continue;
 		}
@@ -79,7 +81,8 @@ static int index_child(const struct sway_container *child) {
 	return i;
 }
 
-struct sway_container *container_add_sibling(struct sway_container *fixed, struct sway_container *active) {
+struct sway_container *container_add_sibling(struct sway_container *fixed,
+		struct sway_container *active) {
 	// TODO handle floating
 	struct sway_container *parent = fixed->parent;
 	int i = index_child(fixed);
@@ -88,7 +91,8 @@ struct sway_container *container_add_sibling(struct sway_container *fixed, struc
 	return active->parent;
 }
 
-void container_add_child(struct sway_container *parent, struct sway_container *child) {
+void container_add_child(struct sway_container *parent,
+		struct sway_container *child) {
 	wlr_log(L_DEBUG, "Adding %p (%d, %fx%f) to %p (%d, %fx%f)",
 			child, child->type, child->width, child->height,
 			parent, parent->type, parent->width, parent->height);
@@ -96,7 +100,9 @@ void container_add_child(struct sway_container *parent, struct sway_container *c
 	child->parent = parent;
 	// set focus for this container
 	/* TODO WLR
-	if (parent->type == C_WORKSPACE && child->type == C_VIEW && (parent->workspace_layout == L_TABBED || parent->workspace_layout == L_STACKED)) {
+	if (parent->type == C_WORKSPACE && child->type == C_VIEW &&
+	(parent->workspace_layout == L_TABBED || parent->workspace_layout ==
+	L_STACKED)) {
 		child = new_container(child, parent->workspace_layout);
 	}
 	*/
@@ -115,7 +121,8 @@ struct sway_container *container_remove_child(struct sway_container *child) {
 	return parent;
 }
 
-enum sway_container_layout container_get_default_layout(struct sway_container *output) {
+enum sway_container_layout container_get_default_layout(
+		struct sway_container *output) {
 	/* TODO WLR
 	if (config->default_layout != L_NONE) {
 		//return config->default_layout;
@@ -160,7 +167,8 @@ static void apply_vert_layout(struct sway_container *container, const double x,
 				const double height, const int start,
 				const int end);
 
-void container_arrange_windows(struct sway_container *container, double width, double height) {
+void container_arrange_windows(struct sway_container *container,
+		double width, double height) {
 	int i;
 	if (width == -1 || height == -1) {
 		width = container->width;
@@ -203,7 +211,8 @@ void container_arrange_windows(struct sway_container *container, double width, d
 		return;
 	case C_WORKSPACE:
 		{
-			struct sway_container *output = container_parent(container, C_OUTPUT);
+			struct sway_container *output =
+				container_parent(container, C_OUTPUT);
 			struct wlr_box *area = &output->sway_output->usable_area;
 			wlr_log(L_DEBUG, "Usable area for ws: %dx%d@%d,%d",
 					area->width, area->height, area->x, area->y);
@@ -259,7 +268,8 @@ static void apply_horiz_layout(struct sway_container *container,
 	double scale = 0;
 	// Calculate total width
 	for (int i = start; i < end; ++i) {
-		double *old_width = &((struct sway_container *)container->children->items[i])->width;
+		double *old_width =
+			&((struct sway_container *)container->children->items[i])->width;
 		if (*old_width <= 0) {
 			if (end - start > 1) {
 				*old_width = width / (end - start - 1);
@@ -309,7 +319,8 @@ void apply_vert_layout(struct sway_container *container,
 	double scale = 0;
 	// Calculate total height
 	for (i = start; i < end; ++i) {
-		double *old_height = &((struct sway_container *)container->children->items[i])->height;
+		double *old_height =
+			&((struct sway_container *)container->children->items[i])->height;
 		if (*old_height <= 0) {
 			if (end - start > 1) {
 				*old_height = height / (end - start - 1);
@@ -354,8 +365,9 @@ void apply_vert_layout(struct sway_container *container,
 /**
  * Get swayc in the direction of newly entered output.
  */
-static struct sway_container *get_swayc_in_output_direction(struct sway_container *output,
-		enum movement_direction dir, struct sway_seat *seat) {
+static struct sway_container *get_swayc_in_output_direction(
+		struct sway_container *output, enum movement_direction dir,
+		struct sway_seat *seat) {
 	if (!output) {
 		return NULL;
 	}
@@ -380,13 +392,15 @@ static struct sway_container *get_swayc_in_output_direction(struct sway_containe
 			return ws->children->items[0];
 		case MOVE_UP:
 		case MOVE_DOWN: {
-			struct sway_container *focused = sway_seat_get_focus_inactive(seat, ws);
+			struct sway_container *focused =
+				sway_seat_get_focus_inactive(seat, ws);
 			if (focused && focused->parent) {
 				struct sway_container *parent = focused->parent;
 				if (parent->layout == L_VERT) {
 					if (dir == MOVE_UP) {
 						// get child furthest down on new output
-						return parent->children->items[parent->children->length-1];
+						int idx = parent->children->length - 1;
+						return parent->children->items[idx];
 					} else if (dir == MOVE_DOWN) {
 						// get child furthest up on new output
 						return parent->children->items[0];
@@ -404,7 +418,8 @@ static struct sway_container *get_swayc_in_output_direction(struct sway_containe
 	return ws;
 }
 
-static void get_layout_center_position(struct sway_container *container, int *x, int *y) {
+static void get_layout_center_position(struct sway_container *container,
+		int *x, int *y) {
 	// FIXME view coords are inconsistently referred to in layout/output systems
 	if (container->type == C_OUTPUT) {
 		*x = container->x + container->width/2;
@@ -423,7 +438,8 @@ static void get_layout_center_position(struct sway_container *container, int *x,
 	}
 }
 
-static bool sway_dir_to_wlr(enum movement_direction dir, enum wlr_direction *out) {
+static bool sway_dir_to_wlr(enum movement_direction dir,
+		enum wlr_direction *out) {
 	switch (dir) {
 	case MOVE_UP:
 		*out = WLR_DIRECTION_UP;
@@ -457,8 +473,9 @@ static struct sway_container *sway_output_from_wlr(struct wlr_output *output) {
 	return NULL;
 }
 
-static struct sway_container *get_swayc_in_direction_under(struct sway_container *container,
-		enum movement_direction dir, struct sway_seat *seat, struct sway_container *limit) {
+static struct sway_container *get_swayc_in_direction_under(
+		struct sway_container *container, enum movement_direction dir,
+		struct sway_seat *seat, struct sway_container *limit) {
 	if (dir == MOVE_CHILD) {
 		return sway_seat_get_focus_inactive(seat, container);
 	}
@@ -498,7 +515,8 @@ static struct sway_container *get_swayc_in_direction_under(struct sway_container
 		wlr_log(L_DEBUG, "Moving from fullscreen view, skipping to output");
 		container = container_parent(container, C_OUTPUT);
 		get_layout_center_position(container, &abs_pos);
-		struct sway_container *output = swayc_adjacent_output(container, dir, &abs_pos, true);
+		struct sway_container *output =
+		swayc_adjacent_output(container, dir, &abs_pos, true);
 		return get_swayc_in_output_direction(output, dir);
 	}
 	if (container->type == C_WORKSPACE && container->fullscreen) {
@@ -521,16 +539,19 @@ static struct sway_container *get_swayc_in_direction_under(struct sway_container
 			}
 			int lx, ly;
 			get_layout_center_position(container, &lx, &ly);
-			struct wlr_output_layout *layout = root_container.sway_root->output_layout;
+			struct wlr_output_layout *layout =
+				root_container.sway_root->output_layout;
 			struct wlr_output *wlr_adjacent =
 				wlr_output_layout_adjacent_output(layout, wlr_dir,
 					container->sway_output->wlr_output, lx, ly);
-			struct sway_container *adjacent = sway_output_from_wlr(wlr_adjacent);
+			struct sway_container *adjacent =
+				sway_output_from_wlr(wlr_adjacent);
 
 			if (!adjacent || adjacent == container) {
 				return wrap_candidate;
 			}
-			struct sway_container *next = get_swayc_in_output_direction(adjacent, dir, seat);
+			struct sway_container *next =
+				get_swayc_in_output_direction(adjacent, dir, seat);
 			if (next == NULL) {
 				return NULL;
 			}
@@ -570,8 +591,9 @@ static struct sway_container *get_swayc_in_direction_under(struct sway_container
 					}
 				}
 			} else {
-				wlr_log(L_DEBUG, "%s cont %d-%p dir %i sibling %d: %p", __func__,
-						idx, container, dir, desired, parent->children->items[desired]);
+				wlr_log(L_DEBUG,
+					"%s cont %d-%p dir %i sibling %d: %p", __func__, idx,
+					container, dir, desired, parent->children->items[desired]);
 				return parent->children->items[desired];
 			}
 		}
@@ -587,7 +609,8 @@ static struct sway_container *get_swayc_in_direction_under(struct sway_container
 	}
 }
 
-struct sway_container *container_get_in_direction(struct sway_container *container, struct sway_seat *seat,
+struct sway_container *container_get_in_direction(
+		struct sway_container *container, struct sway_seat *seat,
 		enum movement_direction dir) {
 	return get_swayc_in_direction_under(container, dir, seat, NULL);
 }

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -587,7 +587,7 @@ static struct sway_container *get_swayc_in_direction_under(struct sway_container
 	}
 }
 
-struct sway_container *get_swayc_in_direction(struct sway_container *container, struct sway_seat *seat,
+struct sway_container *container_get_in_direction(struct sway_container *container, struct sway_seat *seat,
 		enum movement_direction dir) {
 	return get_swayc_in_direction_under(container, dir, seat, NULL);
 }

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -592,7 +592,7 @@ static struct sway_container *get_swayc_in_direction_under(
 				}
 			} else {
 				wlr_log(L_DEBUG,
-					"%s cont %d-%p dir %i sibling %d: %p", __func__, idx,
+					"cont %d-%p dir %i sibling %d: %p", idx,
 					container, dir, desired, parent->children->items[desired]);
 				return parent->children->items[desired];
 			}

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -42,7 +42,7 @@ static void output_layout_change_notify(struct wl_listener *listener,
 		output_container->height = output_box->height;
 	}
 
-	container_arrange_windows(&root_container, -1, -1);
+	arrange_windows(&root_container, -1, -1);
 }
 
 void layout_init(void) {
@@ -167,7 +167,7 @@ static void apply_vert_layout(struct sway_container *container, const double x,
 				const double height, const int start,
 				const int end);
 
-void container_arrange_windows(struct sway_container *container,
+void arrange_windows(struct sway_container *container,
 		double width, double height) {
 	int i;
 	if (width == -1 || height == -1) {
@@ -192,7 +192,7 @@ void container_arrange_windows(struct sway_container *container,
 			struct sway_container *output = container->children->items[i];
 			wlr_log(L_DEBUG, "Arranging output '%s' at %f,%f",
 					output->name, output->x, output->y);
-			container_arrange_windows(output, -1, -1);
+			arrange_windows(output, -1, -1);
 		}
 		return;
 	case C_OUTPUT:
@@ -206,7 +206,7 @@ void container_arrange_windows(struct sway_container *container,
 		// arrange all workspaces:
 		for (i = 0; i < container->children->length; ++i) {
 			struct sway_container *child = container->children->items[i];
-			container_arrange_windows(child, -1, -1);
+			arrange_windows(child, -1, -1);
 		}
 		return;
 	case C_WORKSPACE:
@@ -294,9 +294,9 @@ static void apply_horiz_layout(struct sway_container *container,
 
 			if (i == end - 1) {
 				double remaining_width = x + width - child_x;
-				container_arrange_windows(child, remaining_width, height);
+				arrange_windows(child, remaining_width, height);
 			} else {
-				container_arrange_windows(child, child->width * scale, height);
+				arrange_windows(child, child->width * scale, height);
 			}
 			child_x += child->width;
 		}
@@ -345,9 +345,9 @@ void apply_vert_layout(struct sway_container *container,
 
 			if (i == end - 1) {
 				double remaining_height = y + height - child_y;
-				container_arrange_windows(child, width, remaining_height);
+				arrange_windows(child, width, remaining_height);
 			} else {
-				container_arrange_windows(child, width, child->height * scale);
+				arrange_windows(child, width, child->height * scale);
 			}
 			child_y += child->height;
 		}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -45,7 +45,7 @@ void view_set_size(struct sway_view *view, int width, int height) {
 	}
 }
 
-// TODO make view coordinates
+// TODO make view coordinates in layout coordinates
 void view_set_position(struct sway_view *view, double ox, double oy) {
 	if (view->iface.set_position) {
 		struct wlr_box box = {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,8 +1,8 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_output_layout.h>
-#include "sway/container.h"
-#include "sway/layout.h"
-#include "sway/view.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
+#include "sway/tree/view.h"
 
 const char *view_get_title(struct sway_view *view) {
 	if (view->iface.get_prop) {
@@ -45,6 +45,7 @@ void view_set_size(struct sway_view *view, int width, int height) {
 	}
 }
 
+// TODO make view coordinates
 void view_set_position(struct sway_view *view, double ox, double oy) {
 	if (view->iface.set_position) {
 		struct wlr_box box = {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -52,7 +52,7 @@ struct sway_container *workspace_by_number(const char* name) {
 	if (wbnd.len <= 0) {
 		return NULL;
 	}
-	return sway_container_find(&root_container, _workspace_by_number, (void *) &wbnd);
+	return container_find(&root_container, _workspace_by_number, (void *) &wbnd);
 }
 
 static bool _workspace_by_name(struct sway_container *view, void *data) {
@@ -65,8 +65,8 @@ struct sway_container *workspace_by_name(const char *name) {
 	struct sway_container *current_workspace = NULL, *current_output = NULL;
 	struct sway_container *focus = sway_seat_get_focus(seat);
 	if (focus) {
-		current_workspace = sway_container_parent(focus, C_WORKSPACE);
-		current_output = sway_container_parent(focus, C_OUTPUT);
+		current_workspace = container_parent(focus, C_WORKSPACE);
+		current_output = container_parent(focus, C_OUTPUT);
 	}
 	if (strcmp(name, "prev") == 0) {
 		return workspace_prev(current_workspace);
@@ -79,7 +79,7 @@ struct sway_container *workspace_by_name(const char *name) {
 	} else if (strcmp(name, "current") == 0) {
 		return current_workspace;
 	} else {
-		return sway_container_find(&root_container, _workspace_by_name, (void *) name);
+		return container_find(&root_container, _workspace_by_name, (void *) name);
 	}
 }
 
@@ -95,7 +95,7 @@ struct sway_container *workspace_create(const char *name) {
 			for (i = 0; i < e; ++i) {
 				parent = root_container.children->items[i];
 				if (strcmp(parent->name, wso->output) == 0) {
-					return sway_container_workspace_create(parent, name);
+					return container_workspace_create(parent, name);
 				}
 			}
 			break;
@@ -105,8 +105,8 @@ struct sway_container *workspace_create(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	parent = focus;
-	parent = sway_container_parent(parent, C_OUTPUT);
-	return sway_container_workspace_create(parent, name);
+	parent = container_parent(parent, C_OUTPUT);
+	return container_workspace_create(parent, name);
 }
 
 /**
@@ -124,7 +124,7 @@ struct sway_container *workspace_output_prev_next_impl(struct sway_container *ou
 	struct sway_container *focus = sway_seat_get_focus_inactive(seat, output);
 	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
-			sway_container_parent(focus, C_WORKSPACE));
+			container_parent(focus, C_WORKSPACE));
 
 	int i;
 	for (i = 0; i < output->children->length; i++) {
@@ -207,7 +207,7 @@ bool workspace_switch(struct sway_container *workspace) {
 	}
 	struct sway_container *active_ws = focus;
 	if (active_ws->type != C_WORKSPACE) {
-		sway_container_parent(focus, C_WORKSPACE);
+		container_parent(focus, C_WORKSPACE);
 	}
 
 	if (config->auto_back_and_forth
@@ -236,7 +236,7 @@ bool workspace_switch(struct sway_container *workspace) {
 		next = workspace;
 	}
 	sway_seat_set_focus(seat, next);
-	struct sway_container *output = sway_container_parent(workspace, C_OUTPUT);
-	arrange_windows(output, -1, -1);
+	struct sway_container *output = container_parent(workspace, C_OUTPUT);
+	container_arrange_windows(output, -1, -1);
 	return true;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -52,7 +52,8 @@ struct sway_container *workspace_by_number(const char* name) {
 	if (wbnd.len <= 0) {
 		return NULL;
 	}
-	return container_find(&root_container, _workspace_by_number, (void *) &wbnd);
+	return container_find(&root_container,
+			_workspace_by_number, (void *) &wbnd);
 }
 
 static bool _workspace_by_name(struct sway_container *view, void *data) {
@@ -79,7 +80,8 @@ struct sway_container *workspace_by_name(const char *name) {
 	} else if (strcmp(name, "current") == 0) {
 		return current_workspace;
 	} else {
-		return container_find(&root_container, _workspace_by_name, (void *) name);
+		return container_find(&root_container, _workspace_by_name,
+				(void *)name);
 	}
 }
 
@@ -103,7 +105,8 @@ struct sway_container *workspace_create(const char *name) {
 	}
 	// Otherwise create a new one
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus =
+		sway_seat_get_focus_inactive(seat, &root_container);
 	parent = focus;
 	parent = container_parent(parent, C_OUTPUT);
 	return container_workspace_create(parent, name);
@@ -114,7 +117,8 @@ struct sway_container *workspace_create(const char *name) {
  * the end and beginning.  If next is false, the previous workspace is returned,
  * otherwise the next one is returned.
  */
-struct sway_container *workspace_output_prev_next_impl(struct sway_container *output, bool next) {
+struct sway_container *workspace_output_prev_next_impl(
+		struct sway_container *output, bool next) {
 	if (!sway_assert(output->type == C_OUTPUT,
 				"Argument must be an output, is %d", output->type)) {
 		return NULL;
@@ -134,7 +138,8 @@ struct sway_container *workspace_output_prev_next_impl(struct sway_container *ou
 		}
 	}
 
-	// Doesn't happen, at worst the for loop returns the previously active workspace
+	// Doesn't happen, at worst the for loop returns the previously active
+	// workspace
 	return NULL;
 }
 
@@ -144,7 +149,8 @@ struct sway_container *workspace_output_prev_next_impl(struct sway_container *ou
  * next is false, the previous workspace is returned, otherwise the next one is
  * returned.
  */
-struct sway_container *workspace_prev_next_impl(struct sway_container *workspace, bool next) {
+struct sway_container *workspace_prev_next_impl(
+		struct sway_container *workspace, bool next) {
 	if (!sway_assert(workspace->type == C_WORKSPACE,
 				"Argument must be a workspace, is %d", workspace->type)) {
 		return NULL;
@@ -166,7 +172,8 @@ struct sway_container *workspace_prev_next_impl(struct sway_container *workspace
 		}
 	}
 
-	// Given workspace is the first/last on the output, jump to the previous/next output
+	// Given workspace is the first/last on the output, jump to the
+	// previous/next output
 	int num_outputs = root_container.children->length;
 	for (i = 0; i < num_outputs; i++) {
 		if (root_container.children->items[i] == current_output) {
@@ -176,7 +183,8 @@ struct sway_container *workspace_prev_next_impl(struct sway_container *workspace
 		}
 	}
 
-	// Doesn't happen, at worst the for loop returns the previously active workspace on the active output
+	// Doesn't happen, at worst the for loop returns the previously active
+	// workspace on the active output
 	return NULL;
 }
 
@@ -201,7 +209,8 @@ bool workspace_switch(struct sway_container *workspace) {
 		return false;
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus =
+		sway_seat_get_focus_inactive(seat, &root_container);
 	if (!seat || !focus) {
 		return false;
 	}
@@ -230,7 +239,8 @@ bool workspace_switch(struct sway_container *workspace) {
 
 	// TODO: Deal with sticky containers
 
-	wlr_log(L_DEBUG, "Switching to workspace %p:%s", workspace, workspace->name);
+	wlr_log(L_DEBUG, "Switching to workspace %p:%s",
+		workspace, workspace->name);
 	struct sway_container *next = sway_seat_get_focus_inactive(seat, workspace);
 	if (next == NULL) {
 		next = workspace;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -247,6 +247,6 @@ bool workspace_switch(struct sway_container *workspace) {
 	}
 	sway_seat_set_focus(seat, next);
 	struct sway_container *output = container_parent(workspace, C_OUTPUT);
-	container_arrange_windows(output, -1, -1);
+	arrange_windows(output, -1, -1);
 	return true;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -3,10 +3,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <strings.h>
-#include "sway/container.h"
+#include "sway/tree/container.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
-#include "sway/workspace.h"
+#include "sway/tree/workspace.h"
 #include "log.h"
 #include "util.h"
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -17,7 +17,7 @@ struct workspace_by_number_data {
 	const char *name;
 };
 
-void next_name_map(swayc_t *ws, void *data) {
+void next_name_map(struct sway_container *ws, void *data) {
 	int *count = data;
 	++count;
 }
@@ -37,7 +37,7 @@ char *workspace_next_name(const char *output_name) {
 	return name;
 }
 
-static bool _workspace_by_number(swayc_t *view, void *data) {
+static bool _workspace_by_number(struct sway_container *view, void *data) {
 	if (view->type != C_WORKSPACE) {
 		return false;
 	}
@@ -46,27 +46,27 @@ static bool _workspace_by_number(swayc_t *view, void *data) {
 	return a == wbnd->len && strncmp(view->name, wbnd->name, a) == 0;
 }
 
-swayc_t *workspace_by_number(const char* name) {
+struct sway_container *workspace_by_number(const char* name) {
 	struct workspace_by_number_data wbnd = {0, "1234567890", name};
 	wbnd.len = strspn(name, wbnd.cset);
 	if (wbnd.len <= 0) {
 		return NULL;
 	}
-	return swayc_by_test(&root_container, _workspace_by_number, (void *) &wbnd);
+	return sway_container_find(&root_container, _workspace_by_number, (void *) &wbnd);
 }
 
-static bool _workspace_by_name(swayc_t *view, void *data) {
+static bool _workspace_by_name(struct sway_container *view, void *data) {
 	return (view->type == C_WORKSPACE) &&
 		   (strcasecmp(view->name, (char *) data) == 0);
 }
 
-swayc_t *workspace_by_name(const char *name) {
+struct sway_container *workspace_by_name(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *current_workspace = NULL, *current_output = NULL;
-	swayc_t *focus = sway_seat_get_focus(seat);
+	struct sway_container *current_workspace = NULL, *current_output = NULL;
+	struct sway_container *focus = sway_seat_get_focus(seat);
 	if (focus) {
-		current_workspace = swayc_parent_by_type(focus, C_WORKSPACE);
-		current_output = swayc_parent_by_type(focus, C_OUTPUT);
+		current_workspace = sway_container_parent(focus, C_WORKSPACE);
+		current_output = sway_container_parent(focus, C_OUTPUT);
 	}
 	if (strcmp(name, "prev") == 0) {
 		return workspace_prev(current_workspace);
@@ -79,12 +79,12 @@ swayc_t *workspace_by_name(const char *name) {
 	} else if (strcmp(name, "current") == 0) {
 		return current_workspace;
 	} else {
-		return swayc_by_test(&root_container, _workspace_by_name, (void *) name);
+		return sway_container_find(&root_container, _workspace_by_name, (void *) name);
 	}
 }
 
-swayc_t *workspace_create(const char *name) {
-	swayc_t *parent;
+struct sway_container *workspace_create(const char *name) {
+	struct sway_container *parent;
 	// Search for workspace<->output pair
 	int i, e = config->workspace_outputs->length;
 	for (i = 0; i < e; ++i) {
@@ -95,7 +95,7 @@ swayc_t *workspace_create(const char *name) {
 			for (i = 0; i < e; ++i) {
 				parent = root_container.children->items[i];
 				if (strcmp(parent->name, wso->output) == 0) {
-					return new_workspace(parent, name);
+					return sway_container_workspace_create(parent, name);
 				}
 			}
 			break;
@@ -103,10 +103,10 @@ swayc_t *workspace_create(const char *name) {
 	}
 	// Otherwise create a new one
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	parent = focus;
-	parent = swayc_parent_by_type(parent, C_OUTPUT);
-	return new_workspace(parent, name);
+	parent = sway_container_parent(parent, C_OUTPUT);
+	return sway_container_workspace_create(parent, name);
 }
 
 /**
@@ -114,17 +114,17 @@ swayc_t *workspace_create(const char *name) {
  * the end and beginning.  If next is false, the previous workspace is returned,
  * otherwise the next one is returned.
  */
-swayc_t *workspace_output_prev_next_impl(swayc_t *output, bool next) {
+struct sway_container *workspace_output_prev_next_impl(struct sway_container *output, bool next) {
 	if (!sway_assert(output->type == C_OUTPUT,
 				"Argument must be an output, is %d", output->type)) {
 		return NULL;
 	}
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, output);
-	swayc_t *workspace = (focus->type == C_WORKSPACE ?
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, output);
+	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
-			swayc_parent_by_type(focus, C_WORKSPACE));
+			sway_container_parent(focus, C_WORKSPACE));
 
 	int i;
 	for (i = 0; i < output->children->length; i++) {
@@ -144,13 +144,13 @@ swayc_t *workspace_output_prev_next_impl(swayc_t *output, bool next) {
  * next is false, the previous workspace is returned, otherwise the next one is
  * returned.
  */
-swayc_t *workspace_prev_next_impl(swayc_t *workspace, bool next) {
+struct sway_container *workspace_prev_next_impl(struct sway_container *workspace, bool next) {
 	if (!sway_assert(workspace->type == C_WORKSPACE,
 				"Argument must be a workspace, is %d", workspace->type)) {
 		return NULL;
 	}
 
-	swayc_t *current_output = workspace->parent;
+	struct sway_container *current_output = workspace->parent;
 	int offset = next ? 1 : -1;
 	int start = next ? 0 : 1;
 	int end;
@@ -170,7 +170,7 @@ swayc_t *workspace_prev_next_impl(swayc_t *workspace, bool next) {
 	int num_outputs = root_container.children->length;
 	for (i = 0; i < num_outputs; i++) {
 		if (root_container.children->items[i] == current_output) {
-			swayc_t *next_output = root_container.children->items[
+			struct sway_container *next_output = root_container.children->items[
 				wrap(i + offset, num_outputs)];
 			return workspace_output_prev_next_impl(next_output, next);
 		}
@@ -180,40 +180,40 @@ swayc_t *workspace_prev_next_impl(swayc_t *workspace, bool next) {
 	return NULL;
 }
 
-swayc_t *workspace_output_next(swayc_t *current) {
+struct sway_container *workspace_output_next(struct sway_container *current) {
 	return workspace_output_prev_next_impl(current, true);
 }
 
-swayc_t *workspace_next(swayc_t *current) {
+struct sway_container *workspace_next(struct sway_container *current) {
 	return workspace_prev_next_impl(current, true);
 }
 
-swayc_t *workspace_output_prev(swayc_t *current) {
+struct sway_container *workspace_output_prev(struct sway_container *current) {
 	return workspace_output_prev_next_impl(current, false);
 }
 
-swayc_t *workspace_prev(swayc_t *current) {
+struct sway_container *workspace_prev(struct sway_container *current) {
 	return workspace_prev_next_impl(current, false);
 }
 
-bool workspace_switch(swayc_t *workspace) {
+bool workspace_switch(struct sway_container *workspace) {
 	if (!workspace) {
 		return false;
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	swayc_t *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
 	if (!seat || !focus) {
 		return false;
 	}
-	swayc_t *active_ws = focus;
+	struct sway_container *active_ws = focus;
 	if (active_ws->type != C_WORKSPACE) {
-		swayc_parent_by_type(focus, C_WORKSPACE);
+		sway_container_parent(focus, C_WORKSPACE);
 	}
 
 	if (config->auto_back_and_forth
 			&& active_ws == workspace
 			&& prev_workspace_name) {
-		swayc_t *new_ws = workspace_by_name(prev_workspace_name);
+		struct sway_container *new_ws = workspace_by_name(prev_workspace_name);
 		workspace = new_ws ? new_ws : workspace_create(prev_workspace_name);
 	}
 
@@ -231,12 +231,12 @@ bool workspace_switch(swayc_t *workspace) {
 	// TODO: Deal with sticky containers
 
 	wlr_log(L_DEBUG, "Switching to workspace %p:%s", workspace, workspace->name);
-	swayc_t *next = sway_seat_get_focus_inactive(seat, workspace);
+	struct sway_container *next = sway_seat_get_focus_inactive(seat, workspace);
 	if (next == NULL) {
 		next = workspace;
 	}
 	sway_seat_set_focus(seat, next);
-	swayc_t *output = swayc_parent_by_type(workspace, C_OUTPUT);
+	struct sway_container *output = sway_container_parent(workspace, C_OUTPUT);
 	arrange_windows(output, -1, -1);
 	return true;
 }

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -352,7 +352,7 @@ void ipc_bar_init(struct bar *bar, const char *bar_id) {
 		}
 
 		// add bar to the output
-		struct output *bar_output = new_output(name);
+		struct output *bar_output = sway_container_output_create(name);
 		bar_output->idx = i;
 		list_add(bar->outputs, bar_output);
 	}

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -352,7 +352,7 @@ void ipc_bar_init(struct bar *bar, const char *bar_id) {
 		}
 
 		// add bar to the output
-		struct output *bar_output = sway_container_output_create(name);
+		struct output *bar_output = container_output_create(name);
 		bar_output->idx = i;
 		list_add(bar->outputs, bar_output);
 	}


### PR DESCRIPTION
Various tree refactorings to prepare for split containers, decoration, and damage. Will add todos as I see them.

TODO:

* [x] organize tree includes
* [x] consistent naming conventions for functions
* [x] remove typedefs (`swayc_t`)
* [x] rewrite docstrings

NEXT:

* [ ] use destroy listeners for properties
* [ ] view x/y in layout coordinate system (not output)
* [ ] reevaluate use of `list_t`
* [ ] include coordinates in x/y names (surface, output, layout)