### PR TITLE
Fix pointer events for hidden workspaces

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -390,7 +390,7 @@ static void ipc_get_workspaces_callback(struct sway_container *workspace,
 	struct sway_seat *seat =
 		sway_input_manager_get_default_seat(input_manager);
 	struct sway_container *focused_ws = sway_seat_get_focus(seat);
-	if (focused_ws->type != C_WORKSPACE) {
+	if (focused_ws != NULL && focused_ws->type != C_WORKSPACE) {
 		focused_ws = container_parent(focused_ws, C_WORKSPACE);
 	}
 	bool focused = workspace == focused_ws;


### PR DESCRIPTION
To test, add this at the end of `cursor_send_pointer_motion`:

```c
	static struct sway_container *old = NULL;
	if (old != swayc) {
		wlr_log(L_DEBUG, "focus change: %p", swayc);
	}
	old = swayc;
```

Test plan: open a window on a workspace, switch to an empty workspace. Pointer events shouldn't be sent to the window on the hidden workspace.