### PR TITLE
Check for NULL in container_update_title

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -348,7 +348,7 @@ struct sway_container *container_view_create(struct sway_container *sibling,
 		swayc, title, sibling, sibling ? sibling->type : 0, sibling->name);
 	// Setup values
 	swayc->sway_view = sway_view;
-	container_update_title(swayc, title ? title : "");
+	container_update_title(swayc, title);
 	swayc->width = 0;
 	swayc->height = 0;
 
@@ -660,9 +660,14 @@ static void container_notify_child_title_changed(
 
 void container_update_title(struct sway_container *container,
 		const char *new_title) {
+	if (!new_title) {
+		new_title = "";
+	}
+
 	if (container->name && strcmp(container->name, new_title) == 0) {
 		return;
 	}
+
 	if (container->name) {
 		free(container->name);
 	}


### PR DESCRIPTION
Fixes crash when opening Firefox developer tools:

```
#0  0x00007fd007912a2e in __strcmp_sse2_unaligned () at /usr/lib/libc.so.6
#1  0x000056519c27b023 in container_update_title (container=0x56519dc11ff0, new_title=0x0) at ../sway/sway/tree/container.c:663
#2  0x00007fd0080dd87c in wlr_signal_emit_safe (signal=signal@entry=0x56519dbc5288, data=data@entry=0x56519dbc5210) at ../util/signal.c:29
#3  0x00007fd0080d1176 in surface_commit_pending (surface=surface@entry=0x56519dbc5210) at ../types/wlr_surface.c:434
#4  0x00007fd0080d1881 in surface_commit (client=<optimized out>, resource=<optimized out>) at ../types/wlr_surface.c:514
#5  0x00007fd0052af1c8 in ffi_call_unix64 () at /usr/lib/libffi.so.6
#6  0x00007fd0052aec2a in ffi_call () at /usr/lib/libffi.so.6
#7  0x00007fd00830d7fd in  () at /usr/lib/libwayland-server.so.0
#8  0x00007fd008309f79 in  () at /usr/lib/libwayland-server.so.0
#9  0x00007fd00830b9b2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#10 0x00007fd00830a14c in wl_display_run () at /usr/lib/libwayland-server.so.0
#11 0x000056519c25d8f0 in main (argc=<optimized out>, argv=<optimized out>) at ../sway/sway/main.c:418
```