### PR TITLE
Fix back-and-forth workspace name saving for non-empty workspaces

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -351,7 +351,7 @@ bool workspace_switch(struct sway_container *workspace) {
 	}
 	struct sway_container *active_ws = focus;
 	if (active_ws->type != C_WORKSPACE) {
-		container_parent(focus, C_WORKSPACE);
+		active_ws = container_parent(focus, C_WORKSPACE);
 	}
 
 	if (config->auto_back_and_forth


### PR DESCRIPTION
# Summary
Due to a missing assignment, the name of the active container is saved for workspace back-and-forth instead of the name of the workspace. For an empty workspace, the active container is the workspace. However, for a non-empty workspace, it will be a descendant of the workspace.

This PR makes a single line fix to add that missing assignment so that the name of the workspace is stored in both cases.

# Test Plan
0. Recommended Prerequisite
    - Add a binding for `workspace back-and-forth` to the sway config

1. Switching from an empty workspace
    - Switch to workspace 2
    - Switch to workspace 1
    - Switch to workspace back-and-forth
    - Look at either swaybar and/or the output of `swaymsg -t get_workspaces` and verify that the active workspace is `2`

2. Switching from a non-empty workspace
    - Switch to workspace 2
    - Open a terminal (or any other window)
    - Switch to workspace 1
    - Switch to workspace back-and-forth
    - Look at either swaybar and/or the output of `swaymsg -t get_workspaces` and verify that the active workspace is `2`