### PR TITLE
Criteria improvements

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -20,11 +20,15 @@ enum sway_view_prop {
 	VIEW_PROP_APP_ID,
 	VIEW_PROP_CLASS,
 	VIEW_PROP_INSTANCE,
+	VIEW_PROP_WINDOW_TYPE,
+	VIEW_PROP_WINDOW_ROLE,
+	VIEW_PROP_X11_WINDOW_ID,
 };
 
 struct sway_view_impl {
-	const char *(*get_prop)(struct sway_view *view,
+	const char *(*get_string_prop)(struct sway_view *view,
 			enum sway_view_prop prop);
+	uint32_t (*get_int_prop)(struct sway_view *view, enum sway_view_prop prop);
 	void (*configure)(struct sway_view *view, double ox, double oy, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
@@ -51,6 +55,8 @@ struct sway_view {
 	char *title_format;
 	enum sway_container_border border;
 	int border_thickness;
+
+	list_t *executed_criteria;
 
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
@@ -91,6 +97,9 @@ struct sway_xwayland_view {
 	struct wl_listener request_maximize;
 	struct wl_listener request_configure;
 	struct wl_listener request_fullscreen;
+	struct wl_listener set_title;
+	struct wl_listener set_class;
+	struct wl_listener set_window_type;
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
@@ -165,6 +174,12 @@ const char *view_get_class(struct sway_view *view);
 
 const char *view_get_instance(struct sway_view *view);
 
+uint32_t view_get_x11_window_id(struct sway_view *view);
+
+uint32_t view_get_window_type(struct sway_view *view);
+
+uint32_t view_get_window_role(struct sway_view *view);
+
 const char *view_get_type(struct sway_view *view);
 
 void view_configure(struct sway_view *view, double ox, double oy, int width,
@@ -216,5 +231,11 @@ void view_child_destroy(struct sway_view_child *child);
  * changed.
  */
 void view_update_title(struct sway_view *view, bool force);
+
+/**
+ * Run any criteria that match the view and haven't been run on this view
+ * before.
+ */
+void view_execute_criteria(struct sway_view *view);
 
 #endif

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -287,7 +287,7 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 					break;
 				}
 				if (crit->regex && regex_cmp(class, crit->regex) == 0) {
-					matches++;
+					++matches;
 				}
 				break;
 			}
@@ -308,8 +308,16 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 			// TODO
 			break;
 		case CRIT_ID:
-			// TODO
-			break;
+			{
+				char *endptr;
+				size_t crit_id = strtoul(crit->raw, &endptr, 10);
+
+				if (*endptr == 0
+						&& view_get_x11_window_id(cont->sway_view) == crit_id) {
+					++matches;
+				}
+				break;
+			}
 		case CRIT_APP_ID:
 			{
 				const char *app_id = view_get_app_id(cont->sway_view);
@@ -318,7 +326,7 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 				}
 
 				if (crit->regex && regex_cmp(app_id, crit->regex) == 0) {
-					matches++;
+					++matches;
 				}
 				break;
 			}
@@ -330,12 +338,13 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 				}
 
 				if (crit->regex && regex_cmp(instance, crit->regex) == 0) {
-					matches++;
+					++matches;
 				}
 				break;
 			}
 		case CRIT_TILING:
 			// TODO
+			++matches;
 			break;
 		case CRIT_TITLE:
 			{
@@ -345,7 +354,7 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 				}
 
 				if (crit->regex && regex_cmp(title, crit->regex) == 0) {
-					matches++;
+					++matches;
 				}
 				break;
 			}
@@ -359,8 +368,13 @@ static bool criteria_test(struct sway_container *cont, list_t *tokens) {
 			// TODO
 			break;
 		case CRIT_WORKSPACE:
-			// TODO
-			break;
+			{
+				struct sway_container *ws = container_parent(cont, C_WORKSPACE);
+				if (ws && strcmp(ws->name, crit->raw) == 0) {
+					++matches;
+				}
+				break;
+			}
 		default:
 			sway_abort("Invalid criteria type (%i)", crit->type);
 			break;
@@ -440,6 +454,6 @@ list_t *container_for_crit_tokens(list_t *tokens) {
 		&list_tokens);
 
 	// TODO look in the scratchpad
-	
+
 	return list_tokens.list;
 }

--- a/sway/desktop/wl_shell.c
+++ b/sway/desktop/wl_shell.c
@@ -20,7 +20,7 @@ static struct sway_wl_shell_view *wl_shell_view_from_view(
 	return (struct sway_wl_shell_view *)view;
 }
 
-static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
+static const char *get_string_prop(struct sway_view *view, enum sway_view_prop prop) {
 	if (wl_shell_view_from_view(view) == NULL) {
 		return NULL;
 	}
@@ -70,7 +70,7 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 static const struct sway_view_impl view_impl = {
-	.get_prop = get_prop,
+	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.close = _close,
 	.destroy = destroy,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -80,7 +80,7 @@ static struct sway_xdg_shell_v6_view *xdg_shell_v6_view_from_view(
 	return (struct sway_xdg_shell_v6_view *)view;
 }
 
-static const char *get_prop(struct sway_view *view, enum sway_view_prop prop) {
+static const char *get_string_prop(struct sway_view *view, enum sway_view_prop prop) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return NULL;
 	}
@@ -158,7 +158,7 @@ static void destroy(struct sway_view *view) {
 }
 
 static const struct sway_view_impl view_impl = {
-	.get_prop = get_prop,
+	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
 	.set_fullscreen = set_fullscreen,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -311,7 +311,7 @@ static void handle_set_title(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, xwayland_view, set_title);
 	struct sway_view *view = &xwayland_view->view;
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	if (!xsurface) {
+	if (!xsurface->mapped) {
 		return;
 	}
 	view_update_title(view, false);
@@ -323,7 +323,7 @@ static void handle_set_class(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, xwayland_view, set_class);
 	struct sway_view *view = &xwayland_view->view;
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	if (!xsurface) {
+	if (!xsurface->mapped) {
 		return;
 	}
 	view_execute_criteria(view);
@@ -334,7 +334,7 @@ static void handle_set_window_type(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, xwayland_view, set_window_type);
 	struct sway_view *view = &xwayland_view->view;
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	if (!xsurface) {
+	if (!xsurface->mapped) {
 		return;
 	}
 	view_execute_criteria(view);


### PR DESCRIPTION
Adds support for the following criteria tokens: `id` (X11 window ID), `instance`, `tiling`, `workspace`.

Ensures each view will only execute a criteria once, by storing a list of executed criteria in the view. This is the same strategy used by i3.

This also adds a check for criteria when an xwayland view changes its title, class, instance or window type.

Some implementation notes:

* `get_prop` has been split into `get_string_prop` and `get_int_prop` because some properties like the X11 window ID, window type and role are numeric.
* I started implementing the window_type and window_role tokens, but I think modifications are needed to wlroots to complete it. I've left some supporting code in place for this (event listeners and `view_get_window_{type,role}` functions).
* I discovered xwayland views trigger the `set_title` event when they change their title, so I've moved the call to `view_update_title` out of `handle_commit` and into there. xdg_shell_v6 still does it in `handle_commit` though.