### PR TITLE
Correctly clip title texture if necessary

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -409,6 +409,7 @@ static void render_container_simple_border_normal(struct sway_output *output,
 			WL_OUTPUT_TRANSFORM_NORMAL,
 			0.0, output->wlr_output->transform_matrix);
 
+		texture_box.width = box.width * output_scale;
 		render_texture(output->wlr_output, output_damage, title_texture,
 			&texture_box, matrix, 1.0);
 	}


### PR DESCRIPTION
Test plan: set output config to `scale 1.5 transform 90`, check that the texture stops right before the border.

Fixes #1983