### PR TITLE
[WIP] remove output pos <X,Y> syntax

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -322,7 +322,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 		cmdlist += strspn(cmdlist, whitespace);
 		do {
 			// Split commands
-			cmd = argsep(&cmdlist, ";");
+			cmd = argsep(&cmdlist, ",");
 			cmd += strspn(cmd, whitespace);
 			if (strcmp(cmd, "") == 0) {
 				wlr_log(L_INFO, "Ignoring empty command.");

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -322,7 +322,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 		cmdlist += strspn(cmdlist, whitespace);
 		do {
 			// Split commands
-			cmd = argsep(&cmdlist, ",");
+			cmd = argsep(&cmdlist, ";");
 			cmd += strspn(cmd, whitespace);
 			if (strcmp(cmd, "") == 0) {
 				wlr_log(L_INFO, "Ignoring empty command.");

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -73,29 +73,15 @@ static struct cmd_results *cmd_output_position(struct output_config *output,
 
 	char *end;
 	output->x = strtol(argv[*i], &end, 10);
+	// Format is 1234 4321
+	if (++*i >= argc) {
+		return cmd_results_new(CMD_INVALID, "output",
+			"Missing position argument (y).");
+	}
+	output->y = strtol(argv[*i], &end, 10);
 	if (*end) {
-		// Format is 1234,4321
-		if (*end != ',') {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position x.");
-		}
-		++end;
-		output->y = strtol(end, &end, 10);
-		if (*end) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position y.");
-		}
-	} else {
-		// Format is 1234 4321 (legacy)
-		if (++*i >= argc) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Missing position argument (y).");
-		}
-		output->y = strtol(argv[*i], &end, 10);
-		if (*end) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position y.");
-		}
+		return cmd_results_new(CMD_INVALID, "output",
+			"Invalid position y.");
 	}
 
 	return NULL;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -73,15 +73,17 @@ static struct cmd_results *cmd_output_position(struct output_config *output,
 
 	char *end;
 	output->x = strtol(argv[*i], &end, 10);
-	// Format is 1234 4321
-	if (++*i >= argc) {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Missing position argument (y).");
-	}
-	output->y = strtol(argv[*i], &end, 10);
 	if (*end) {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Invalid position y.");
+		// Format is 1234 4321
+		if (++*i >= argc) {
+			return cmd_results_new(CMD_INVALID, "output",
+				"Missing position argument (y).");
+		}
+		output->y = strtol(argv[*i], &end, 10);
+		if (*end) {
+			return cmd_results_new(CMD_INVALID, "output",
+				"Invalid position y.");
+		}
 	}
 
 	return NULL;

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -374,7 +374,7 @@ The default colors are:
 	+
 	output HDMI-A-1 mode 1920x1080@60Hz
 
-**output** <name> position|pos <X,Y>::
+**output** <name> position|pos <X> <Y>::
 	Configures the specified output to be arranged at the given position.
 
 **output** <name> scale <I>::


### PR DESCRIPTION
Deprecate "output <X,Y>" in faviour or the legacy  "output \<X\> \<Y\>".

Fixes #1822