### PR TITLE
Implement mouse warping

### DIFF
--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+
+struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "mouse_warping", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	} else if (strcasecmp(argv[0], "output") == 0) {
+		config->mouse_warping = true;
+	} else if (strcasecmp(argv[0], "none") == 0) {
+		config->mouse_warping = false;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "mouse_warping",
+				"Expected 'mouse_warping output|none'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -156,8 +156,8 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	cursor_send_pointer_motion(cursor, event->time_msec);
 }
 
-static void handle_cursor_motion_absolute(struct wl_listener *listener,
-		void *data) {
+static void handle_cursor_motion_absolute(
+		struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, motion_absolute);
 	struct wlr_event_pointer_motion_absolute *event = data;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -63,6 +63,7 @@ sway_sources = files(
 	'commands/input/xkb_options.c',
 	'commands/input/xkb_rules.c',
 	'commands/input/xkb_variant.c',
+	'commands/mouse_warping.c',
 	'commands/output.c',
 	'commands/reload.c',
 	'commands/workspace.c',


### PR DESCRIPTION
Test plan:

- `mouse_warping output` (default) should make the mouse follow the focused output.
- `mouse_warping none` should not warp the mouse at all.