### PR TITLE
Implement show_marks

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -63,6 +63,11 @@ struct sway_view {
 	list_t *executed_criteria; // struct criteria *
 	list_t *marks;             // char *
 
+	struct wlr_texture *marks_focused;
+	struct wlr_texture *marks_focused_inactive;
+	struct wlr_texture *marks_unfocused;
+	struct wlr_texture *marks_urgent;
+
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
 		struct wlr_xdg_surface *wlr_xdg_surface;
@@ -266,5 +271,7 @@ bool view_find_and_unmark(char *mark);
 void view_clear_marks(struct sway_view *view);
 
 bool view_has_mark(struct sway_view *view, char *mark);
+
+void view_update_marks_textures(struct sway_view *view);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -116,6 +116,7 @@ static struct cmd_handler handlers[] = {
 	{ "mouse_warping", cmd_mouse_warping },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },
+	{ "show_marks", cmd_show_marks },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -62,6 +62,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	}
 
 	free(mark);
+	view_update_marks_textures(view);
 	view_execute_criteria(view);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -1,0 +1,43 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/view.h"
+#include "sway/output.h"
+#include "list.h"
+#include "log.h"
+#include "stringop.h"
+
+static void rebuild_marks_iterator(struct sway_container *con, void *data) {
+	if (con->type == C_VIEW) {
+		view_update_marks_textures(con->sway_view);
+	}
+}
+
+struct cmd_results *cmd_show_marks(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "show_marks", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (strcmp(*argv, "yes") == 0) {
+		config->show_marks = true;
+	} else if (strcmp(*argv, "no") == 0) {
+		config->show_marks = false;
+	} else {
+		return cmd_results_new(CMD_INVALID, "show_marks",
+				"Expected 'show_marks <yes|no>'");
+	}
+
+	if (config->show_marks) {
+		container_for_each_descendant_dfs(&root_container,
+				rebuild_marks_iterator, NULL);
+	}
+
+	for (int i = 0; i < root_container.children->length; ++i) {
+		struct sway_container *con = root_container.children->items[i];
+		output_damage_whole(con->sway_output);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -10,6 +10,7 @@
 static void remove_all_marks_iterator(struct sway_container *con, void *data) {
 	if (con->type == C_VIEW) {
 		view_clear_marks(con->sway_view);
+		view_update_marks_textures(con->sway_view);
 	}
 }
 
@@ -45,6 +46,7 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 	} else if (view && !mark) {
 		// Clear all marks from the given view
 		view_clear_marks(view);
+		view_update_marks_textures(view);
 	} else if (!view && mark) {
 		// Remove mark from whichever view has it
 		view_find_and_unmark(mark);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -962,10 +962,15 @@ static void handle_transform(struct wl_listener *listener, void *data) {
 	arrange_output(output->swayc);
 }
 
+static void handle_scale_iterator(struct sway_container *view, void *data) {
+	view_update_marks_textures(view->sway_view);
+}
+
 static void handle_scale(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, scale);
 	arrange_layers(output);
 	arrange_output(output->swayc);
+	container_descendants(output->swayc, C_VIEW, handle_scale_iterator, NULL);
 }
 
 void handle_new_output(struct wl_listener *listener, void *data) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -60,6 +60,7 @@ sway_sources = files(
 	'commands/seat/cursor.c',
 	'commands/seat/fallback.c',
 	'commands/set.c',
+	'commands/show_marks.c',
 	'commands/split.c',
 	'commands/swaybg_command.c',
 	'commands/title_format.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -174,7 +174,7 @@ runtime.
 	Assigns views matching _criteria_ (see *CRITERIA* for details) to
 	_workspace_. The → (U+2192) is optional and cosmetic. This command is
 	equivalent to:
-	
+
 		for\_window <criteria> move container to workspace <workspace>
 
 *bindsym* <key combo> <command>
@@ -238,7 +238,7 @@ The default colors are:
 [- *class*
 :[ _border_
 :[ _background_
-:[ _text_ 
+:[ _text_
 :[ _indicator_
 :[ _child\_border_
 |[ *background*
@@ -451,10 +451,10 @@ You can get a list of output names with *swaymsg -t get\_outputs*. You may also
 match any output by using the output name "\*". Be sure to add this output
 config after the others, or it will be matched instead of the others.
 
-*show\_marks* on|off
-	If *show\_marks* is on, marks will be displayed in the window borders.
-	Any mark that starts with an underscore will not be drawn even if the
-	option is on. The default is _on_.
+*show\_marks* yes|no
+	If *show\_marks* is yes, marks will be displayed in the window borders.
+	Any mark that starts with an underscore will not be drawn even if
+	*show\_marks* is yes. The default is _yes_.
 
 *opacity* <value>
 	Set the opacity of the window between 0 (completely transparent) and 1

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -592,6 +592,7 @@ static void update_title_texture(struct sway_container *con,
 	}
 	if (*texture) {
 		wlr_texture_destroy(*texture);
+		*texture = NULL;
 	}
 	if (!con->formatted_title) {
 		return;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -123,13 +123,12 @@ static void _container_destroy(struct sway_container *cont) {
 	if (cont->name) {
 		free(cont->name);
 	}
-	if (cont->title_focused) {
-		// If one is set then all of these are set
-		wlr_texture_destroy(cont->title_focused);
-		wlr_texture_destroy(cont->title_focused_inactive);
-		wlr_texture_destroy(cont->title_unfocused);
-		wlr_texture_destroy(cont->title_urgent);
-	}
+
+	wlr_texture_destroy(cont->title_focused);
+	wlr_texture_destroy(cont->title_focused_inactive);
+	wlr_texture_destroy(cont->title_unfocused);
+	wlr_texture_destroy(cont->title_urgent);
+
 	list_free(cont->children);
 	cont->children = NULL;
 	free(cont);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -43,13 +43,10 @@ void view_destroy(struct sway_view *view) {
 	}
 	list_free(view->marks);
 
-	if (view->marks_focused) {
-		// If one is set then all of these are set
-		wlr_texture_destroy(view->marks_focused);
-		wlr_texture_destroy(view->marks_focused_inactive);
-		wlr_texture_destroy(view->marks_unfocused);
-		wlr_texture_destroy(view->marks_urgent);
-	}
+	wlr_texture_destroy(view->marks_focused);
+	wlr_texture_destroy(view->marks_focused_inactive);
+	wlr_texture_destroy(view->marks_unfocused);
+	wlr_texture_destroy(view->marks_urgent);
 
 	container_destroy(view->swayc);
 
@@ -802,6 +799,11 @@ static void update_marks_texture(struct sway_view *view,
 	}
 	char *buffer = calloc(len + 1, 1);
 	char *part = malloc(len + 1);
+
+	if (!sway_assert(buffer && part, "Unable to allocate memory")) {
+		free(buffer);
+		return;
+	}
 
 	for (int i = 0; i < view->marks->length; ++i) {
 		char *mark = view->marks->items[i];

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -779,6 +779,7 @@ static void update_marks_texture(struct sway_view *view,
 	}
 	if (*texture) {
 		wlr_texture_destroy(*texture);
+		*texture = NULL;
 	}
 	if (!view->marks->length) {
 		return;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -43,6 +43,14 @@ void view_destroy(struct sway_view *view) {
 	}
 	list_free(view->marks);
 
+	if (view->marks_focused) {
+		// If one is set then all of these are set
+		wlr_texture_destroy(view->marks_focused);
+		wlr_texture_destroy(view->marks_focused_inactive);
+		wlr_texture_destroy(view->marks_unfocused);
+		wlr_texture_destroy(view->marks_urgent);
+	}
+
 	container_destroy(view->swayc);
 
 	if (view->impl->destroy) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -786,15 +786,20 @@ static void update_marks_texture(struct sway_view *view,
 
 	size_t len = 0;
 	for (int i = 0; i < view->marks->length; ++i) {
-		len += strlen((char *)view->marks->items[i]) + 2;
+		char *mark = view->marks->items[i];
+		if (mark[0] != '_') {
+			len += strlen(mark) + 2;
+		}
 	}
 	char *buffer = calloc(len + 1, 1);
 	char *part = malloc(len + 1);
 
 	for (int i = 0; i < view->marks->length; ++i) {
 		char *mark = view->marks->items[i];
-		sprintf(part, "[%s]", mark);
-		strcat(buffer, part);
+		if (mark[0] != '_') {
+			sprintf(part, "[%s]", mark);
+			strcat(buffer, part);
+		}
 	}
 	free(part);
 


### PR DESCRIPTION
The implementation is similar to titles: store a texture for each focus class.

Tests:

* Run `show_marks yes` and `show_marks no` in both config and swaymsg
* `swaymsg mark foo`
* Test with scaled outputs (I've already done this but doesn't hurt to double check)

If the title is long enough to intersect the mark then the mark is drawn on top. However, I've noticed an unrelated bug where the title isn't scissored properly and renders into the right side border if it's long enough. This makes a few pixels of it appear to the right of the mark which looks bad. I won't fix that as part of this PR because it's a separate issue.