### PR TITLE
Fix json_object ref_count underflow in ipc_event_binding:1175.

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -1172,7 +1172,7 @@ void ipc_event_binding_keyboard(struct sway_binding *sb) {
 				json_object *str = json_object_new_string(buffer);
 				json_object_array_add(symbols, str);
 				if (i == 0) {
-					symbol = str;
+					symbol = json_object_new_string(buffer);
 				}
 			}
 		}


### PR DESCRIPTION
json_object *str is added to the symbols array in line 1174.
json-c documentation states that the ref count is not incremented
by json_object_array_add so the ownership to str is lost.
Unfortunately str gets re-added to sb_obj in line 1184 and
leads to segfault when json_object_put is called in ipc_event_binding.
Either find a way to increment ref count or dup string as implemented
in this bugfix.