### PR TITLE
Fix segfault in view_unmap()

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -302,7 +302,11 @@ void view_unmap(struct sway_view *view) {
 	view->swayc = NULL;
 	view->surface = NULL;
 
-	arrange_children_of(parent);
+	if (parent->type == C_OUTPUT) {
+		arrange_output(parent);
+	} else {
+		arrange_children_of(parent);
+	}
 }
 
 void view_update_position(struct sway_view *view, double ox, double oy) {


### PR DESCRIPTION
If the last remaining view on a workspace is unmapped and the workspace is not visible, parent will be a C_OUTPUT. Call the arrange_output() function in this case.

To test:

* Launch a terminal
* Within that terminal, run something like `urxvt -e sleep 5`
* Move the new terminal window to a new workspace
* Ensure the workspace is not visible at the time the sleep command finishes