### PR TITLE
Implement focus_follows_mouse

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -304,7 +304,6 @@ struct sway_config {
 	bool reloading;
 	bool reading;
 	bool auto_back_and_forth;
-	bool seamless_mouse;
 	bool show_marks;
 
 	bool edge_gaps;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -98,6 +98,7 @@ static struct cmd_handler handlers[] = {
 	{ "bindsym", cmd_bindsym },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
+	{ "focus_follows_mouse", cmd_focus_follows_mouse },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -1,0 +1,12 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+
+struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	config->focus_follows_mouse = !strcasecmp(argv[0], "yes");
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -178,7 +178,6 @@ static void config_defaults(struct sway_config *config) {
 	config->active = false;
 	config->failed = false;
 	config->auto_back_and_forth = false;
-	config->seamless_mouse = true;
 	config->reading = false;
 	config->show_marks = true;
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -125,7 +125,10 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	struct wlr_seat *seat = cursor->seat->wlr_seat;
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	container_at_cursor(cursor, &surface, &sx, &sy);
+	struct sway_container *c = container_at_cursor(cursor, &surface, &sx, &sy);
+	if (c && config->focus_follows_mouse) {
+		sway_seat_set_focus(cursor->seat, c);
+	}
 
 	// reset cursor if switching between clients
 	struct wl_client *client = NULL;
@@ -170,33 +173,31 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, button);
 	struct wlr_event_pointer_button *event = data;
 
-	if (event->button == BTN_LEFT) {
-		struct wlr_surface *surface = NULL;
-		double sx, sy;
-		struct sway_container *cont =
-			container_at_cursor(cursor, &surface, &sx, &sy);
-		// Avoid moving keyboard focus from a surface that accepts it to one
-		// that does not unless the change would move us to a new workspace.
-		//
-		// This prevents, for example, losing focus when clicking on swaybar.
-		//
-		// TODO: Replace this condition with something like
-		// !surface_accepts_keyboard_input
-		if (surface && cont && cont->type != C_VIEW) {
-			struct sway_container *new_ws = cont;
-			if (new_ws && new_ws->type != C_WORKSPACE) {
-				new_ws = container_parent(new_ws, C_WORKSPACE);
-			}
-			struct sway_container *old_ws = sway_seat_get_focus(cursor->seat);
-			if (old_ws && old_ws->type != C_WORKSPACE) {
-				old_ws = container_parent(old_ws, C_WORKSPACE);
-			}
-			if (new_ws != old_ws) {
-				sway_seat_set_focus(cursor->seat, cont);
-			}
-		} else {
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+	struct sway_container *cont =
+		container_at_cursor(cursor, &surface, &sx, &sy);
+	// Avoid moving keyboard focus from a surface that accepts it to one
+	// that does not unless the change would move us to a new workspace.
+	//
+	// This prevents, for example, losing focus when clicking on swaybar.
+	//
+	// TODO: Replace this condition with something like
+	// !surface_accepts_keyboard_input
+	if (surface && cont && cont->type != C_VIEW) {
+		struct sway_container *new_ws = cont;
+		if (new_ws && new_ws->type != C_WORKSPACE) {
+			new_ws = container_parent(new_ws, C_WORKSPACE);
+		}
+		struct sway_container *old_ws = sway_seat_get_focus(cursor->seat);
+		if (old_ws && old_ws->type != C_WORKSPACE) {
+			old_ws = container_parent(old_ws, C_WORKSPACE);
+		}
+		if (new_ws != old_ws) {
 			sway_seat_set_focus(cursor->seat, cont);
 		}
+	} else {
+		sway_seat_set_focus(cursor->seat, cont);
 	}
 
 	wlr_seat_pointer_notify_button(cursor->seat->wlr_seat, event->time_msec,

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -13,6 +13,7 @@ sway_sources = files(
 	'commands/exec.c',
 	'commands/exec_always.c',
 	'commands/focus.c',
+	'commands/focus_follows_mouse.c',
 	'commands/kill.c',
 	'commands/include.c',
 	'commands/input.c',


### PR DESCRIPTION
Also contains two other small changes:

- Clicking any button will focus the container clicked (not just left)
- Remove seamless_mouse (doesn't make sense on wlroots)

Test plan:

- `focus_follows_mouse yes` (default) should move focus as the mouse moves over new views/containers
- `focus_follows_mouse no` should not move focus as the mouse moves over new views/containers
- Should not break when mouse is moved over popups, layers, etc

Fixes #786 