### PR TITLE
Seat fixes and cleanup

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -377,6 +377,7 @@ void free_config(struct sway_config *config);
 void config_clear_handler_context(struct sway_config *config);
 
 void free_sway_variable(struct sway_variable *var);
+
 /**
  * Does variable replacement for a string based on the config's currently loaded variables.
  */
@@ -385,44 +386,68 @@ char *do_var_replacement(char *str);
 struct cmd_results *check_security_config();
 
 int input_identifier_cmp(const void *item, const void *data);
+
 struct input_config *new_input_config(const char* identifier);
+
 void merge_input_config(struct input_config *dst, struct input_config *src);
+
 struct input_config *copy_input_config(struct input_config *ic);
+
 void free_input_config(struct input_config *ic);
+
 void apply_input_config(struct input_config *input);
 
 int seat_name_cmp(const void *item, const void *data);
+
 struct seat_config *new_seat_config(const char* name);
+
 void merge_seat_config(struct seat_config *dst, struct seat_config *src);
+
 struct seat_config *copy_seat_config(struct seat_config *seat);
+
 void free_seat_config(struct seat_config *ic);
+
 struct seat_attachment_config *seat_attachment_config_new();
+
 struct seat_attachment_config *seat_config_get_attachment(
 		struct seat_config *seat_config, char *identifier);
+
 void apply_seat_config(struct seat_config *seat);
 
 int output_name_cmp(const void *item, const void *data);
+
 void output_get_identifier(char *identifier, size_t len,
 	struct sway_output *output);
+
 struct output_config *new_output_config(const char *name);
+
 void merge_output_config(struct output_config *dst, struct output_config *src);
+
 void apply_output_config(struct output_config *oc,
 		struct sway_container *output);
+
 void free_output_config(struct output_config *oc);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);
 
 int sway_binding_cmp(const void *a, const void *b);
+
 int sway_binding_cmp_qsort(const void *a, const void *b);
+
 int sway_binding_cmp_keys(const void *a, const void *b);
+
 void free_sway_binding(struct sway_binding *sb);
+
 struct sway_binding *sway_binding_dup(struct sway_binding *sb);
 
-/* Bar stuff */
 void load_swaybars();
+
 void invoke_swaybar(struct bar_config *bar);
+
 void terminate_swaybg(pid_t pid);
+
 struct bar_config *default_bar_config(void);
+
 void free_bar_config(struct bar_config *bar);
 
 /* Global config singleton. */

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -27,24 +27,23 @@ struct sway_input_manager {
 	struct wl_listener new_input;
 };
 
-struct sway_input_manager *sway_input_manager_create(
-		struct sway_server *server);
+struct sway_input_manager *input_manager_create(struct sway_server *server);
 
-bool sway_input_manager_has_focus(struct sway_input_manager *input,
+bool input_manager_has_focus(struct sway_input_manager *input,
 		struct sway_container *container);
 
-void sway_input_manager_set_focus(struct sway_input_manager *input,
+void input_manager_set_focus(struct sway_input_manager *input,
 		struct sway_container *container);
 
-void sway_input_manager_configure_xcursor(struct sway_input_manager *input);
+void input_manager_configure_xcursor(struct sway_input_manager *input);
 
-void sway_input_manager_apply_input_config(struct sway_input_manager *input,
+void input_manager_apply_input_config(struct sway_input_manager *input,
 		struct input_config *input_config);
 
-void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
+void input_manager_apply_seat_config(struct sway_input_manager *input,
 		struct seat_config *seat_config);
 
-struct sway_seat *sway_input_manager_get_default_seat(
+struct sway_seat *input_manager_get_default_seat(
 		struct sway_input_manager *input);
 
 struct sway_seat *input_manager_get_seat(struct sway_input_manager *input,

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -14,7 +14,6 @@ extern struct sway_input_manager *input_manager;
 struct sway_input_device {
 	char *identifier;
 	struct wlr_input_device *wlr_device;
-	struct input_config *config;
 	struct wl_list link;
 	struct wl_listener device_destroy;
 };
@@ -49,7 +48,12 @@ struct sway_seat *input_manager_get_default_seat(
 struct sway_seat *input_manager_get_seat(struct sway_input_manager *input,
 		const char *seat_name);
 
-/** Gets the last seat the user interacted with */
+/**
+ * Gets the last seat the user interacted with
+ */
 struct sway_seat *input_manager_current_seat(struct sway_input_manager *input);
+
+struct input_config *input_device_get_config(struct sway_input_device *device);
+
 
 #endif

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -38,28 +38,28 @@ struct sway_seat {
 	struct wl_list link; // input_manager::seats
 };
 
-struct sway_seat *sway_seat_create(struct sway_input_manager *input,
+struct sway_seat *seat_create(struct sway_input_manager *input,
 		const char *seat_name);
 
-void sway_seat_destroy(struct sway_seat *seat);
+void seat_destroy(struct sway_seat *seat);
 
-void sway_seat_add_device(struct sway_seat *seat,
+void seat_add_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 
-void sway_seat_configure_device(struct sway_seat *seat,
+void seat_configure_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 
-void sway_seat_remove_device(struct sway_seat *seat,
+void seat_remove_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 
-void sway_seat_configure_xcursor(struct sway_seat *seat);
+void seat_configure_xcursor(struct sway_seat *seat);
 
-void sway_seat_set_focus(struct sway_seat *seat, struct sway_container *container);
+void seat_set_focus(struct sway_seat *seat, struct sway_container *container);
 
-void sway_seat_set_focus_warp(struct sway_seat *seat,
+void seat_set_focus_warp(struct sway_seat *seat,
 		struct sway_container *container, bool warp);
 
-struct sway_container *sway_seat_get_focus(struct sway_seat *seat);
+struct sway_container *seat_get_focus(struct sway_seat *seat);
 
 /**
  * Return the last container to be focused for the seat (or the most recently
@@ -70,12 +70,12 @@ struct sway_container *sway_seat_get_focus(struct sway_seat *seat);
  * is destroyed, or focus moves to a container with children and we need to
  * descend into the next leaf in focus order.
  */
-struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat,
+struct sway_container *seat_get_focus_inactive(struct sway_seat *seat,
 		struct sway_container *container);
 
-struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
+struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		enum sway_container_type type);
 
-void sway_seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
+void seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
 
 #endif

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -23,7 +23,6 @@ struct sway_seat_container {
 
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
-	struct seat_config *config;
 	struct sway_cursor *cursor;
 	struct sway_input_manager *input;
 
@@ -76,6 +75,8 @@ struct sway_container *seat_get_focus_inactive(struct sway_seat *seat,
 struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		enum sway_container_type type);
 
-void seat_set_config(struct sway_seat *seat, struct seat_config *seat_config);
+void seat_apply_config(struct sway_seat *seat, struct seat_config *seat_config);
+
+struct seat_config *seat_get_config(struct sway_seat *seat);
 
 #endif

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -8,7 +8,6 @@ struct sway_seat_device {
 	struct sway_seat *sway_seat;
 	struct sway_input_device *input_device;
 	struct sway_keyboard *keyboard;
-	struct seat_attachment_config *attachment_config;
 	struct wl_list link; // sway_seat::devices
 };
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -340,7 +340,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 				// without criteria, the command acts upon the focused
 				// container
 				config->handler_context.current_container =
-					sway_seat_get_focus_inactive(seat, &root_container);
+					seat_get_focus_inactive(seat, &root_container);
 				if (!sway_assert(config->handler_context.current_container,
 						"could not get focus-inactive for root container")) {
 					return NULL;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -72,7 +72,7 @@ void apply_input_config(struct input_config *input) {
 		list_add(config->input_configs, input);
 	}
 
-	sway_input_manager_apply_input_config(input_manager, input);
+	input_manager_apply_input_config(input_manager, input);
 }
 
 void apply_seat_config(struct seat_config *seat) {
@@ -88,7 +88,7 @@ void apply_seat_config(struct seat_config *seat) {
 		list_add(config->seat_configs, seat);
 	}
 
-	sway_input_manager_apply_seat_config(input_manager, seat);
+	input_manager_apply_seat_config(input_manager, seat);
 }
 
 /* Keep alphabetized */
@@ -262,7 +262,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 
 	if (seat == NULL) {
 		// passing a NULL seat means we just pick the default seat
-		seat = sway_input_manager_get_default_seat(input_manager);
+		seat = input_manager_get_default_seat(input_manager);
 		if (!sway_assert(seat, "could not find a seat to run the command on")) {
 			return NULL;
 		}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -75,20 +75,20 @@ void apply_input_config(struct input_config *input) {
 	input_manager_apply_input_config(input_manager, input);
 }
 
-void apply_seat_config(struct seat_config *seat) {
+void apply_seat_config(struct seat_config *seat_config) {
 	int i;
-	i = list_seq_find(config->seat_configs, seat_name_cmp, seat->name);
+	i = list_seq_find(config->seat_configs, seat_name_cmp, seat_config->name);
 	if (i >= 0) {
 		// merge existing config
 		struct seat_config *sc = config->seat_configs->items[i];
-		merge_seat_config(sc, seat);
-		free_seat_config(seat);
-		seat = sc;
+		merge_seat_config(sc, seat_config);
+		free_seat_config(seat_config);
+		seat_config = sc;
 	} else {
-		list_add(config->seat_configs, seat);
+		list_add(config->seat_configs, seat_config);
 	}
 
-	input_manager_apply_seat_config(input_manager, seat);
+	input_manager_apply_seat_config(input_manager, seat_config);
 }
 
 /* Keep alphabetized */

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -40,7 +40,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	}
 
 	if (argc == 0) {
-		sway_seat_set_focus(seat, con);
+		seat_set_focus(seat, con);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
@@ -53,7 +53,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 
 	struct sway_container *next_focus = container_get_in_direction(con, seat, direction);
 	if (next_focus) {
-		sway_seat_set_focus(seat, next_focus);
+		seat_set_focus(seat, next_focus);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -14,7 +14,8 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 		free_seat_config(config->handler_context.seat_config);
 		config->handler_context.seat_config = new_seat_config(argv[0]);
 		if (!config->handler_context.seat_config) {
-			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+			return cmd_results_new(CMD_FAILURE, NULL,
+					"Couldn't allocate config");
 		}
 		wlr_log(L_DEBUG, "entering seat block: %s", argv[0]);
 		return cmd_results_new(CMD_BLOCK_SEAT, NULL, NULL);
@@ -28,7 +29,8 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	if (!has_context) {
 		config->handler_context.seat_config = new_seat_config(argv[0]);
 		if (!config->handler_context.seat_config) {
-			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+			return cmd_results_new(CMD_FAILURE, NULL,
+					"Couldn't allocate config");
 		}
 	}
 
@@ -41,7 +43,10 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	} else if (strcasecmp("fallback", argv[1]) == 0) {
 		res = seat_cmd_fallback(argc_new, argv_new);
 	} else {
-		res = cmd_results_new(CMD_INVALID, "seat <name>", "Unknown command %s", argv[1]);
+		res =
+			cmd_results_new(CMD_INVALID,
+				"seat <name>", "Unknown command %s",
+				argv[1]);
 	}
 
 	if (!has_context) {

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -91,7 +91,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 		workspace_switch(ws);
 		current_container =
-			sway_seat_get_focus(config->handler_context.seat);
+			seat_get_focus(config->handler_context.seat);
 		struct sway_container *new_output = container_parent(current_container, C_OUTPUT);
 
 		if (config->mouse_warping && old_output != new_output) {

--- a/sway/config.c
+++ b/sway/config.c
@@ -125,7 +125,7 @@ static void destroy_removed_seats(struct sway_config *old_config,
 				seat_name_cmp, seat_config->name) < 0) {
 			seat = input_manager_get_seat(input_manager,
 				seat_config->name);
-			sway_seat_destroy(seat);
+			seat_destroy(seat);
 		}
 	}
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -370,7 +370,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		wl_list_init(&output->layers[i]);
 	}
 
-	sway_input_manager_configure_xcursor(input_manager);
+	input_manager_configure_xcursor(input_manager);
 
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->destroy.notify = handle_destroy;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -228,7 +228,7 @@ static void render_output(struct sway_output *output, struct timespec *when,
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus =
-		sway_seat_get_focus_inactive(seat, output->swayc);
+		seat_get_focus_inactive(seat, output->swayc);
 	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
 			container_parent(focus, C_WORKSPACE));

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -133,7 +133,7 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&shell_surface->events.destroy, &sway_surface->destroy);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus = seat_get_focus_inactive(seat, &root_container);
 	struct sway_container *cont = container_view_create(focus, sway_view);
 	sway_view->swayc = cont;
 

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -138,5 +138,5 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	sway_view->swayc = cont;
 
 	arrange_windows(cont->parent, -1, -1);
-	sway_input_manager_set_focus(input_manager, cont);
+	input_manager_set_focus(input_manager, cont);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -102,7 +102,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_container *cont = container_view_create(focus, view);
 	view->swayc = cont;
 	arrange_windows(cont->parent, -1, -1);
-	sway_input_manager_set_focus(input_manager, cont);
+	input_manager_set_focus(input_manager, cont);
 
 	view_damage_whole(sway_surface->view);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -98,7 +98,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	container_view_destroy(view->swayc);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus = seat_get_focus_inactive(seat, &root_container);
 	struct sway_container *cont = container_view_create(focus, view);
 	view->swayc = cont;
 	arrange_windows(cont->parent, -1, -1);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -148,7 +148,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		struct sway_container *cont = container_view_create(focus, view);
 		view->swayc = cont;
 		arrange_windows(cont->parent, -1, -1);
-		sway_input_manager_set_focus(input_manager, cont);
+		input_manager_set_focus(input_manager, cont);
 	}
 
 	view_damage_whole(sway_surface->view);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -143,7 +143,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		wlr_xwayland_surface_set_maximized(xsurface, true);
 
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		struct sway_container *focus = sway_seat_get_focus_inactive(seat,
+		struct sway_container *focus = seat_get_focus_inactive(seat,
 			&root_container);
 		struct sway_container *cont = container_view_create(focus, view);
 		view->swayc = cont;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -84,7 +84,7 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 
 	// find the focused workspace on the output for this seat
 	struct sway_container *ws =
-		sway_seat_get_focus_inactive(cursor->seat, output->swayc);
+		seat_get_focus_inactive(cursor->seat, output->swayc);
 	if (ws && ws->type != C_WORKSPACE) {
 		ws = container_parent(ws, C_WORKSPACE);
 	}
@@ -129,7 +129,7 @@ static void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	double sx, sy;
 	struct sway_container *c = container_at_cursor(cursor, &surface, &sx, &sy);
 	if (c && config->focus_follows_mouse) {
-		sway_seat_set_focus_warp(cursor->seat, c, false);
+		seat_set_focus_warp(cursor->seat, c, false);
 	}
 
 	// reset cursor if switching between clients
@@ -191,15 +191,15 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 		if (new_ws && new_ws->type != C_WORKSPACE) {
 			new_ws = container_parent(new_ws, C_WORKSPACE);
 		}
-		struct sway_container *old_ws = sway_seat_get_focus(cursor->seat);
+		struct sway_container *old_ws = seat_get_focus(cursor->seat);
 		if (old_ws && old_ws->type != C_WORKSPACE) {
 			old_ws = container_parent(old_ws, C_WORKSPACE);
 		}
 		if (new_ws != old_ws) {
-			sway_seat_set_focus(cursor->seat, cont);
+			seat_set_focus(cursor->seat, cont);
 		}
 	} else {
-		sway_seat_set_focus(cursor->seat, cont);
+		seat_set_focus(cursor->seat, cont);
 	}
 
 	wlr_seat_pointer_notify_button(cursor->seat->wlr_seat, event->time_msec,

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -40,7 +40,7 @@ struct sway_seat *input_manager_get_seat(
 		}
 	}
 
-	return sway_seat_create(input, seat_name);
+	return seat_create(input, seat_name);
 }
 
 static char *get_device_identifier(struct wlr_input_device *device) {
@@ -175,7 +175,7 @@ static void handle_device_destroy(struct wl_listener *listener, void *data) {
 
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input_manager->seats, link) {
-		sway_seat_remove_device(seat, input_device);
+		seat_remove_device(seat, input_device);
 	}
 
 	wl_list_remove(&input_device->link);
@@ -221,7 +221,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	if (!input_has_seat_configuration(input)) {
 		wlr_log(L_DEBUG, "no seat configuration, using default seat");
 		seat = input_manager_get_seat(input, default_seat);
-		sway_seat_add_device(seat, input_device);
+		seat_add_device(seat, input_device);
 		return;
 	}
 
@@ -232,7 +232,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 			 seat_config_get_attachment(seat->config, "*"));
 
 		if (has_attachment) {
-			sway_seat_add_device(seat, input_device);
+			seat_add_device(seat, input_device);
 			added = true;
 		}
 	}
@@ -240,7 +240,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	if (!added) {
 		wl_list_for_each(seat, &input->seats, link) {
 			if (seat->config && seat->config->fallback == 1) {
-				sway_seat_add_device(seat, input_device);
+				seat_add_device(seat, input_device);
 				added = true;
 			}
 		}
@@ -281,7 +281,7 @@ bool sway_input_manager_has_focus(struct sway_input_manager *input,
 		struct sway_container *container) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
-		if (sway_seat_get_focus(seat) == container) {
+		if (seat_get_focus(seat) == container) {
 			return true;
 		}
 	}
@@ -293,7 +293,7 @@ void sway_input_manager_set_focus(struct sway_input_manager *input,
 		struct sway_container *container) {
 	struct sway_seat *seat ;
 	wl_list_for_each(seat, &input->seats, link) {
-		sway_seat_set_focus(seat, container);
+		seat_set_focus(seat, container);
 	}
 }
 
@@ -311,7 +311,7 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 
 			struct sway_seat *seat = NULL;
 			wl_list_for_each(seat, &input->seats, link) {
-				sway_seat_configure_device(seat, input_device);
+				seat_configure_device(seat, input_device);
 			}
 		}
 	}
@@ -326,7 +326,7 @@ void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 		return;
 	}
 
-	sway_seat_set_config(seat, seat_config);
+	seat_set_config(seat, seat_config);
 
 	// for every device, try to add it to a seat and if no seat has it
 	// attached, add it to the fallback seats.
@@ -355,17 +355,17 @@ void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 					}
 				}
 				if (attached) {
-					sway_seat_add_device(seat, input_device);
+					seat_add_device(seat, input_device);
 				} else {
-					sway_seat_remove_device(seat, input_device);
+					seat_remove_device(seat, input_device);
 				}
 			}
 		} else {
 			wl_list_for_each(seat, &input->seats, link) {
 				if (seat->config && seat->config->fallback == 1) {
-					sway_seat_add_device(seat, input_device);
+					seat_add_device(seat, input_device);
 				} else {
-					sway_seat_remove_device(seat, input_device);
+					seat_remove_device(seat, input_device);
 				}
 			}
 		}
@@ -376,7 +376,7 @@ void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 void sway_input_manager_configure_xcursor(struct sway_input_manager *input) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
-		sway_seat_configure_xcursor(seat);
+		seat_configure_xcursor(seat);
 	}
 }
 

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -26,7 +26,7 @@ struct seat_config *current_seat_config = NULL;
 struct sway_seat *input_manager_current_seat(struct sway_input_manager *input) {
 	struct sway_seat *seat = config->handler_context.seat;
 	if (!seat) {
-		seat = sway_input_manager_get_default_seat(input_manager);
+		seat = input_manager_get_default_seat(input_manager);
 	}
 	return seat;
 }
@@ -91,7 +91,7 @@ static bool input_has_seat_configuration(struct sway_input_manager *input) {
 	return false;
 }
 
-static void sway_input_manager_libinput_config_pointer(struct sway_input_device *input_device) {
+static void input_manager_libinput_config_pointer(struct sway_input_device *input_device) {
 	struct wlr_input_device *wlr_device = input_device->wlr_device;
 	struct input_config *ic = input_device->config;
 	struct libinput_device *libinput_device;
@@ -101,7 +101,7 @@ static void sway_input_manager_libinput_config_pointer(struct sway_input_device 
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	wlr_log(L_DEBUG, "sway_input_manager_libinput_config_pointer(%s)", ic->identifier);
+	wlr_log(L_DEBUG, "input_manager_libinput_config_pointer(%s)", ic->identifier);
 
 	if (ic->accel_profile != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
@@ -214,7 +214,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	}
 
 	if (input_device->wlr_device->type == WLR_INPUT_DEVICE_POINTER) {
-		sway_input_manager_libinput_config_pointer(input_device);
+		input_manager_libinput_config_pointer(input_device);
 	}
 
 	struct sway_seat *seat = NULL;
@@ -256,7 +256,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	input_device->device_destroy.notify = handle_device_destroy;
 }
 
-struct sway_input_manager *sway_input_manager_create(
+struct sway_input_manager *input_manager_create(
 		struct sway_server *server) {
 	struct sway_input_manager *input =
 		calloc(1, sizeof(struct sway_input_manager));
@@ -277,7 +277,7 @@ struct sway_input_manager *sway_input_manager_create(
 	return input;
 }
 
-bool sway_input_manager_has_focus(struct sway_input_manager *input,
+bool input_manager_has_focus(struct sway_input_manager *input,
 		struct sway_container *container) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
@@ -289,7 +289,7 @@ bool sway_input_manager_has_focus(struct sway_input_manager *input,
 	return false;
 }
 
-void sway_input_manager_set_focus(struct sway_input_manager *input,
+void input_manager_set_focus(struct sway_input_manager *input,
 		struct sway_container *container) {
 	struct sway_seat *seat ;
 	wl_list_for_each(seat, &input->seats, link) {
@@ -297,7 +297,7 @@ void sway_input_manager_set_focus(struct sway_input_manager *input,
 	}
 }
 
-void sway_input_manager_apply_input_config(struct sway_input_manager *input,
+void input_manager_apply_input_config(struct sway_input_manager *input,
 		struct input_config *input_config) {
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &input->devices, link) {
@@ -306,7 +306,7 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 			input_device->config = copy_input_config(input_config);
 
 			if (input_device->wlr_device->type == WLR_INPUT_DEVICE_POINTER) {
-				sway_input_manager_libinput_config_pointer(input_device);
+				input_manager_libinput_config_pointer(input_device);
 			}
 
 			struct sway_seat *seat = NULL;
@@ -317,7 +317,7 @@ void sway_input_manager_apply_input_config(struct sway_input_manager *input,
 	}
 }
 
-void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
+void input_manager_apply_seat_config(struct sway_input_manager *input,
 		struct seat_config *seat_config) {
 	wlr_log(L_DEBUG, "applying new seat config for seat %s",
 		seat_config->name);
@@ -373,14 +373,14 @@ void sway_input_manager_apply_seat_config(struct sway_input_manager *input,
 	}
 }
 
-void sway_input_manager_configure_xcursor(struct sway_input_manager *input) {
+void input_manager_configure_xcursor(struct sway_input_manager *input) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
 		seat_configure_xcursor(seat);
 	}
 }
 
-struct sway_seat *sway_input_manager_get_default_seat(
+struct sway_seat *input_manager_get_default_seat(
 		struct sway_input_manager *input) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -230,11 +230,10 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	struct seat_config *seat_config = seat_get_config(seat);
-
 	bool added = false;
 	wl_list_for_each(seat, &input->seats, link) {
-		bool has_attachment = config &&
+		struct seat_config *seat_config = seat_get_config(seat);
+		bool has_attachment = seat_config &&
 			(seat_config_get_attachment(seat_config, input_device->identifier) ||
 			 seat_config_get_attachment(seat_config, "*"));
 
@@ -246,6 +245,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 
 	if (!added) {
 		wl_list_for_each(seat, &input->seats, link) {
+			struct seat_config *seat_config = seat_get_config(seat);
 			if (seat_config && seat_config->fallback == 1) {
 				seat_add_device(seat, input_device);
 				added = true;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -92,7 +92,8 @@ static bool input_has_seat_configuration(struct sway_input_manager *input) {
 	return false;
 }
 
-static void input_manager_libinput_config_pointer(struct sway_input_device *input_device) {
+static void input_manager_libinput_config_pointer(
+		struct sway_input_device *input_device) {
 	struct wlr_input_device *wlr_device = input_device->wlr_device;
 	struct input_config *ic = input_device->config;
 	struct libinput_device *libinput_device;
@@ -102,22 +103,27 @@ static void input_manager_libinput_config_pointer(struct sway_input_device *inpu
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	wlr_log(L_DEBUG, "input_manager_libinput_config_pointer(%s)", ic->identifier);
+	wlr_log(L_DEBUG, "input_manager_libinput_config_pointer(%s)",
+		ic->identifier);
 
 	if (ic->accel_profile != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
 			ic->identifier, ic->accel_profile);
-		libinput_device_config_accel_set_profile(libinput_device, ic->accel_profile);
+		libinput_device_config_accel_set_profile(libinput_device,
+			ic->accel_profile);
 	}
 	if (ic->click_method != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
 			ic->identifier, ic->click_method);
-		libinput_device_config_click_set_method(libinput_device, ic->click_method);
+		libinput_device_config_click_set_method(libinput_device,
+			ic->click_method);
 	}
 	if (ic->drag_lock != INT_MIN) {
-		wlr_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
+		wlr_log(L_DEBUG,
+			"libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			ic->identifier, ic->click_method);
-		libinput_device_config_tap_set_drag_lock_enabled(libinput_device, ic->drag_lock);
+		libinput_device_config_tap_set_drag_lock_enabled(libinput_device,
+			ic->drag_lock);
 	}
 	if (ic->dwt != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
@@ -125,34 +131,43 @@ static void input_manager_libinput_config_pointer(struct sway_input_device *inpu
 		libinput_device_config_dwt_set_enabled(libinput_device, ic->dwt);
 	}
 	if (ic->left_handed != INT_MIN) {
-		wlr_log(L_DEBUG, "libinput_config_pointer(%s) left_handed_set_enabled(%d)",
+		wlr_log(L_DEBUG,
+			"libinput_config_pointer(%s) left_handed_set_enabled(%d)",
 			ic->identifier, ic->left_handed);
-		libinput_device_config_left_handed_set(libinput_device, ic->left_handed);
+		libinput_device_config_left_handed_set(libinput_device,
+			ic->left_handed);
 	}
 	if (ic->middle_emulation != INT_MIN) {
-		wlr_log(L_DEBUG, "libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
+		wlr_log(L_DEBUG,
+			"libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
 			ic->identifier, ic->middle_emulation);
-		libinput_device_config_middle_emulation_set_enabled(libinput_device, ic->middle_emulation);
+		libinput_device_config_middle_emulation_set_enabled(libinput_device,
+			ic->middle_emulation);
 	}
 	if (ic->natural_scroll != INT_MIN) {
-		wlr_log(L_DEBUG, "libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
+		wlr_log(L_DEBUG,
+			"libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
 			ic->identifier, ic->natural_scroll);
-		libinput_device_config_scroll_set_natural_scroll_enabled(libinput_device, ic->natural_scroll);
+		libinput_device_config_scroll_set_natural_scroll_enabled(
+			libinput_device, ic->natural_scroll);
 	}
 	if (ic->pointer_accel != FLT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
 			ic->identifier, ic->pointer_accel);
-		libinput_device_config_accel_set_speed(libinput_device, ic->pointer_accel);
+		libinput_device_config_accel_set_speed(libinput_device,
+			ic->pointer_accel);
 	}
 	if (ic->scroll_method != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
 			ic->identifier, ic->scroll_method);
-		libinput_device_config_scroll_set_method(libinput_device, ic->scroll_method);
+		libinput_device_config_scroll_set_method(libinput_device,
+			ic->scroll_method);
 	}
 	if (ic->send_events != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
-		libinput_device_config_send_events_set_mode(libinput_device, ic->send_events);
+		libinput_device_config_send_events_set_mode(libinput_device,
+			ic->send_events);
 	}
 	if (ic->tap != INT_MIN) {
 		wlr_log(L_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -428,7 +428,7 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 	struct xkb_rule_names rules;
 	memset(&rules, 0, sizeof(rules));
 	struct input_config *input_config =
-		keyboard->seat_device->input_device->config;
+		input_device_get_config(keyboard->seat_device->input_device);
 	struct wlr_input_device *wlr_device =
 		keyboard->seat_device->input_device->wlr_device;
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -49,7 +49,8 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 	if  (is_focus) {
 		// pick next focus
 		seat_set_focus(seat, NULL);
-		struct sway_container *next = seat_get_focus_inactive(seat, con->parent);
+		struct sway_container *next =
+			seat_get_focus_inactive(seat, con->parent);
 		if (next == NULL) {
 			next = con->parent;
 		}
@@ -133,7 +134,8 @@ struct sway_seat *seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	container_for_each_descendant_dfs(&root_container, collect_focus_iter, seat);
+	container_for_each_descendant_dfs(&root_container,
+		collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);
@@ -165,7 +167,8 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	if (!seat_device->keyboard) {
 		sway_keyboard_create(seat, seat_device);
 	}
-	struct wlr_keyboard *wlr_keyboard = seat_device->input_device->wlr_device->keyboard;
+	struct wlr_keyboard *wlr_keyboard =
+		seat_device->input_device->wlr_device->keyboard;
 	sway_keyboard_configure(seat_device->keyboard);
 	wlr_seat_set_keyboard(seat->wlr_seat,
 			seat_device->input_device->wlr_device);
@@ -275,7 +278,8 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 	}
 
 	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *output_container = root_container.children->items[i];
+		struct sway_container *output_container =
+			root_container.children->items[i];
 		struct wlr_output *output =
 			output_container->sway_output->wlr_output;
 		bool result =
@@ -379,7 +383,8 @@ void seat_set_focus(struct sway_seat *seat,
 	seat_set_focus_warp(seat, container, true);
 }
 
-struct sway_container *seat_get_focus_inactive(struct sway_seat *seat, struct sway_container *container) {
+struct sway_container *seat_get_focus_inactive(struct sway_seat *seat,
+		struct sway_container *container) {
 	struct sway_seat_container *current = NULL;
 	struct sway_container *parent = NULL;
 	wl_list_for_each(current, &seat->focus_stack, link) {
@@ -409,7 +414,8 @@ struct sway_container *seat_get_focus(struct sway_seat *seat) {
 
 struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		enum sway_container_type type) {
-	struct sway_container *focus = seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus =
+		seat_get_focus_inactive(seat, &root_container);
 	if (focus->type == type) {
 		return focus;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -202,13 +202,6 @@ void seat_configure_device(struct sway_seat *seat,
 		return;
 	}
 
-	struct seat_config *seat_config = seat_get_config(seat);
-
-	if (seat_config) {
-		seat_device->attachment_config =
-			seat_config_get_attachment(seat_config, input_device->identifier);
-	}
-
 	switch (input_device->wlr_device->type) {
 		case WLR_INPUT_DEVICE_POINTER:
 			seat_configure_pointer(seat, seat_device);
@@ -426,9 +419,6 @@ struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 void seat_apply_config(struct sway_seat *seat,
 		struct seat_config *seat_config) {
 	struct sway_seat_device *seat_device = NULL;
-	wl_list_for_each(seat_device, &seat->devices, link) {
-		seat_device->attachment_config = NULL;
-	}
 
 	if (!seat_config) {
 		return;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -25,7 +25,7 @@ static void seat_device_destroy(struct sway_seat_device *seat_device) {
 	free(seat_device);
 }
 
-void sway_seat_destroy(struct sway_seat *seat) {
+void seat_destroy(struct sway_seat *seat) {
 	struct sway_seat_device *seat_device, *next;
 	wl_list_for_each_safe(seat_device, next, &seat->devices, link) {
 		seat_device_destroy(seat_device);
@@ -42,18 +42,18 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 	struct sway_seat *seat = seat_con->seat;
 	struct sway_container *con = seat_con->container;
 
-	bool is_focus = (sway_seat_get_focus(seat) == con);
+	bool is_focus = (seat_get_focus(seat) == con);
 
 	wl_list_remove(&seat_con->link);
 
 	if  (is_focus) {
 		// pick next focus
-		sway_seat_set_focus(seat, NULL);
-		struct sway_container *next = sway_seat_get_focus_inactive(seat, con->parent);
+		seat_set_focus(seat, NULL);
+		struct sway_container *next = seat_get_focus_inactive(seat, con->parent);
 		if (next == NULL) {
 			next = con->parent;
 		}
-		sway_seat_set_focus(seat, next);
+		seat_set_focus(seat, next);
 	}
 
 	wl_list_remove(&seat_con->destroy.link);
@@ -110,7 +110,7 @@ static void collect_focus_iter(struct sway_container *con, void *data) {
 	wl_list_insert(&seat->focus_stack, &seat_con->link);
 }
 
-struct sway_seat *sway_seat_create(struct sway_input_manager *input,
+struct sway_seat *seat_create(struct sway_input_manager *input,
 		const char *seat_name) {
 	struct sway_seat *seat = calloc(1, sizeof(struct sway_seat));
 	if (!seat) {
@@ -147,7 +147,7 @@ struct sway_seat *sway_seat_create(struct sway_input_manager *input,
 		WL_SEAT_CAPABILITY_POINTER |
 		WL_SEAT_CAPABILITY_TOUCH);
 
-	sway_seat_configure_xcursor(seat);
+	seat_configure_xcursor(seat);
 
 	wl_list_insert(&input->seats, &seat->link);
 
@@ -169,7 +169,7 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	sway_keyboard_configure(seat_device->keyboard);
 	wlr_seat_set_keyboard(seat->wlr_seat,
 			seat_device->input_device->wlr_device);
-	struct sway_container *focus = sway_seat_get_focus(seat);
+	struct sway_container *focus = seat_get_focus(seat);
 	if (focus && focus->type == C_VIEW) {
 		// force notify reenter to pick up the new configuration
 		wlr_seat_keyboard_clear_focus(seat->wlr_seat);
@@ -179,7 +179,7 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	}
 }
 
-static struct sway_seat_device *sway_seat_get_device(struct sway_seat *seat,
+static struct sway_seat_device *seat_get_device(struct sway_seat *seat,
 		struct sway_input_device *input_device) {
 	struct sway_seat_device *seat_device = NULL;
 	wl_list_for_each(seat_device, &seat->devices, link) {
@@ -191,10 +191,10 @@ static struct sway_seat_device *sway_seat_get_device(struct sway_seat *seat,
 	return NULL;
 }
 
-void sway_seat_configure_device(struct sway_seat *seat,
+void seat_configure_device(struct sway_seat *seat,
 		struct sway_input_device *input_device) {
 	struct sway_seat_device *seat_device =
-		sway_seat_get_device(seat, input_device);
+		seat_get_device(seat, input_device);
 	if (!seat_device) {
 		return;
 	}
@@ -219,10 +219,10 @@ void sway_seat_configure_device(struct sway_seat *seat,
 	}
 }
 
-void sway_seat_add_device(struct sway_seat *seat,
+void seat_add_device(struct sway_seat *seat,
 		struct sway_input_device *input_device) {
-	if (sway_seat_get_device(seat, input_device)) {
-		sway_seat_configure_device(seat, input_device);
+	if (seat_get_device(seat, input_device)) {
+		seat_configure_device(seat, input_device);
 		return;
 	}
 
@@ -240,13 +240,13 @@ void sway_seat_add_device(struct sway_seat *seat,
 	seat_device->input_device = input_device;
 	wl_list_insert(&seat->devices, &seat_device->link);
 
-	sway_seat_configure_device(seat, input_device);
+	seat_configure_device(seat, input_device);
 }
 
-void sway_seat_remove_device(struct sway_seat *seat,
+void seat_remove_device(struct sway_seat *seat,
 		struct sway_input_device *input_device) {
 	struct sway_seat_device *seat_device =
-		sway_seat_get_device(seat, input_device);
+		seat_get_device(seat, input_device);
 
 	if (!seat_device) {
 		return;
@@ -258,7 +258,7 @@ void sway_seat_remove_device(struct sway_seat *seat,
 	seat_device_destroy(seat_device);
 }
 
-void sway_seat_configure_xcursor(struct sway_seat *seat) {
+void seat_configure_xcursor(struct sway_seat *seat) {
 	// TODO configure theme and size
 	const char *cursor_theme = NULL;
 
@@ -292,9 +292,9 @@ void sway_seat_configure_xcursor(struct sway_seat *seat) {
 		seat->cursor->cursor->y);
 }
 
-void sway_seat_set_focus_warp(struct sway_seat *seat,
+void seat_set_focus_warp(struct sway_seat *seat,
 		struct sway_container *container, bool warp) {
-	struct sway_container *last_focus = sway_seat_get_focus(seat);
+	struct sway_container *last_focus = seat_get_focus(seat);
 
 	if (container && last_focus == container) {
 		return;
@@ -372,12 +372,12 @@ void sway_seat_set_focus_warp(struct sway_seat *seat,
 	seat->has_focus = (container != NULL);
 }
 
-void sway_seat_set_focus(struct sway_seat *seat,
+void seat_set_focus(struct sway_seat *seat,
 		struct sway_container *container) {
-	sway_seat_set_focus_warp(seat, container, true);
+	seat_set_focus_warp(seat, container, true);
 }
 
-struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat, struct sway_container *container) {
+struct sway_container *seat_get_focus_inactive(struct sway_seat *seat, struct sway_container *container) {
 	struct sway_seat_container *current = NULL;
 	struct sway_container *parent = NULL;
 	wl_list_for_each(current, &seat->focus_stack, link) {
@@ -398,16 +398,16 @@ struct sway_container *sway_seat_get_focus_inactive(struct sway_seat *seat, stru
 	return NULL;
 }
 
-struct sway_container *sway_seat_get_focus(struct sway_seat *seat) {
+struct sway_container *seat_get_focus(struct sway_seat *seat) {
 	if (!seat->has_focus) {
 		return NULL;
 	}
-	return sway_seat_get_focus_inactive(seat, &root_container);
+	return seat_get_focus_inactive(seat, &root_container);
 }
 
-struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
+struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		enum sway_container_type type) {
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, &root_container);
+	struct sway_container *focus = seat_get_focus_inactive(seat, &root_container);
 	if (focus->type == type) {
 		return focus;
 	}
@@ -415,7 +415,7 @@ struct sway_container *sway_seat_get_focus_by_type(struct sway_seat *seat,
 	return container_parent(focus, type);
 }
 
-void sway_seat_set_config(struct sway_seat *seat,
+void seat_set_config(struct sway_seat *seat,
 		struct seat_config *seat_config) {
 	// clear configs
 	free_seat_config(seat->config);
@@ -434,6 +434,6 @@ void sway_seat_set_config(struct sway_seat *seat,
 	seat->config = copy_seat_config(seat_config);
 
 	wl_list_for_each(seat_device, &seat->devices, link) {
-		sway_seat_configure_device(seat, seat_device->input_device);
+		seat_configure_device(seat, seat_device->input_device);
 	}
 }

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -364,7 +364,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 	}
 
 	if (last_focus && last_focus->type == C_VIEW &&
-			!sway_input_manager_has_focus(seat->input, last_focus)) {
+			!input_manager_has_focus(seat->input, last_focus)) {
 		struct sway_view *view = last_focus->sway_view;
 		view_set_activated(view, false);
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -88,7 +88,7 @@ static void ipc_json_describe_output(struct sway_container *container, json_obje
 		json_object_new_string(
 			ipc_json_get_output_transform(wlr_output->transform)));
 
-	struct sway_seat *seat = sway_input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
 	const char *ws = NULL;
 	if (seat) {
 		struct sway_container *focus =
@@ -139,7 +139,7 @@ json_object *ipc_json_describe_container(struct sway_container *c) {
 		return NULL;
 	}
 
-	struct sway_seat *seat = sway_input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
 	bool focused = seat_get_focus(seat) == c;
 
 	json_object *object = json_object_new_object();

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -92,7 +92,7 @@ static void ipc_json_describe_output(struct sway_container *container, json_obje
 	const char *ws = NULL;
 	if (seat) {
 		struct sway_container *focus =
-			sway_seat_get_focus_inactive(seat, container);
+			seat_get_focus_inactive(seat, container);
 		if (focus && focus->type != C_WORKSPACE) {
 			focus = container_parent(focus, C_WORKSPACE);
 		}
@@ -140,7 +140,7 @@ json_object *ipc_json_describe_container(struct sway_container *c) {
 	}
 
 	struct sway_seat *seat = sway_input_manager_get_default_seat(input_manager);
-	bool focused = sway_seat_get_focus(seat) == c;
+	bool focused = seat_get_focus(seat) == c;
 
 	json_object *object = json_object_new_object();
 

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -389,7 +389,7 @@ static void ipc_get_workspaces_callback(struct sway_container *workspace,
 	// it's set differently for the get_workspaces reply
 	struct sway_seat *seat =
 		sway_input_manager_get_default_seat(input_manager);
-	struct sway_container *focused_ws = sway_seat_get_focus(seat);
+	struct sway_container *focused_ws = seat_get_focus(seat);
 	if (focused_ws != NULL && focused_ws->type != C_WORKSPACE) {
 		focused_ws = container_parent(focused_ws, C_WORKSPACE);
 	}
@@ -399,7 +399,7 @@ static void ipc_get_workspaces_callback(struct sway_container *workspace,
 			json_object_new_boolean(focused));
 	json_object_array_add((json_object *)data, workspace_json);
 
-	focused_ws = sway_seat_get_focus_inactive(seat, workspace->parent);
+	focused_ws = seat_get_focus_inactive(seat, workspace->parent);
 	if (focused_ws->type != C_WORKSPACE) {
 		focused_ws = container_parent(focused_ws, C_WORKSPACE);
 	}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -388,7 +388,7 @@ static void ipc_get_workspaces_callback(struct sway_container *workspace,
 	// override the default focused indicator because
 	// it's set differently for the get_workspaces reply
 	struct sway_seat *seat =
-		sway_input_manager_get_default_seat(input_manager);
+		input_manager_get_default_seat(input_manager);
 	struct sway_container *focused_ws = seat_get_focus(seat);
 	if (focused_ws != NULL && focused_ws->type != C_WORKSPACE) {
 		focused_ws = container_parent(focused_ws, C_WORKSPACE);

--- a/sway/server.c
+++ b/sway/server.c
@@ -109,7 +109,7 @@ bool server_init(struct sway_server *server) {
 		return false;
 	}
 
-	input_manager = sway_input_manager_create(server);
+	input_manager = input_manager_create(server);
 	return true;
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -144,7 +144,7 @@ struct sway_container *container_output_create(
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input_manager->seats, link) {
 		if (!seat->has_focus) {
-			sway_seat_set_focus(seat, ws);
+			seat_set_focus(seat, ws);
 		}
 	}
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -404,7 +404,7 @@ static struct sway_container *get_swayc_in_output_direction(
 		return NULL;
 	}
 
-	struct sway_container *ws = sway_seat_get_focus_inactive(seat, output);
+	struct sway_container *ws = seat_get_focus_inactive(seat, output);
 	if (ws->type != C_WORKSPACE) {
 		ws = container_parent(ws, C_WORKSPACE);
 	}
@@ -425,7 +425,7 @@ static struct sway_container *get_swayc_in_output_direction(
 		case MOVE_UP:
 		case MOVE_DOWN: {
 			struct sway_container *focused =
-				sway_seat_get_focus_inactive(seat, ws);
+				seat_get_focus_inactive(seat, ws);
 			if (focused && focused->parent) {
 				struct sway_container *parent = focused->parent;
 				if (parent->layout == L_VERT) {
@@ -509,7 +509,7 @@ static struct sway_container *get_swayc_in_direction_under(
 		struct sway_container *container, enum movement_direction dir,
 		struct sway_seat *seat, struct sway_container *limit) {
 	if (dir == MOVE_CHILD) {
-		return sway_seat_get_focus_inactive(seat, container);
+		return seat_get_focus_inactive(seat, container);
 	}
 
 	struct sway_container *parent = container->parent;
@@ -589,7 +589,7 @@ static struct sway_container *get_swayc_in_direction_under(
 			}
 			if (next->children && next->children->length) {
 				// TODO consider floating children as well
-				return sway_seat_get_focus_inactive(seat, next);
+				return seat_get_focus_inactive(seat, next);
 			} else {
 				return next;
 			}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -158,7 +158,7 @@ static bool _workspace_by_name(struct sway_container *view, void *data) {
 struct sway_container *workspace_by_name(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *current_workspace = NULL, *current_output = NULL;
-	struct sway_container *focus = sway_seat_get_focus(seat);
+	struct sway_container *focus = seat_get_focus(seat);
 	if (focus) {
 		current_workspace = container_parent(focus, C_WORKSPACE);
 		current_output = container_parent(focus, C_OUTPUT);
@@ -200,7 +200,7 @@ struct sway_container *workspace_create(const char *name) {
 	// Otherwise create a new one
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus =
-		sway_seat_get_focus_inactive(seat, &root_container);
+		seat_get_focus_inactive(seat, &root_container);
 	parent = focus;
 	parent = container_parent(parent, C_OUTPUT);
 	struct sway_container *new_ws = container_workspace_create(parent, name);
@@ -260,7 +260,7 @@ struct sway_container *workspace_output_prev_next_impl(
 	}
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, output);
+	struct sway_container *focus = seat_get_focus_inactive(seat, output);
 	struct sway_container *workspace = (focus->type == C_WORKSPACE ?
 			focus :
 			container_parent(focus, C_WORKSPACE));
@@ -345,7 +345,7 @@ bool workspace_switch(struct sway_container *workspace) {
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus =
-		sway_seat_get_focus_inactive(seat, &root_container);
+		seat_get_focus_inactive(seat, &root_container);
 	if (!seat || !focus) {
 		return false;
 	}
@@ -376,11 +376,11 @@ bool workspace_switch(struct sway_container *workspace) {
 
 	wlr_log(L_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);
-	struct sway_container *next = sway_seat_get_focus_inactive(seat, workspace);
+	struct sway_container *next = seat_get_focus_inactive(seat, workspace);
 	if (next == NULL) {
 		next = workspace;
 	}
-	sway_seat_set_focus(seat, next);
+	seat_set_focus(seat, next);
 	struct sway_container *output = container_parent(workspace, C_OUTPUT);
 	arrange_windows(output, -1, -1);
 	return true;
@@ -389,7 +389,7 @@ bool workspace_switch(struct sway_container *workspace) {
 bool workspace_is_visible(struct sway_container *ws) {
 	struct sway_container *output = container_parent(ws, C_OUTPUT);
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = sway_seat_get_focus_inactive(seat, output);
+	struct sway_container *focus = seat_get_focus_inactive(seat, output);
 	if (focus->type != C_WORKSPACE) {
 		focus = container_parent(focus, C_WORKSPACE);
 	}


### PR DESCRIPTION
* take `sway_` prefix off of seat and input manager functions for consistency.
* dont copy seat config on the seat
* dont copy input device config on the input device
* general cleanups and refactorings

No changes in functionality, just code cleanup.

see `sway-input.5.txt`

example:

```
seat seat1 {
        fallback true
}

seat seat0 {
	attach '9494:39:CM_Storm_Coolermaster_Novatouch_TKL'
	attach '1267:12306:ELAN1010:00_04F3:3012_Touchpad' 

}

input '1267:12306:ELAN1010:00_04F3:3012_Touchpad' {
}

input '9494:39:CM_Storm_Coolermaster_Novatouch_TKL' {
  xkb_layout de
}
```