### PR TITLE
Fix a bunch of swaybar memory leaks

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -79,4 +79,6 @@ void bar_setup(struct swaybar *bar,
 void bar_run(struct swaybar *bar);
 void bar_teardown(struct swaybar *bar);
 
+void free_workspaces(struct wl_list *list);
+
 #endif

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -29,7 +29,7 @@ struct swaybar_config {
 	bool binding_mode_indicator;
 	bool wrap_scroll;
 	bool workspace_buttons;
-	struct wl_list outputs;
+	struct wl_list outputs; // config_output::link
 	bool all_outputs;
 	int height;
 

--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -73,5 +73,6 @@ void status_line_free(struct status_line *status);
 bool i3bar_handle_readable(struct status_line *status);
 void i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, int x, int y, uint32_t button);
+void i3bar_block_free(struct i3bar_block *block);
 
 #endif

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -25,13 +25,21 @@
 #include "ipc-client.h"
 #include "list.h"
 #include "log.h"
-#include "pango.h"
 #include "pool-buffer.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 static void bar_init(struct swaybar *bar) {
 	bar->config = init_config();
 	wl_list_init(&bar->outputs);
+}
+
+void free_workspaces(struct wl_list *list) {
+	struct swaybar_workspace *ws, *tmp;
+	wl_list_for_each_safe(ws, tmp, list, link) {
+		wl_list_remove(&ws->link);
+		free(ws->name);
+		free(ws);
+	}
 }
 
 static void swaybar_output_free(struct swaybar_output *output) {
@@ -44,12 +52,7 @@ static void swaybar_output_free(struct swaybar_output *output) {
 	wl_output_destroy(output->output);
 	destroy_buffer(&output->buffers[0]);
 	destroy_buffer(&output->buffers[1]);
-	struct swaybar_workspace *ws, *ws_tmp;
-	wl_list_for_each_safe(ws, ws_tmp, &output->workspaces, link) {
-		wl_list_remove(&ws->link);
-		free(ws->name);
-		free(ws);
-	}
+	free_workspaces(&output->workspaces);
 	struct swaybar_hotspot *hotspot, *hotspot_tmp;
 	wl_list_for_each_safe(hotspot, hotspot_tmp, &output->hotspots, link) {
 		if (hotspot->destroy) {
@@ -468,9 +471,7 @@ void bar_run(struct swaybar *bar) {
 static void free_outputs(struct wl_list *list) {
 	struct swaybar_output *output, *tmp;
 	wl_list_for_each_safe(output, tmp, list, link) {
-		wl_list_remove(&output->link);
-		free(output->name);
-		free(output);
+		swaybar_output_free(output);
 	}
 }
 

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -74,5 +74,11 @@ void free_config(struct swaybar_config *config) {
 	free(config->font);
 	free(config->mode);
 	free(config->sep_symbol);
+	struct config_output *coutput, *tmp;
+	wl_list_for_each_safe(coutput, tmp, &config->outputs, link) {
+		wl_list_remove(&coutput->link);
+		free(coutput->name);
+		free(coutput);
+	}
 	free(config);
 }

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -7,7 +7,7 @@
 #include "swaybar/config.h"
 #include "swaybar/status_line.h"
 
-static void i3bar_block_free(struct i3bar_block *block) {
+void i3bar_block_free(struct i3bar_block *block) {
 	if (!block) {
 		return;
 	}
@@ -18,6 +18,7 @@ static void i3bar_block_free(struct i3bar_block *block) {
 	free(block->name);
 	free(block->instance);
 	free(block->color);
+	free(block);
 }
 
 static bool i3bar_parse_json(struct status_line *status, const char *text) {

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -216,15 +216,6 @@ static void ipc_parse_config(
 	json_object_put(bar_config);
 }
 
-static void free_workspaces(struct wl_list *list) {
-	struct swaybar_workspace *ws, *tmp;
-	wl_list_for_each_safe(ws, tmp, list, link) {
-		wl_list_remove(&ws->link);
-		free(ws->name);
-		free(ws);
-	}
-}
-
 void ipc_get_workspaces(struct swaybar *bar) {
 	bar->focused_output = NULL;
 	struct swaybar_output *output;
@@ -290,8 +281,8 @@ static void ipc_get_outputs(struct swaybar *bar) {
 			continue;
 		}
 		if (bar->config->all_outputs) {
-			struct config_output *coutput = calloc(
-					1, sizeof(struct config_output));
+			struct config_output *coutput =
+				calloc(1, sizeof(struct config_output));
 			coutput->name = strdup(name);
 			coutput->index = i;
 			wl_list_insert(&bar->config->outputs, &coutput->link);

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #include <fcntl.h>
 #include <json-c/json.h>
 #include <stdlib.h>
@@ -126,5 +126,17 @@ void status_line_free(struct status_line *status) {
 	close(status->read_fd);
 	close(status->write_fd);
 	kill(status->pid, SIGTERM);
+	switch (status->protocol) {
+	case PROTOCOL_I3BAR:;
+		struct i3bar_block *block, *tmp;
+		wl_list_for_each_safe(block, tmp, &status->blocks, link) {
+			i3bar_block_free(block);
+		}
+		free(status->i3bar_state.buffer);
+		break;
+	default:
+		free(status->text_state.buffer);
+		break;
+	}
 	free(status);
 }


### PR DESCRIPTION
There are more leaks from fontconfig and cairo. I guess we can't do anything about it.