### PR TITLE
Use reasonable default for font height

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -172,7 +172,7 @@ static void config_defaults(struct sway_config *config) {
 	config->default_layout = L_NONE;
 	config->default_orientation = L_NONE;
 	if (!(config->font = strdup("monospace 10"))) goto cleanup;
-	config->font_height = 0;
+	config->font_height = 17; // height of monospace 10
 
 	// floating view
 	config->floating_maximum_width = 0;


### PR DESCRIPTION
Fixes #1949 

When your config lacks a `font` directive, the font height was being set to 0 and it wasn't being recalculated. This sets the default to 17, which is the font height for `monospace 10` as defined on the line above.