### PR TITLE
<sway/man: Fix path typo for sway-security(7) default path>

### DIFF
--- a/sway/sway-security.7.txt
+++ b/sway/sway-security.7.txt
@@ -92,7 +92,7 @@ policies. These features are:
 	Permission to take screenshots or record the screen.
 
 By default, no permissions are granted (though saner defaults are provided in
-/etc/sway/config.d/security). You can use the following configuration options to control
+/etc/sway/security.d/00-defaults). You can use the following configuration options to control
 a program's access:
 
 **permit** <executable> <features...>::


### PR DESCRIPTION
Update the path provided in the documentation that refer to the
default security value provided by swaywm project.