### PR TITLE
Fixed #1888 GCC cannot compile due to uninitialized variables

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -88,6 +88,9 @@ void view_autoconfigure(struct sway_view *view) {
 	}
 
 	double x, y, width, height;
+
+	x = y = width = height = 0;
+
 	switch (view->border) {
 	case B_NONE:
 		x = view->swayc->x;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -88,9 +88,7 @@ void view_autoconfigure(struct sway_view *view) {
 	}
 
 	double x, y, width, height;
-
 	x = y = width = height = 0;
-
 	switch (view->border) {
 	case B_NONE:
 		x = view->swayc->x;


### PR DESCRIPTION
This is a fix for: #1888 
Sway wouldn't compile on Archlinux due to uninitialized variables.

For the record, these build flags are passed automatically to GCC on Archlinux in makepkg:
```
CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt"
LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
CPPFLAGS="-D_FORTIFY_SOURCE=2"
```

Note that I don't have a lot of experience in C so please let me know if this is not the way it should be fixed.