### PR TITLE
Fix two segfaults when destroying outputs

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -238,11 +238,12 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&sway_layer->unmap.link);
 	wl_list_remove(&sway_layer->surface_commit.link);
 	if (sway_layer->layer_surface->output != NULL) {
+		struct sway_output *output = sway_layer->layer_surface->output->data;
+		arrange_layers(output);
+
 		wl_list_remove(&sway_layer->output_destroy.link);
 	}
-	struct sway_output *output = sway_layer->layer_surface->output->data;
 	free(sway_layer);
-	arrange_layers(output);
 }
 
 static void handle_map(struct wl_listener *listener, void *data) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -107,7 +107,7 @@ struct sway_container *container_reap_empty(struct sway_container *container) {
 		return NULL;
 	}
 	wlr_log(L_DEBUG, "reaping %p %s", container, container->name);
-	while (container->children->length == 0) {
+	while (container != &root_container && container->children->length == 0) {
 		if (container->type == C_WORKSPACE) {
 			if (!workspace_is_visible(container)) {
 				struct sway_container *parent = container->parent;


### PR DESCRIPTION
Test plan: open two outputs on the X11 backend, close them.