### PR TITLE
Remove sway_container.workspace_layout

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -68,7 +68,6 @@ struct sway_container {
 	enum sway_container_type type;
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_layout;
-	enum sway_container_layout workspace_layout;
 
 	// For C_ROOT, this has no meaning
 	// For C_OUTPUT, this is the output position in layout coordinates

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -49,9 +49,6 @@ struct sway_container *container_remove_child(struct sway_container *child);
 struct sway_container *container_replace_child(struct sway_container *child,
 		struct sway_container *new_child);
 
-struct sway_container *container_set_layout(struct sway_container *container,
-		enum sway_container_layout layout);
-
 void container_move_to(struct sway_container* container,
 		struct sway_container* destination);
 

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -26,9 +26,9 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	// TODO: stacks and tabs
 
 	if (strcasecmp(argv[0], "default") == 0) {
-		container_set_layout(parent, parent->prev_layout);
+		parent->layout = parent->prev_layout;
 		if (parent->layout == L_NONE) {
-			container_set_layout(parent, container_get_default_layout(parent));
+			parent->layout = container_get_default_layout(parent);
 		}
 	} else {
 		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
@@ -36,15 +36,14 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 
 		if (strcasecmp(argv[0], "splith") == 0) {
-			container_set_layout(parent, L_HORIZ);
+			parent->layout = L_HORIZ;
 		} else if (strcasecmp(argv[0], "splitv") == 0) {
-			container_set_layout(parent, L_VERT);
+			parent->layout = L_VERT;
 		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
-			if (parent->layout == L_HORIZ && (parent->workspace_layout == L_NONE
-					|| parent->workspace_layout == L_HORIZ)) {
-				container_set_layout(parent, L_VERT);
+			if (parent->layout == L_HORIZ) {
+				parent->layout = L_VERT;
 			} else {
-				container_set_layout(parent, L_HORIZ);
+				parent->layout = L_HORIZ;
 			}
 		}
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -148,7 +148,7 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
 	json_object_object_add(object, "urgent", json_object_new_boolean(false));
 
-	const char *layout = ipc_json_layout_description(workspace->workspace_layout);
+	const char *layout = ipc_json_layout_description(workspace->layout);
 	json_object_object_add(object, "layout", json_object_new_string(layout));
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -78,7 +78,6 @@ struct sway_container *container_create(enum sway_container_type type) {
 	}
 	c->id = next_id++;
 	c->layout = L_NONE;
-	c->workspace_layout = L_NONE;
 	c->type = type;
 	c->alpha = 1.0f;
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -33,19 +33,6 @@ static void output_layout_handle_change(struct wl_listener *listener,
 	arrange_windows(&root_container, layout_box->width, layout_box->height);
 }
 
-struct sway_container *container_set_layout(struct sway_container *container,
-		enum sway_container_layout layout) {
-	if (container->type == C_WORKSPACE) {
-		container->workspace_layout = layout;
-		if (layout == L_HORIZ || layout == L_VERT) {
-			container->layout = layout;
-		}
-	} else {
-		container->layout = layout;
-	}
-	return container;
-}
-
 void layout_init(void) {
 	root_container.id = 0; // normally assigned in new_swayc()
 	root_container.type = C_ROOT;
@@ -305,8 +292,8 @@ static void workspace_rejigger(struct sway_container *ws,
 
 	int index = move_offs(move_dir);
 	container_insert_child(ws, child, index < 0 ? 0 : 1);
-	container_set_layout(ws,
-			move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT);
+	ws->layout =
+		move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT;
 
 	container_flatten(ws);
 	container_reap_empty_recursive(original_parent);
@@ -387,9 +374,9 @@ void container_move(struct sway_container *container,
 					workspace_rejigger(current, container, move_dir);
 				} else if (current->children->length == 2) {
 					wlr_log(L_DEBUG, "Changing workspace layout");
-					container_set_layout(current,
+					current->layout =
 						move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ?
-						L_HORIZ : L_VERT);
+						L_HORIZ : L_VERT;
 					container_insert_child(current, container, offs < 0 ? 0 : 1);
 					arrange_windows(current, -1, -1);
 				}
@@ -1066,7 +1053,7 @@ struct sway_container *container_split(struct sway_container *child,
 
 		container_add_child(workspace, cont);
 		enum sway_container_layout old_layout = workspace->layout;
-		container_set_layout(workspace, layout);
+		workspace->layout = layout;
 		cont->layout = old_layout;
 
 		if (set_focus) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -57,7 +57,6 @@ struct sway_container *workspace_create(struct sway_container *output,
 	workspace->name = !name ? NULL : strdup(name);
 	workspace->prev_layout = L_NONE;
 	workspace->layout = container_get_default_layout(output);
-	workspace->workspace_layout = workspace->layout;
 
 	struct sway_workspace *swayws = calloc(1, sizeof(struct sway_workspace));
 	if (!swayws) {


### PR DESCRIPTION
Resolves #1716.

The `container_set_layout()` function turned into a single `container->layout` assignment, so I opted to remove the function completely.