### PR TITLE
Render unmanaged xwayland views when an xwayland view is fullscreen

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -282,6 +282,11 @@ static void render_output(struct sway_output *output, struct timespec *when,
 		wlr_renderer_clear(renderer, clear_color);
 		// TODO: handle views smaller than the output
 		render_container(output, workspace->sway_workspace->fullscreen->swayc);
+
+		if (workspace->sway_workspace->fullscreen->type == SWAY_VIEW_XWAYLAND) {
+			render_unmanaged(output,
+					&root_container.sway_root->xwayland_unmanaged);
+		}
 	} else {
 		float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 		wlr_renderer_clear(renderer, clear_color);


### PR DESCRIPTION
This makes Chromium context menus appear when fullscreen.

Fixes an item on #1828.

Question: This will render all unmanaged xwayland views, even if it doesn't belong to the fullscreen view. Do I need to worry about this, and if so how do I filter them?

To test:

* Launch Chromium, fullscreen it, then right click on the page or open the context menu in the top right.