### PR TITLE
Rebuild textures if needed when moving a container

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -98,6 +98,8 @@ struct sway_container {
 		// Passed the previous parent
 		struct wl_signal reparent;
 	} events;
+
+	struct wl_listener reparent;
 };
 
 struct sway_container *container_create(enum sway_container_type type);


### PR DESCRIPTION
When moving a container to an output which has a different scale than the previous, rebuild the title and marks textures at the new scale.

Fixes #1999.

To test:

* Have two outputs at different scales
* Mark a container with `swaymsg mark foo`
* Move the container between the outputs, using both `mod+shift+<direction>`, as well as `mod+shift+<workspace-number>`