### PR TITLE
swaylock: Securely zero-out password.

### DIFF
--- a/include/swaylock/swaylock.h
+++ b/include/swaylock/swaylock.h
@@ -24,9 +24,8 @@ struct swaylock_args {
 };
 
 struct swaylock_password {
-	size_t size;
 	size_t len;
-	char *buffer;
+	char buffer[1024];
 };
 
 struct swaylock_state {


### PR DESCRIPTION
- Replace char* with static array. Any chars > 1024 will be discarded.
- mlock() password buffer so it can't be written to swap.
- Clear password buffer after auth succeeds or fails.

This is basically the same treatment I gave the 0.15 branch in https://github.com/swaywm/sway/pull/1519