### PR TITLE
Implement marks

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -368,6 +368,7 @@ struct sway_config {
 		struct seat_config *seat_config;
 		struct sway_seat *seat;
 		struct sway_container *current_container;
+		bool using_criteria;
 	} handler_context;
 };
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -60,7 +60,8 @@ struct sway_view {
 	bool border_left;
 	bool border_right;
 
-	list_t *executed_criteria;
+	list_t *executed_criteria; // struct criteria *
+	list_t *marks;             // char *
 
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
@@ -252,5 +253,18 @@ void view_update_title(struct sway_view *view, bool force);
  * before.
  */
 void view_execute_criteria(struct sway_view *view);
+
+/**
+ * Find any view that has the given mark and remove the mark from the view.
+ * Returns true if it matched a view.
+ */
+bool view_find_and_unmark(char *mark);
+
+/**
+ * Remove all marks from the view.
+ */
+void view_clear_marks(struct sway_view *view);
+
+bool view_has_mark(struct sway_view *view, char *mark);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -175,6 +175,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "focus", cmd_focus },
 	{ "kill", cmd_kill },
 	{ "layout", cmd_layout },
+	{ "mark", cmd_mark },
 	{ "move", cmd_move },
 	{ "opacity", cmd_opacity },
 	{ "reload", cmd_reload },
@@ -185,6 +186,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "splitt", cmd_splitt },
 	{ "splitv", cmd_splitv },
 	{ "title_format", cmd_title_format },
+	{ "unmark", cmd_unmark },
 };
 
 static int handler_compare(const void *_a, const void *_b) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -302,7 +302,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 	head = exec;
 	do {
 		// Extract criteria (valid for this command list only).
-		bool has_criteria = false;
+		config->handler_context.using_criteria = false;
 		if (*head == '[') {
 			char *error = NULL;
 			struct criteria *criteria = criteria_parse(head, &error);
@@ -315,7 +315,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 			views = criteria_get_views(criteria);
 			head += strlen(criteria->raw);
 			criteria_destroy(criteria);
-			has_criteria = true;
+			config->handler_context.using_criteria = true;
 			// Skip leading whitespace
 			head += strspn(head, whitespace);
 		}
@@ -352,7 +352,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 				goto cleanup;
 			}
 
-			if (!has_criteria) {
+			if (!config->handler_context.using_criteria) {
 				// without criteria, the command acts upon the focused
 				// container
 				config->handler_context.current_container =

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -57,7 +57,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 
 	view_find_and_unmark(mark);
 
-	if (!toggle || (toggle && !had_mark)) {
+	if (!toggle || !had_mark) {
 		list_add(view->marks, strdup(mark));
 	}
 

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -1,0 +1,68 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/view.h"
+#include "list.h"
+#include "log.h"
+#include "stringop.h"
+
+// mark foo                      Same as mark --replace foo
+// mark --add foo                Add this mark to view's list
+// mark --replace foo            Replace view's marks with this single one
+// mark --add --toggle foo       Toggle current mark and persist other marks
+// mark --replace --toggle foo   Toggle current mark and remove other marks
+
+struct cmd_results *cmd_mark(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "mark", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct sway_container *container =
+		config->handler_context.current_container;
+	if (container->type != C_VIEW) {
+		return cmd_results_new(CMD_INVALID, "mark",
+				"Only views can have marks");
+	}
+	struct sway_view *view = container->sway_view;
+
+	bool add = false, toggle = false;
+	while (argc > 0 && strncmp(*argv, "--", 2) == 0) {
+		if (strcmp(*argv, "--add") == 0) {
+			add = true;
+		} else if (strcmp(*argv, "--replace") == 0) {
+			add = false;
+		} else if (strcmp(*argv, "--toggle") == 0) {
+			toggle = true;
+		} else {
+			return cmd_results_new(CMD_INVALID, "mark",
+					"Unrecognized argument '%s'", *argv);
+		}
+		++argv;
+		--argc;
+	}
+
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, "mark",
+				"Expected '[--add|--replace] [--toggle] <identifier>'");
+	}
+
+	char *mark = join_args(argv, argc);
+	bool had_mark = view_has_mark(view, mark);
+
+	if (!add) {
+		// Replacing
+		view_clear_marks(view);
+	}
+
+	view_find_and_unmark(mark);
+
+	if (!toggle || (toggle && !had_mark)) {
+		list_add(view->marks, strdup(mark));
+	}
+
+	free(mark);
+	view_execute_criteria(view);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -7,26 +7,53 @@
 #include "log.h"
 #include "stringop.h"
 
+static void remove_all_marks_iterator(struct sway_container *con, void *data) {
+	if (con->type == C_VIEW) {
+		view_clear_marks(con->sway_view);
+	}
+}
+
+// unmark                  Remove all marks from all views
+// unmark foo              Remove single mark from whichever view has it
+// [criteria] unmark       Remove all marks from matched view
+// [criteria] unmark foo   Remove single mark from matched view
+
 struct cmd_results *cmd_unmark(int argc, char **argv) {
-	if (argc == 0) {
-		// Remove all marks from the current container
+	// Determine the view
+	struct sway_view *view = NULL;
+	if (config->handler_context.using_criteria) {
 		struct sway_container *container =
 			config->handler_context.current_container;
 		if (container->type != C_VIEW) {
 			return cmd_results_new(CMD_INVALID, "unmark",
 					"Only views can have marks");
 		}
-		view_clear_marks(container->sway_view);
-	} else {
-		// Remove a single mark from whichever container has it
-		char *mark = join_args(argv, argc);
-		if (!view_find_and_unmark(mark)) {
-			free(mark);
-			return cmd_results_new(CMD_INVALID, "unmark",
-					"No view exists with that mark");
-		}
-		free(mark);
+		view = container->sway_view;
 	}
+
+	// Determine the mark
+	char *mark = NULL;
+	if (argc > 0) {
+		mark = join_args(argv, argc);
+	}
+
+	if (view && mark) {
+		// Remove the mark from the given view
+		if (view_has_mark(view, mark)) {
+			view_find_and_unmark(mark);
+		}
+	} else if (view && !mark) {
+		// Clear all marks from the given view
+		view_clear_marks(view);
+	} else if (!view && mark) {
+		// Remove mark from whichever view has it
+		view_find_and_unmark(mark);
+	} else {
+		// Remove all marks from all views
+		container_for_each_descendant_dfs(&root_container,
+				remove_all_marks_iterator, NULL);
+	}
+	free(mark);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -1,0 +1,32 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/view.h"
+#include "list.h"
+#include "log.h"
+#include "stringop.h"
+
+struct cmd_results *cmd_unmark(int argc, char **argv) {
+	if (argc == 0) {
+		// Remove all marks from the current container
+		struct sway_container *container =
+			config->handler_context.current_container;
+		if (container->type != C_VIEW) {
+			return cmd_results_new(CMD_INVALID, "unmark",
+					"Only views can have marks");
+		}
+		view_clear_marks(container->sway_view);
+	} else {
+		// Remove a single mark from whichever container has it
+		char *mark = join_args(argv, argc);
+		if (!view_find_and_unmark(mark)) {
+			free(mark);
+			return cmd_results_new(CMD_INVALID, "unmark",
+					"No view exists with that mark");
+		}
+		free(mark);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -75,8 +75,16 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->con_mark) {
-		// TODO
-		return false;
+		bool exists = false;
+		for (int i = 0; i < view->marks->length; ++i) {
+			if (regex_cmp(view->marks->items[i], criteria->con_mark) == 0) {
+				exists = true;
+				break;
+			}
+		}
+		if (!exists) {
+			return false;
+		}
 	}
 
 	if (criteria->con_id) { // Internal ID

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -43,6 +43,7 @@ sway_sources = files(
 	'commands/fullscreen.c',
 	'commands/hide_edge_borders.c',
 	'commands/kill.c',
+	'commands/mark.c',
 	'commands/opacity.c',
 	'commands/include.c',
 	'commands/input.c',
@@ -62,6 +63,7 @@ sway_sources = files(
 	'commands/split.c',
 	'commands/swaybg_command.c',
 	'commands/title_format.c',
+	'commands/unmark.c',
 	'commands/workspace.c',
 	'commands/ws_auto_back_and_forth.c',
 


### PR DESCRIPTION
This implements the `mark` and `unmark` commands, including the `--add`, `--replace` and `--toggle` arguments for the `mark` command, and also implements mark matching in criteria.

To test, run a variety of these commands:

* `swaymsg mark foo` (replaces any existing marks on this view with `foo`)
* `swaymsg 'mark --add bar'` (will append `bar` to view's marks list)
* `swaymsg [con_mark="foo"] opacity 0.9`
* `swaymsg [con_mark="foo"] mark bar`
* `swaymsg 'mark --add --toggle bar'` (keep existing marks list and toggle `bar`)

Try to break it:

* `swaymsg mark`
* `swaymsg 'mark --add'`
* `swaymsg 'mark --asdf'`

Note that single quotes are required when using `--add` and friends, otherwise your shell may interpret them.

There's no easy well to get a view's marks (`show_marks` is not yet implemented), so my method is to test using the opacity example.