### PR TITLE
Revert PR #1881

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,6 @@ config = configuration_data()
 config.set('sysconfdir', join_paths(prefix, sysconfdir))
 config.set('datadir', join_paths(prefix, datadir))
 config.set('prefix', prefix)
-config.set('sway_libexecdir', sway_libexecdir)
 
 configure_file(
 	configuration: config,

--- a/meson.build
+++ b/meson.build
@@ -19,13 +19,12 @@ is_freebsd = host_machine.system().startswith('freebsd')
 datadir = get_option('datadir')
 sysconfdir = get_option('sysconfdir')
 prefix = get_option('prefix')
-libexecdir = get_option('libexecdir')
+instlibdir = get_option('instlibdir')
 
-if libexecdir == ''
-	libexecdir = 'lib'
+if instlibdir == ''
+  instlibdir = join_paths(prefix, 'lib/sway')
 endif
-sway_libexecdir = join_paths(prefix, libexecdir, 'sway')
-add_project_arguments('-DSWAY_LIBEXECDIR="/@0@"'.format(sway_libexecdir), language : 'c')
+add_project_arguments('-DINSTLIBDIR="/@0@"'.format(instlibdir), language : 'c')
 
 
 jsonc          = dependency('json-c', version: '>=0.13')

--- a/meson.build
+++ b/meson.build
@@ -19,13 +19,6 @@ is_freebsd = host_machine.system().startswith('freebsd')
 datadir = get_option('datadir')
 sysconfdir = get_option('sysconfdir')
 prefix = get_option('prefix')
-instlibdir = get_option('instlibdir')
-
-if instlibdir == ''
-  instlibdir = join_paths(prefix, 'lib/sway')
-endif
-add_project_arguments('-DINSTLIBDIR="/@0@"'.format(instlibdir), language : 'c')
-
 
 jsonc          = dependency('json-c', version: '>=0.13')
 pcre           = dependency('libpcre')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,3 @@
-option('instlibdir', type: 'string', description: 'Installation path for sway-internal executables, such as swaybg or swaybar.  (Default: prefix/lib/sway)')
 option('sway_version', type : 'string', description: 'The version string reported in `sway --version`.')
 option('default_wallpaper', type: 'boolean', value: true, description: 'Install the default wallpaper.')
 option('zsh_completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('instlibdir', type: 'string', description: 'Installation path for sway-internal executables, such as swaybg or swaybar.  (Default: prefix/lib/sway)')
 option('sway_version', type : 'string', description: 'The version string reported in `sway --version`.')
 option('default_wallpaper', type: 'boolean', value: true, description: 'Install the default wallpaper.')
 option('zsh_completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')

--- a/security.d/00-defaults.in
+++ b/security.d/00-defaults.in
@@ -11,9 +11,9 @@
 # Configures enabled compositor features for specific programs
 permit * fullscreen keyboard mouse
 permit @prefix@/bin/swaylock lock
+permit @prefix@/bin/swaybg background
 permit @prefix@/bin/swaygrab screenshot
-permit @sway_libexecdir@/swaybg  background
-permit @sway_libexecdir@/swaybar panel
+permit @prefix@/bin/swaybar panel
 
 # Configures enabled IPC features for specific programs
 ipc @prefix@/bin/swaymsg {
@@ -24,7 +24,7 @@ ipc @prefix@/bin/swaymsg {
     }
 }
 
-ipc @sway_libexecdir@/swaybar {
+ipc @prefix@/bin/swaybar {
     bar-config enabled
     outputs enabled
     workspaces enabled

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -55,8 +55,8 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 		if ((*child = fork()) == 0) {
 			// Acquire the current PATH
 			char *path = getenv("PATH");
-			const char *extra_path = ":" INSTLIBDIR;
-			const size_t extra_size = sizeof(INSTLIBDIR) + 1;
+			const char *extra_path = ":/usr/lib/sway";
+			const size_t extra_size = sizeof("/usr/lib/sway") + 1;
 
 			if (!path) {
 				size_t n = confstr(_CS_PATH, NULL, 0);

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -11,7 +11,6 @@
 #include "log.h"
 #include "stringop.h"
 
-
 struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if (!config->active) return cmd_results_new(CMD_DEFER, NULL, NULL);
@@ -63,8 +62,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 				size_t n = confstr(_CS_PATH, NULL, 0);
 				path = malloc(n + extra_size);
 				if (!path) {
-					wlr_log(L_ERROR, "exec_always: Unable to allocate PATH");
-					exit(EXIT_FAILURE);
+					return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to allocate PATH");
 				}
 				confstr(_CS_PATH, path, n);
 
@@ -72,8 +70,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 				size_t n = strlen(path) + 1;
 				char *tmp = malloc(n + extra_size);
 				if (!tmp) {
-					wlr_log(L_ERROR, "exec_always: Unable to allocate PATH");
-					exit(EXIT_FAILURE);
+					return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to allocate PATH");
 				}
 
 				strncpy(tmp, path, n);
@@ -84,8 +81,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 			strcat(path, extra_path);
 			if (setenv("PATH", path, 1) == -1) {
 				free(path);
-				wlr_log(L_ERROR, "exec_always: Unable to set PATH");
-				exit(EXIT_FAILURE);
+				return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to set PATH");
 			}
 			free(path);
 

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -51,41 +51,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	if ((pid = fork()) == 0) {
 		// Fork child process again
 		setsid();
-
 		if ((*child = fork()) == 0) {
-			// Acquire the current PATH
-			char *path = getenv("PATH");
-			const char *extra_path = ":/usr/lib/sway";
-			const size_t extra_size = sizeof("/usr/lib/sway") + 1;
-
-			if (!path) {
-				size_t n = confstr(_CS_PATH, NULL, 0);
-				path = malloc(n + extra_size);
-				if (!path) {
-					return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to allocate PATH");
-				}
-				confstr(_CS_PATH, path, n);
-
-			} else {
-				size_t n = strlen(path) + 1;
-				char *tmp = malloc(n + extra_size);
-				if (!tmp) {
-					return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to allocate PATH");
-				}
-
-				strncpy(tmp, path, n);
-				path = tmp;
-			}
-
-			// Append /usr/lib/sway to PATH
-			strcat(path, extra_path);
-			if (setenv("PATH", path, 1) == -1) {
-				free(path);
-				return cmd_results_new(CMD_FAILURE, "exec_always", "Unable to set PATH");
-			}
-			free(path);
-
-			// Execute the command
 			execl("/bin/sh", "/bin/sh", "-c", cmd, (void *)NULL);
 			// Not reached
 		}

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -55,8 +55,8 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 		if ((*child = fork()) == 0) {
 			// Acquire the current PATH
 			char *path = getenv("PATH");
-			const char *extra_path = ":" SWAY_LIBEXECDIR;
-			const size_t extra_size = sizeof(SWAY_LIBEXECDIR) + 1;
+			const char *extra_path = ":" INSTLIBDIR;
+			const size_t extra_size = sizeof(INSTLIBDIR) + 1;
 
 			if (!path) {
 				size_t n = confstr(_CS_PATH, NULL, 0);

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -25,5 +25,5 @@ executable(
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true,
-	install_dir: instlibdir
+	install_dir: 'usr/lib/sway'
 )

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -24,6 +24,5 @@ executable(
 		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
-	install: true,
-	install_dir: 'usr/lib/sway'
+	install: true
 )

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -25,5 +25,5 @@ executable(
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true,
-	install_dir: sway_libexecdir
+	install_dir: instlibdir
 )

--- a/swaybg/meson.build
+++ b/swaybg/meson.build
@@ -15,5 +15,5 @@ executable(
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true,
-	install_dir: sway_libexecdir
+	install_dir: instlibdir
 )

--- a/swaybg/meson.build
+++ b/swaybg/meson.build
@@ -14,6 +14,5 @@ executable(
 		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
-	install: true,
-	install_dir: 'usr/lib/sway'
+	install: true
 )

--- a/swaybg/meson.build
+++ b/swaybg/meson.build
@@ -15,5 +15,5 @@ executable(
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true,
-	install_dir: instlibdir
+	install_dir: 'usr/lib/sway'
 )


### PR DESCRIPTION
1.) has an unneeded / in meson.build which causes the PATH env variable to have an incorrectly appended libexec directory for sway
2.) breaks launching swaybar and swaybg at startup with a message "sh: swaybar[/bg]: command not found"