### PR TITLE
Damage tracking for view children

### DIFF
--- a/include/sway/desktop.h
+++ b/include/sway/desktop.h
@@ -1,0 +1,7 @@
+#include <wlr/types/wlr_surface.h>
+
+void desktop_damage_whole_surface(struct wlr_surface *surface, double lx,
+	double ly);
+
+void desktop_damage_from_surface(struct wlr_surface *surface, double lx,
+	double ly);

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -37,8 +37,8 @@ void output_damage_whole(struct sway_output *output);
 void output_damage_whole_view(struct sway_output *output,
 	struct sway_view *view);
 
-void output_damage_whole_surface(struct sway_output *output,
-	struct wlr_surface *surface, double ox, double oy);
+void output_damage_whole_rect(struct sway_output *output, double ox, double oy,
+	int width, int height);
 
 struct sway_container *output_by_name(const char *name);
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -37,6 +37,9 @@ void output_damage_whole(struct sway_output *output);
 void output_damage_whole_view(struct sway_output *output,
 	struct sway_view *view);
 
+void output_damage_whole_surface(struct sway_output *output,
+	struct wlr_surface *surface, double ox, double oy);
+
 struct sway_container *output_by_name(const char *name);
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -34,11 +34,14 @@ struct sway_output {
 
 void output_damage_whole(struct sway_output *output);
 
+void output_damage_whole_surface(struct sway_output *output,
+	double ox, double oy, struct wlr_surface *surface);
+
 void output_damage_whole_view(struct sway_output *output,
 	struct sway_view *view);
 
-void output_damage_whole_rect(struct sway_output *output, double ox, double oy,
-	int width, int height);
+void output_damage_whole_container(struct sway_output *output,
+	struct sway_container *con);
 
 struct sway_container *output_by_name(const char *name);
 

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -97,8 +97,7 @@ struct sway_container *container_create(enum sway_container_type type);
 
 const char *container_type_to_str(enum sway_container_type type);
 
-struct sway_container *output_create(
-		struct sway_output *sway_output);
+struct sway_container *output_create(struct sway_output *sway_output);
 
 /**
  * Create a new container container. A container container can be a a child of
@@ -116,7 +115,8 @@ struct sway_container *output_create(struct sway_output *sway_output);
  * Create a new workspace container. Workspaces are children of an output
  * container and are ordered alphabetically by name.
  */
-struct sway_container *workspace_create(struct sway_container *output, const char *name);
+struct sway_container *workspace_create(struct sway_container *output,
+		const char *name);
 
 /*
  * Create a new view container. A view can be a child of a workspace container
@@ -181,5 +181,7 @@ bool container_has_child(struct sway_container *con,
 		struct sway_container *child);
 
 void container_create_notify(struct sway_container *container);
+
+void container_damage_whole(struct sway_container *container);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -87,6 +87,9 @@ struct sway_xwayland_unmanaged {
 	struct wlr_xwayland_surface *wlr_xwayland_surface;
 	struct wl_list link;
 
+	struct wl_listener commit;
+	struct wl_listener map;
+	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -87,6 +87,7 @@ struct sway_xwayland_unmanaged {
 	struct wlr_xwayland_surface *wlr_xwayland_surface;
 	struct wl_list link;
 
+	struct wl_listener request_configure;
 	struct wl_listener commit;
 	struct wl_listener map;
 	struct wl_listener unmap;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -45,6 +45,12 @@ struct sway_view {
 		struct wlr_xwayland_surface *wlr_xwayland_surface;
 		struct wlr_wl_shell_surface *wlr_wl_shell_surface;
 	};
+
+	struct {
+		struct wl_signal unmap;
+	} events;
+
+	struct wl_listener surface_new_subsurface;
 };
 
 struct sway_xdg_shell_v6_view {
@@ -95,6 +101,27 @@ struct sway_wl_shell_view {
 	int pending_width, pending_height;
 };
 
+struct sway_view_child;
+
+struct sway_view_child_impl {
+	void (*destroy)(struct sway_view_child *child);
+};
+
+/**
+ * A view child is a surface in the view tree, such as a subsurface or a popup.
+ */
+struct sway_view_child {
+	const struct sway_view_child_impl *impl;
+
+	struct sway_view *view;
+	struct wlr_surface *surface;
+
+	struct wl_listener surface_commit;
+	struct wl_listener surface_new_subsurface;
+	struct wl_listener surface_destroy;
+	struct wl_listener view_unmap;
+};
+
 const char *view_get_title(struct sway_view *view);
 
 const char *view_get_app_id(struct sway_view *view);
@@ -128,5 +155,11 @@ void view_unmap(struct sway_view *view);
 void view_update_position(struct sway_view *view, double ox, double oy);
 
 void view_update_size(struct sway_view *view, int width, int height);
+
+void view_child_init(struct sway_view_child *child,
+	const struct sway_view_child_impl *impl, struct sway_view *view,
+	struct wlr_surface *surface);
+
+void view_child_destroy(struct sway_view_child *child);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -87,6 +87,8 @@ struct sway_xwayland_unmanaged {
 	struct wlr_xwayland_surface *wlr_xwayland_surface;
 	struct wl_list link;
 
+	int lx, ly;
+
 	struct wl_listener request_configure;
 	struct wl_listener commit;
 	struct wl_listener map;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -60,6 +60,7 @@ struct sway_xdg_shell_v6_view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
+	struct wl_listener new_popup;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
@@ -120,6 +121,16 @@ struct sway_view_child {
 	struct wl_listener surface_new_subsurface;
 	struct wl_listener surface_destroy;
 	struct wl_listener view_unmap;
+};
+
+struct sway_xdg_popup_v6 {
+	struct sway_view_child child;
+
+	struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
+
+	struct wl_listener new_popup;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
 };
 
 const char *view_get_title(struct sway_view *view);

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -7,9 +7,8 @@ void desktop_damage_whole_surface(struct wlr_surface *surface, double lx,
 	for (int i = 0; i < root_container.children->length; ++i) {
 		struct sway_container *cont = root_container.children->items[i];
 		if (cont->type == C_OUTPUT) {
-			output_damage_whole_rect(cont->sway_output,
-				lx - cont->x, ly - cont->y,
-				surface->current->width, surface->current->height);
+			output_damage_whole_surface(cont->sway_output,
+				lx - cont->x, ly - cont->y, surface);
 		}
 	}
 }

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -1,0 +1,20 @@
+#include "sway/tree/container.h"
+#include "sway/desktop.h"
+#include "sway/output.h"
+
+void desktop_damage_whole_surface(struct wlr_surface *surface, double lx,
+		double ly) {
+	for (int i = 0; i < root_container.children->length; ++i) {
+		struct sway_container *cont = root_container.children->items[i];
+		if (cont->type == C_OUTPUT) {
+			output_damage_whole_surface(cont->sway_output, surface,
+				lx - cont->x, ly - cont->y);
+		}
+	}
+}
+
+void desktop_damage_from_surface(struct wlr_surface *surface, double lx,
+		double ly) {
+	// TODO
+	desktop_damage_whole_surface(surface, lx, ly);
+}

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -7,8 +7,9 @@ void desktop_damage_whole_surface(struct wlr_surface *surface, double lx,
 	for (int i = 0; i < root_container.children->length; ++i) {
 		struct sway_container *cont = root_container.children->items[i];
 		if (cont->type == C_OUTPUT) {
-			output_damage_whole_surface(cont->sway_output, surface,
-				lx - cont->x, ly - cont->y);
+			output_damage_whole_rect(cont->sway_output,
+				lx - cont->x, ly - cont->y,
+				surface->current->width, surface->current->height);
 		}
 	}
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -341,8 +341,8 @@ void output_damage_whole_view(struct sway_output *output,
 	output_damage_whole(output);
 }
 
-void output_damage_whole_surface(struct sway_output *output,
-		struct wlr_surface *surface, double ox, double oy) {
+void output_damage_whole_rect(struct sway_output *output,
+		double ox, double oy, int width, int height) {
 	// TODO
 	output_damage_whole(output);
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -335,14 +335,20 @@ void output_damage_whole(struct sway_output *output) {
 	wlr_output_damage_add_whole(output->damage);
 }
 
+void output_damage_whole_surface(struct sway_output *output,
+		double ox, double oy, struct wlr_surface *surface) {
+	// TODO
+	output_damage_whole(output);
+}
+
 void output_damage_whole_view(struct sway_output *output,
 		struct sway_view *view) {
 	// TODO
 	output_damage_whole(output);
 }
 
-void output_damage_whole_rect(struct sway_output *output,
-		double ox, double oy, int width, int height) {
+void output_damage_whole_container(struct sway_output *output,
+		struct sway_container *con) {
 	// TODO
 	output_damage_whole(output);
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -341,6 +341,12 @@ void output_damage_whole_view(struct sway_output *output,
 	output_damage_whole(output);
 }
 
+void output_damage_whole_surface(struct sway_output *output,
+		struct wlr_surface *surface, double ox, double oy) {
+	// TODO
+	output_damage_whole(output);
+}
+
 static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output =
 		wl_container_of(listener, output, damage_destroy);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -267,17 +267,14 @@ static void render_output(struct sway_output *output, struct timespec *when,
 
 	// render unmanaged views on top
 	struct wl_list *unmanaged = &root_container.sway_root->xwayland_unmanaged;
-	struct sway_xwayland_unmanaged *sway_surface;
-	wl_list_for_each(sway_surface, unmanaged, link) {
+	struct sway_xwayland_unmanaged *unmanaged_surface;
+	wl_list_for_each(unmanaged_surface, unmanaged, link) {
 		struct wlr_xwayland_surface *xsurface =
-			sway_surface->wlr_xwayland_surface;
-		if (xsurface->surface == NULL) {
-			continue;
-		}
+			unmanaged_surface->wlr_xwayland_surface;
 
 		const struct wlr_box view_box = {
-			.x = xsurface->x,
-			.y = xsurface->y,
+			.x = unmanaged_surface->lx,
+			.y = unmanaged_surface->ly,
 			.width = xsurface->width,
 			.height = xsurface->height,
 		};

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -68,6 +68,7 @@ static const struct sway_view_impl view_impl = {
 	.get_prop = get_prop,
 	.configure = configure,
 	.close = _close,
+	.destroy = destroy,
 };
 
 static void handle_commit(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -147,6 +147,7 @@ static const struct sway_view_impl view_impl = {
 	.configure = configure,
 	.set_activated = set_activated,
 	.close = _close,
+	.destroy = destroy,
 };
 
 static void handle_commit(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -176,12 +176,6 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	view_damage_from(view);
 }
 
-static void handle_destroy(struct wl_listener *listener, void *data) {
-	struct sway_xwayland_view *xwayland_view =
-		wl_container_of(listener, xwayland_view, destroy);
-	view_destroy(&xwayland_view->view);
-}
-
 static void handle_unmap(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, unmap);
@@ -203,6 +197,17 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	// Put it back into the tree
 	wlr_xwayland_surface_set_maximized(xsurface, true);
 	view_map(view, xsurface->surface);
+}
+
+static void handle_destroy(struct wl_listener *listener, void *data) {
+	struct sway_xwayland_view *xwayland_view =
+		wl_container_of(listener, xwayland_view, destroy);
+	struct sway_view *view = &xwayland_view->view;
+	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
+	if (xsurface->mapped) {
+		handle_unmap(&xwayland_view->unmap, xsurface);
+	}
+	view_destroy(&xwayland_view->view);
 }
 
 static void handle_request_configure(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -14,6 +14,16 @@
 #include "sway/input/input-manager.h"
 #include "log.h"
 
+static void unmanaged_handle_request_configure(struct wl_listener *listener,
+		void *data) {
+	struct sway_xwayland_unmanaged *surface =
+		wl_container_of(listener, surface, request_configure);
+	struct wlr_xwayland_surface *xsurface = surface->wlr_xwayland_surface;
+	struct wlr_xwayland_surface_configure_event *ev = data;
+	wlr_xwayland_surface_configure(xsurface, ev->x, ev->y,
+		ev->width, ev->height);
+}
+
 static void unmanaged_handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_unmanaged *surface =
 		wl_container_of(listener, surface, commit);
@@ -63,6 +73,9 @@ static struct sway_xwayland_unmanaged *create_unmanaged(
 
 	surface->wlr_xwayland_surface = xsurface;
 
+	wl_signal_add(&xsurface->events.request_configure,
+		&surface->request_configure);
+	surface->request_configure.notify = unmanaged_handle_request_configure;
 	wl_signal_add(&xsurface->events.map, &surface->map);
 	surface->map.notify = unmanaged_handle_map;
 	wl_signal_add(&xsurface->events.unmap, &surface->unmap);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -48,17 +48,13 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	// check for unmanaged views first
 	struct wl_list *unmanaged = &root_container.sway_root->xwayland_unmanaged;
-	struct sway_xwayland_unmanaged *sway_surface;
-	wl_list_for_each_reverse(sway_surface, unmanaged, link) {
+	struct sway_xwayland_unmanaged *unmanaged_surface;
+	wl_list_for_each_reverse(unmanaged_surface, unmanaged, link) {
 		struct wlr_xwayland_surface *xsurface =
-			sway_surface->wlr_xwayland_surface;
-		if (xsurface->surface == NULL) {
-			continue;
-		}
-
+			unmanaged_surface->wlr_xwayland_surface;
 		struct wlr_box box = {
-			.x = xsurface->x,
-			.y = xsurface->y,
+			.x = unmanaged_surface->lx,
+			.y = unmanaged_surface->ly,
 			.width = xsurface->width,
 			.height = xsurface->height,
 		};

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -8,6 +8,7 @@ sway_sources = files(
 	'ipc-server.c',
 	'security.c',
 
+	'desktop/desktop.c',
 	'desktop/output.c',
 	'desktop/layer_shell.c',
 	'desktop/wl_shell.c',

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -512,9 +512,18 @@ static bool find_child_func(struct sway_container *con, void *data) {
 
 bool container_has_child(struct sway_container *con,
 		struct sway_container *child) {
-	if (con == NULL || con->type == C_VIEW ||
-			con->children->length == 0) {
+	if (con == NULL || con->type == C_VIEW || con->children->length == 0) {
 		return false;
 	}
 	return container_find(con, find_child_func, child);
+}
+
+void container_damage_whole(struct sway_container *con) {
+	struct sway_container *output = con;
+	if (output->type != C_OUTPUT) {
+		output = container_parent(output, C_OUTPUT);
+	}
+
+	output_damage_whole_rect(output->sway_output, con->x, con->y, con->width,
+		con->height);
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -523,7 +523,5 @@ void container_damage_whole(struct sway_container *con) {
 	if (output->type != C_OUTPUT) {
 		output = container_parent(output, C_OUTPUT);
 	}
-
-	output_damage_whole_rect(output->sway_output, con->x, con->y, con->width,
-		con->height);
+	output_damage_whole_container(output->sway_output, con);
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -176,6 +176,8 @@ void view_unmap(struct sway_view *view) {
 
 	struct sway_container *parent = container_destroy(view->swayc);
 
+	wl_list_remove(&view->surface_new_subsurface.link);
+
 	view->swayc = NULL;
 	view->surface = NULL;
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -161,8 +161,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 
 	view_damage_whole(view);
 	view_update_outputs(view, NULL);
-
-	// TODO: create view children for subsurfaces
 }
 
 void view_unmap(struct sway_view *view) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -11,6 +11,7 @@ void view_init(struct sway_view *view, enum sway_view_type type,
 		const struct sway_view_impl *impl) {
 	view->type = type;
 	view->impl = impl;
+	wl_signal_init(&view->events.unmap);
 }
 
 void view_destroy(struct sway_view *view) {
@@ -123,6 +124,20 @@ static void view_update_outputs(struct sway_view *view,
 	}
 }
 
+static void view_subsurface_create(struct sway_view *view,
+	struct wlr_subsurface *subsurface);
+
+static void view_init_subsurfaces(struct sway_view *view,
+	struct wlr_surface *surface);
+
+static void view_handle_surface_new_subsurface(struct wl_listener *listener,
+		void *data) {
+	struct sway_view *view =
+		wl_container_of(listener, view, surface_new_subsurface);
+	struct wlr_subsurface *subsurface = data;
+	view_subsurface_create(view, subsurface);
+}
+
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	if (!sway_assert(view->surface == NULL, "cannot map mapped view")) {
 		return;
@@ -136,17 +151,26 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	view->surface = wlr_surface;
 	view->swayc = cont;
 
+	view_init_subsurfaces(view, wlr_surface);
+	wl_signal_add(&wlr_surface->events.new_subsurface,
+		&view->surface_new_subsurface);
+	view->surface_new_subsurface.notify = view_handle_surface_new_subsurface;
+
 	arrange_windows(cont->parent, -1, -1);
 	input_manager_set_focus(input_manager, cont);
 
 	view_damage_whole(view);
 	view_update_outputs(view, NULL);
+
+	// TODO: create view children for subsurfaces
 }
 
 void view_unmap(struct sway_view *view) {
 	if (!sway_assert(view->surface != NULL, "cannot unmap unmapped view")) {
 		return;
 	}
+
+	wl_signal_emit(&view->events.unmap, view);
 
 	view_damage_whole(view);
 
@@ -184,4 +208,92 @@ void view_update_size(struct sway_view *view, int width, int height) {
 	view->height = height;
 	view_update_outputs(view, &box);
 	view_damage_whole(view);
+}
+
+
+static void view_subsurface_create(struct sway_view *view,
+		struct wlr_subsurface *subsurface) {
+	struct sway_view_child *child = calloc(1, sizeof(struct sway_view_child));
+	if (child == NULL) {
+		wlr_log(L_ERROR, "Allocation failed");
+		return;
+	}
+	view_child_init(child, NULL, view, subsurface->surface);
+}
+
+static void view_child_handle_surface_commit(struct wl_listener *listener,
+		void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, surface_commit);
+	// TODO: only accumulate damage from the child
+	view_damage_from(child->view);
+}
+
+static void view_child_handle_surface_new_subsurface(
+		struct wl_listener *listener, void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, surface_new_subsurface);
+	struct wlr_subsurface *subsurface = data;
+	view_subsurface_create(child->view, subsurface);
+}
+
+static void view_child_handle_surface_destroy(struct wl_listener *listener,
+		void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, surface_destroy);
+	view_child_destroy(child);
+}
+
+static void view_child_handle_view_unmap(struct wl_listener *listener,
+		void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, view_unmap);
+	view_child_destroy(child);
+}
+
+static void view_init_subsurfaces(struct sway_view *view,
+		struct wlr_surface *surface) {
+	struct wlr_subsurface *subsurface;
+	wl_list_for_each(subsurface, &surface->subsurface_list, parent_link) {
+		view_subsurface_create(view, subsurface);
+	}
+}
+
+void view_child_init(struct sway_view_child *child,
+		const struct sway_view_child_impl *impl, struct sway_view *view,
+		struct wlr_surface *surface) {
+	child->impl = impl;
+	child->view = view;
+	child->surface = surface;
+
+	wl_signal_add(&surface->events.commit, &child->surface_commit);
+	child->surface_commit.notify = view_child_handle_surface_commit;
+	wl_signal_add(&surface->events.new_subsurface,
+		&child->surface_new_subsurface);
+	child->surface_new_subsurface.notify =
+		view_child_handle_surface_new_subsurface;
+	wl_signal_add(&surface->events.destroy, &child->surface_destroy);
+	child->surface_destroy.notify = view_child_handle_surface_destroy;
+	wl_signal_add(&view->events.unmap, &child->view_unmap);
+	child->view_unmap.notify = view_child_handle_view_unmap;
+
+	view_init_subsurfaces(child->view, surface);
+
+	// TODO: only damage the whole child
+	view_damage_whole(child->view);
+}
+
+void view_child_destroy(struct sway_view_child *child) {
+	// TODO: only damage the whole child
+	view_damage_whole(child->view);
+
+	wl_list_remove(&child->surface_commit.link);
+	wl_list_remove(&child->surface_destroy.link);
+	wl_list_remove(&child->view_unmap.link);
+
+	if (child->impl && child->impl->destroy) {
+		child->impl->destroy(child);
+	} else {
+		free(child);
+	}
 }


### PR DESCRIPTION
Test plan: make sure damage is accumulated when view children commit.

* Add `wlr_log(L_DEBUG, "child damaged");` in `view.c` on line 231
* Add `wlr_log(L_DEBUG, "unmanaged surface damaged");` in `xwayland.c` on line 32

Check that these appear in the log when opening a popup and a combo in `gnome-calculator`, under xdg-shell and xwayland.