### PR TITLE
Update cursor when workspace focus changes

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -59,9 +59,8 @@ static struct sway_container *container_at_cursor(struct sway_cursor *cursor,
 	// find the output the cursor is on
 	struct wlr_output_layout *output_layout =
 		root_container.sway_root->output_layout;
-	struct wlr_output *wlr_output =
-		wlr_output_layout_output_at(output_layout,
-				cursor->cursor->x, cursor->cursor->y);
+	struct wlr_output *wlr_output = wlr_output_layout_output_at(output_layout,
+		cursor->cursor->x, cursor->cursor->y);
 	if (wlr_output == NULL) {
 		return NULL;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -564,6 +564,12 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		view_set_activated(view, false);
 	}
 
+	if (last_workspace && last_workspace != new_workspace) {
+		struct timespec now;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		cursor_send_pointer_motion(seat->cursor, now.tv_nsec / 1000);
+	}
+
 	seat->has_focus = (container != NULL);
 
 	update_debug_tree();


### PR DESCRIPTION
Not only this updates the cursor image, but this also (and more importantly) sends pointer enter/leave events.