### PR TITLE
Fix layer surface segfault on output destroy

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -128,6 +128,10 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 	struct wlr_output *wlr_output = output->sway_output->wlr_output;
 
 	if (oc && oc->enabled == 0) {
+		if (output->sway_output->bg_pid != 0) {
+			terminate_swaybg(output->sway_output->bg_pid);
+			output->sway_output->bg_pid = 0;
+		}
 		container_destroy(output);
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -255,6 +255,9 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 		return;
 	}
 	struct sway_output *output = wlr_output->data;
+	if (output == NULL) {
+		return;
+	}
 	output_damage_surface(output, sway_layer->geo.x, sway_layer->geo.y,
 		sway_layer->layer_surface->surface, true);
 }
@@ -274,9 +277,11 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&sway_layer->surface_commit.link);
 	if (sway_layer->layer_surface->output != NULL) {
 		struct sway_output *output = sway_layer->layer_surface->output->data;
-		arrange_layers(output);
-
+		if (output != NULL) {
+			arrange_layers(output);
+		}
 		wl_list_remove(&sway_layer->output_destroy.link);
+		sway_layer->layer_surface->output = NULL;
 	}
 	free(sway_layer);
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -156,6 +156,9 @@ static struct sway_container *container_output_destroy(
 	wl_list_remove(&output->sway_output->damage_destroy.link);
 	wl_list_remove(&output->sway_output->damage_frame.link);
 
+	// clear the wlr_output reference to this container
+	output->sway_output->wlr_output->data = NULL;
+
 	wlr_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
 	_container_destroy(output);
 	return &root_container;


### PR DESCRIPTION
Before freeing sway_output, NULL the wlr_output reference to it. Check for that
NULL in layer_shell handle_destroy. Don't damage null container in unmap.
Additionaly, terminate swaybg if its output is being disabled.

Fixes #1877 segfaults, but reenabling output still doesn't work.