### PR TITLE
Fix name generation from workspace number commands

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -87,6 +87,24 @@ char *workspace_next_name(const char *output_name) {
 				continue;
 			}
 
+			// If the command is workspace number <name>, isolate the name
+			if (strncmp(_target, "number ", strlen("number ")) == 0) {
+				size_t length = strlen(_target) - strlen("number ") + 1;
+				char *temp = malloc(length);
+				strncpy(temp, _target + strlen("number "), length - 1);
+				temp[length - 1] = '\0';
+				free(_target);
+				_target = temp;
+				wlr_log(L_DEBUG, "Isolated name from workspace number: '%s'", _target);
+
+				// Make sure the workspace number doesn't already exist
+				if (workspace_by_number(_target)) {
+					free(_target);
+					free(dup);
+					continue;
+				}
+			}
+
 			// Make sure that the workspace doesn't already exist
 			if (workspace_by_name(_target)) {
 				free(_target);


### PR DESCRIPTION
# Summary
A workspace name is generated by looking at the bindings and finding the first workspace command with an unused workspace name. When a command of the form `workspace number <name>` is found, the generated name is `number <name>`.

This PR isolates the `<name>` portion. Additionally, there is a check added to make sure that a workspace with that number does not already exist.

# Test Plan
1. Either use the minimal config below or add bindings for the following before any others in the sway config
   - `workspace number 1:First`
   - `workspace number 1:ThisShouldBeSkipped`
   - `workspace number 2:Second`
2. Run sway with two outputs using the command `env WLR_X11_OUTPUTS=2 sway -d -c <path-to-config>`
3. Look at swaybar and/or `swaymsg -t get_workspaces` and verify that the workspace names in use are `1:First` and `2:Second`.

# Minimal Config
<details>
<summary>Show minimal config</summary>
<pre>
set $mod Mod1
set $term urxvt
bindsym $mod+Return exec $term
bindsym $mod+Shift+e exit
bindsym $mod+1 workspace number 1:First
bindsym $mod+2 workspace number 1:ThisShouldBeSkipped
bindsym $mod+3 workspace number 2:Second
bar {
}
</pre>
</details>