### PR TITLE
ipc layout

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -12,37 +12,22 @@
 #include "wlr-layer-shell-unstable-v1-protocol.h"
 
 static const char *ipc_json_layout_description(enum sway_container_layout l) {
-	const char *layout;
-
 	switch (l) {
 	case L_VERT:
-		layout = "splitv";
-		break;
-
+		return "splitv";
 	case L_HORIZ:
-		layout = "splith";
-		break;
-
+		return "splith";
 	case L_TABBED:
-		layout = "tabbed";
-		break;
-
+		return "tabbed";
 	case L_STACKED:
-		layout = "stacked";
-		break;
-
+		return "stacked";
 	case L_FLOATING:
-		layout = "floating";
-		break;
-
-	case L_NONE: // fallthrough
-	case L_LAYOUTS: // fallthrough; this should never happen, I'm just trying to silence compiler warnings
-	default:
-		layout = "null";
+		return "floating";
+	case L_NONE:
+	case L_LAYOUTS:
 		break;
 	}
-
-	return layout;
+	return "none";
 }
 
 json_object *ipc_json_get_version() {
@@ -149,9 +134,8 @@ static void ipc_json_describe_output(struct sway_container *container, json_obje
 			json_object_new_int(mode->refresh));
 		json_object_array_add(modes_array, mode_object);
 	}
+
 	json_object_object_add(object, "modes", modes_array);
-
-
 	json_object_object_add(object, "layout", json_object_new_string("output"));
 }
 
@@ -166,8 +150,7 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 	json_object_object_add(object, "urgent", json_object_new_boolean(false));
 
 	const char *layout = ipc_json_layout_description(workspace->workspace_layout);
-	json_object_object_add(object, "layout", (strcmp(layout, "null") == 0) ?
-		NULL : json_object_new_string(layout));
+	json_object_object_add(object, "layout", json_object_new_string(layout));
 }
 
 static void ipc_json_describe_view(struct sway_container *c, json_object *object) {
@@ -176,10 +159,11 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "type", json_object_new_string("con"));
 
 	if (c->parent) {
-		const char *layout = (c->parent->type == C_CONTAINER) ?
-			ipc_json_layout_description(c->parent->layout) : "none";
+		enum sway_container_layout layout = (c->parent->type == C_CONTAINER) ?
+			c->parent->layout : c->layout;
+
 		json_object_object_add(object, "layout",
-			(strcmp(layout, "null") == 0) ? NULL : json_object_new_string(layout));
+			json_object_new_string(ipc_json_layout_description(layout)));
 	}
 }
 

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -242,19 +242,13 @@ int ipc_client_handle_readable(int client_fd, uint32_t mask, void *data) {
 }
 
 static bool ipc_has_event_listeners(enum ipc_command_type event) {
-	bool has_listeners = false;
-
-	struct ipc_client *client;
 	for (int i = 0; i < ipc_client_list->length; i++) {
-		client = ipc_client_list->items[i];
+		struct ipc_client *client = ipc_client_list->items[i];
 		if ((client->subscribed_events & event_mask(event)) == 0) {
-			continue;
+			return true;
 		}
-		has_listeners = true;
-		break;
 	}
-
-	return has_listeners;
+	return false;
 }
 
 static void ipc_send_event(const char *json_string, enum ipc_command_type event) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -241,10 +241,25 @@ int ipc_client_handle_readable(int client_fd, uint32_t mask, void *data) {
 	return 0;
 }
 
-static void ipc_send_event(const char *json_string, enum ipc_command_type event) {
-	int i;
+static bool ipc_has_event_listeners(enum ipc_command_type event) {
+	bool has_listeners = false;
+
 	struct ipc_client *client;
-	for (i = 0; i < ipc_client_list->length; i++) {
+	for (int i = 0; i < ipc_client_list->length; i++) {
+		client = ipc_client_list->items[i];
+		if ((client->subscribed_events & event_mask(event)) == 0) {
+			continue;
+		}
+		has_listeners = true;
+		break;
+	}
+
+	return has_listeners;
+}
+
+static void ipc_send_event(const char *json_string, enum ipc_command_type event) {
+	struct ipc_client *client;
+	for (int i = 0; i < ipc_client_list->length; i++) {
 		client = ipc_client_list->items[i];
 		if ((client->subscribed_events & event_mask(event)) == 0) {
 			continue;
@@ -259,6 +274,9 @@ static void ipc_send_event(const char *json_string, enum ipc_command_type event)
 
 void ipc_event_workspace(struct sway_container *old,
 		struct sway_container *new, const char *change) {
+	if (!ipc_has_event_listeners(IPC_EVENT_WORKSPACE)) {
+		return;
+	}
 	wlr_log(L_DEBUG, "Sending workspace::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
@@ -284,6 +302,9 @@ void ipc_event_workspace(struct sway_container *old,
 }
 
 void ipc_event_window(struct sway_container *window, const char *change) {
+	if (!ipc_has_event_listeners(IPC_EVENT_WINDOW)) {
+		return;
+	}
 	wlr_log(L_DEBUG, "Sending window::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
@@ -295,6 +316,9 @@ void ipc_event_window(struct sway_container *window, const char *change) {
 }
 
 void ipc_event_barconfig_update(struct bar_config *bar) {
+	if (!ipc_has_event_listeners(IPC_EVENT_BARCONFIG_UPDATE)) {
+		return;
+	}
 	wlr_log(L_DEBUG, "Sending barconfig_update event");
 	json_object *json = ipc_json_describe_bar_config(bar);
 
@@ -304,6 +328,9 @@ void ipc_event_barconfig_update(struct bar_config *bar) {
 }
 
 void ipc_event_mode(const char *mode) {
+	if (!ipc_has_event_listeners(IPC_EVENT_MODE)) {
+		return;
+	}
 	wlr_log(L_DEBUG, "Sending mode::%s event", mode);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(mode));


### PR DESCRIPTION
Make the containers have the "layout" in ipc json for tests.

[layout tests](https://github.com/swaywm/sway-tests/blob/master/test/test_layout.py)

Will also be added to move tests.

Also don't send container json if no listeners are subscribed to the event.

