### PR TITLE
Refactor arrange_windows()

### DIFF
--- a/include/sway/tree/arrange.h
+++ b/include/sway/tree/arrange.h
@@ -1,0 +1,20 @@
+#ifndef _SWAY_ARRANGE_H
+#define _SWAY_ARRANGE_H
+
+struct sway_container;
+
+void arrange_windows(struct sway_container *container);
+
+// Determine the root container's geometry, then iterate to everything below
+void arrange_root(void);
+
+// Determine the output's geometry, then iterate to everything below
+void arrange_output(struct sway_container *output);
+
+// Determine the workspace's geometry, then iterate to everything below
+void arrange_workspace(struct sway_container *workspace);
+
+// Arrange layout for all the children of the given workspace/container
+void arrange_children_of(struct sway_container *parent);
+
+#endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -75,6 +75,7 @@ struct sway_container {
 	double x, y;
 	// does not include borders or gaps.
 	double width, height;
+	double saved_width, saved_height;
 
 	list_t *children;
 

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -60,9 +60,6 @@ enum sway_container_layout container_get_default_layout(
 
 void container_sort_workspaces(struct sway_container *output);
 
-void arrange_windows(struct sway_container *container,
-		double width, double height);
-
 struct sway_container *container_get_in_direction(struct sway_container
 		*container, struct sway_seat *seat, enum movement_direction dir);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -162,6 +162,8 @@ void view_configure(struct sway_view *view, double ox, double oy, int width,
 
 void view_set_activated(struct sway_view *view, bool activated);
 
+void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen);
+
 void view_set_fullscreen(struct sway_view *view, bool fullscreen);
 
 void view_close(struct sway_view *view);

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
-#include "sway/tree/layout.h"
 #include "log.h"
 
 struct cmd_results *cmd_layout(int argc, char **argv) {
@@ -48,7 +48,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 	}
 
-	arrange_windows(parent, parent->width, parent->height);
+	arrange_children_of(parent);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -1,6 +1,6 @@
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/tree/layout.h"
+#include "sway/tree/arrange.h"
 
 struct cmd_results *cmd_reload(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -12,6 +12,6 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 	}
 
 	load_swaybars();
-	arrange_windows(&root_container, -1, -1);
+	arrange_root();
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -6,7 +6,7 @@
 #include <strings.h>
 #include <wlr/util/log.h>
 #include "sway/commands.h"
-#include "sway/tree/layout.h"
+#include "sway/tree/arrange.h"
 #include "log.h"
 
 static const int MIN_SANE_W = 100, MIN_SANE_H = 60;
@@ -182,7 +182,7 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 		}
 	}
 
-	arrange_windows(parent->parent, -1, -1);
+	arrange_children_of(parent->parent);
 }
 
 static void resize(int amount, enum resize_axis axis, enum resize_unit unit) {

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
-#include "sway/tree/layout.h"
 #include "sway/tree/view.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -12,7 +12,7 @@ static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.current_container;
 	struct sway_container *parent = container_split(con, layout);
 	container_create_notify(parent);
-	arrange_windows(parent, -1, -1);
+	arrange_children_of(parent);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -12,6 +12,7 @@
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/layout.h"
 #include "log.h"
 
@@ -175,7 +176,7 @@ void arrange_layers(struct sway_output *output) {
 				sizeof(struct wlr_box)) != 0) {
 		wlr_log(L_DEBUG, "Usable area changed, rearranging output");
 		memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
-		arrange_windows(output->swayc, -1, -1);
+		arrange_output(output->swayc);
 	}
 
 	// Arrange non-exlusive surfaces from top->bottom

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -19,6 +19,7 @@
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/layout.h"
 #include "sway/tree/view.h"
@@ -534,19 +535,19 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
 	arrange_layers(output);
-	arrange_windows(output->swayc, -1, -1);
+	arrange_output(output->swayc);
 }
 
 static void handle_transform(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, transform);
 	arrange_layers(output);
-	arrange_windows(output->swayc, -1, -1);
+	arrange_output(output->swayc);
 }
 
 static void handle_scale(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, scale);
 	arrange_layers(output);
-	arrange_windows(output->swayc, -1, -1);
+	arrange_output(output->swayc);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {
@@ -598,5 +599,5 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->damage_destroy.notify = damage_handle_destroy;
 
 	arrange_layers(output);
-	arrange_windows(&root_container, -1, -1);
+	arrange_root();
 }

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -16,6 +16,7 @@
 #include "sway/ipc-server.h"
 #include "sway/layers.h"
 #include "sway/output.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -105,6 +105,7 @@ sway_sources = files(
 	'commands/input/xkb_rules.c',
 	'commands/input/xkb_variant.c',
 
+	'tree/arrange.c',
 	'tree/container.c',
 	'tree/layout.c',
 	'tree/view.c',

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -1,0 +1,239 @@
+#define _POSIX_C_SOURCE 200809L
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_output_layout.h>
+#include "sway/debug.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
+#include "sway/output.h"
+#include "sway/tree/workspace.h"
+#include "sway/tree/view.h"
+#include "list.h"
+#include "log.h"
+
+struct sway_container root_container;
+
+void arrange_windows(struct sway_container *container) {
+	switch (container->type) {
+	case C_ROOT:
+		arrange_root();
+		break;
+	case C_OUTPUT:
+		arrange_output(container);
+		break;
+	case C_WORKSPACE:
+		arrange_workspace(container);
+		break;
+	case C_CONTAINER:
+		arrange_children_of(container);
+		break;
+	case C_VIEW:
+		// ignore
+		break;
+	case C_TYPES:
+		sway_assert(
+				false, "Called arrange_windows() with container type C_TYPES");
+		break;
+	}
+}
+
+void arrange_root() {
+	if (config->reloading) {
+		return;
+	}
+	struct wlr_output_layout *output_layout =
+		root_container.sway_root->output_layout;
+	const struct wlr_box *layout_box =
+		wlr_output_layout_get_box(output_layout, NULL);
+	root_container.x = layout_box->x;
+	root_container.y = layout_box->y;
+	root_container.width = layout_box->width;
+	root_container.height = layout_box->height;
+	for (int i = 0; i < root_container.children->length; ++i) {
+		struct sway_container *output = root_container.children->items[i];
+		arrange_output(output);
+	}
+}
+
+void arrange_output(struct sway_container *output) {
+	if (config->reloading) {
+		return;
+	}
+	if (!sway_assert(output->type == C_OUTPUT,
+			"called arrange_output() on non-output container")) {
+		return;
+	}
+	const struct wlr_box *output_box = wlr_output_layout_get_box(
+			root_container.sway_root->output_layout,
+			output->sway_output->wlr_output);
+	output->x = output_box->x;
+	output->y = output_box->y;
+	output->width = output_box->width;
+	output->height = output_box->height;
+	wlr_log(L_DEBUG, "Arranging output '%s' at %f,%f",
+			output->name, output->x, output->y);
+	for (int i = 0; i < output->children->length; ++i) {
+		struct sway_container *workspace = output->children->items[i];
+		arrange_workspace(workspace);
+	}
+	container_damage_whole(output);
+}
+
+void arrange_workspace(struct sway_container *workspace) {
+	if (config->reloading) {
+		return;
+	}
+	if (!sway_assert(workspace->type == C_WORKSPACE,
+			"called arrange_workspace() on non-workspace container")) {
+		return;
+	}
+	struct sway_container *output = workspace->parent;
+	struct wlr_box *area = &output->sway_output->usable_area;
+	wlr_log(L_DEBUG, "Usable area for ws: %dx%d@%d,%d",
+			area->width, area->height, area->x, area->y);
+	workspace->width = area->width;
+	workspace->height = area->height;
+	workspace->x = area->x;
+	workspace->y = area->y;
+	wlr_log(L_DEBUG, "Arranging workspace '%s' at %f, %f",
+			workspace->name, workspace->x, workspace->y);
+	arrange_children_of(workspace);
+	container_damage_whole(workspace);
+}
+
+static void apply_horiz_layout(struct sway_container *parent) {
+	size_t num_children = parent->children->length;
+	if (!num_children) {
+		return;
+	}
+	// Calculate total width of children
+	double total_width = 0;
+	for (size_t i = 0; i < num_children; ++i) {
+		struct sway_container *child = parent->children->items[i];
+		if (child->width <= 0) {
+			if (num_children > 1) {
+				child->width = parent->width / (num_children - 1);
+			} else {
+				child->width = parent->width;
+			}
+		}
+		total_width += child->width;
+	}
+	double scale = parent->width / total_width;
+
+	// Resize windows
+	wlr_log(L_DEBUG, "Arranging %p horizontally", parent);
+	double child_x = parent->x;
+	struct sway_container *child;
+	for (size_t i = 0; i < num_children; ++i) {
+		child = parent->children->items[i];
+		wlr_log(L_DEBUG,
+				"Calculating arrangement for %p:%d (will scale %f by %f)",
+				child, child->type, child->width, scale);
+		child->x = child_x;
+		child->y = parent->y;
+		child->width = floor(child->width * scale);
+		child->height = parent->height;
+		child_x += child->width;
+	}
+	// Make last child use remaining width of parent
+	child->width = parent->x + parent->width - child->x;
+}
+
+static void apply_vert_layout(struct sway_container *parent) {
+	size_t num_children = parent->children->length;
+	if (!num_children) {
+		return;
+	}
+	// Calculate total height of children
+	double total_height = 0;
+	for (size_t i = 0; i < num_children; ++i) {
+		struct sway_container *child = parent->children->items[i];
+		if (child->height <= 0) {
+			if (num_children > 1) {
+				child->height = parent->height / (num_children - 1);
+			} else {
+				child->height = parent->height;
+			}
+		}
+		total_height += child->height;
+	}
+	double scale = parent->height / total_height;
+
+	// Resize
+	wlr_log(L_DEBUG, "Arranging %p vertically", parent);
+	double child_y = parent->y;
+	struct sway_container *child;
+	for (size_t i = 0; i < num_children; ++i) {
+		child = parent->children->items[i];
+		wlr_log(L_DEBUG,
+				"Calculating arrangement for %p:%d (will scale %f by %f)",
+				child, child->type, child->height, scale);
+		child->x = parent->x;
+		child->y = child_y;
+		child->width = parent->width;
+		child->height = floor(child->height * scale);
+		child_y += child->height;
+	}
+	// Make last child use remaining height of parent
+	child->height = parent->y + parent->height - child->y;
+}
+
+void arrange_children_of(struct sway_container *parent) {
+	if (config->reloading) {
+		return;
+	}
+	if (!sway_assert(parent->type == C_WORKSPACE || parent->type == C_CONTAINER,
+			"container is a %s", container_type_to_str(parent->type))) {
+		return;
+	}
+
+	struct sway_container *workspace = parent;
+	if (workspace->type != C_WORKSPACE) {
+		workspace = container_parent(workspace, C_WORKSPACE);
+	}
+	if (workspace->sway_workspace->fullscreen) {
+		// Just arrange the fullscreen view and jump out
+		struct sway_container *view =
+			workspace->sway_workspace->fullscreen->swayc;
+		view_configure(view->sway_view, 0, 0,
+				workspace->parent->width, workspace->parent->height);
+		view->width = workspace->parent->width;
+		view->height = workspace->parent->height;
+		return;
+	}
+
+	wlr_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", parent,
+		parent->name, parent->width, parent->height, parent->x, parent->y);
+
+	// Calculate x, y, width and height of children
+	switch (parent->layout) {
+	case L_HORIZ:
+		apply_horiz_layout(parent);
+		break;
+	case L_VERT:
+		apply_vert_layout(parent);
+		break;
+	default:
+		wlr_log(L_DEBUG, "TODO: arrange layout type %d", parent->layout);
+		apply_horiz_layout(parent);
+		break;
+	}
+
+	// Apply x, y, width and height to children and recurse if needed
+	for (int i = 0; i < parent->children->length; ++i) {
+		struct sway_container *child = parent->children->items[i];
+		if (child->type == C_VIEW) {
+			view_configure(child->sway_view, child->x, child->y,
+					child->width, child->height);
+		} else {
+			arrange_children_of(child);
+		}
+	}
+	container_damage_whole(parent);
+	update_debug_tree();
+}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -13,6 +13,7 @@
 #include "sway/ipc-server.h"
 #include "sway/output.h"
 #include "sway/server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/layout.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
@@ -143,8 +144,7 @@ static struct sway_container *container_output_destroy(
 				container_add_child(root_container.children->items[p], child);
 			}
 			container_sort_workspaces(root_container.children->items[p]);
-			arrange_windows(root_container.children->items[p],
-				-1, -1);
+			arrange_output(root_container.children->items[p]);
 		}
 	}
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -9,6 +9,7 @@
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"
 #include "log.h"
@@ -392,7 +393,7 @@ bool workspace_switch(struct sway_container *workspace) {
 	}
 	seat_set_focus(seat, next);
 	struct sway_container *output = container_parent(workspace, C_OUTPUT);
-	arrange_windows(output, -1, -1);
+	arrange_output(output);
 	return true;
 }
 


### PR DESCRIPTION
The arrange_windows() function hurts my brain. Here's a refactor for your consideration.

* I've split `arrange_windows()` into a function for each container type. So you can call `arrange_root()`, `arrange_output(output)`, `arrange_workspace(workspace)` or `arrange_children_of(workspace_or_container)`. Each one iterates its children and recurses as needed.
* For convenience, if you don't know what type of container you're dealing with and just want it to work, you can pass it to `arrange_windows(whatever)` and it'll figure it out.
* Because there's now several more functions related to arranging, I've moved this out of layout.c and into a new file.
* Passing -1, -1 to the function is now unnecessary, as it gets it from the provided parent and updates the child's dimensions before iterating into it.
* Previously, `arrange_windows()` had inconsistent behaviour as to whether it would update properties on the passed container (eg. root and output would only work with their children). Now they always update the given container's properties, except for `arrange_children_of()` which is obvious from the name.
* The `apply_{horiz,vert}_layout()` functions no longer need `start` and `end` variables passed to them, as it always uses the full children list.
* Additionally, they no longer pass the parent's dimensions separately.
* The `apply_{horiz,vert}_layout()` functions no longer recurse. They only set the child's properties, then execution is returned to `arrange_children_of()` which handles the recursion. This means the function call stack is `arrange_children_of()` => `arrange_children_of()` rather than `arrange_children_of()` => `apply_horiz_layout()` => `arrange_children_of()` which I believe is easier to follow.
* Fullscreen is implemented differently this way. It saves the view's dimensions and restores them. Previously it was calling `view_configure()` without changing the swayc's stored width and height.

Also note I had to split view_set_fullscreen() into a lower level function called view_set_fullscreen_raw(), because I had to call the lower level one from elsewhere without having it go and rearrange the windows on me.