### PR TITLE
Implement focus_follows_mouse, mouse_warping

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -304,7 +304,6 @@ struct sway_config {
 	bool reloading;
 	bool reading;
 	bool auto_back_and_forth;
-	bool seamless_mouse;
 	bool show_marks;
 
 	bool edge_gaps;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -56,6 +56,9 @@ void sway_seat_configure_xcursor(struct sway_seat *seat);
 
 void sway_seat_set_focus(struct sway_seat *seat, struct sway_container *container);
 
+void sway_seat_set_focus_warp(struct sway_seat *seat,
+		struct sway_container *container, bool warp);
+
 struct sway_container *sway_seat_get_focus(struct sway_seat *seat);
 
 /**

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -98,6 +98,7 @@ static struct cmd_handler handlers[] = {
 	{ "bindsym", cmd_bindsym },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
+	{ "focus_follows_mouse", cmd_focus_follows_mouse },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -101,6 +101,7 @@ static struct cmd_handler handlers[] = {
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },
+	{ "mouse_warping", cmd_mouse_warping },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },
 	{ "workspace", cmd_workspace },

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -1,0 +1,12 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+
+struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	config->focus_follows_mouse = !strcasecmp(argv[0], "yes");
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+
+struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "mouse_warping", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	} else if (strcasecmp(argv[0], "output") == 0) {
+		config->mouse_warping = true;
+	} else if (strcasecmp(argv[0], "none") == 0) {
+		config->mouse_warping = false;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "mouse_warping",
+				"Expected 'mouse_warping output|none'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+

--- a/sway/config.c
+++ b/sway/config.c
@@ -178,7 +178,6 @@ static void config_defaults(struct sway_config *config) {
 	config->active = false;
 	config->failed = false;
 	config->auto_back_and_forth = false;
-	config->seamless_mouse = true;
 	config->reading = false;
 	config->show_marks = true;
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -125,7 +125,10 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	struct wlr_seat *seat = cursor->seat->wlr_seat;
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	container_at_cursor(cursor, &surface, &sx, &sy);
+	struct sway_container *c = container_at_cursor(cursor, &surface, &sx, &sy);
+	if (c && config->focus_follows_mouse) {
+		sway_seat_set_focus(cursor->seat, c);
+	}
 
 	// reset cursor if switching between clients
 	struct wl_client *client = NULL;
@@ -170,33 +173,31 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, button);
 	struct wlr_event_pointer_button *event = data;
 
-	if (event->button == BTN_LEFT) {
-		struct wlr_surface *surface = NULL;
-		double sx, sy;
-		struct sway_container *cont =
-			container_at_cursor(cursor, &surface, &sx, &sy);
-		// Avoid moving keyboard focus from a surface that accepts it to one
-		// that does not unless the change would move us to a new workspace.
-		//
-		// This prevents, for example, losing focus when clicking on swaybar.
-		//
-		// TODO: Replace this condition with something like
-		// !surface_accepts_keyboard_input
-		if (surface && cont && cont->type != C_VIEW) {
-			struct sway_container *new_ws = cont;
-			if (new_ws && new_ws->type != C_WORKSPACE) {
-				new_ws = container_parent(new_ws, C_WORKSPACE);
-			}
-			struct sway_container *old_ws = sway_seat_get_focus(cursor->seat);
-			if (old_ws && old_ws->type != C_WORKSPACE) {
-				old_ws = container_parent(old_ws, C_WORKSPACE);
-			}
-			if (new_ws != old_ws) {
-				sway_seat_set_focus(cursor->seat, cont);
-			}
-		} else {
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+	struct sway_container *cont =
+		container_at_cursor(cursor, &surface, &sx, &sy);
+	// Avoid moving keyboard focus from a surface that accepts it to one
+	// that does not unless the change would move us to a new workspace.
+	//
+	// This prevents, for example, losing focus when clicking on swaybar.
+	//
+	// TODO: Replace this condition with something like
+	// !surface_accepts_keyboard_input
+	if (surface && cont && cont->type != C_VIEW) {
+		struct sway_container *new_ws = cont;
+		if (new_ws && new_ws->type != C_WORKSPACE) {
+			new_ws = container_parent(new_ws, C_WORKSPACE);
+		}
+		struct sway_container *old_ws = sway_seat_get_focus(cursor->seat);
+		if (old_ws && old_ws->type != C_WORKSPACE) {
+			old_ws = container_parent(old_ws, C_WORKSPACE);
+		}
+		if (new_ws != old_ws) {
 			sway_seat_set_focus(cursor->seat, cont);
 		}
+	} else {
+		sway_seat_set_focus(cursor->seat, cont);
 	}
 
 	wlr_seat_pointer_notify_button(cursor->seat->wlr_seat, event->time_msec,

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -120,6 +120,9 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 	return NULL;
 }
 
+void _sway_seat_set_focus(struct sway_seat *seat,
+		struct sway_container *container, bool warp);
+
 static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 		uint32_t time) {
 	struct wlr_seat *seat = cursor->seat->wlr_seat;
@@ -127,7 +130,7 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	double sx, sy;
 	struct sway_container *c = container_at_cursor(cursor, &surface, &sx, &sy);
 	if (c && config->focus_follows_mouse) {
-		sway_seat_set_focus(cursor->seat, c);
+		_sway_seat_set_focus(cursor->seat, c, false);
 	}
 
 	// reset cursor if switching between clients

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -120,9 +120,6 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 	return NULL;
 }
 
-void _sway_seat_set_focus(struct sway_seat *seat,
-		struct sway_container *container, bool warp);
-
 static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 		uint32_t time) {
 	struct wlr_seat *seat = cursor->seat->wlr_seat;
@@ -130,7 +127,7 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	double sx, sy;
 	struct sway_container *c = container_at_cursor(cursor, &surface, &sx, &sy);
 	if (c && config->focus_follows_mouse) {
-		_sway_seat_set_focus(cursor->seat, c, false);
+		sway_seat_set_focus_warp(cursor->seat, c, false);
 	}
 
 	// reset cursor if switching between clients

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -156,8 +156,8 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	cursor_send_pointer_motion(cursor, event->time_msec);
 }
 
-static void handle_cursor_motion_absolute(struct wl_listener *listener,
-		void *data) {
+static void handle_cursor_motion_absolute(
+		struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, motion_absolute);
 	struct wlr_event_pointer_motion_absolute *event = data;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -291,8 +291,8 @@ void sway_seat_configure_xcursor(struct sway_seat *seat) {
 		seat->cursor->cursor->y);
 }
 
-void sway_seat_set_focus(struct sway_seat *seat,
-		struct sway_container *container) {
+void _sway_seat_set_focus(struct sway_seat *seat,
+		struct sway_container *container, bool warp) {
 	struct sway_container *last_focus = sway_seat_get_focus(seat);
 
 	if (container && last_focus == container) {
@@ -349,7 +349,9 @@ void sway_seat_set_focus(struct sway_seat *seat,
 		if (new_output && new_output->type != C_OUTPUT) {
 			new_output = container_parent(new_output, C_OUTPUT);
 		}
-		if (new_output != last_output && config->mouse_warping) {
+		if (new_output && last_output && new_output != last_output
+				&& config->mouse_warping && warp) {
+			wlr_log(L_DEBUG, "warpin the mouse baby");
 			struct wlr_output *output = new_output->sway_output->wlr_output;
 			// TODO: Change container coords to layout coords
 			double x = container->x + output->lx + container->width / 2.0;
@@ -365,6 +367,11 @@ void sway_seat_set_focus(struct sway_seat *seat,
 	}
 
 	seat->has_focus = (container != NULL);
+}
+
+void sway_seat_set_focus(struct sway_seat *seat,
+		struct sway_container *container) {
+	_sway_seat_set_focus(seat, container, true);
 }
 
 struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat, struct sway_container *container) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -63,6 +63,7 @@ sway_sources = files(
 	'commands/input/xkb_options.c',
 	'commands/input/xkb_rules.c',
 	'commands/input/xkb_variant.c',
+	'commands/mouse_warping.c',
 	'commands/output.c',
 	'commands/reload.c',
 	'commands/workspace.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -13,6 +13,7 @@ sway_sources = files(
 	'commands/exec.c',
 	'commands/exec_always.c',
 	'commands/focus.c',
+	'commands/focus_follows_mouse.c',
 	'commands/kill.c',
 	'commands/include.c',
 	'commands/input.c',


### PR DESCRIPTION
Superceeds #1680, #1683 

Test plan:

- `mouse_warping output` (default) should make the mouse follow the focused output.
- `mouse_warping none` should not warp the mouse at all.
- `focus_follows_mouse yes` (default) should move focus as the mouse moves over new views/containers
- `focus_follows_mouse no` should not move focus as the mouse moves over new views/containers
- Should not break when mouse is moved over popups, layers, etc