### PR TITLE
Don't destroy view child on xdg-popup unmap

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -153,7 +153,6 @@ struct sway_xdg_popup_v6 {
 	struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
 
 	struct wl_listener new_popup;
-	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -20,7 +20,6 @@ static void popup_destroy(struct sway_view_child *child) {
 	}
 	struct sway_xdg_popup_v6 *popup = (struct sway_xdg_popup_v6 *)child;
 	wl_list_remove(&popup->new_popup.link);
-	wl_list_remove(&popup->unmap.link);
 	wl_list_remove(&popup->destroy.link);
 	free(popup);
 }
@@ -37,11 +36,6 @@ static void popup_handle_new_popup(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, popup, new_popup);
 	struct wlr_xdg_popup_v6 *wlr_popup = data;
 	popup_create(wlr_popup, popup->child.view);
-}
-
-static void popup_handle_unmap(struct wl_listener *listener, void *data) {
-	struct sway_xdg_popup_v6 *popup = wl_container_of(listener, popup, unmap);
-	view_child_destroy(&popup->child);
 }
 
 static void popup_handle_destroy(struct wl_listener *listener, void *data) {
@@ -62,8 +56,6 @@ static struct sway_xdg_popup_v6 *popup_create(
 
 	wl_signal_add(&xdg_surface->events.new_popup, &popup->new_popup);
 	popup->new_popup.notify = popup_handle_new_popup;
-	wl_signal_add(&xdg_surface->events.unmap, &popup->unmap);
-	popup->unmap.notify = popup_handle_unmap;
 	wl_signal_add(&xdg_surface->events.destroy, &popup->destroy);
 	popup->destroy.notify = popup_handle_destroy;
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -82,10 +82,6 @@ static void unmanaged_handle_unmap(struct wl_listener *listener, void *data) {
 static void unmanaged_handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_unmanaged *surface =
 		wl_container_of(listener, surface, destroy);
-	struct wlr_xwayland_surface *xsurface = surface->wlr_xwayland_surface;
-	if (xsurface->mapped) {
-		unmanaged_handle_unmap(&surface->unmap, xsurface);
-	}
 	wl_list_remove(&surface->map.link);
 	wl_list_remove(&surface->unmap.link);
 	wl_list_remove(&surface->destroy.link);


### PR DESCRIPTION
The current code prevents an unmapped xdg-popup from being re-mapped again.

This PR also removes an extraneous `if (surface is unmapped)` check on destroy: unmap is guaranteed to always be triggered before destroy.