### PR TITLE
Implement pango support

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -305,6 +305,7 @@ struct sway_config {
 	enum sway_container_layout default_layout;
 	char *font;
 	size_t font_height;
+	bool pango_markup;
 
 	// Flags
 	bool focus_follows_mouse;

--- a/sway/commands/font.c
+++ b/sway/commands/font.c
@@ -12,7 +12,16 @@ struct cmd_results *cmd_font(int argc, char **argv) {
 	}
 	char *font = join_args(argv, argc);
 	free(config->font);
-	config->font = strdup(font);
+
+	if (strncmp(font, "pango:", 6) == 0) {
+		config->pango_markup = true;
+		config->font = strdup(font + 6);
+	} else {
+		config->pango_markup = false;
+		config->font = strdup(font);
+	}
+
+	free(font);
 	config_update_font_height(true);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -580,7 +580,7 @@ static void update_title_texture(struct sway_container *con,
 	int height = config->font_height * scale;
 
 	cairo_t *c = cairo_create(NULL);
-	get_text_size(c, config->font, &width, NULL, scale, false,
+	get_text_size(c, config->font, &width, NULL, scale, config->pango_markup,
 			"%s", con->formatted_title);
 	cairo_destroy(c);
 
@@ -596,7 +596,8 @@ static void update_title_texture(struct sway_container *con,
 			class->text[2], class->text[3]);
 	cairo_move_to(cairo, 0, 0);
 
-	pango_printf(cairo, config->font, scale, false, "%s", con->formatted_title);
+	pango_printf(cairo, config->font, scale, config->pango_markup,
+			"%s", con->formatted_title);
 
 	cairo_surface_flush(surface);
 	unsigned char *data = cairo_image_surface_get_data(surface);
@@ -628,7 +629,7 @@ void container_calculate_title_height(struct sway_container *container) {
 	}
 	cairo_t *cairo = cairo_create(NULL);
 	int height;
-	get_text_size(cairo, config->font, NULL, &height, 1, false,
+	get_text_size(cairo, config->font, NULL, &height, 1, config->pango_markup,
 			"%s", container->formatted_title);
 	cairo_destroy(cairo);
 	container->title_height = height;


### PR DESCRIPTION
Implements support for the `pango:` prefix in the font command.

Also fixes a missing `free()` in the font command.

Closes #1903.

Merge after #1915 (Implement title_format).

Example config:

    font pango:DejaVu Sans 10
    for_window [title=".*"] title_format <b>%title</b>