### PR TITLE
Fix swaybar not showing all status blocks

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -159,9 +159,10 @@ static uint32_t render_status_block(cairo_t *cairo,
 		if (config->sep_symbol) {
 			get_text_size(cairo, config->font, &sep_width, &sep_height,
 					output->scale, false, "%s", config->sep_symbol);
-			uint32_t _ideal_height = sep_height + ws_vertical_padding * 2;
-			if (_ideal_height * output->scale > height) {
-				return _ideal_height;
+			uint32_t _ideal_surface_height = ws_vertical_padding * 2
+				+ sep_height;
+			if (_ideal_surface_height > surface_height) {
+				return _ideal_surface_height;
 			}
 			if (sep_width > block->separator_block_width) {
 				block->separator_block_width = sep_width + margin * 2;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -154,15 +154,14 @@ static uint32_t render_status_block(cairo_t *cairo,
 		block_width += block->border_right + margin;
 	}
 
-	int sep_width;
+	int sep_width, sep_height;
 	if (!edge) {
 		if (config->sep_symbol) {
-			int _height;
-			get_text_size(cairo, config->font, &sep_width, &_height,
+			get_text_size(cairo, config->font, &sep_width, &sep_height,
 					output->scale, false, "%s", config->sep_symbol);
-			uint32_t _ideal_height = _height + ws_vertical_padding * 2;
-			if ((uint32_t)_height < _ideal_height / output->scale) {
-				return _height / output->scale;
+			uint32_t _ideal_height = sep_height + ws_vertical_padding * 2;
+			if (_ideal_height * output->scale > height) {
+				return _ideal_height;
 			}
 			if (sep_width > block->separator_block_width) {
 				block->separator_block_width = sep_width + margin * 2;
@@ -240,7 +239,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 		}
 		if (config->sep_symbol) {
 			offset = pos + (block->separator_block_width - sep_width) / 2;
-			cairo_move_to(cairo, offset, margin);
+			cairo_move_to(cairo, offset, height / 2.0 - sep_height / 2.0);
 			pango_printf(cairo, config->font, output->scale, false,
 					"%s", config->sep_symbol);
 		} else {


### PR DESCRIPTION
Fixes #1790.

When rendering a non-edge block, swaybar's render_status_block() was miscalculating the height needed for the separator and was returning early, expecting itself to be called again later with a new surface height.

I've redone the logic here, as well as renamed _height to sep_height.

In addition to this, the separator symbol was not positioned correctly vertically.

For anyone checking my logic, my understanding is:

* `height` is the bar height with scaling applied
* `sep_height` and `_ideal_height` are both without scaling
* The function expects the return value to be without scaling

I've tested with output scales of 0.5, 1 and 2, and the pipe character as the separator symbol.