### PR TITLE
Fix dynamic output disabling

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -131,6 +131,7 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 		container_destroy(output);
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);
+		wlr_output_destroy(wlr_output);
 		return;
 	}
 


### PR DESCRIPTION
Adds missing `wlr_output_destroy`, which emits output destroy signal. The change makes swaybg correctly shut down on output destroy, while swaybar now doesn't cause a segfault by arranging windows on nonexistent container.

Fixes #1877