### PR TITLE
Fix cursor motion issues

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -8,7 +8,6 @@ struct sway_cursor {
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 
-	double x, y;
 	struct wl_client *image_client;
 
 	struct wl_listener motion;
@@ -30,5 +29,6 @@ struct sway_cursor {
 
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
+void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time);
 
 #endif

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -434,6 +434,9 @@ void seat_set_focus_warp(struct sway_seat *seat,
 						wlr_output, seat->cursor->cursor->x,
 						seat->cursor->cursor->y)) {
 					wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
+					struct timespec now;
+					clock_gettime(CLOCK_MONOTONIC, &now);
+					cursor_send_pointer_motion(seat->cursor, now.tv_nsec / 1000);
 				}
 			}
 		}


### PR DESCRIPTION
Use only one canonical cursor x/y position and send cursor enter when
mouse is warped.

Tangentally related to #1714