### PR TITLE
Use 'private-code' for wayland-scanner code generation

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -2,10 +2,17 @@ wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
 wayland_scanner = find_program('wayland-scanner')
 
+# should check wayland_scanner's version, but it is hard to get
+if wayland_server.version().version_compare('>=1.14.91')
+	code_type = 'private-code'
+else
+	code_type = 'code'
+endif
+
 wayland_scanner_code = generator(
 	wayland_scanner,
 	output: '@BASENAME@-protocol.c',
-	arguments: ['code', '@INPUT@', '@OUTPUT@'],
+	arguments: [code_type, '@INPUT@', '@OUTPUT@'],
 )
 
 wayland_scanner_client = generator(


### PR DESCRIPTION
Same as for wlroots - autodetect version and use either 'code' or the
new one