### PR TITLE
Use full ws->name in swaybar hotspot callback

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -352,6 +352,7 @@ static uint32_t render_workspace_button(cairo_t *cairo,
 		struct swaybar_output *output, struct swaybar_config *config,
 		struct swaybar_workspace *ws, double *x, uint32_t surface_height) {
 	const char *name = ws->name;
+	const char *whole_name = ws->name;
 	if (config->strip_workspace_numbers) {
 		name = strip_workspace_number(ws->name);
 	}
@@ -411,7 +412,7 @@ static uint32_t render_workspace_button(cairo_t *cairo,
 	hotspot->height = height;
 	hotspot->callback = workspace_hotspot_callback;
 	hotspot->destroy = free;
-	hotspot->data = strdup(name);
+	hotspot->data = strdup(whole_name);
 	wl_list_insert(&output->hotspots, &hotspot->link);
 
 	*x += width;


### PR DESCRIPTION
Problem: clicking on swaybar workspace hotspot creates new workspace if `strip_workspace_numers` is enabled. Reason is wrong name in hotspot callback.

Example config subset:
```
set $ws1 "1:&#x3B1;"
set $ws2 "2:&#x3B2;"

bindsym $mod+1 workspace $ws1
bindsym $mod+2 workspace $ws2

bar {
	strip_workspace_numbers yes
}
```