### PR TITLE
Implement rename workspace command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -131,6 +131,7 @@ sway_cmd cmd_output;
 sway_cmd cmd_permit;
 sway_cmd cmd_reject;
 sway_cmd cmd_reload;
+sway_cmd cmd_rename;
 sway_cmd cmd_resize;
 sway_cmd cmd_scratchpad;
 sway_cmd cmd_seamless_mouse;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -167,6 +167,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "move", cmd_move },
 	{ "opacity", cmd_opacity },
 	{ "reload", cmd_reload },
+	{ "rename", cmd_rename },
 	{ "resize", cmd_resize },
 	{ "split", cmd_split },
 	{ "splith", cmd_splith },

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -1,0 +1,78 @@
+#define _XOPEN_SOURCE 500
+#include <string.h>
+#include <strings.h>
+#include "log.h"
+#include "stringop.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/ipc-server.h"
+#include "sway/tree/container.h"
+#include "sway/tree/workspace.h"
+
+static const char* expected_syntax =
+	"Expected 'rename workspace <old_name> to <new_name>' or "
+	"'rename workspace to <new_name>'";
+
+struct cmd_results *cmd_rename(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "rename", EXPECTED_AT_LEAST, 3))) {
+		return error;
+	}
+	if (strcasecmp(argv[0], "workspace") != 0) {
+		return cmd_results_new(CMD_INVALID, "rename", expected_syntax);
+	}
+
+	int argn = 1;
+	struct sway_container *workspace;
+
+	if (strcasecmp(argv[1], "to") == 0) {
+		// 'rename workspace to new_name'
+		workspace = config->handler_context.current_container;
+		if (workspace->type != C_WORKSPACE) {
+			workspace = container_parent(workspace, C_WORKSPACE);
+		}
+	} else if (strcasecmp(argv[1], "number") == 0) {
+		// 'rename workspace number x to new_name'
+		workspace = workspace_by_number(argv[2]);
+		while (argn < argc && strcasecmp(argv[argn], "to") != 0) {
+			++argn;
+		}
+	} else {
+		// 'rename workspace old_name to new_name'
+		int end = argn;
+		while (end < argc && strcasecmp(argv[end], "to") != 0) {
+			++end;
+		}
+		char *old_name = join_args(argv + argn, end - argn);
+		workspace = workspace_by_name(old_name);
+		free(old_name);
+		argn = end;
+	}
+
+	if (!workspace) {
+		return cmd_results_new(CMD_INVALID, "rename",
+				"There is no workspace with that name");
+	}
+
+	++argn; // move past "to"
+
+	if (argn >= argc) {
+		return cmd_results_new(CMD_INVALID, "rename", expected_syntax);
+	}
+
+	char *new_name = join_args(argv + argn, argc - argn);
+	struct sway_container *tmp_workspace = workspace_by_name(new_name);
+	if (tmp_workspace) {
+		free(new_name);
+		return cmd_results_new(CMD_INVALID, "rename",
+				"Workspace already exists");
+	}
+
+	wlr_log(L_DEBUG, "renaming workspace '%s' to '%s'", workspace->name, new_name);
+	free(workspace->name);
+	workspace->name = new_name;
+
+	ipc_event_workspace(NULL, workspace, "rename");
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -72,6 +72,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	free(workspace->name);
 	workspace->name = new_name;
 
+	container_sort_workspaces(workspace->parent);
 	ipc_event_workspace(NULL, workspace, "rename");
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -45,6 +45,7 @@ sway_sources = files(
 	'commands/move.c',
 	'commands/output.c',
 	'commands/reload.c',
+	'commands/rename.c',
 	'commands/resize.c',
 	'commands/seat.c',
 	'commands/seat/attach.c',


### PR DESCRIPTION
This implements the following commands:

* `rename workspace to new_name`
* `rename workspace old_name to new_name`
* `rename workspace number n to new_name`

General tests:

* `swaymsg rename workspace to foo`
* `swaymsg rename workspace to foo bar`
* `swaymsg rename workspace foo to bar`
* `swaymsg rename workspace foo bar to bar`
* `swaymsg rename workspace number 1 to foo`
* `swaymsg rename workspace number 1: foo to bar`

Failure handling tests:

* `swaymsg rename workspace`
* `swaymsg rename workspace to`
* `swaymsg rename workspace foo to`
* `swaymsg rename workspace foo to foo` (same name)
* `swaymsg rename workspace foo to bar` (where bar already exists)