### PR TITLE
Fix some typographic characters in German README

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -10,8 +10,8 @@ eingesehen werden.
 
 [![](https://sr.ht/ICd5.png)](https://sr.ht/ICd5.png)
 
-Falls du die Sway Entwicklung unterstützen möchtest, kannst du das auf der 
-[Patreonseite](https://patreon.com/sircmpwn) tun, oder indem du zu
+Falls du die Entwicklung von Sway unterstützen möchtest, kannst du das auf der 
+[Patreon-Seite](https://patreon.com/sircmpwn) tun, oder indem du zu
 [Entwicklungsprämien](https://github.com/swaywm/sway/issues/986) 
 bestimmter Features beiträgst. Jeder ist dazu eingeladen, eine Prämie in Anspruch
 zu nehmen oder für gewünschte Features bereitzustellen. Patreon ist eher dafür
@@ -40,13 +40,13 @@ signiert und [auf Github](https://github.com/swaywm/sway/releases) veröffentlic
 
 ### Als Paket
 
-Sway ist in vielen Distributionen verfügbar: versuche einfach, das "sway"-Paket
-zu installieren. Falls es nicht vorhanden ist, schau dir 
+Sway ist in vielen Distributionen verfügbar: versuche einfach, das „sway“-Paket
+zu installieren. Falls es nicht vorhanden ist, schaue dir 
 [diese Wikiseite](https://github.com/swaywm/sway/wiki/Unsupported-packages) für 
 distributionsspezifische Installationsinformationen an.
 
 Wenn du Interesse hast, Sway für deine Distribution als Paket bereitzustellen, 
-schau im IRC-Channel vorbei oder schreibe eine e-Mail an sir@cmpwn.com (nur englischsprachig).
+schaue im IRC-Channel vorbei oder schreibe eine E‑Mail an sir@cmpwn.com (nur englischsprachig).
 
 ### Kompilieren des Quellcodes
 


### PR DESCRIPTION
This PR fixes some minor typographic character issues in the German README file.

Some argumentation for these changes:
* "sway"-Paket → „sway“-Paket
  https://de.wikipedia.org/wiki/Anf%C3%BChrungszeichen#Deutschland_und_%C3%96sterreich
* e-Mail → E‑Mail
  https://de.wikipedia.org/wiki/Gesch%C3%BCtzter_Bindestrich