### PR TITLE
Implement shell views

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -8,55 +8,6 @@
 #include "sway/input/seat.h"
 
 struct sway_container;
-struct sway_view;
-
-struct sway_xdg_surface_v6 {
-	struct sway_view *view;
-
-	struct wl_listener commit;
-	struct wl_listener request_move;
-	struct wl_listener request_resize;
-	struct wl_listener request_maximize;
-	struct wl_listener map;
-	struct wl_listener unmap;
-	struct wl_listener destroy;
-
-	int pending_width, pending_height;
-};
-
-struct sway_xwayland_surface {
-	struct sway_view *view;
-
-	struct wl_listener commit;
-	struct wl_listener request_move;
-	struct wl_listener request_resize;
-	struct wl_listener request_maximize;
-	struct wl_listener request_configure;
-	struct wl_listener map;
-	struct wl_listener unmap;
-	struct wl_listener destroy;
-
-	int pending_width, pending_height;
-};
-
-struct sway_xwayland_unmanaged {
-	struct wlr_xwayland_surface *wlr_xwayland_surface;
-	struct wl_list link;
-
-	struct wl_listener destroy;
-};
-
-struct sway_wl_shell_surface {
-	struct sway_view *view;
-
-	struct wl_listener commit;
-	struct wl_listener request_move;
-	struct wl_listener request_resize;
-	struct wl_listener request_maximize;
-	struct wl_listener destroy;
-
-	int pending_width, pending_height;
-};
 
 enum sway_view_type {
 	SWAY_VIEW_WL_SHELL,
@@ -78,6 +29,7 @@ struct sway_view_impl {
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
 	void (*close)(struct sway_view *view);
+	void (*destroy)(struct sway_view *view);
 };
 
 struct sway_view {
@@ -93,18 +45,55 @@ struct sway_view {
 		struct wlr_xwayland_surface *wlr_xwayland_surface;
 		struct wlr_wl_shell_surface *wlr_wl_shell_surface;
 	};
-
-	union {
-		struct sway_xdg_surface_v6 *sway_xdg_surface_v6;
-		struct sway_xwayland_surface *sway_xwayland_surface;
-		struct sway_wl_shell_surface *sway_wl_shell_surface;
-	};
 };
 
-struct sway_view *view_create(enum sway_view_type type,
-	const struct sway_view_impl *impl);
+struct sway_xdg_shell_v6_view {
+	struct sway_view view;
 
-void view_destroy(struct sway_view *view);
+	struct wl_listener commit;
+	struct wl_listener request_move;
+	struct wl_listener request_resize;
+	struct wl_listener request_maximize;
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+
+	int pending_width, pending_height;
+};
+
+struct sway_xwayland_view {
+	struct sway_view view;
+
+	struct wl_listener commit;
+	struct wl_listener request_move;
+	struct wl_listener request_resize;
+	struct wl_listener request_maximize;
+	struct wl_listener request_configure;
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+
+	int pending_width, pending_height;
+};
+
+struct sway_xwayland_unmanaged {
+	struct wlr_xwayland_surface *wlr_xwayland_surface;
+	struct wl_list link;
+
+	struct wl_listener destroy;
+};
+
+struct sway_wl_shell_view {
+	struct sway_view view;
+
+	struct wl_listener commit;
+	struct wl_listener request_move;
+	struct wl_listener request_resize;
+	struct wl_listener request_maximize;
+	struct wl_listener destroy;
+
+	int pending_width, pending_height;
+};
 
 const char *view_get_title(struct sway_view *view);
 
@@ -126,6 +115,11 @@ void view_damage_whole(struct sway_view *view);
 void view_damage_from(struct sway_view *view);
 
 // view implementation
+
+void view_init(struct sway_view *view, enum sway_view_type type,
+	const struct sway_view_impl *impl);
+
+void view_destroy(struct sway_view *view);
 
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface);
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -11,13 +11,17 @@
 #include "sway/input/input-manager.h"
 #include "log.h"
 
-static bool assert_xdg(struct sway_view *view) {
-	return sway_assert(view->type == SWAY_VIEW_XDG_SHELL_V6,
-			"Expected xdg shell v6 view!");
+static struct sway_xdg_shell_v6_view *xdg_shell_v6_view_from_view(
+		struct sway_view *view) {
+	if (!sway_assert(view->type == SWAY_VIEW_XDG_SHELL_V6,
+			"Expected xdg_shell_v6 view")) {
+		return NULL;
+	}
+	return (struct sway_xdg_shell_v6_view *)view;
 }
 
 static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
-	if (!assert_xdg(view)) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return NULL;
 	}
 	switch (prop) {
@@ -32,18 +36,20 @@ static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
 
 static void configure(struct sway_view *view, double ox, double oy, int width,
 		int height) {
-	if (!assert_xdg(view)) {
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		xdg_shell_v6_view_from_view(view);
+	if (xdg_shell_v6_view == NULL) {
 		return;
 	}
 
 	view_update_position(view, ox, oy);
-	view->sway_xdg_surface_v6->pending_width = width;
-	view->sway_xdg_surface_v6->pending_height = height;
+	xdg_shell_v6_view->pending_width = width;
+	xdg_shell_v6_view->pending_height = height;
 	wlr_xdg_toplevel_v6_set_size(view->wlr_xdg_surface_v6, width, height);
 }
 
 static void set_activated(struct sway_view *view, bool activated) {
-	if (!assert_xdg(view)) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
@@ -53,13 +59,26 @@ static void set_activated(struct sway_view *view, bool activated) {
 }
 
 static void _close(struct sway_view *view) {
-	if (!assert_xdg(view)) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
 	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
 		wlr_xdg_surface_v6_send_close(surface);
 	}
+}
+
+static void destroy(struct sway_view *view) {
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		xdg_shell_v6_view_from_view(view);
+	if (xdg_shell_v6_view == NULL) {
+		return;
+	}
+	wl_list_remove(&xdg_shell_v6_view->commit.link);
+	wl_list_remove(&xdg_shell_v6_view->destroy.link);
+	wl_list_remove(&xdg_shell_v6_view->map.link);
+	wl_list_remove(&xdg_shell_v6_view->unmap.link);
+	free(xdg_shell_v6_view);
 }
 
 static const struct sway_view_impl view_impl = {
@@ -70,83 +89,74 @@ static const struct sway_view_impl view_impl = {
 };
 
 static void handle_commit(struct wl_listener *listener, void *data) {
-	struct sway_xdg_surface_v6 *sway_surface =
-		wl_container_of(listener, sway_surface, commit);
-	struct sway_view *view = sway_surface->view;
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, commit);
+	struct sway_view *view = &xdg_shell_v6_view->view;
 	// NOTE: We intentionally discard the view's desired width here
 	// TODO: Store this for restoration when moving to floating plane
 	// TODO: Let floating views do whatever
-	view_update_size(view, sway_surface->pending_width,
-		sway_surface->pending_height);
+	view_update_size(view, xdg_shell_v6_view->pending_width,
+		xdg_shell_v6_view->pending_height);
 	view_damage_from(view);
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {
-	struct sway_xdg_surface_v6 *sway_surface =
-		wl_container_of(listener, sway_surface, unmap);
-	view_unmap(sway_surface->view);
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, unmap);
+	view_unmap(&xdg_shell_v6_view->view);
 }
 
 static void handle_map(struct wl_listener *listener, void *data) {
-	struct sway_xdg_surface_v6 *sway_surface =
-		wl_container_of(listener, sway_surface, map);
-	struct sway_view *view = sway_surface->view;
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, map);
+	struct sway_view *view = &xdg_shell_v6_view->view;
 	view_map(view, view->wlr_xdg_surface_v6->surface);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
-	struct sway_xdg_surface_v6 *sway_xdg_surface =
-		wl_container_of(listener, sway_xdg_surface, destroy);
-	wl_list_remove(&sway_xdg_surface->commit.link);
-	wl_list_remove(&sway_xdg_surface->destroy.link);
-	wl_list_remove(&sway_xdg_surface->map.link);
-	wl_list_remove(&sway_xdg_surface->unmap.link);
-	view_destroy(sway_xdg_surface->view);
-	free(sway_xdg_surface);
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, destroy);
+	view_destroy(&xdg_shell_v6_view->view);
 }
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(
-			listener, server, xdg_shell_v6_surface);
+	struct sway_server *server = wl_container_of(listener, server,
+		xdg_shell_v6_surface);
 	struct wlr_xdg_surface_v6 *xdg_surface = data;
 
 	if (xdg_surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP) {
-		// TODO: popups
+		wlr_log(L_DEBUG, "New xdg_shell_v6 popup");
 		return;
 	}
 
 	wlr_log(L_DEBUG, "New xdg_shell_v6 toplevel title='%s' app_id='%s'",
-			xdg_surface->toplevel->title, xdg_surface->toplevel->app_id);
+		xdg_surface->toplevel->title, xdg_surface->toplevel->app_id);
 	wlr_xdg_surface_v6_ping(xdg_surface);
 	wlr_xdg_toplevel_v6_set_maximized(xdg_surface, true);
 
-	struct sway_xdg_surface_v6 *sway_surface =
-		calloc(1, sizeof(struct sway_xdg_surface_v6));
-	if (!sway_assert(sway_surface, "Failed to allocate surface!")) {
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		calloc(1, sizeof(struct sway_xdg_shell_v6_view));
+	if (!sway_assert(xdg_shell_v6_view, "Failed to allocate view")) {
 		return;
 	}
 
-	struct sway_view *view = view_create(SWAY_VIEW_XDG_SHELL_V6, &view_impl);
-	if (!sway_assert(view, "Failed to allocate view")) {
-		return;
-	}
-	view->wlr_xdg_surface_v6 = xdg_surface;
-	view->sway_xdg_surface_v6 = sway_surface;
-	sway_surface->view = view;
+	view_init(&xdg_shell_v6_view->view, SWAY_VIEW_XDG_SHELL_V6, &view_impl);
+	xdg_shell_v6_view->view.wlr_xdg_surface_v6 = xdg_surface;
 
 	// TODO:
 	// - Look up pid and open on appropriate workspace
 	// - Criteria
 
-	sway_surface->commit.notify = handle_commit;
-	wl_signal_add(&xdg_surface->surface->events.commit, &sway_surface->commit);
+	xdg_shell_v6_view->commit.notify = handle_commit;
+	wl_signal_add(&xdg_surface->surface->events.commit,
+		&xdg_shell_v6_view->commit);
 
-	sway_surface->map.notify = handle_map;
-	wl_signal_add(&xdg_surface->events.map, &sway_surface->map);
+	xdg_shell_v6_view->map.notify = handle_map;
+	wl_signal_add(&xdg_surface->events.map, &xdg_shell_v6_view->map);
 
-	sway_surface->unmap.notify = handle_unmap;
-	wl_signal_add(&xdg_surface->events.unmap, &sway_surface->unmap);
+	xdg_shell_v6_view->unmap.notify = handle_unmap;
+	wl_signal_add(&xdg_surface->events.unmap, &xdg_shell_v6_view->unmap);
 
-	sway_surface->destroy.notify = handle_destroy;
-	wl_signal_add(&xdg_surface->events.destroy, &sway_surface->destroy);
+	xdg_shell_v6_view->destroy.notify = handle_destroy;
+	wl_signal_add(&xdg_surface->events.destroy, &xdg_shell_v6_view->destroy);
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -7,15 +7,10 @@
 #include "sway/tree/layout.h"
 #include "sway/tree/view.h"
 
-struct sway_view *view_create(enum sway_view_type type,
+void view_init(struct sway_view *view, enum sway_view_type type,
 		const struct sway_view_impl *impl) {
-	struct sway_view *view = calloc(1, sizeof(struct sway_view));
-	if (view == NULL) {
-		return NULL;
-	}
 	view->type = type;
 	view->impl = impl;
-	return view;
 }
 
 void view_destroy(struct sway_view *view) {
@@ -28,6 +23,12 @@ void view_destroy(struct sway_view *view) {
 	}
 
 	container_destroy(view->swayc);
+
+	if (view->impl->destroy) {
+		view->impl->destroy(view);
+	} else {
+		free(view);
+	}
 }
 
 const char *view_get_title(struct sway_view *view) {


### PR DESCRIPTION
This removes per-shell `sway_*_surface` and replaces them with `sway_*_view` which are more in line with the impl pattern. I believe this also fixes #1738.