### PR TITLE
Run in verbose mode

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Sway
 Comment=SirCmpwn's Wayland window manager
-Exec=sway
+Exec=sway --verbose
 Type=Application


### PR DESCRIPTION
### Proposal

This change causes display managers to launch `sway` using the `--verbose` option.

With this change, systemd-enabled systems can access sway's log using `journalctl` tool.