### PR TITLE
Use scissor to render title texture

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -308,12 +308,10 @@ static void render_container_simple_border_normal(struct sway_output *output,
 
 	// Title text
 	if (title_texture) {
-		double x = (con->x + con->sway_view->border_thickness)
-			* output->wlr_output->scale;
-		double y = (con->y + con->sway_view->border_thickness)
-			* output->wlr_output->scale;
+		wlr_renderer_scissor(renderer, &box);
 		wlr_render_texture(renderer, title_texture,
-				output->wlr_output->transform_matrix, x, y, 1);
+				output->wlr_output->transform_matrix, box.x, box.y, 1);
+		wlr_renderer_scissor(renderer, NULL);
 	}
 }
 

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -203,7 +203,6 @@ void arrange_children_of(struct sway_container *parent) {
 		} else {
 			arrange_children_of(child);
 		}
-		container_update_title_textures(child);
 	}
 	container_damage_whole(parent);
 	update_debug_tree();

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -584,12 +584,6 @@ static void update_title_texture(struct sway_container *con,
 	get_text_size(c, config->font, &width, NULL, scale, false, "%s", con->name);
 	cairo_destroy(c);
 
-	int borders = (con->type == C_VIEW ? con->sway_view->border_thickness :
-			config->border_thickness) * 2 * scale;
-	if (width > con->width * scale - borders) {
-		width = con->width * scale - borders;
-	}
-
 	cairo_surface_t *surface = cairo_image_surface_create(
 			CAIRO_FORMAT_ARGB32, width, height);
 	cairo_t *cairo = cairo_create(surface);


### PR DESCRIPTION
This allows the title's texture to always be the full width of the text, and clipped at render time according to the desired width (eg. tabs...).

As an added bonus, the texture no longer needs to be updated when containers are arranged.