### PR TITLE
Implement basic touch support

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -315,6 +315,13 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	}
 }
 
+static void seat_configure_touch(struct sway_seat *seat,
+		struct sway_seat_device *sway_device) {
+	wlr_cursor_attach_input_device(seat->cursor->cursor,
+		sway_device->input_device->wlr_device);
+	seat_apply_input_config(seat, sway_device);
+}
+
 static void seat_configure_tablet_tool(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
@@ -349,12 +356,14 @@ void seat_configure_device(struct sway_seat *seat,
 		case WLR_INPUT_DEVICE_KEYBOARD:
 			seat_configure_keyboard(seat, seat_device);
 			break;
+		case WLR_INPUT_DEVICE_TOUCH:
+			seat_configure_touch(seat, seat_device);
+			break;
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
 			seat_configure_tablet_tool(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
-		case WLR_INPUT_DEVICE_TOUCH:
-			wlr_log(L_DEBUG, "TODO: configure other devices");
+			wlr_log(L_DEBUG, "TODO: configure tablet pad");
 			break;
 	}
 }


### PR DESCRIPTION
This required changing container_at_cursor to container_at_coords so
that we could get the appropriate surface (and sx/xy) without moving the
cursor.

Future work:

- Simulate a pointer for clients which have not bound to wl_touch
  - With long-press to right click
- Keep sending motion events when moving outside the surface (#1892)
- Bind gestures to sway commands