### PR TITLE
Fix buffer issues in swaybar status line

### DIFF
--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -113,8 +113,9 @@ bool i3bar_handle_readable(struct status_line *status) {
 	char *cur = &state->buffer[state->buffer_index];
 	ssize_t n = read(status->read_fd, cur,
 			state->buffer_size - state->buffer_index);
-	if (n == 0) {
-		return 0;
+	if (n == -1) {
+		status_error(status, "[failed to read from status command]");
+		return false;
 	}
 
 	if (n == (ssize_t)(state->buffer_size - state->buffer_index)) {
@@ -123,7 +124,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 		if (!new_buffer) {
 			free(state->buffer);
 			status_error(status, "[failed to allocate buffer]");
-			return -1;
+			return true;
 		}
 		state->current_node += new_buffer - state->buffer;
 		cur += new_buffer - state->buffer;

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -125,9 +125,12 @@ bool i3bar_handle_readable(struct status_line *status) {
 			status_error(status, "[failed to allocate buffer]");
 			return -1;
 		}
+		state->current_node += new_buffer - state->buffer;
+		cur += new_buffer - state->buffer;
 		state->buffer = new_buffer;
 	}
 
+	cur[n] = '\0';
 	bool redraw = false;
 	while (*cur) {
 		if (state->nodes[state->depth] == JSON_NODE_STRING) {


### PR DESCRIPTION
This PR fixes a null termination issue and two dangling pointers.

# Null termination issue

The string that read() returns is not null terminated, so the `while (*cur)` loop could run into garbage data. In all my testing this has sometimes resulted in a "failed to parse i3bar json" message, and sometimes an infinite loop where swaybar pegs the CPU and nothing is displayed (or updated) in the status line part of the bar.

To prevent this I'm setting the null byte manually.

To test, run swaybar with a status command several times. Without my PR one of the above symptoms occurs about once in every 5 launches. With my PR it should not display the parse error message nor become unresponsive at all.

# Dangling pointers

When increasing the buffer size, `cur` and `state->current_node` need to be updated accordingly as these point into the old buffer.

To test this, you can make Conky return a JSON element over 4096 bytes long, but it's easier to temporarily change the default buffer_size from 4096 to something small like 16 in swaybar/status_line.c line 74.