### PR TITLE
Fix null deref in server_init

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -48,6 +48,10 @@ bool server_init(struct sway_server *server) {
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 	server->backend = wlr_backend_autocreate(server->wl_display);
 
+	if (!server->backend) {
+		wlr_log(L_ERROR, "Unable to create backend");
+		return false;
+	}
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(server->backend);
 	assert(renderer);
 


### PR DESCRIPTION
If the backend fails to be created, log an error and immidiately return
from server_init.