### PR TITLE
sway: run commands without waiting for Xwayland

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -40,7 +40,6 @@ struct sway_server {
 	struct wlr_xwayland *xwayland;
 	struct wlr_xcursor_manager *xcursor_manager;
 	struct wl_listener xwayland_surface;
-	struct wl_listener xwayland_ready;
 
 	struct wlr_wl_shell *wl_shell;
 	struct wl_listener wl_shell_surface;


### PR DESCRIPTION
Xwayland is lazy now, there is no need to wait at all

Test plan: Try to add stuff to your .sway/config as 'exec' statements to run at startup, see nothing fails unexpectedly because we didn't wait enough.
(works for me: X11 app (urxvt), swayidle, swaylock)