### PR TITLE
Swaybar: Respect pango_markup config

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -298,7 +298,7 @@ static uint32_t render_binding_mode_indicator(cairo_t *cairo,
 
 	int text_width, text_height;
 	get_text_size(cairo, config->font, &text_width, &text_height,
-			output->scale, true, "%s", mode);
+			output->scale, config->pango_markup, "%s", mode);
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING * output->scale;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING * output->scale;
@@ -329,7 +329,8 @@ static uint32_t render_binding_mode_indicator(cairo_t *cairo,
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_set_source_u32(cairo, config->colors.binding_mode.text);
 	cairo_move_to(cairo, x + width / 2 - text_width / 2, (int)floor(text_y));
-	pango_printf(cairo, config->font, output->scale, true, "%s", mode);
+	pango_printf(cairo, config->font, output->scale, config->pango_markup,
+			"%s", mode);
 	return surface_height;
 }
 
@@ -374,7 +375,7 @@ static uint32_t render_workspace_button(cairo_t *cairo,
 
 	int text_width, text_height;
 	get_text_size(cairo, config->font, &text_width, &text_height,
-			output->scale, true, "%s", name);
+			output->scale, config->pango_markup, "%s", name);
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING * output->scale;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING * output->scale;
@@ -406,7 +407,8 @@ static uint32_t render_workspace_button(cairo_t *cairo,
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_set_source_u32(cairo, box_colors.text);
 	cairo_move_to(cairo, *x + width / 2 - text_width / 2, (int)floor(text_y));
-	pango_printf(cairo, config->font, output->scale, true, "%s", name);
+	pango_printf(cairo, config->font, output->scale, config->pango_markup,
+			"%s", name);
 
 	struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
 	hotspot->x = *x;


### PR DESCRIPTION
Makes swaybar respect the user's `pango_markup` configuration in the workspace buttons and binding mode indicator.