### PR TITLE
Fix crash in container_descendants()

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -355,14 +355,15 @@ struct sway_container *container_view_create(struct sway_container *sibling,
 void container_descendants(struct sway_container *root,
 		enum sway_container_type type,
 		void (*func)(struct sway_container *item, void *data), void *data) {
+	if (!root->children || !root->children->length) {
+		return;
+	}
 	for (int i = 0; i < root->children->length; ++i) {
 		struct sway_container *item = root->children->items[i];
 		if (item->type == type) {
 			func(item, data);
 		}
-		if (item->children && item->children->length) {
-			container_descendants(item, type, func, data);
-		}
+		container_descendants(item, type, func, data);
 	}
 }
 


### PR DESCRIPTION
If root is a C_VIEW, the children property is a null pointer.

While at a glance it doesn't make sense to call container_descendants() on a C_VIEW, it can still happen.

To test, spawn a terminal and run `swaymsg opacity 0.9`.