### PR TITLE
Fix gcc warnings

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -48,7 +48,7 @@ int ipc_open_socket(const char *socket_path) {
 		sway_abort("Unable to open Unix socket");
 	}
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path));
+	strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
 	addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
 	int l = sizeof(struct sockaddr_un);
 	if (connect(socketfd, (struct sockaddr *)&addr, l) == -1) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -601,7 +601,7 @@ struct cmd_results *add_color(const char *name,
 					"Invalid color definition %s", color);
 		}
 	}
-	strncpy(buffer, color, len);
+	strcpy(buffer, color);
 	// add default alpha channel if color was defined without it
 	if (len == 7) {
 		buffer[7] = 'f';

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -32,7 +32,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 
 	// Put argument into cmd array
 	char cmd[4096];
-	strncpy(cmd, tmp, sizeof(cmd));
+	strncpy(cmd, tmp, sizeof(cmd) - 1);
 	cmd[sizeof(cmd) - 1] = 0;
 	free(tmp);
 	wlr_log(L_DEBUG, "Executing %s", cmd);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -64,7 +64,7 @@ void ipc_init(struct sway_server *server) {
 
 	// We want to use socket name set by user, not existing socket from another sway instance.
 	if (getenv("SWAYSOCK") != NULL && access(getenv("SWAYSOCK"), F_OK) == -1) {
-		strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path));
+		strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path) - 1);
 		ipc_sockaddr->sun_path[sizeof(ipc_sockaddr->sun_path) - 1] = 0;
 	}
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -288,8 +288,11 @@ void container_move(struct sway_container *container,
 
 		switch (current->type) {
 		case C_OUTPUT: {
-			enum wlr_direction wlr_dir;
-			sway_dir_to_wlr(move_dir, &wlr_dir);
+			enum wlr_direction wlr_dir = 0;
+			if (!sway_assert(sway_dir_to_wlr(move_dir, &wlr_dir),
+						"got invalid direction: %d", move_dir)) {
+				return;
+			}
 			double ref_lx = current->x + current->width / 2;
 			double ref_ly = current->y + current->height / 2;
 			struct wlr_output *next = wlr_output_layout_adjacent_output(


### PR DESCRIPTION
Similar to wlroots as well, some string truncations
 * the -1s are harmless since we manually force the final \0 all the time;
 * the strncpy->strcpy is because we based the strncpy on the source length and gcc complained that we never wrote the final \0 then when adding 1 that `strncpy(dst, src, strlen(str)+1)` is useless..........

and another maybe-uninitialized variable