### PR TITLE
Implement title_format

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -144,6 +144,7 @@ sway_cmd cmd_splitt;
 sway_cmd cmd_splitv;
 sway_cmd cmd_sticky;
 sway_cmd cmd_swaybg_command;
+sway_cmd cmd_title_format;
 sway_cmd cmd_unmark;
 sway_cmd cmd_workspace;
 sway_cmd cmd_ws_auto_back_and_forth;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -465,8 +465,11 @@ void free_bar_config(struct bar_config *bar);
  * Updates the value of config->font_height based on the max title height
  * reported by each container. If recalculate is true, the containers will
  * recalculate their heights before reporting.
+ *
+ * If the height has changed, all containers will be rearranged to take on the
+ * new size.
  */
-void config_find_font_height(bool recalculate);
+void config_update_font_height(bool recalculate);
 
 /* Global config singleton. */
 extern struct sway_config *config;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -63,7 +63,8 @@ struct sway_container {
 	 */
 	size_t id;
 
-	char *name;
+	char *name;            // The view's title (unformatted)
+	char *formatted_title; // The title displayed in the title bar
 
 	enum sway_container_type type;
 	enum sway_container_layout layout;
@@ -204,7 +205,6 @@ void container_update_title_textures(struct sway_container *container);
  */
 void container_calculate_title_height(struct sway_container *container);
 
-void container_update_title(struct sway_container *container,
-		const char *new_title);
+void container_notify_child_title_changed(struct sway_container *container);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -48,6 +48,7 @@ struct sway_view {
 
 	bool is_fullscreen;
 
+	char *title_format;
 	enum sway_container_border border;
 	int border_thickness;
 
@@ -164,6 +165,8 @@ const char *view_get_class(struct sway_view *view);
 
 const char *view_get_instance(struct sway_view *view);
 
+const char *view_get_type(struct sway_view *view);
+
 void view_configure(struct sway_view *view, double ox, double oy, int width,
 	int height);
 
@@ -206,5 +209,12 @@ void view_child_init(struct sway_view_child *child,
 	struct wlr_surface *surface);
 
 void view_child_destroy(struct sway_view_child *child);
+
+/**
+ * Re-read the view's title property and update any relevant title bars.
+ * The force argument makes it recreate the title bars even if the title hasn't
+ * changed.
+ */
+void view_update_title(struct sway_view *view, bool force);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -182,6 +182,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "splith", cmd_splith },
 	{ "splitt", cmd_splitt },
 	{ "splitv", cmd_splitv },
+	{ "title_format", cmd_title_format },
 };
 
 static int handler_compare(const void *_a, const void *_b) {

--- a/sway/commands/font.c
+++ b/sway/commands/font.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/tree/arrange.h"
 #include "log.h"
 #include "stringop.h"
 
@@ -14,9 +13,6 @@ struct cmd_results *cmd_font(int argc, char **argv) {
 	char *font = join_args(argv, argc);
 	free(config->font);
 	config->font = strdup(font);
-	config_find_font_height(true);
-	if (!config->reading) {
-		arrange_root();
-	}
+	config_update_font_height(true);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/tree/arrange.h"
 #include "sway/tree/view.h"
 #include "log.h"
 #include "stringop.h"
@@ -25,7 +24,6 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	}
 	view->title_format = format;
 	view_update_title(view, true);
-	config_find_font_height(true);
-	arrange_root();
+	config_update_font_height(true);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -1,0 +1,31 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "log.h"
+#include "stringop.h"
+
+struct cmd_results *cmd_title_format(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "title_format", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct sway_container *container =
+		config->handler_context.current_container;
+	if (container->type != C_VIEW) {
+		return cmd_results_new(CMD_INVALID, "title_format",
+				"Only views can have a title_format");
+	}
+	struct sway_view *view = container->sway_view;
+	char *format = join_args(argv, argc);
+	if (view->title_format) {
+		free(view->title_format);
+	}
+	view->title_format = strdup(format);
+	view_update_title(view, true);
+	config_find_font_height(true);
+	arrange_root();
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -23,7 +23,7 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	if (view->title_format) {
 		free(view->title_format);
 	}
-	view->title_format = strdup(format);
+	view->title_format = format;
 	view_update_title(view, true);
 	config_find_font_height(true);
 	arrange_root();

--- a/sway/config.c
+++ b/sway/config.c
@@ -24,6 +24,7 @@
 #include "sway/input/seat.h"
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/layout.h"
 #include "cairo.h"
 #include "pango.h"
@@ -741,8 +742,14 @@ static void find_font_height_iterator(struct sway_container *container,
 	}
 }
 
-void config_find_font_height(bool recalculate) {
+void config_update_font_height(bool recalculate) {
+	size_t prev_max_height = config->font_height;
 	config->font_height = 0;
+
 	container_for_each_descendant_dfs(&root_container,
 			find_font_height_iterator, &recalculate);
+
+	if (config->font_height != prev_max_height) {
+		arrange_root();
+	}
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -176,8 +176,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	// TODO: Let floating views do whatever
 	view_update_size(view, xdg_shell_v6_view->pending_width,
 		xdg_shell_v6_view->pending_height);
-	container_update_title(view->swayc,
-			view->wlr_xdg_surface_v6->toplevel->title);
+	view_update_title(view, false);
 	view_damage(view, false);
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -223,7 +223,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	view_update_size(view, xwayland_view->pending_width,
 		xwayland_view->pending_height);
 	view_damage(view, false);
-	container_update_title(view->swayc, view->wlr_xwayland_surface->title);
+	view_update_title(view, false);
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -60,6 +60,7 @@ sway_sources = files(
 	'commands/set.c',
 	'commands/split.c',
 	'commands/swaybg_command.c',
+	'commands/title_format.c',
 	'commands/workspace.c',
 	'commands/ws_auto_back_and_forth.c',
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -501,10 +501,10 @@ void view_child_destroy(struct sway_view_child *child) {
 static size_t parse_title_format(struct sway_view *view, char *buffer) {
 	if (!view->title_format || strcmp(view->title_format, "%title") == 0) {
 		const char *title = view_get_title(view);
-		if (buffer) {
+		if (buffer && title) {
 			strcpy(buffer, title);
 		}
-		return strlen(title);
+		return title ? strlen(title) : 0;
 	}
 	const char *title = view_get_title(view);
 	const char *class = view_get_class(view);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -601,10 +601,5 @@ void view_update_title(struct sway_view *view, bool force) {
 	container_calculate_title_height(view->swayc);
 	container_update_title_textures(view->swayc);
 	container_notify_child_title_changed(view->swayc->parent);
-
-	size_t prev_max_height = config->font_height;
-	config_find_font_height(false);
-	if (config->font_height != prev_max_height) {
-		arrange_root();
-	}
+	config_update_font_height(false);
 }


### PR DESCRIPTION
This implements the `title_format` command, with a new placeholder `%shell` which gets substituted with the view type (xwayland, xdg_shell_v6 or wl_shell).

Example config:

    for_window [title=".*"] title_format %title (class=%class instance=%instance shell=%shell)

You can change the title using swaymsg:

    $ swaymsg title_format %title

Some implementation notes:
* container_update_title() has been renamed to view_update_title() and moved into view.c as it only applies to views.
* Because of the above, container_notify_child_title_changed() is now public.
* The arguments of view_update_title() have changed. It used to have the title given to it via an argument; now it reads it from view_get_title().
* Containers now have both a `name` and `formatted_title` property. The `name` is used purely for `strcmp()`, so we don't blindly recreate the title textures if the view hasn't changed its title.

I've also tested it will null titles (Firefox developer tools as per #1912).