### PR TITLE
Implement fullscreen

### DIFF
--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_IPC_SERVER_H
 #define _SWAY_IPC_SERVER_H
 #include <sys/socket.h>
+#include "sway/config.h"
 #include "sway/tree/container.h"
 #include "ipc.h"
 

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -72,7 +72,6 @@ struct sway_container {
 	// For C_OUTPUT, this is the output position in layout coordinates
 	// For other types, this is the position in output-local coordinates
 	double x, y;
-	double saved_x, saved_y;
 	// does not include borders or gaps.
 	double width, height;
 

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -45,6 +45,7 @@ enum sway_container_border {
 
 struct sway_root;
 struct sway_output;
+struct sway_workspace;
 struct sway_view;
 
 struct sway_container {
@@ -52,6 +53,7 @@ struct sway_container {
 		// TODO: Encapsulate state for other node types as well like C_CONTAINER
 		struct sway_root *sway_root;
 		struct sway_output *sway_output;
+		struct sway_workspace *sway_workspace;
 		struct sway_view *sway_view;
 	};
 
@@ -74,9 +76,6 @@ struct sway_container {
 	double x, y;
 	// does not include borders or gaps.
 	double width, height;
-
-	// For C_WORKSPACE only
-	struct sway_view *fullscreen;
 
 	list_t *children;
 

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -72,8 +72,12 @@ struct sway_container {
 	// For C_OUTPUT, this is the output position in layout coordinates
 	// For other types, this is the position in output-local coordinates
 	double x, y;
+	double saved_x, saved_y;
 	// does not include borders or gaps.
 	double width, height;
+
+	// For C_WORKSPACE only
+	struct sway_view *fullscreen;
 
 	list_t *children;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -28,6 +28,7 @@ struct sway_view_impl {
 	void (*configure)(struct sway_view *view, double ox, double oy, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
+	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 	void (*close)(struct sway_view *view);
@@ -41,6 +42,8 @@ struct sway_view {
 	struct sway_container *swayc; // NULL for unmanaged views
 	struct wlr_surface *surface; // NULL for unmapped views
 	int width, height;
+	int saved_width, saved_height;
+	bool is_fullscreen;
 
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
@@ -63,6 +66,7 @@ struct sway_xdg_shell_v6_view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
+	struct wl_listener request_fullscreen;
 	struct wl_listener new_popup;
 	struct wl_listener map;
 	struct wl_listener unmap;
@@ -79,6 +83,7 @@ struct sway_xwayland_view {
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_configure;
+	struct wl_listener request_fullscreen;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
@@ -93,6 +98,7 @@ struct sway_xwayland_unmanaged {
 	int lx, ly;
 
 	struct wl_listener request_configure;
+	struct wl_listener request_fullscreen;
 	struct wl_listener commit;
 	struct wl_listener map;
 	struct wl_listener unmap;
@@ -106,6 +112,7 @@ struct sway_wl_shell_view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
+	struct wl_listener request_fullscreen;
 	struct wl_listener destroy;
 
 	int pending_width, pending_height;
@@ -154,6 +161,8 @@ void view_configure(struct sway_view *view, double ox, double oy, int width,
 	int height);
 
 void view_set_activated(struct sway_view *view, bool activated);
+
+void view_set_fullscreen(struct sway_view *view, bool fullscreen);
 
 void view_close(struct sway_view *view);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -42,7 +42,6 @@ struct sway_view {
 	struct sway_container *swayc; // NULL for unmanaged views
 	struct wlr_surface *surface; // NULL for unmapped views
 	int width, height;
-	int saved_width, saved_height;
 	bool is_fullscreen;
 
 	union {

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -112,6 +112,7 @@ struct sway_wl_shell_view {
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
 	struct wl_listener request_fullscreen;
+	struct wl_listener set_state;
 	struct wl_listener destroy;
 
 	int pending_width, pending_height;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -3,6 +3,13 @@
 
 #include "sway/tree/container.h"
 
+struct sway_view;
+
+struct sway_workspace {
+	struct sway_container *swayc;
+	struct sway_view *fullscreen;
+};
+
 extern char *prev_workspace_name;
 
 char *workspace_next_name(const char *output_name);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -99,6 +99,7 @@ static struct cmd_handler handlers[] = {
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "focus_follows_mouse", cmd_focus_follows_mouse },
+	{ "fullscreen", cmd_fullscreen },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -1,0 +1,40 @@
+#include <wlr/types/wlr_wl_shell.h>
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "sway/tree/layout.h"
+
+// fullscreen toggle|enable|disable
+struct cmd_results *cmd_fullscreen(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if (config->reading) return cmd_results_new(CMD_FAILURE, "fullscreen", "Can't be used in config file.");
+	if (!config->active) return cmd_results_new(CMD_FAILURE, "fullscreen", "Can only be used when sway is running.");
+	if ((error = checkarg(argc, "fullscreen", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct sway_container *container =
+		config->handler_context.current_container;
+	if (container->type != C_VIEW) {
+		return cmd_results_new(CMD_INVALID, "fullscreen",
+				"Only views can fullscreen");
+	}
+	struct sway_view *view = container->sway_view;
+	bool wants_fullscreen;
+
+	if (strcmp(argv[0], "enable") == 0) {
+		wants_fullscreen = true;
+	} else if (strcmp(argv[0], "disable") == 0) {
+		wants_fullscreen = false;
+	} else if (strcmp(argv[0], "toggle") == 0) {
+		wants_fullscreen = !view->is_fullscreen;
+	} else {
+		return cmd_results_new(CMD_INVALID, "fullscreen",
+				"Expected 'fullscreen <enable|disable|toggle>'");
+	}
+
+	view_set_fullscreen(view, wants_fullscreen);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -6,8 +6,11 @@
 #include "sway/tree/view.h"
 #include "sway/tree/layout.h"
 
-// fullscreen toggle|enable|disable
 struct cmd_results *cmd_fullscreen(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "fullscreen", EXPECTED_LESS_THAN, 2))) {
+		return error;
+	}
 	struct sway_container *container =
 		config->handler_context.current_container;
 	if (container->type != C_VIEW) {
@@ -25,7 +28,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		wants_fullscreen = false;
 	} else {
 		return cmd_results_new(CMD_INVALID, "fullscreen",
-				"Expected 'fullscreen' or fullscreen <enable|disable|toggle>'");
+				"Expected 'fullscreen' or 'fullscreen <enable|disable|toggle>'");
 	}
 
 	view_set_fullscreen(view, wants_fullscreen);

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -8,12 +8,6 @@
 
 // fullscreen toggle|enable|disable
 struct cmd_results *cmd_fullscreen(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if (config->reading) return cmd_results_new(CMD_FAILURE, "fullscreen", "Can't be used in config file.");
-	if (!config->active) return cmd_results_new(CMD_FAILURE, "fullscreen", "Can only be used when sway is running.");
-	if ((error = checkarg(argc, "fullscreen", EXPECTED_AT_LEAST, 1))) {
-		return error;
-	}
 	struct sway_container *container =
 		config->handler_context.current_container;
 	if (container->type != C_VIEW) {
@@ -23,15 +17,15 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	struct sway_view *view = container->sway_view;
 	bool wants_fullscreen;
 
-	if (strcmp(argv[0], "enable") == 0) {
+	if (argc == 0 || strcmp(argv[0], "toggle") == 0) {
+		wants_fullscreen = !view->is_fullscreen;
+	} else if (strcmp(argv[0], "enable") == 0) {
 		wants_fullscreen = true;
 	} else if (strcmp(argv[0], "disable") == 0) {
 		wants_fullscreen = false;
-	} else if (strcmp(argv[0], "toggle") == 0) {
-		wants_fullscreen = !view->is_fullscreen;
 	} else {
 		return cmd_results_new(CMD_INVALID, "fullscreen",
-				"Expected 'fullscreen <enable|disable|toggle>'");
+				"Expected 'fullscreen' or fullscreen <enable|disable|toggle>'");
 	}
 
 	view_set_fullscreen(view, wants_fullscreen);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -469,6 +469,12 @@ void output_damage_view(struct sway_output *output, struct sway_view *view,
 		return;
 	}
 
+	struct sway_container *workspace = container_parent(view->swayc,
+			C_WORKSPACE);
+	if (workspace->sway_workspace->fullscreen && !view->is_fullscreen) {
+		return;
+	}
+
 	struct damage_data data = {
 		.output = output,
 		.whole = whole,

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -22,6 +22,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/layout.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 
 struct sway_container *output_by_name(const char *name) {
 	for (int i = 0; i < root_container.children->length; ++i) {
@@ -275,9 +276,9 @@ static void render_output(struct sway_output *output, struct timespec *when,
 
 	struct sway_container *workspace = output_get_active_workspace(output);
 
-	if (workspace->fullscreen) {
+	if (workspace->sway_workspace->fullscreen) {
 		wlr_output_set_fullscreen_surface(wlr_output,
-				workspace->fullscreen->surface);
+				workspace->sway_workspace->fullscreen->surface);
 	} else {
 		wlr_output_set_fullscreen_surface(wlr_output, NULL);
 		render_layer(output,

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -229,7 +229,11 @@ static void render_container_iterator(struct sway_container *con,
 
 static void render_container(struct sway_output *output,
 		struct sway_container *con) {
-	container_descendants(con, C_VIEW, render_container_iterator, output);
+	if (con->type == C_VIEW) { // Happens if a view is fullscreened
+		render_container_iterator(con, output);
+	} else {
+		container_descendants(con, C_VIEW, render_container_iterator, output);
+	}
 }
 
 static struct sway_container *output_get_active_workspace(
@@ -277,10 +281,8 @@ static void render_output(struct sway_output *output, struct timespec *when,
 	struct sway_container *workspace = output_get_active_workspace(output);
 
 	if (workspace->sway_workspace->fullscreen) {
-		wlr_output_set_fullscreen_surface(wlr_output,
-				workspace->sway_workspace->fullscreen->surface);
+		render_container(output, workspace->sway_workspace->fullscreen->swayc);
 	} else {
-		wlr_output_set_fullscreen_surface(wlr_output, NULL);
 		render_layer(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
 		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -287,11 +287,9 @@ static void render_output(struct sway_output *output, struct timespec *when,
 		render_container(output, workspace);
 
 		render_unmanaged(output, &root_container.sway_root->xwayland_unmanaged);
-
-		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
-		render_layer(output,
-				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 	}
+	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
+	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 
 renderer_end:
 	if (root_container.sway_root->debug_tree) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -273,17 +273,25 @@ static void render_output(struct sway_output *output, struct timespec *when,
 	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 	wlr_renderer_clear(renderer, clear_color);
 
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
-
 	struct sway_container *workspace = output_get_active_workspace(output);
-	render_container(output, workspace);
 
-	render_unmanaged(output, &root_container.sway_root->xwayland_unmanaged);
+	if (workspace->fullscreen) {
+		wlr_output_set_fullscreen_surface(wlr_output,
+				workspace->fullscreen->surface);
+	} else {
+		wlr_output_set_fullscreen_surface(wlr_output, NULL);
+		render_layer(output,
+				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
+		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
-	// TODO: consider revising this when fullscreen windows are supported
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
+		render_container(output, workspace);
+
+		render_unmanaged(output, &root_container.sway_root->xwayland_unmanaged);
+
+		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
+		render_layer(output,
+				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
+	}
 
 renderer_end:
 	if (root_container.sway_root->debug_tree) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -275,16 +275,18 @@ static void render_output(struct sway_output *output, struct timespec *when,
 	wlr_output_transformed_resolution(wlr_output, &width, &height);
 	pixman_region32_union_rect(damage, damage, 0, 0, width, height);
 
-	float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
-	wlr_renderer_clear(renderer, clear_color);
-
 	struct sway_container *workspace = output_get_active_workspace(output);
 
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
-
 	if (workspace->sway_workspace->fullscreen) {
+		float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
+		wlr_renderer_clear(renderer, clear_color);
 		render_container(output, workspace->sway_workspace->fullscreen->swayc);
 	} else {
+		float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
+		wlr_renderer_clear(renderer, clear_color);
+
+		render_layer(output,
+				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
 		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
 		render_container(output, workspace);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -280,6 +280,7 @@ static void render_output(struct sway_output *output, struct timespec *when,
 	if (workspace->sway_workspace->fullscreen) {
 		float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
 		wlr_renderer_clear(renderer, clear_color);
+		// TODO: handle views smaller than the output
 		render_container(output, workspace->sway_workspace->fullscreen->swayc);
 	} else {
 		float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -280,11 +280,11 @@ static void render_output(struct sway_output *output, struct timespec *when,
 
 	struct sway_container *workspace = output_get_active_workspace(output);
 
+	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
+
 	if (workspace->sway_workspace->fullscreen) {
 		render_container(output, workspace->sway_workspace->fullscreen->swayc);
 	} else {
-		render_layer(output,
-				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
 		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]);
 
 		render_container(output, workspace);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -292,8 +292,8 @@ static void render_output(struct sway_output *output, struct timespec *when,
 		render_container(output, workspace);
 
 		render_unmanaged(output, &root_container.sway_root->xwayland_unmanaged);
+		render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
-	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	render_layer(output, &output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 
 renderer_end:

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -128,4 +128,8 @@ void handle_wl_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&shell_surface->events.destroy, &wl_shell_view->destroy);
 
 	view_map(&wl_shell_view->view, shell_surface->surface);
+
+	if (shell_surface->state == WLR_WL_SHELL_SURFACE_STATE_FULLSCREEN) {
+		view_set_fullscreen(&wl_shell_view->view, true);
+	}
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -234,6 +234,9 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 				xdg_shell_v6_view->view.wlr_xdg_surface_v6->role)) {
 		return;
 	}
+	if (!xdg_shell_v6_view->view.wlr_xdg_surface_v6->mapped) {
+		return;
+	}
 
 	view_set_fullscreen(&xdg_shell_v6_view->view, e->fullscreen);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -212,6 +212,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xdg_shell_v6_view->new_popup.notify = handle_new_popup;
 	wl_signal_add(&xdg_surface->events.new_popup,
 		&xdg_shell_v6_view->new_popup);
+
+	if (xdg_surface->toplevel->current.fullscreen) {
+		view_set_fullscreen(view, true);
+	}
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -213,7 +213,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	wl_signal_add(&xdg_surface->events.new_popup,
 		&xdg_shell_v6_view->new_popup);
 
-	if (xdg_surface->toplevel->current.fullscreen) {
+	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		view_set_fullscreen(view, true);
 	}
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -118,6 +118,14 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
+static void set_fullscreen(struct sway_view *view, bool fullscreen) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
+		return;
+	}
+	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
+	wlr_xdg_toplevel_v6_set_fullscreen(surface, fullscreen);
+}
+
 static void for_each_surface(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
@@ -146,6 +154,7 @@ static void destroy(struct sway_view *view) {
 	wl_list_remove(&xdg_shell_v6_view->destroy.link);
 	wl_list_remove(&xdg_shell_v6_view->map.link);
 	wl_list_remove(&xdg_shell_v6_view->unmap.link);
+	wl_list_remove(&xdg_shell_v6_view->request_fullscreen.link);
 	free(xdg_shell_v6_view);
 }
 
@@ -153,6 +162,7 @@ static const struct sway_view_impl view_impl = {
 	.get_prop = get_prop,
 	.configure = configure,
 	.set_activated = set_activated,
+	.set_fullscreen = set_fullscreen,
 	.for_each_surface = for_each_surface,
 	.close = _close,
 	.destroy = destroy,
@@ -210,6 +220,18 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	view_destroy(&xdg_shell_v6_view->view);
 }
 
+static void handle_request_fullscreen(struct wl_listener *listener, void *data) {
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, request_fullscreen);
+	struct wlr_xdg_toplevel_v6_set_fullscreen_event *e = data;
+
+	if (xdg_shell_v6_view->view.wlr_xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		return;
+	}
+
+	view_set_fullscreen(&xdg_shell_v6_view->view, e->fullscreen);
+}
+
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server,
 		xdg_shell_v6_surface);
@@ -246,4 +268,8 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 
 	xdg_shell_v6_view->destroy.notify = handle_destroy;
 	wl_signal_add(&xdg_surface->events.destroy, &xdg_shell_v6_view->destroy);
+
+	xdg_shell_v6_view->request_fullscreen.notify = handle_request_fullscreen;
+	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
+			&xdg_shell_v6_view->request_fullscreen);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -229,7 +229,9 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		wl_container_of(listener, xdg_shell_v6_view, request_fullscreen);
 	struct wlr_xdg_toplevel_v6_set_fullscreen_event *e = data;
 
-	if (xdg_shell_v6_view->view.wlr_xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+	if (!sway_assert(xdg_shell_v6_view->view.wlr_xdg_surface_v6->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL,
+				"xdg_shell_v6 requested fullscreen of surface with role %i",
+				xdg_shell_v6_view->view.wlr_xdg_surface_v6->role)) {
 		return;
 	}
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -248,6 +248,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	// Put it back into the tree
 	wlr_xwayland_surface_set_maximized(xsurface, true);
 	view_map(view, xsurface->surface);
+
+	if (xsurface->fullscreen) {
+		view_set_fullscreen(view, true);
+	}
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -25,15 +25,6 @@ static void unmanaged_handle_request_configure(struct wl_listener *listener,
 		ev->width, ev->height);
 }
 
-static void unmanaged_handle_request_fullscreen(struct wl_listener *listener,
-		void *data) {
-	struct sway_xwayland_view *xwayland_view =
-		wl_container_of(listener, xwayland_view, request_fullscreen);
-	struct sway_view *view = &xwayland_view->view;
-	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	view_set_fullscreen(view, xsurface->fullscreen);
-}
-
 static void unmanaged_handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_unmanaged *surface =
 		wl_container_of(listener, surface, commit);
@@ -115,9 +106,6 @@ static struct sway_xwayland_unmanaged *create_unmanaged(
 	wl_signal_add(&xsurface->events.request_configure,
 		&surface->request_configure);
 	surface->request_configure.notify = unmanaged_handle_request_configure;
-	wl_signal_add(&xsurface->events.request_fullscreen,
-		&surface->request_fullscreen);
-	surface->request_fullscreen.notify = unmanaged_handle_request_fullscreen;
 	wl_signal_add(&xsurface->events.map, &surface->map);
 	surface->map.notify = unmanaged_handle_map;
 	wl_signal_add(&xsurface->events.unmap, &surface->unmap);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -12,6 +12,7 @@
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
 
 static struct wlr_surface *layer_surface_at(struct sway_output *output,
@@ -87,6 +88,13 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
 				ox, oy, sx, sy))) {
 		return ws;
+	}
+
+	if (ws->sway_workspace->fullscreen) {
+		*sx = ox;
+		*sy = oy;
+		*surface = ws->sway_workspace->fullscreen->surface;
+		return ws->sway_workspace->fullscreen->swayc;
 	}
 
 	struct sway_container *c;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -84,17 +84,20 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 				ox, oy, sx, sy))) {
 		return ws;
 	}
+	if (ws->sway_workspace->fullscreen) {
+		struct wlr_surface *wlr_surface = ws->sway_workspace->fullscreen->surface;
+		if (wlr_surface_point_accepts_input(wlr_surface, ox, oy)) {
+			*sx = ox;
+			*sy = oy;
+			*surface = wlr_surface;
+			return ws->sway_workspace->fullscreen->swayc;
+		}
+		return NULL;
+	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
 				ox, oy, sx, sy))) {
 		return ws;
-	}
-
-	if (ws->sway_workspace->fullscreen) {
-		*sx = ox;
-		*sy = oy;
-		*surface = ws->sway_workspace->fullscreen->surface;
-		return ws->sway_workspace->fullscreen->swayc;
 	}
 
 	struct sway_container *c;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -458,7 +458,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		new_workspace = container_parent(new_workspace, C_WORKSPACE);
 	}
 
-	if (last_workspace == new_workspace
+	if (last_workspace && last_workspace == new_workspace
 			&& last_workspace->sway_workspace->fullscreen
 			&& !container->sway_view->is_fullscreen) {
 		return;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -18,6 +18,7 @@
 #include "sway/output.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "log.h"
 
 static void seat_device_destroy(struct sway_seat_device *seat_device) {
@@ -457,7 +458,8 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		new_workspace = container_parent(new_workspace, C_WORKSPACE);
 	}
 
-	if (last_workspace == new_workspace && last_workspace->fullscreen
+	if (last_workspace == new_workspace
+			&& last_workspace->sway_workspace->fullscreen
 			&& !container->sway_view->is_fullscreen) {
 		return;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -448,6 +448,20 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		return;
 	}
 
+	struct sway_container *last_workspace = last_focus;
+	if (last_workspace && last_workspace->type != C_WORKSPACE) {
+		last_workspace = container_parent(last_workspace, C_WORKSPACE);
+	}
+	struct sway_container *new_workspace = container;
+	if (new_workspace && new_workspace->type != C_WORKSPACE) {
+		new_workspace = container_parent(new_workspace, C_WORKSPACE);
+	}
+
+	if (last_workspace == new_workspace && last_workspace->fullscreen
+			&& !container->sway_view->is_fullscreen) {
+		return;
+	}
+
 	struct sway_container *last_output = last_focus;
 	if (last_output && last_output->type != C_OUTPUT) {
 		last_output = container_parent(last_output, C_OUTPUT);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -34,6 +34,7 @@ sway_sources = files(
 	'commands/exec_always.c',
 	'commands/focus.c',
 	'commands/focus_follows_mouse.c',
+	'commands/fullscreen.c',
 	'commands/kill.c',
 	'commands/opacity.c',
 	'commands/include.c',

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -197,6 +197,7 @@ static struct sway_container *container_workspace_destroy(
 		}
 	}
 
+	free(workspace->sway_workspace);
 	_container_destroy(workspace);
 
 	output_damage_whole(output->sway_output);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -596,12 +596,6 @@ void arrange_windows(struct sway_container *container,
 		container->name, container->width, container->height, container->x,
 		container->y);
 
-	if (container->type == C_WORKSPACE
-			&& container->sway_workspace->fullscreen) {
-		view_configure(container->sway_workspace->fullscreen, 0, 0,
-				container->parent->width, container->parent->height);
-	}
-
 	double x = 0, y = 0;
 	switch (container->type) {
 	case C_ROOT:
@@ -628,9 +622,6 @@ void arrange_windows(struct sway_container *container,
 		return;
 	case C_WORKSPACE:
 		{
-			if (container->sway_workspace->fullscreen) {
-				return;
-			}
 			struct sway_container *output =
 				container_parent(container, C_OUTPUT);
 			struct wlr_box *area = &output->sway_output->usable_area;
@@ -642,6 +633,11 @@ void arrange_windows(struct sway_container *container,
 			container->y = y = area->y;
 			wlr_log(L_DEBUG, "Arranging workspace '%s' at %f, %f",
 					container->name, container->x, container->y);
+			if (container->sway_workspace->fullscreen) {
+				view_configure(container->sway_workspace->fullscreen, 0, 0,
+						output->width, output->height);
+				return;
+			}
 		}
 		// children are properly handled below
 		break;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -138,7 +138,7 @@ void container_move_to(struct sway_container *container,
 		return;
 	}
 
-	if (container->sway_view->is_fullscreen) {
+	if (container->type == C_VIEW && container->sway_view->is_fullscreen) {
 		struct sway_container *old_workspace = container;
 		if (old_workspace->type != C_WORKSPACE) {
 			old_workspace = container_parent(old_workspace, C_WORKSPACE);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -137,6 +137,21 @@ void container_move_to(struct sway_container *container,
 			|| container_has_anscestor(container, destination)) {
 		return;
 	}
+
+	if (container->sway_view->is_fullscreen) {
+		struct sway_container *old_workspace = container;
+		if (old_workspace->type != C_WORKSPACE) {
+			old_workspace = container_parent(old_workspace, C_WORKSPACE);
+		}
+		struct sway_container *new_workspace = destination;
+		if (new_workspace->type != C_WORKSPACE) {
+			new_workspace = container_parent(new_workspace, C_WORKSPACE);
+		}
+		if (old_workspace != new_workspace) {
+			view_set_fullscreen(container->sway_view, false);
+		}
+	}
+
 	struct sway_container *old_parent = container_remove_child(container);
 	container->width = container->height = 0;
 	struct sway_container *new_parent;
@@ -557,6 +572,9 @@ void arrange_windows(struct sway_container *container,
 		return;
 	case C_WORKSPACE:
 		{
+			if (container->fullscreen) {
+				return;
+			}
 			struct sway_container *output =
 				container_parent(container, C_OUTPUT);
 			struct wlr_box *area = &output->sway_output->usable_area;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -82,6 +82,37 @@ static int index_child(const struct sway_container *child) {
 	return i;
 }
 
+static void container_handle_fullscreen_reparent(struct sway_container *viewcon,
+		struct sway_container *old_parent) {
+	if (viewcon->type != C_VIEW || !viewcon->sway_view->is_fullscreen) {
+		return;
+	}
+	struct sway_view *view = viewcon->sway_view;
+	struct sway_container *old_workspace = old_parent;
+	if (old_workspace && old_workspace->type != C_WORKSPACE) {
+		old_workspace = container_parent(old_workspace, C_WORKSPACE);
+	}
+	struct sway_container *new_workspace = container_parent(view->swayc,
+			C_WORKSPACE);
+	if (old_workspace == new_workspace) {
+		return;
+	}
+	// Unmark the old workspace as fullscreen
+	if (old_workspace) {
+		old_workspace->sway_workspace->fullscreen = NULL;
+	}
+
+	// Mark the new workspace as fullscreen
+	if (new_workspace->sway_workspace->fullscreen) {
+		view_set_fullscreen(new_workspace->sway_workspace->fullscreen, false);
+	}
+	new_workspace->sway_workspace->fullscreen = view;
+	// Resize view to new output dimensions
+	struct sway_output *output = new_workspace->parent->sway_output;
+	view_configure(view, 0, 0,
+			output->wlr_output->width, output->wlr_output->height);
+}
+
 void container_insert_child(struct sway_container *parent,
 		struct sway_container *child, int i) {
 	struct sway_container *old_parent = child->parent;
@@ -91,6 +122,7 @@ void container_insert_child(struct sway_container *parent,
 	wlr_log(L_DEBUG, "Inserting id:%zd at index %d", child->id, i);
 	list_insert(parent->children, i, child);
 	child->parent = parent;
+	container_handle_fullscreen_reparent(child, old_parent);
 	wl_signal_emit(&child->events.reparent, old_parent);
 }
 
@@ -106,6 +138,7 @@ struct sway_container *container_add_sibling(struct sway_container *fixed,
 	int i = index_child(fixed);
 	list_insert(parent->children, i + 1, active);
 	active->parent = parent;
+	container_handle_fullscreen_reparent(active, old_parent);
 	wl_signal_emit(&active->events.reparent, old_parent);
 	return active->parent;
 }
@@ -115,11 +148,18 @@ void container_add_child(struct sway_container *parent,
 	wlr_log(L_DEBUG, "Adding %p (%d, %fx%f) to %p (%d, %fx%f)",
 			child, child->type, child->width, child->height,
 			parent, parent->type, parent->width, parent->height);
+	struct sway_container *old_parent = child->parent;
 	list_add(parent->children, child);
+	container_handle_fullscreen_reparent(child, old_parent);
 	child->parent = parent;
 }
 
 struct sway_container *container_remove_child(struct sway_container *child) {
+	if (child->type == C_VIEW && child->sway_view->is_fullscreen) {
+		struct sway_container *workspace = container_parent(child, C_WORKSPACE);
+		workspace->sway_workspace->fullscreen = NULL;
+	}
+
 	struct sway_container *parent = child->parent;
 	for (int i = 0; i < parent->children->length; ++i) {
 		if (parent->children->items[i] == child) {
@@ -137,21 +177,6 @@ void container_move_to(struct sway_container *container,
 			|| container_has_anscestor(container, destination)) {
 		return;
 	}
-
-	if (container->type == C_VIEW && container->sway_view->is_fullscreen) {
-		struct sway_container *old_workspace = container;
-		if (old_workspace->type != C_WORKSPACE) {
-			old_workspace = container_parent(old_workspace, C_WORKSPACE);
-		}
-		struct sway_container *new_workspace = destination;
-		if (new_workspace->type != C_WORKSPACE) {
-			new_workspace = container_parent(new_workspace, C_WORKSPACE);
-		}
-		if (old_workspace != new_workspace) {
-			view_set_fullscreen(container->sway_view, false);
-		}
-	}
-
 	struct sway_container *old_parent = container_remove_child(container);
 	container->width = container->height = 0;
 	struct sway_container *new_parent;
@@ -179,6 +204,26 @@ void container_move_to(struct sway_container *container,
 		arrange_windows(old_parent, -1, -1);
 	}
 	arrange_windows(new_parent, -1, -1);
+	// If view was moved to a fullscreen workspace, refocus the fullscreen view
+	struct sway_container *new_workspace = container;
+	if (new_workspace->type != C_WORKSPACE) {
+		new_workspace = container_parent(new_workspace, C_WORKSPACE);
+	}
+	if (new_workspace->sway_workspace->fullscreen) {
+		struct sway_seat *seat;
+		struct sway_container *focus, *focus_ws;
+		wl_list_for_each(seat, &input_manager->seats, link) {
+			focus = seat_get_focus(seat);
+			focus_ws = focus;
+			if (focus_ws->type != C_WORKSPACE) {
+				focus_ws = container_parent(focus_ws, C_WORKSPACE);
+			}
+			seat_set_focus(seat, new_workspace->sway_workspace->fullscreen->swayc);
+			if (focus_ws != new_workspace) {
+				seat_set_focus(seat, focus);
+			}
+		}
+	}
 }
 
 static bool sway_dir_to_wlr(enum movement_direction dir,
@@ -282,6 +327,11 @@ void container_move(struct sway_container *container,
 	struct sway_container *sibling = NULL;
 	struct sway_container *current = container;
 	struct sway_container *parent = current->parent;
+
+	// If moving a fullscreen view, only consider outputs
+	if (container->type == C_VIEW && container->sway_view->is_fullscreen) {
+		current = container_parent(container, C_OUTPUT);
+	}
 
 	if (parent != container_flatten(parent)) {
 		// Special case: we were the last one in this container, so flatten it
@@ -545,6 +595,14 @@ void arrange_windows(struct sway_container *container,
 	wlr_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", container,
 		container->name, container->width, container->height, container->x,
 		container->y);
+
+	if (container->type == C_WORKSPACE
+			&& container->sway_workspace->fullscreen) {
+		struct wlr_output *wlr_output
+			= container->parent->sway_output->wlr_output;
+		view_configure(container->sway_workspace->fullscreen, 0, 0,
+				wlr_output->width, wlr_output->height);
+	}
 
 	double x = 0, y = 0;
 	switch (container->type) {
@@ -831,19 +889,27 @@ static struct sway_container *sway_output_from_wlr(struct wlr_output *output) {
 	return NULL;
 }
 
-struct sway_container *container_get_in_direction(
+static struct sway_container *container_get_in_direction_naive(
 		struct sway_container *container, struct sway_seat *seat,
 		enum movement_direction dir) {
-	if (dir == MOVE_CHILD) {
-		return seat_get_focus_inactive(seat, container);
-	}
-
 	struct sway_container *parent = container->parent;
-	if (dir == MOVE_PARENT) {
-		if (parent->type == C_OUTPUT) {
+
+	if (container->type == C_VIEW && container->sway_view->is_fullscreen) {
+		if (dir == MOVE_PARENT || dir == MOVE_CHILD) {
 			return NULL;
-		} else {
-			return parent;
+		}
+		container = container_parent(container, C_OUTPUT);
+		parent = container->parent;
+	} else {
+		if (dir == MOVE_CHILD) {
+			return seat_get_focus_inactive(seat, container);
+		}
+		if (dir == MOVE_PARENT) {
+			if (parent->type == C_OUTPUT) {
+				return NULL;
+			} else {
+				return parent;
+			}
 		}
 	}
 
@@ -930,6 +996,28 @@ struct sway_container *container_get_in_direction(
 			}
 		}
 	}
+}
+
+struct sway_container *container_get_in_direction(
+		struct sway_container *container, struct sway_seat *seat,
+		enum movement_direction dir) {
+	struct sway_container *result = container_get_in_direction_naive(container,
+			seat, dir);
+	if (!result) {
+		return NULL;
+	}
+	struct sway_container *old_workspace = container;
+	if (old_workspace->type != C_WORKSPACE) {
+		old_workspace = container_parent(old_workspace, C_WORKSPACE);
+	}
+	struct sway_container *new_workspace = result;
+	if (new_workspace->type != C_WORKSPACE) {
+		new_workspace = container_parent(new_workspace, C_WORKSPACE);
+	}
+	if (old_workspace != new_workspace && new_workspace->sway_workspace->fullscreen) {
+		result = new_workspace->sway_workspace->fullscreen->swayc;
+	}
+	return result;
 }
 
 struct sway_container *container_replace_child(struct sway_container *child,

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -572,7 +572,7 @@ void arrange_windows(struct sway_container *container,
 		return;
 	case C_WORKSPACE:
 		{
-			if (container->fullscreen) {
+			if (container->sway_workspace->fullscreen) {
 				return;
 			}
 			struct sway_container *output =
@@ -846,22 +846,6 @@ struct sway_container *container_get_in_direction(
 			return parent;
 		}
 	}
-
-	// TODO WLR fullscreen
-	/*
-	if (container->type == C_VIEW && swayc_is_fullscreen(container)) {
-		wlr_log(L_DEBUG, "Moving from fullscreen view, skipping to output");
-		container = container_parent(container, C_OUTPUT);
-		get_layout_center_position(container, &abs_pos);
-		struct sway_container *output =
-		swayc_adjacent_output(container, dir, &abs_pos, true);
-		return get_swayc_in_output_direction(output, dir);
-	}
-	if (container->type == C_WORKSPACE && container->fullscreen) {
-		sway_log(L_DEBUG, "Moving to fullscreen view");
-		return container->fullscreen;
-	}
-	*/
 
 	struct sway_container *wrap_candidate = NULL;
 	while (true) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -598,10 +598,8 @@ void arrange_windows(struct sway_container *container,
 
 	if (container->type == C_WORKSPACE
 			&& container->sway_workspace->fullscreen) {
-		struct wlr_output *wlr_output
-			= container->parent->sway_output->wlr_output;
 		view_configure(container->sway_workspace->fullscreen, 0, 0,
-				wlr_output->width, wlr_output->height);
+				container->parent->width, container->parent->height);
 	}
 
 	double x = 0, y = 0;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -7,6 +7,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/layout.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 
 void view_init(struct sway_view *view, enum sway_view_type type,
 		const struct sway_view_impl *impl) {
@@ -90,10 +91,10 @@ void view_set_fullscreen(struct sway_view *view, bool fullscreen) {
 	view->is_fullscreen = fullscreen;
 
 	if (fullscreen) {
-		workspace->fullscreen = view;
+		workspace->sway_workspace->fullscreen = view;
 		view_configure(view, 0, 0, output->wlr_output->width, output->wlr_output->height);
 	} else {
-		workspace->fullscreen = NULL;
+		workspace->sway_workspace->fullscreen = NULL;
 		arrange_windows(workspace, -1, -1);
 	}
 
@@ -105,7 +106,7 @@ void view_set_fullscreen(struct sway_view *view, bool fullscreen) {
 void view_close(struct sway_view *view) {
 	if (view->is_fullscreen) {
 		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-		ws->fullscreen = NULL;
+		ws->sway_workspace->fullscreen = NULL;
 	}
 
 	if (view->impl->close) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -79,31 +79,25 @@ void view_set_fullscreen(struct sway_view *view, bool fullscreen) {
 		return;
 	}
 
-	struct sway_container *container = container_parent(view->swayc, C_OUTPUT);
-	struct sway_output *output = container->sway_output;
 	struct sway_container *workspace = container_parent(view->swayc, C_WORKSPACE);
+	struct sway_container *container = container_parent(workspace, C_OUTPUT);
+	struct sway_output *output = container->sway_output;
 
 	if (view->impl->set_fullscreen) {
 		view->impl->set_fullscreen(view, fullscreen);
 	}
 
+	view->is_fullscreen = fullscreen;
+
 	if (fullscreen) {
-		view->swayc->saved_x = view->swayc->x;
-		view->swayc->saved_y = view->swayc->y;
-		view->saved_width = view->width;
-		view->saved_height = view->height;
-		view_configure(view, 0, 0, output->wlr_output->width, output->wlr_output->height);
 		workspace->fullscreen = view;
+		view_configure(view, 0, 0, output->wlr_output->width, output->wlr_output->height);
 	} else {
-		view_configure(view, view->swayc->saved_x, view->swayc->saved_y,
-				view->saved_width, view->saved_height);
 		workspace->fullscreen = NULL;
+		arrange_windows(workspace, -1, -1);
 	}
 
-	view->is_fullscreen = fullscreen;
 	output_damage_whole(output);
-
-	arrange_windows(workspace, -1, -1);
 
 	ipc_event_window(view->swayc, "fullscreen_mode");
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -104,11 +104,6 @@ void view_set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 void view_close(struct sway_view *view) {
-	if (view->is_fullscreen) {
-		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-		ws->sway_workspace->fullscreen = NULL;
-	}
-
 	if (view->impl->close) {
 		view->impl->close(view);
 	}
@@ -231,6 +226,11 @@ void view_unmap(struct sway_view *view) {
 	}
 
 	wl_signal_emit(&view->events.unmap, view);
+
+	if (view->is_fullscreen) {
+		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+		ws->sway_workspace->fullscreen = NULL;
+	}
 
 	view_damage(view, true);
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -59,6 +59,13 @@ struct sway_container *workspace_create(struct sway_container *output,
 	workspace->layout = container_get_default_layout(output);
 	workspace->workspace_layout = workspace->layout;
 
+	struct sway_workspace *swayws = calloc(1, sizeof(struct sway_workspace));
+	if (!swayws) {
+		return NULL;
+	}
+	swayws->swayc = workspace;
+	workspace->sway_workspace = swayws;
+
 	container_add_child(output, workspace);
 	container_sort_workspaces(output);
 	container_create_notify(workspace);


### PR DESCRIPTION
This implements `fullscreen enable`, `fullscreen disable`, `fullscreen toggle`, and allows views to request fullscreen.

This is my first significant PR for sway and I've had to learn a lot about how everything works, so please scrutinise this carefully.

Note that sway 0.15 allows the command `fullscreen` without any arguments which acts as toggle, but this is different to the i3 user guide so I've implemented it as described above. As a result, if you're porting config from sway 0.15 you may need to update your command to be `fullscreen toggle`.

wl_shell seems a bit lacking with its fullscreen ability, and from what I understand wl_shell is deprecated anyway, so I've not implemented fullscreen for that. If someone could confirm then that'd be appreciated.

There is one known issue, and that is that popups don't show when the parent view is fullscreen, but I'd like to either resolve that in a separate PR or leave it for someone else to look into.

Tests:

* Run fullscreen enable, fullscreen disable, fullscreen toggle on an xdg_v6 view
* Run fullscreen enable, fullscreen disable, fullscreen toggle on an xwayland view
* Attempt to fullscreen a container - should be ignored 
* Fullscreen a view, then kill it
* Open two views on one workspace, fullscreen one, then attempt to focus the other - focus should remain on fullscreen view
* Open two views on different workspaces, fullscreen one, then attempt to focus the other and back again - workspaces should focus correctly
* Fullscreen view, then move view to another workspace - view should be unfullscreened
* Make an xwayland view request fullscreen, eg. launch firefox and press F11
* Make an xdg_v6 view request fullscreen, eg. launch `mpv --opengl-backend=wayland` and press f