### PR TITLE
Fix border commands from changing focus

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -29,7 +29,8 @@ struct sway_cursor {
 
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
-void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec);
+void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
+		bool allow_refocusing);
 void dispatch_cursor_button(struct sway_cursor *cursor, uint32_t time_msec,
 	uint32_t button, enum wlr_button_state state);
 

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -41,7 +41,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	if (seat->cursor) {
-		cursor_send_pointer_motion(seat->cursor, 0);
+		cursor_send_pointer_motion(seat->cursor, 0, false);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -36,7 +36,7 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 		int delta_x = strtol(argv[1], NULL, 10);
 		int delta_y = strtol(argv[2], NULL, 10);
 		wlr_cursor_move(cursor->cursor, NULL, delta_x, delta_y);
-		cursor_send_pointer_motion(cursor, 0);
+		cursor_send_pointer_motion(cursor, 0, true);
 	} else if (strcasecmp(argv[0], "set") == 0) {
 		if (argc < 3) {
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);
@@ -45,7 +45,7 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 		float x = strtof(argv[1], NULL) / root_container.width;
 		float y = strtof(argv[2], NULL) / root_container.height;
 		wlr_cursor_warp_absolute(cursor->cursor, NULL, x, y);
-		cursor_send_pointer_motion(cursor, 0);
+		cursor_send_pointer_motion(cursor, 0, true);
 	} else {
 		if (argc < 2) {
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -135,7 +135,8 @@ static struct sway_container *container_at_coords(
 	return output->swayc;
 }
 
-void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec) {
+void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
+		bool allow_refocusing) {
 	if (time_msec == 0) {
 		time_msec = get_current_time_msec();
 	}
@@ -145,7 +146,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec) 
 	double sx, sy;
 	struct sway_container *c = container_at_coords(cursor->seat,
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
-	if (c && config->focus_follows_mouse) {
+	if (c && config->focus_follows_mouse && allow_refocusing) {
 		if (c->type == C_WORKSPACE) {
 			// Only follow the mouse if it would move to a new output
 			// Otherwise we'll focus the workspace, which is probably wrong
@@ -193,7 +194,7 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_motion *event = data;
 	wlr_cursor_move(cursor->cursor, event->device,
 		event->delta_x, event->delta_y);
-	cursor_send_pointer_motion(cursor, event->time_msec);
+	cursor_send_pointer_motion(cursor, event->time_msec, true);
 }
 
 static void handle_cursor_motion_absolute(
@@ -203,7 +204,7 @@ static void handle_cursor_motion_absolute(
 	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_motion_absolute *event = data;
 	wlr_cursor_warp_absolute(cursor->cursor, event->device, event->x, event->y);
-	cursor_send_pointer_motion(cursor, event->time_msec);
+	cursor_send_pointer_motion(cursor, event->time_msec, true);
 }
 
 void dispatch_cursor_button(struct sway_cursor *cursor,
@@ -373,7 +374,7 @@ static void handle_tool_axis(struct wl_listener *listener, void *data) {
 	}
 
 	wlr_cursor_warp_absolute(cursor->cursor, event->device, x, y);
-	cursor_send_pointer_motion(cursor, event->time_msec);
+	cursor_send_pointer_motion(cursor, event->time_msec, true);
 }
 
 static void handle_tool_tip(struct wl_listener *listener, void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -602,7 +602,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 						wlr_output, seat->cursor->cursor->x,
 						seat->cursor->cursor->y)) {
 					wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
-					cursor_send_pointer_motion(seat->cursor, 0);
+					cursor_send_pointer_motion(seat->cursor, 0, true);
 				}
 			}
 		}
@@ -613,7 +613,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 	}
 
 	if (last_workspace && last_workspace != new_workspace) {
-		cursor_send_pointer_motion(seat->cursor, 0);
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 	}
 
 	seat->has_focus = (container != NULL);


### PR DESCRIPTION
Fixes #1951 

This allows the border commands to update the cursor without having the side effect of `focus_follows_mouse` changing the focus. All other calls to `cursor_send_pointer_motion` currently allow refocusing (no change) so `focus_follows_mouse` should continue to work as expected.