### PR TITLE
Implement floating

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -84,6 +84,7 @@ struct sway_container {
 	// Includes borders
 	double x, y;
 	double width, height;
+	double saved_x, saved_y;
 	double saved_width, saved_height;
 
 	list_t *children;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -40,6 +40,7 @@ enum sway_container_layout {
 	L_VERT,
 	L_STACKED,
 	L_TABBED,
+	L_FLOATING,
 };
 
 enum sway_container_border {
@@ -74,10 +75,6 @@ struct sway_container {
 	enum sway_container_type type;
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_layout;
-
-	// Allow the container to be automatically removed if it's empty. True by
-	// default, false for the magic floating container that each workspace has.
-	bool reapable;
 
 	// Saves us from searching the list of children/floating in the parent
 	bool is_floating;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -75,8 +75,13 @@ struct sway_container {
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_layout;
 
+	// Allow the container to be automatically removed if it's empty. True by
+	// default, false for the magic floating container that each workspace has.
+	bool reapable;
+
 	// Saves us from searching the list of children/floating in the parent
 	bool is_floating;
+	bool is_sticky;
 
 	// For C_ROOT, this has no meaning
 	// For C_OUTPUT, this is the output position in layout coordinates
@@ -174,6 +179,13 @@ struct sway_container *container_at(struct sway_container *container,
 		double *sx, double *sy);
 
 /**
+ * Same as container_at, but only checks floating views and expects coordinates
+ * to be layout coordinates, as that's what floating views use.
+ */
+struct sway_container *floating_container_at(double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy);
+
+/**
  * Apply the function for each descendant of the container breadth first.
  */
 void container_for_each_descendant_bfs(struct sway_container *container,
@@ -228,5 +240,15 @@ void container_notify_subtree_changed(struct sway_container *container);
  * Return the height of a regular title bar.
  */
 size_t container_titlebar_height(void);
+
+void container_set_floating(struct sway_container *container, bool enable);
+
+void container_set_geometry_from_view(struct sway_container *container);
+
+/**
+ * Determine if the given container is itself floating or has a floating
+ * ancestor.
+ */
+bool container_self_or_parent_floating(struct sway_container *container);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -246,10 +246,4 @@ void container_set_geometry_from_floating_view(struct sway_container *con);
  */
 bool container_is_floating(struct sway_container *container);
 
-/**
- * Determine if the given container is itself floating or is a child of a
- * floating container.
- */
-bool container_self_or_parent_floating(struct sway_container *container);
-
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -79,8 +79,7 @@ struct sway_container {
 	bool is_sticky;
 
 	// For C_ROOT, this has no meaning
-	// For C_OUTPUT, this is the output position in layout coordinates
-	// For other types, this is the position in output-local coordinates
+	// For other types, this is the position in layout coordinates
 	// Includes borders
 	double x, y;
 	double width, height;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -76,6 +76,9 @@ struct sway_container {
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_layout;
 
+	// Saves us from searching the list of children/floating in the parent
+	bool is_floating;
+
 	// For C_ROOT, this has no meaning
 	// For C_OUTPUT, this is the output position in layout coordinates
 	// For other types, this is the position in output-local coordinates

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -76,8 +76,6 @@ struct sway_container {
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_layout;
 
-	// Saves us from searching the list of children/floating in the parent
-	bool is_floating;
 	bool is_sticky;
 
 	// For C_ROOT, this has no meaning
@@ -243,8 +241,14 @@ void container_set_floating(struct sway_container *container, bool enable);
 void container_set_geometry_from_view(struct sway_container *container);
 
 /**
- * Determine if the given container is itself floating or has a floating
- * ancestor.
+ * Determine if the given container is itself floating.
+ * This will return false for any descendants of a floating container.
+ */
+bool container_is_floating(struct sway_container *container);
+
+/**
+ * Determine if the given container is itself floating or is a child of a
+ * floating container.
  */
 bool container_self_or_parent_floating(struct sway_container *container);
 

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -40,7 +40,6 @@ enum sway_container_layout {
 	L_VERT,
 	L_STACKED,
 	L_TABBED,
-	L_FLOATING,
 };
 
 enum sway_container_border {

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -238,7 +238,7 @@ size_t container_titlebar_height(void);
 
 void container_set_floating(struct sway_container *container, bool enable);
 
-void container_set_geometry_from_view(struct sway_container *container);
+void container_set_geometry_from_floating_view(struct sway_container *con);
 
 /**
  * Determine if the given container is itself floating.

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -46,9 +46,6 @@ struct sway_container *container_add_sibling(struct sway_container *parent,
 
 struct sway_container *container_remove_child(struct sway_container *child);
 
-void container_add_floating(struct sway_container *workspace,
-		struct sway_container *child);
-
 struct sway_container *container_replace_child(struct sway_container *child,
 		struct sway_container *new_child);
 

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -46,6 +46,9 @@ struct sway_container *container_add_sibling(struct sway_container *parent,
 
 struct sway_container *container_remove_child(struct sway_container *child);
 
+void container_add_floating(struct sway_container *workspace,
+		struct sway_container *child);
+
 struct sway_container *container_replace_child(struct sway_container *child,
 		struct sway_container *new_child);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -32,7 +32,9 @@ struct sway_view_impl {
 	void (*configure)(struct sway_view *view, double ox, double oy, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
+	void (*set_maximized)(struct sway_view *view, bool maximized);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
+	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 	void (*close)(struct sway_view *view);
@@ -49,6 +51,10 @@ struct sway_view {
 	// Geometry of the view itself (excludes borders)
 	double x, y;
 	int width, height;
+
+	// The size the view would want to be if it weren't tiled.
+	// Used when changing a view from tiled to floating.
+	int natural_width, natural_height;
 
 	bool is_fullscreen;
 
@@ -214,6 +220,8 @@ void view_autoconfigure(struct sway_view *view);
 
 void view_set_activated(struct sway_view *view, bool activated);
 
+void view_set_maximized(struct sway_view *view, bool maximized);
+
 void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen);
 
 void view_set_fullscreen(struct sway_view *view, bool fullscreen);
@@ -236,7 +244,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface);
 
 void view_unmap(struct sway_view *view);
 
-void view_update_position(struct sway_view *view, double ox, double oy);
+void view_update_position(struct sway_view *view, double lx, double ly);
 
 void view_update_size(struct sway_view *view, int width, int height);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -137,6 +137,7 @@ struct sway_xwayland_view {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 
+	int pending_lx, pending_ly;
 	int pending_width, pending_height;
 };
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -29,7 +29,7 @@ struct sway_view_impl {
 	const char *(*get_string_prop)(struct sway_view *view,
 			enum sway_view_prop prop);
 	uint32_t (*get_int_prop)(struct sway_view *view, enum sway_view_prop prop);
-	void (*configure)(struct sway_view *view, double ox, double oy, int width,
+	void (*configure)(struct sway_view *view, double lx, double ly, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
 	void (*set_tiled)(struct sway_view *view, bool tiled);
@@ -48,7 +48,7 @@ struct sway_view {
 	struct sway_container *swayc; // NULL for unmapped views
 	struct wlr_surface *surface; // NULL for unmapped views
 
-	// Geometry of the view itself (excludes borders)
+	// Geometry of the view itself (excludes borders) in layout coordinates
 	double x, y;
 	int width, height;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -32,7 +32,6 @@ struct sway_view_impl {
 	void (*configure)(struct sway_view *view, double lx, double ly, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
-	void (*set_tiled)(struct sway_view *view, bool tiled);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
 	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
@@ -220,8 +219,6 @@ void view_configure(struct sway_view *view, double ox, double oy, int width,
 void view_autoconfigure(struct sway_view *view);
 
 void view_set_activated(struct sway_view *view, bool activated);
-
-void view_set_tiled(struct sway_view *view, bool tiled);
 
 void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -32,7 +32,7 @@ struct sway_view_impl {
 	void (*configure)(struct sway_view *view, double ox, double oy, int width,
 		int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
-	void (*set_maximized)(struct sway_view *view, bool maximized);
+	void (*set_tiled)(struct sway_view *view, bool tiled);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
 	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
@@ -220,7 +220,7 @@ void view_autoconfigure(struct sway_view *view);
 
 void view_set_activated(struct sway_view *view, bool activated);
 
-void view_set_maximized(struct sway_view *view, bool maximized);
+void view_set_tiled(struct sway_view *view, bool tiled);
 
 void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -51,6 +51,9 @@ struct sway_view {
 	double x, y;
 	int width, height;
 
+	double saved_x, saved_y;
+	int saved_width, saved_height;
+
 	// The size the view would want to be if it weren't tiled.
 	// Used when changing a view from tiled to floating.
 	int natural_width, natural_height;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -8,7 +8,7 @@ struct sway_view;
 struct sway_workspace {
 	struct sway_container *swayc;
 	struct sway_view *fullscreen;
-	list_t *floating;
+	struct sway_container *floating;
 };
 
 extern char *prev_workspace_name;
@@ -30,5 +30,7 @@ struct sway_container *workspace_output_prev(struct sway_container *current);
 struct sway_container *workspace_prev(struct sway_container *current);
 
 bool workspace_is_visible(struct sway_container *ws);
+
+bool workspace_is_empty(struct sway_container *ws);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -8,6 +8,7 @@ struct sway_view;
 struct sway_workspace {
 	struct sway_container *swayc;
 	struct sway_view *fullscreen;
+	list_t *floating;
 };
 
 extern char *prev_workspace_name;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -190,6 +190,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "splith", cmd_splith },
 	{ "splitt", cmd_splitt },
 	{ "splitv", cmd_splitv },
+	{ "sticky", cmd_sticky },
 	{ "swap", cmd_swap },
 	{ "title_format", cmd_title_format },
 	{ "unmark", cmd_unmark },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -110,7 +110,6 @@ static struct cmd_handler handlers[] = {
 	{ "font", cmd_font },
 	{ "for_window", cmd_for_window },
 	{ "force_focus_wrapping", cmd_force_focus_wrapping },
-	{ "fullscreen", cmd_fullscreen },
 	{ "hide_edge_borders", cmd_hide_edge_borders },
 	{ "include", cmd_include },
 	{ "input", cmd_input },
@@ -176,7 +175,9 @@ static struct cmd_handler config_handlers[] = {
 static struct cmd_handler command_handlers[] = {
 	{ "border", cmd_border },
 	{ "exit", cmd_exit },
+	{ "floating", cmd_floating },
 	{ "focus", cmd_focus },
+	{ "fullscreen", cmd_fullscreen },
 	{ "kill", cmd_kill },
 	{ "layout", cmd_layout },
 	{ "mark", cmd_mark },

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -37,7 +37,13 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 				"or 'border pixel <px>'");
 	}
 
-	view_autoconfigure(view);
+	if (container_is_floating(view->swayc)) {
+		container_damage_whole(view->swayc);
+		container_set_geometry_from_floating_view(view->swayc);
+		container_damage_whole(view->swayc);
+	} else {
+		view_autoconfigure(view);
+	}
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	if (seat->cursor) {

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -1,0 +1,48 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/input/seat.h"
+#include "sway/ipc-server.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
+#include "sway/tree/layout.h"
+#include "list.h"
+
+struct cmd_results *cmd_floating(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	struct sway_container *container =
+		config->handler_context.current_container;
+	if (container->type != C_VIEW) {
+		// TODO: This doesn't strictly speaking have to be true
+		return cmd_results_new(CMD_INVALID, "float", "Only views can float");
+	}
+
+	bool wants_floating;
+	if (strcasecmp(argv[0], "enable") == 0) {
+		wants_floating = true;
+	} else if (strcasecmp(argv[0], "disable") == 0) {
+		wants_floating = false;
+	} else if (strcasecmp(argv[0], "toggle") == 0) {
+		wants_floating = !container->is_floating;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "floating",
+			"Expected 'floating <enable|disable|toggle>");
+	}
+
+	// Change from tiled to floating
+	if (!container->is_floating && wants_floating) {
+		struct sway_container *workspace = container_parent(
+				container, C_WORKSPACE);
+		container_remove_child(container);
+		container_add_floating(workspace, container);
+		seat_set_focus(config->handler_context.seat, container);
+		arrange_workspace(workspace);
+	} else if (container->is_floating && !wants_floating) {
+		// TODO
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -28,7 +28,7 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "disable") == 0) {
 		wants_floating = false;
 	} else if (strcasecmp(argv[0], "toggle") == 0) {
-		wants_floating = !container->is_floating;
+		wants_floating = !container_is_floating(container);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "floating",
 			"Expected 'floating <enable|disable|toggle>'");

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -3,9 +3,11 @@
 #include "sway/commands.h"
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
+#include "sway/output.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/layout.h"
+#include "sway/tree/view.h"
 #include "list.h"
 
 struct cmd_results *cmd_floating(int argc, char **argv) {
@@ -38,6 +40,17 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 				container, C_WORKSPACE);
 		container_remove_child(container);
 		container_add_floating(workspace, container);
+
+		struct sway_output *output = workspace->parent->sway_output;
+		output_damage_whole_container(output, container);
+		// Reset to sane size and position
+		container->width = 640;
+		container->height = 480;
+		container->x = workspace->width / 2 - container->width / 2;
+		container->y = workspace->height / 2 - container->height / 2;
+		view_autoconfigure(container->sway_view);
+		output_damage_whole_container(output, container);
+
 		seat_set_focus(config->handler_context.seat, container);
 		arrange_workspace(workspace);
 	} else if (container->is_floating && !wants_floating) {

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -12,18 +12,14 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	}
 	struct sway_container *parent = config->handler_context.current_container;
 
-	// TODO: floating
-	/*
-	if (parent->is_floating) {
-		return cmd_results_new(CMD_FAILURE, "layout", "Unable to change layout of floating windows");
+	if (container_is_floating(parent)) {
+		return cmd_results_new(CMD_FAILURE, "layout",
+				"Unable to change layout of floating windows");
 	}
-	*/
 
 	while (parent->type == C_VIEW) {
 		parent = parent->parent;
 	}
-
-	// TODO: stacks and tabs
 
 	if (strcasecmp(argv[0], "default") == 0) {
 		parent->layout = parent->prev_layout;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -13,16 +13,14 @@
 #include "stringop.h"
 #include "list.h"
 
-static const char* expected_syntax = 
+static const char* expected_syntax =
 	"Expected 'move <left|right|up|down> <[px] px>' or "
 	"'move <container|window> to workspace <name>' or "
 	"'move <container|window|workspace> to output <name|direction>' or "
 	"'move position mouse'";
 
 static struct sway_container *output_in_direction(const char *direction,
-		struct wlr_output *reference, int ref_ox, int ref_oy) {
-	int ref_lx = ref_ox + reference->lx,
-		ref_ly = ref_oy + reference->ly;
+		struct wlr_output *reference, int ref_lx, int ref_ly) {
 	struct {
 		char *name;
 		enum wlr_direction direction;

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -10,6 +10,10 @@
 
 static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.current_container;
+	if (container_is_floating(con)) {
+		return cmd_results_new(CMD_FAILURE, "split",
+			"Can't split a floating view");
+	}
 	struct sway_container *parent = container_split(con, layout);
 	container_create_notify(parent);
 	arrange_children_of(parent);
@@ -23,24 +27,23 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 		return error;
 	}
 	if (strcasecmp(argv[0], "v") == 0 || strcasecmp(argv[0], "vertical") == 0) {
-		do_split(L_VERT);
+		return do_split(L_VERT);
 	} else if (strcasecmp(argv[0], "h") == 0 ||
 			strcasecmp(argv[0], "horizontal") == 0) {
-		do_split(L_HORIZ);
+		return do_split(L_HORIZ);
 	} else if (strcasecmp(argv[0], "t") == 0 ||
 			strcasecmp(argv[0], "toggle") == 0) {
 		struct sway_container *focused =
 			config->handler_context.current_container;
 
 		if (focused->parent->layout == L_VERT) {
-			do_split(L_HORIZ);
+			return do_split(L_HORIZ);
 		} else {
-			do_split(L_VERT);
+			return do_split(L_VERT);
 		}
 	} else {
-		error = cmd_results_new(CMD_FAILURE, "split",
+		return cmd_results_new(CMD_FAILURE, "split",
 			"Invalid split command (expected either horizontal or vertical).");
-		return error;
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -10,31 +10,31 @@
 #include "sway/tree/view.h"
 #include "list.h"
 
-struct cmd_results *cmd_floating(int argc, char **argv) {
+struct cmd_results *cmd_sticky(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "sticky", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
 	struct sway_container *container =
 		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
-		// TODO: This doesn't strictly speaking have to be true
-		return cmd_results_new(CMD_INVALID, "float", "Only views can float");
+	if (!container->is_floating) {
+		return cmd_results_new(CMD_FAILURE, "sticky",
+			"Can't set sticky on a tiled container");
 	}
 
-	bool wants_floating;
+	bool wants_sticky;
 	if (strcasecmp(argv[0], "enable") == 0) {
-		wants_floating = true;
+		wants_sticky = true;
 	} else if (strcasecmp(argv[0], "disable") == 0) {
-		wants_floating = false;
+		wants_sticky = false;
 	} else if (strcasecmp(argv[0], "toggle") == 0) {
-		wants_floating = !container->is_floating;
+		wants_sticky = !container->is_sticky;
 	} else {
-		return cmd_results_new(CMD_FAILURE, "floating",
-			"Expected 'floating <enable|disable|toggle>'");
+		return cmd_results_new(CMD_FAILURE, "sticky",
+			"Expected 'sticky <enable|disable|toggle>'");
 	}
 
-	container_set_floating(container, wants_floating);
+	container->is_sticky = wants_sticky;
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -17,7 +17,7 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 	}
 	struct sway_container *container =
 		config->handler_context.current_container;
-	if (!container->is_floating) {
+	if (!container_is_floating(container)) {
 		return cmd_results_new(CMD_FAILURE, "sticky",
 			"Can't set sticky on a tiled container");
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -756,7 +756,7 @@ void config_update_font_height(bool recalculate) {
 	for (int i = 0; i < root_container.children->length; ++i) {
 		struct sway_container *output = root_container.children->items[i];
 		for (int j = 0; j < output->children->length; ++j) {
-			struct sway_container *ws = output->children->items[i];
+			struct sway_container *ws = output->children->items[j];
 			container_for_each_descendant_dfs(ws->sway_workspace->floating,
 					find_font_height_iterator, &recalculate);
 		}

--- a/sway/config.c
+++ b/sway/config.c
@@ -26,6 +26,7 @@
 #include "sway/config.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/layout.h"
+#include "sway/tree/workspace.h"
 #include "cairo.h"
 #include "pango.h"
 #include "readline.h"
@@ -750,6 +751,16 @@ void config_update_font_height(bool recalculate) {
 
 	container_for_each_descendant_dfs(&root_container,
 			find_font_height_iterator, &recalculate);
+
+	// Also consider floating views
+	for (int i = 0; i < root_container.children->length; ++i) {
+		struct sway_container *output = root_container.children->items[i];
+		for (int j = 0; j < output->children->length; ++j) {
+			struct sway_container *ws = output->children->items[i];
+			container_for_each_descendant_dfs(ws->sway_workspace->floating,
+					find_font_height_iterator, &recalculate);
+		}
+	}
 
 	if (config->font_height != prev_max_height) {
 		arrange_root();

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -121,13 +121,13 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->floating) {
-		if (!view->swayc->is_floating) {
+		if (!container_is_floating(view->swayc)) {
 			return false;
 		}
 	}
 
 	if (criteria->tiling) {
-		if (view->swayc->is_floating) {
+		if (container_is_floating(view->swayc)) {
 			return false;
 		}
 	}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -121,12 +121,15 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->floating) {
-		// TODO
-		return false;
+		if (!view->swayc->is_floating) {
+			return false;
+		}
 	}
 
 	if (criteria->tiling) {
-		// TODO
+		if (view->swayc->is_floating) {
+			return false;
+		}
 	}
 
 	if (criteria->urgent) {

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -22,8 +22,6 @@ static const char *layout_to_str(enum sway_container_layout layout) {
 		return "L_STACKED";
 	case L_TABBED:
 		return "L_TABBED";
-	case L_FLOATING:
-		return "L_FLOATING";
 	case L_NONE:
 	default:
 		return "L_NONE";

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -22,10 +22,12 @@ static const char *layout_to_str(enum sway_container_layout layout) {
 		return "L_STACKED";
 	case L_TABBED:
 		return "L_TABBED";
+	case L_FLOATING:
+		return "L_FLOATING";
 	case L_NONE:
-	default:
 		return "L_NONE";
 	}
+	return "L_NONE";
 }
 
 static int draw_container(cairo_t *cairo, struct sway_container *container,

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -818,6 +818,7 @@ static void render_output(struct sway_output *output, struct timespec *when,
 		}
 	} else {
 		float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
+		wlr_renderer_clear(renderer, clear_color);
 
 		int nrects;
 		pixman_box32_t *rects = pixman_region32_rectangles(damage, &nrects);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -832,12 +832,13 @@ static void render_floating(struct sway_output *soutput,
 		for (int j = 0; j < output->children->length; ++j) {
 			struct sway_container *workspace = output->children->items[j];
 			struct sway_workspace *ws = workspace->sway_workspace;
-			bool ws_is_visible = workspace_is_visible(workspace);
+			if (!workspace_is_visible(workspace)) {
+				continue;
+			}
 			for (int k = 0; k < ws->floating->children->length; ++k) {
 				struct sway_container *floater =
 					ws->floating->children->items[k];
-				if ((ws_is_visible || floater->is_sticky)
-						&& floater_intersects_output(floater, soutput->swayc)) {
+				if (floater_intersects_output(floater, soutput->swayc)) {
 					render_floating_container(soutput, damage, floater);
 				}
 			}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -904,13 +904,12 @@ static void render_output(struct sway_output *output, struct timespec *when,
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
 		struct sway_container *focus = seat_get_focus(seat);
 		render_container(output, damage, workspace, focus == workspace);
+		render_floating(output, damage);
 
 		render_unmanaged(output, damage,
 			&root_container.sway_root->xwayland_unmanaged);
 		render_layer(output, damage,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
-
-		render_floating(output, damage);
 	}
 	render_layer(output, damage,
 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -767,18 +767,6 @@ static void render_container(struct sway_output *output,
 	}
 }
 
-static bool floater_intersects_output(struct sway_container *floater,
-		struct sway_container *output) {
-	struct wlr_box box = {
-		.x = floater->x,
-		.y = floater->y,
-		.width = floater->width,
-		.height = floater->height,
-	};
-	return wlr_output_layout_intersects(root_container.sway_root->output_layout,
-			output->sway_output->wlr_output, &box);
-}
-
 static void render_floating_container(struct sway_output *soutput,
 		pixman_region32_t *damage, struct sway_container *con) {
 	if (con->type == C_VIEW) {
@@ -824,9 +812,7 @@ static void render_floating(struct sway_output *soutput,
 			for (int k = 0; k < ws->floating->children->length; ++k) {
 				struct sway_container *floater =
 					ws->floating->children->items[k];
-				if (floater_intersects_output(floater, soutput->swayc)) {
-					render_floating_container(soutput, damage, floater);
-				}
+				render_floating_container(soutput, damage, floater);
 			}
 		}
 	}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -810,8 +810,13 @@ static void render_floating_container(struct sway_output *soutput,
 			title_texture = con->title_unfocused;
 			marks_texture = view->marks_unfocused;
 		}
-		render_titlebar(soutput, damage, con, con->x, con->y, con->width,
-				colors, title_texture, marks_texture);
+
+		if (con->sway_view->border == B_NORMAL) {
+			render_titlebar(soutput, damage, con, con->x, con->y, con->width,
+					colors, title_texture, marks_texture);
+		} else {
+			render_top_border(soutput, damage, con, colors);
+		}
 		render_view(soutput, damage, con, colors);
 	} else {
 		render_container(soutput, damage, con, false);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -124,8 +124,8 @@ static void output_view_for_each_surface(struct sway_view *view,
 		struct root_geometry *geo, wlr_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct render_data *data = user_data;
-	geo->x = view->x - data->output->wlr_output->lx;
-	geo->y = view->y - data->output->wlr_output->ly;
+	geo->x = view->x - data->output->swayc->x;
+	geo->y = view->y - data->output->swayc->y;
 	geo->width = view->surface->current->width;
 	geo->height = view->surface->current->height;
 	geo->rotation = 0; // TODO
@@ -453,10 +453,9 @@ static void render_titlebar(struct sway_output *output,
 		struct wlr_box texture_box;
 		wlr_texture_get_size(marks_texture,
 			&texture_box.width, &texture_box.height);
-		texture_box.x =
-			(x - output->wlr_output->lx + width - TITLEBAR_H_PADDING)
+		texture_box.x = (x - output->swayc->x + width - TITLEBAR_H_PADDING)
 			* output_scale - texture_box.width;
-		texture_box.y = (y - output->wlr_output->ly + TITLEBAR_V_PADDING)
+		texture_box.y = (y - output->swayc->y + TITLEBAR_V_PADDING)
 			* output_scale;
 
 		float matrix[9];
@@ -478,9 +477,9 @@ static void render_titlebar(struct sway_output *output,
 		struct wlr_box texture_box;
 		wlr_texture_get_size(title_texture,
 			&texture_box.width, &texture_box.height);
-		texture_box.x = (x - output->wlr_output->lx + TITLEBAR_H_PADDING)
+		texture_box.x = (x - output->swayc->x + TITLEBAR_H_PADDING)
 			* output_scale;
-		texture_box.y = (y - output->wlr_output->ly + TITLEBAR_V_PADDING)
+		texture_box.y = (y - output->swayc->y + TITLEBAR_V_PADDING)
 			* output_scale;
 
 		float matrix[9];

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -754,6 +754,8 @@ static void render_container(struct sway_output *output,
 	case L_TABBED:
 		render_container_tabbed(output, damage, con, parent_focused);
 		break;
+	case L_FLOATING:
+		sway_assert(false, "Didn't expect to see floating here");
 	}
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1147,7 +1147,7 @@ void output_damage_whole_container(struct sway_output *output,
 		.width = con->width,
 		.height = con->height,
 	};
-	if (con->is_floating) {
+	if (container_is_floating(con)) {
 		box.x -= output->wlr_output->lx;
 		box.y -= output->wlr_output->ly;
 	}

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -185,7 +185,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		view->natural_width = geometry->width;
 		view->natural_height = geometry->height;
 	}
-	if (view->swayc && view->swayc->is_floating) {
+	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, geometry->width, geometry->height);
 	} else {
 		view_update_size(view, xdg_shell_view->pending_width,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -87,7 +87,7 @@ static const char *get_string_prop(struct sway_view *view, enum sway_view_prop p
 	}
 }
 
-static void configure(struct sway_view *view, double ox, double oy, int width,
+static void configure(struct sway_view *view, double lx, double ly, int width,
 		int height) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		xdg_shell_view_from_view(view);
@@ -98,7 +98,7 @@ static void configure(struct sway_view *view, double ox, double oy, int width,
 	xdg_shell_view->pending_width = width;
 	xdg_shell_view->pending_height = height;
 	wlr_xdg_toplevel_set_size(view->wlr_xdg_surface, width, height);
-	view_update_position(view, ox, oy);
+	view_update_position(view, lx, ly);
 }
 
 static void set_activated(struct sway_view *view, bool activated) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -128,8 +128,10 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 static bool wants_floating(struct sway_view *view) {
-	// TODO
-	return false;
+	struct wlr_xdg_toplevel_state *state =
+		&view->wlr_xdg_surface->toplevel->current;
+	return state->min_width == state->max_width
+		&& state->min_height == state->max_height;
 }
 
 static void for_each_surface(struct sway_view *view,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -111,12 +111,12 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-static void set_maximized(struct sway_view *view, bool maximized) {
+static void set_tiled(struct sway_view *view, bool tiled) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
-	wlr_xdg_toplevel_set_maximized(surface, maximized);
+	wlr_xdg_toplevel_set_maximized(surface, tiled);
 }
 
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
@@ -168,7 +168,7 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_maximized = set_maximized,
+	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -111,14 +111,6 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-static void set_tiled(struct sway_view *view, bool tiled) {
-	if (xdg_shell_view_from_view(view) == NULL) {
-		return;
-	}
-	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
-	wlr_xdg_toplevel_set_maximized(surface, tiled);
-}
-
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return;
@@ -170,7 +162,6 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -182,13 +182,18 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
 	struct sway_view *view = &xdg_shell_view->view;
-	struct wlr_box *geometry = &view->wlr_xdg_surface->geometry;
+	int width = view->wlr_xdg_surface->geometry.width;
+	int height = view->wlr_xdg_surface->geometry.height;
+	if (!width && !height) {
+		width = view->wlr_xdg_surface->surface->current->width;
+		height = view->wlr_xdg_surface->surface->current->height;
+	}
 	if (!view->natural_width && !view->natural_height) {
-		view->natural_width = geometry->width;
-		view->natural_height = geometry->height;
+		view->natural_width = width;
+		view->natural_height = height;
 	}
 	if (view->swayc && container_is_floating(view->swayc)) {
-		view_update_size(view, geometry->width, geometry->height);
+		view_update_size(view, width, height);
 	} else {
 		view_update_size(view, xdg_shell_view->pending_width,
 				xdg_shell_view->pending_height);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -173,17 +173,13 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
 	struct sway_view *view = &xdg_shell_view->view;
-	int width = view->wlr_xdg_surface->geometry.width;
-	int height = view->wlr_xdg_surface->geometry.height;
-	if (!width && !height) {
-		width = view->wlr_xdg_surface->surface->current->width;
-		height = view->wlr_xdg_surface->surface->current->height;
-	}
-	if (!view->natural_width && !view->natural_height) {
-		view->natural_width = width;
-		view->natural_height = height;
-	}
 	if (view->swayc && container_is_floating(view->swayc)) {
+		int width = view->wlr_xdg_surface->geometry.width;
+		int height = view->wlr_xdg_surface->geometry.height;
+		if (!width && !height) {
+			width = view->wlr_xdg_surface->surface->current->width;
+			height = view->wlr_xdg_surface->surface->current->height;
+		}
 		view_update_size(view, width, height);
 	} else {
 		view_update_size(view, xdg_shell_view->pending_width,
@@ -216,6 +212,12 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_view->view;
 	struct wlr_xdg_surface *xdg_surface = view->wlr_xdg_surface;
 
+	view->natural_width = view->wlr_xdg_surface->geometry.width;
+	view->natural_height = view->wlr_xdg_surface->geometry.height;
+	if (!view->natural_width && !view->natural_height) {
+		view->natural_width = view->wlr_xdg_surface->surface->current->width;
+		view->natural_height = view->wlr_xdg_surface->surface->current->height;
+	}
 	view_map(view, view->wlr_xdg_surface->surface);
 
 	xdg_shell_view->commit.notify = handle_commit;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -122,7 +122,8 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 static bool wants_floating(struct sway_view *view) {
 	struct wlr_xdg_toplevel_state *state =
 		&view->wlr_xdg_surface->toplevel->current;
-	return state->min_width == state->max_width
+	return state->min_width != 0 && state->min_height != 0
+		&& state->min_width == state->max_width
 		&& state->min_height == state->max_height;
 }
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -98,6 +98,7 @@ static void configure(struct sway_view *view, double ox, double oy, int width,
 	xdg_shell_view->pending_width = width;
 	xdg_shell_view->pending_height = height;
 	wlr_xdg_toplevel_set_size(view->wlr_xdg_surface, width, height);
+	view_update_position(view, ox, oy);
 }
 
 static void set_activated(struct sway_view *view, bool activated) {
@@ -110,12 +111,25 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
+static void set_maximized(struct sway_view *view, bool maximized) {
+	if (xdg_shell_view_from_view(view) == NULL) {
+		return;
+	}
+	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
+	wlr_xdg_toplevel_set_maximized(surface, maximized);
+}
+
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
 	wlr_xdg_toplevel_set_fullscreen(surface, fullscreen);
+}
+
+static bool wants_floating(struct sway_view *view) {
+	// TODO
+	return false;
 }
 
 static void for_each_surface(struct sway_view *view,
@@ -154,7 +168,9 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
+	.set_maximized = set_maximized,
 	.set_fullscreen = set_fullscreen,
+	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
 	.close = _close,
 	.destroy = destroy,
@@ -164,11 +180,17 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
 	struct sway_view *view = &xdg_shell_view->view;
-	// NOTE: We intentionally discard the view's desired width here
-	// TODO: Store this for restoration when moving to floating plane
-	// TODO: Let floating views do whatever
-	view_update_size(view, xdg_shell_view->pending_width,
-		xdg_shell_view->pending_height);
+	struct wlr_box *geometry = &view->wlr_xdg_surface->geometry;
+	if (!view->natural_width && !view->natural_height) {
+		view->natural_width = geometry->width;
+		view->natural_height = geometry->height;
+	}
+	if (view->swayc && view->swayc->is_floating) {
+		view_update_size(view, geometry->width, geometry->height);
+	} else {
+		view_update_size(view, xdg_shell_view->pending_width,
+				xdg_shell_view->pending_height);
+	}
 	view_update_title(view, false);
 	view_damage_from(view);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -172,17 +172,13 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, commit);
 	struct sway_view *view = &xdg_shell_v6_view->view;
-	int width = view->wlr_xdg_surface_v6->geometry.width;
-	int height = view->wlr_xdg_surface_v6->geometry.height;
-	if (!width && !height) {
-		width = view->wlr_xdg_surface_v6->surface->current->width;
-		height = view->wlr_xdg_surface_v6->surface->current->height;
-	}
-	if (!view->natural_width && !view->natural_height) {
-		view->natural_width = width;
-		view->natural_height = height;
-	}
 	if (view->swayc && container_is_floating(view->swayc)) {
+		int width = view->wlr_xdg_surface_v6->geometry.width;
+		int height = view->wlr_xdg_surface_v6->geometry.height;
+		if (!width && !height) {
+			width = view->wlr_xdg_surface_v6->surface->current->width;
+			height = view->wlr_xdg_surface_v6->surface->current->height;
+		}
 		view_update_size(view, width, height);
 	} else {
 		view_update_size(view, xdg_shell_v6_view->pending_width,
@@ -215,6 +211,12 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_v6_view->view;
 	struct wlr_xdg_surface_v6 *xdg_surface = view->wlr_xdg_surface_v6;
 
+	view->natural_width = view->wlr_xdg_surface_v6->geometry.width;
+	view->natural_height = view->wlr_xdg_surface_v6->geometry.height;
+	if (!view->natural_width && !view->natural_height) {
+		view->natural_width = view->wlr_xdg_surface_v6->surface->current->width;
+		view->natural_height = view->wlr_xdg_surface_v6->surface->current->height;
+	}
 	view_map(view, view->wlr_xdg_surface_v6->surface);
 
 	xdg_shell_v6_view->commit.notify = handle_commit;

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -184,7 +184,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		view->natural_width = geometry->width;
 		view->natural_height = geometry->height;
 	}
-	if (view->swayc && view->swayc->is_floating) {
+	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, geometry->width, geometry->height);
 	} else {
 		view_update_size(view, xdg_shell_v6_view->pending_width,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -181,13 +181,18 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, commit);
 	struct sway_view *view = &xdg_shell_v6_view->view;
-	struct wlr_box *geometry = &view->wlr_xdg_surface_v6->geometry;
+	int width = view->wlr_xdg_surface_v6->geometry.width;
+	int height = view->wlr_xdg_surface_v6->geometry.height;
+	if (!width && !height) {
+		width = view->wlr_xdg_surface_v6->surface->current->width;
+		height = view->wlr_xdg_surface_v6->surface->current->height;
+	}
 	if (!view->natural_width && !view->natural_height) {
-		view->natural_width = geometry->width;
-		view->natural_height = geometry->height;
+		view->natural_width = width;
+		view->natural_height = height;
 	}
 	if (view->swayc && container_is_floating(view->swayc)) {
-		view_update_size(view, geometry->width, geometry->height);
+		view_update_size(view, width, height);
 	} else {
 		view_update_size(view, xdg_shell_v6_view->pending_width,
 				xdg_shell_v6_view->pending_height);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -110,14 +110,6 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-static void set_tiled(struct sway_view *view, bool tiled) {
-	if (xdg_shell_v6_view_from_view(view) == NULL) {
-		return;
-	}
-	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
-	wlr_xdg_toplevel_v6_set_maximized(surface, tiled);
-}
-
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
@@ -169,7 +161,6 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -110,12 +110,12 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-static void set_maximized(struct sway_view *view, bool maximized) {
+static void set_tiled(struct sway_view *view, bool tiled) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
-	wlr_xdg_toplevel_v6_set_maximized(surface, maximized);
+	wlr_xdg_toplevel_v6_set_maximized(surface, tiled);
 }
 
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
@@ -167,7 +167,7 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_maximized = set_maximized,
+	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -97,6 +97,7 @@ static void configure(struct sway_view *view, double ox, double oy, int width,
 	xdg_shell_v6_view->pending_width = width;
 	xdg_shell_v6_view->pending_height = height;
 	wlr_xdg_toplevel_v6_set_size(view->wlr_xdg_surface_v6, width, height);
+	view_update_position(view, ox, oy);
 }
 
 static void set_activated(struct sway_view *view, bool activated) {
@@ -109,12 +110,25 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
+static void set_maximized(struct sway_view *view, bool maximized) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
+		return;
+	}
+	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
+	wlr_xdg_toplevel_v6_set_maximized(surface, maximized);
+}
+
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xdg_surface_v6 *surface = view->wlr_xdg_surface_v6;
 	wlr_xdg_toplevel_v6_set_fullscreen(surface, fullscreen);
+}
+
+static bool wants_floating(struct sway_view *view) {
+	// TODO
+	return false;
 }
 
 static void for_each_surface(struct sway_view *view,
@@ -153,7 +167,9 @@ static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
 	.configure = configure,
 	.set_activated = set_activated,
+	.set_maximized = set_maximized,
 	.set_fullscreen = set_fullscreen,
+	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
 	.close = _close,
 	.destroy = destroy,
@@ -163,11 +179,17 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, commit);
 	struct sway_view *view = &xdg_shell_v6_view->view;
-	// NOTE: We intentionally discard the view's desired width here
-	// TODO: Store this for restoration when moving to floating plane
-	// TODO: Let floating views do whatever
-	view_update_size(view, xdg_shell_v6_view->pending_width,
-		xdg_shell_v6_view->pending_height);
+	struct wlr_box *geometry = &view->wlr_xdg_surface_v6->geometry;
+	if (!view->natural_width && !view->natural_height) {
+		view->natural_width = geometry->width;
+		view->natural_height = geometry->height;
+	}
+	if (view->swayc && view->swayc->is_floating) {
+		view_update_size(view, geometry->width, geometry->height);
+	} else {
+		view_update_size(view, xdg_shell_v6_view->pending_width,
+				xdg_shell_v6_view->pending_height);
+	}
 	view_update_title(view, false);
 	view_damage_from(view);
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -86,7 +86,7 @@ static const char *get_string_prop(struct sway_view *view, enum sway_view_prop p
 	}
 }
 
-static void configure(struct sway_view *view, double ox, double oy, int width,
+static void configure(struct sway_view *view, double lx, double ly, int width,
 		int height) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		xdg_shell_v6_view_from_view(view);
@@ -97,7 +97,7 @@ static void configure(struct sway_view *view, double ox, double oy, int width,
 	xdg_shell_v6_view->pending_width = width;
 	xdg_shell_v6_view->pending_height = height;
 	wlr_xdg_toplevel_v6_set_size(view->wlr_xdg_surface_v6, width, height);
-	view_update_position(view, ox, oy);
+	view_update_position(view, lx, ly);
 }
 
 static void set_activated(struct sway_view *view, bool activated) {

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -121,7 +121,8 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 static bool wants_floating(struct sway_view *view) {
 	struct wlr_xdg_toplevel_v6_state *state =
 		&view->wlr_xdg_surface_v6->toplevel->current;
-	return state->min_width == state->max_width
+	return state->min_width != 0 && state->min_height != 0
+		&& state->min_width == state->max_width
 		&& state->min_height == state->max_height;
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -127,8 +127,10 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 static bool wants_floating(struct sway_view *view) {
-	// TODO
-	return false;
+	struct wlr_xdg_toplevel_v6_state *state =
+		&view->wlr_xdg_surface_v6->toplevel->current;
+	return state->min_width == state->max_width
+		&& state->min_height == state->max_height;
 }
 
 static void for_each_surface(struct sway_view *view,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -201,22 +201,6 @@ static bool wants_floating(struct sway_view *view) {
 	//
 	// We also want to return true if the NET_WM_STATE is MODAL.
 	// wlroots doesn't appear to provide all this information at the moment.
-	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	uint32_t *atom = xsurface->window_type;
-	for (size_t i = 0; i < xsurface->window_type_len; ++i) {
-		wlr_log(L_DEBUG, "xwayland window type %i", *atom);
-		// TODO: Come up with a better way of doing this
-		switch (*atom) {
-		case 36: // NET_WM_WINDOW_TYPE_UTILITY
-		case 44: // NET_WM_WINDOW_TYPE_SPLASH
-		case 276: // ? PGP passphrase dialog
-		case 337: // ? Firefox open file dialog
-		case 338: // ? Firefox open file dialog
-			return true;
-		}
-		++atom;
-	}
-
 	return false;
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -152,39 +152,13 @@ static uint32_t get_int_prop(struct sway_view *view, enum sway_view_prop prop) {
 	}
 }
 
-// The x and y arguments are output-local for tiled views, and layout
-// coordinates for floating views.
-static void configure(struct sway_view *view, double x, double y, int width,
+static void configure(struct sway_view *view, double lx, double ly, int width,
 		int height) {
 	struct sway_xwayland_view *xwayland_view = xwayland_view_from_view(view);
 	if (xwayland_view == NULL) {
 		return;
 	}
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-
-	double lx, ly;
-	if (container_is_floating(view->swayc)) {
-		lx = x;
-		ly = y;
-	} else {
-		struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
-		if (!sway_assert(output, "view must be within tree to set position")) {
-			return;
-		}
-		struct sway_container *root = container_parent(output, C_ROOT);
-		if (!sway_assert(root, "output must be within tree to set position")) {
-			return;
-		}
-		struct wlr_output_layout *layout = root->sway_root->output_layout;
-		struct wlr_output_layout_output *loutput =
-			wlr_output_layout_get(layout, output->sway_output->wlr_output);
-		if (!sway_assert(loutput,
-					"output must be within layout to set position")) {
-			return;
-		}
-		lx = x + loutput->x;
-		ly = y + loutput->y;
-	}
 
 	xwayland_view->pending_width = width;
 	xwayland_view->pending_height = height;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -237,12 +237,12 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, xsurface->width, xsurface->height);
-		view_update_position(view,
-				xwayland_view->pending_lx, xwayland_view->pending_ly);
 	} else {
 		view_update_size(view, xwayland_view->pending_width,
 				xwayland_view->pending_height);
 	}
+	view_update_position(view,
+			xwayland_view->pending_lx, xwayland_view->pending_ly);
 	view_damage_from(view);
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -235,10 +235,6 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, xwayland_view, commit);
 	struct sway_view *view = &xwayland_view->view;
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
-	if (!view->natural_width && !view->natural_height) {
-		view->natural_width = xsurface->width;
-		view->natural_height = xsurface->height;
-	}
 	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, xsurface->width, xsurface->height);
 		view_update_position(view,
@@ -262,6 +258,9 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, xwayland_view, map);
 	struct wlr_xwayland_surface *xsurface = data;
 	struct sway_view *view = &xwayland_view->view;
+
+	view->natural_width = xsurface->width;
+	view->natural_height = xsurface->height;
 
 	// Wire up the commit listener here, because xwayland map/unmap can change
 	// the underlying wlr_surface

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -163,7 +163,7 @@ static void configure(struct sway_view *view, double x, double y, int width,
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 
 	double lx, ly;
-	if (view->swayc->is_floating) {
+	if (container_is_floating(view->swayc)) {
 		lx = x;
 		ly = y;
 	} else {
@@ -288,7 +288,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		view->natural_width = xsurface->width;
 		view->natural_height = xsurface->height;
 	}
-	if (view->swayc && view->swayc->is_floating) {
+	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, xsurface->width, xsurface->height);
 		view_update_position(view, xsurface->x, xsurface->y);
 	} else {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -199,12 +199,12 @@ static void set_activated(struct sway_view *view, bool activated) {
 	wlr_xwayland_surface_activate(surface, activated);
 }
 
-static void set_maximized(struct sway_view *view, bool maximized) {
+static void set_tiled(struct sway_view *view, bool tiled) {
 	if (xwayland_view_from_view(view) == NULL) {
 		return;
 	}
 	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
-	wlr_xwayland_surface_set_maximized(surface, maximized);
+	wlr_xwayland_surface_set_maximized(surface, tiled);
 }
 
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
@@ -272,7 +272,7 @@ static const struct sway_view_impl view_impl = {
 	.get_int_prop = get_int_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_maximized = set_maximized,
+	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.close = _close,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -175,14 +175,6 @@ static void set_activated(struct sway_view *view, bool activated) {
 	wlr_xwayland_surface_activate(surface, activated);
 }
 
-static void set_tiled(struct sway_view *view, bool tiled) {
-	if (xwayland_view_from_view(view) == NULL) {
-		return;
-	}
-	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
-	wlr_xwayland_surface_set_maximized(surface, tiled);
-}
-
 static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	if (xwayland_view_from_view(view) == NULL) {
 		return;
@@ -232,7 +224,6 @@ static const struct sway_view_impl view_impl = {
 	.get_int_prop = get_int_prop,
 	.configure = configure,
 	.set_activated = set_activated,
-	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.close = _close,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -160,6 +160,8 @@ static void configure(struct sway_view *view, double lx, double ly, int width,
 	}
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 
+	xwayland_view->pending_lx = lx;
+	xwayland_view->pending_ly = ly;
 	xwayland_view->pending_width = width;
 	xwayland_view->pending_height = height;
 	wlr_xwayland_surface_configure(xsurface, lx, ly, width, height);
@@ -264,7 +266,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	}
 	if (view->swayc && container_is_floating(view->swayc)) {
 		view_update_size(view, xsurface->width, xsurface->height);
-		view_update_position(view, xsurface->x, xsurface->y);
+		view_update_position(view,
+				xwayland_view->pending_lx, xwayland_view->pending_ly);
 	} else {
 		view_update_size(view, xwayland_view->pending_width,
 				xwayland_view->pending_height);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -46,7 +46,7 @@ static struct wlr_surface *layer_surface_at(struct sway_output *output,
  * location, it is stored in **surface (it may not be a view).
  */
 static struct sway_container *container_at_coords(
-		struct sway_seat *seat, double x, double y,
+		struct sway_seat *seat, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	// check for unmanaged views first
 	struct wl_list *unmanaged = &root_container.sway_root->xwayland_unmanaged;
@@ -55,8 +55,8 @@ static struct sway_container *container_at_coords(
 		struct wlr_xwayland_surface *xsurface =
 			unmanaged_surface->wlr_xwayland_surface;
 
-		double _sx = x - unmanaged_surface->lx;
-		double _sy = y - unmanaged_surface->ly;
+		double _sx = lx - unmanaged_surface->lx;
+		double _sy = ly - unmanaged_surface->ly;
 		if (wlr_surface_point_accepts_input(xsurface->surface, _sx, _sy)) {
 			*surface = xsurface->surface;
 			*sx = _sx;
@@ -69,12 +69,12 @@ static struct sway_container *container_at_coords(
 	struct wlr_output_layout *output_layout =
 		root_container.sway_root->output_layout;
 	struct wlr_output *wlr_output = wlr_output_layout_output_at(
-			output_layout, x, y);
+			output_layout, lx, ly);
 	if (wlr_output == NULL) {
 		return NULL;
 	}
 	struct sway_output *output = wlr_output->data;
-	double ox = x, oy = y;
+	double ox = lx, oy = ly;
 	wlr_output_layout_output_coords(output_layout, wlr_output, &ox, &oy);
 
 	// find the focused workspace on the output for this seat
@@ -108,10 +108,10 @@ static struct sway_container *container_at_coords(
 	}
 
 	struct sway_container *c;
-	if ((c = floating_container_at(x, y, surface, sx, sy))) {
+	if ((c = floating_container_at(lx, ly, surface, sx, sy))) {
 		return c;
 	}
-	if ((c = container_at(ws, ox, oy, surface, sx, sy))) {
+	if ((c = container_at(ws, lx, ly, surface, sx, sy))) {
 		return c;
 	}
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -108,6 +108,9 @@ static struct sway_container *container_at_coords(
 	}
 
 	struct sway_container *c;
+	if ((c = floating_container_at(x, y, surface, sx, sy))) {
+		return c;
+	}
 	if ((c = container_at(ws, ox, oy, surface, sx, sy))) {
 		return c;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -601,10 +601,8 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 		if (config->mouse_warping && warp) {
 			if (new_output && last_output && new_output != last_output) {
-				double x = new_output->x + container->x +
-					container->width / 2.0;
-				double y = new_output->y + container->y +
-					container->height / 2.0;
+				double x = container->x + container->width / 2.0;
+				double y = container->y + container->height / 2.0;
 				struct wlr_output *wlr_output =
 					new_output->sway_output->wlr_output;
 				if (!wlr_output_layout_contains_point(

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -113,7 +113,14 @@ static void seat_send_focus(struct sway_container *con,
 
 static struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		struct sway_container *container, enum sway_container_type type) {
-	if (container->type == C_VIEW || container->children->length == 0) {
+	if (container->type == C_VIEW) {
+		return container;
+	}
+
+	struct sway_container *floating = container->type == C_WORKSPACE ?
+		container->sway_workspace->floating : NULL;
+	if (container->children->length == 0 &&
+			(!floating || floating->children->length == 0)) {
 		return container;
 	}
 
@@ -124,6 +131,9 @@ static struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 		}
 
 		if (container_has_child(container, current->container)) {
+			return current->container;
+		}
+		if (floating && container_has_child(floating, current->container)) {
 			return current->container;
 		}
 	}
@@ -568,7 +578,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 	// clean up unfocused empty workspace on new output
 	if (new_output_last_ws) {
 		if (!workspace_is_visible(new_output_last_ws)
-				&& new_output_last_ws->children->length == 0) {
+				&& workspace_is_empty(new_output_last_ws)) {
 			if (last_workspace == new_output_last_ws) {
 				last_focus = NULL;
 				last_workspace = NULL;
@@ -581,7 +591,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		if (last_workspace) {
 			ipc_event_workspace(last_workspace, container, "focus");
 			if (!workspace_is_visible(last_workspace)
-					&& last_workspace->children->length == 0) {
+					&& workspace_is_empty(last_workspace)) {
 				if (last_workspace == last_focus) {
 					last_focus = NULL;
 				}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -21,8 +21,6 @@ static const char *ipc_json_layout_description(enum sway_container_layout l) {
 		return "tabbed";
 	case L_STACKED:
 		return "stacked";
-	case L_FLOATING:
-		return "floating";
 	case L_NONE:
 		break;
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -22,6 +22,8 @@ static const char *ipc_json_layout_description(enum sway_container_layout l) {
 		return "tabbed";
 	case L_STACKED:
 		return "stacked";
+	case L_FLOATING:
+		return "floating";
 	case L_NONE:
 		break;
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -4,6 +4,7 @@
 #include "log.h"
 #include "sway/ipc-json.h"
 #include "sway/tree/container.h"
+#include "sway/tree/workspace.h"
 #include "sway/output.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -150,6 +151,15 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 
 	const char *layout = ipc_json_layout_description(workspace->layout);
 	json_object_object_add(object, "layout", json_object_new_string(layout));
+
+	// Floating
+	json_object *floating_array = json_object_new_array();
+	struct sway_container *floating = workspace->sway_workspace->floating;
+	for (int i = 0; i < floating->children->length; ++i) {
+		struct sway_container *floater = floating->children->items[i];
+		json_object_array_add(floating_array, ipc_json_describe_container_recursive(floater));
+	}
+	json_object_object_add(object, "floating_nodes", floating_array);
 }
 
 static void ipc_json_describe_view(struct sway_container *c, json_object *object) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -36,6 +36,7 @@ sway_sources = files(
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',
+	'commands/floating.c',
 	'commands/focus.c',
 	'commands/focus_follows_mouse.c',
 	'commands/focus_wrapping.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -65,6 +65,7 @@ sway_sources = files(
 	'commands/set.c',
 	'commands/show_marks.c',
 	'commands/split.c',
+	'commands/sticky.c',
 	'commands/swaybg_command.c',
 	'commands/swap.c',
 	'commands/title_format.c',

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -73,8 +73,8 @@ void arrange_workspace(struct sway_container *workspace) {
 			area->width, area->height, area->x, area->y);
 	workspace->width = area->width;
 	workspace->height = area->height;
-	workspace->x = area->x;
-	workspace->y = area->y;
+	workspace->x = output->x + area->x;
+	workspace->y = output->y + area->y;
 	wlr_log(L_DEBUG, "Arranging workspace '%s' at %f, %f",
 			workspace->name, workspace->x, workspace->y);
 	arrange_children_of(workspace);

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -247,6 +247,18 @@ void arrange_children_of(struct sway_container *parent) {
 			arrange_children_of(child);
 		}
 	}
+
+	// If container is a workspace, process floating containers too
+	if (parent->type == C_WORKSPACE) {
+		struct sway_workspace *ws = workspace->sway_workspace;
+		for (int i = 0; i < ws->floating->children->length; ++i) {
+			struct sway_container *child = ws->floating->children->items[i];
+			if (child->type != C_VIEW) {
+				arrange_children_of(child);
+			}
+		}
+	}
+
 	container_damage_whole(parent);
 	update_debug_tree();
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -930,23 +930,23 @@ void container_set_floating(struct sway_container *container, bool enable) {
 	container_damage_whole(container);
 }
 
-void container_set_geometry_from_view(struct sway_container *container) {
-	if (!sway_assert(container->type == C_VIEW, "Expected a view")) {
+void container_set_geometry_from_floating_view(struct sway_container *con) {
+	if (!sway_assert(con->type == C_VIEW, "Expected a view")) {
 		return;
 	}
-	if (!sway_assert(container_is_floating(container),
+	if (!sway_assert(container_is_floating(con),
 				"Expected a floating view")) {
 		return;
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = con->sway_view;
 	size_t border_width = view->border_thickness * (view->border != B_NONE);
 	size_t top =
 		view->border == B_NORMAL ? container_titlebar_height() : border_width;
 
-	container->x = view->x - border_width;
-	container->y = view->y - top;
-	container->width = view->width + border_width * 2;
-	container->height = top + view->height + border_width;
+	con->x = view->x - border_width;
+	con->y = view->y - top;
+	con->width = view->width + border_width * 2;
+	con->height = top + view->height + border_width;
 }
 
 bool container_self_or_parent_floating(struct sway_container *container) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -920,9 +920,6 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_add_child(workspace, container);
 		container->width = container->parent->width;
 		container->height = container->parent->height;
-		if (container->type == C_VIEW) {
-			view_set_tiled(container->sway_view, true);
-		}
 		container->is_sticky = false;
 		container_reap_empty_recursive(workspace->sway_workspace->floating);
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -921,7 +921,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container->width = container->parent->width;
 		container->height = container->parent->height;
 		if (container->type == C_VIEW) {
-			view_set_maximized(container->sway_view, true);
+			view_set_tiled(container->sway_view, true);
 		}
 		container->is_sticky = false;
 		container_reap_empty_recursive(workspace->sway_workspace->floating);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -123,7 +123,6 @@ struct sway_container *container_create(enum sway_container_type type) {
 	c->layout = L_NONE;
 	c->type = type;
 	c->alpha = 1.0f;
-	c->reapable = true;
 
 	if (type != C_VIEW) {
 		c->children = create_list();
@@ -280,7 +279,8 @@ static void container_root_finish(struct sway_container *con) {
 }
 
 bool container_reap_empty(struct sway_container *con) {
-	if (!con->reapable) {
+	if (con->layout == L_FLOATING) {
+		// Don't reap the magical floating container that each workspace has
 		return false;
 	}
 	switch (con->type) {
@@ -618,6 +618,9 @@ struct sway_container *container_at(struct sway_container *parent,
 		return container_at_tabbed(parent, ox, oy, surface, sx, sy);
 	case L_STACKED:
 		return container_at_stacked(parent, ox, oy, surface, sx, sy);
+	case L_FLOATING:
+		sway_assert(false, "Didn't expect to see floating here");
+		return NULL;
 	case L_NONE:
 		return NULL;
 	}
@@ -841,6 +844,9 @@ static size_t get_tree_representation(struct sway_container *parent, char *buffe
 		break;
 	case L_STACKED:
 		lenient_strcat(buffer, "S[");
+		break;
+	case L_FLOATING:
+		strcpy(buffer, "F[");
 		break;
 	case L_NONE:
 		lenient_strcat(buffer, "D[");

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -906,23 +906,6 @@ size_t container_titlebar_height() {
 	return config->font_height + TITLEBAR_V_PADDING * 2;
 }
 
-static void configure_floating_view(struct sway_view *view) {
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	int max_width = ws->width * 0.6666;
-	int max_height = ws->height * 0.6666;
-	int width =
-		view->natural_width > max_width ? max_width : view->natural_width;
-	int height =
-		view->natural_height > max_height ? max_height : view->natural_height;
-	struct sway_container *output = ws->parent;
-	int lx = output->x + (ws->width - width) / 2;
-	int ly = output->y + (ws->height - height) / 2;
-
-	view->border_left = view->border_right = view->border_bottom = true;
-	view_set_maximized(view, false);
-	view_configure(view, lx, ly, width, height);
-}
-
 void container_set_floating(struct sway_container *container, bool enable) {
 	if (container_is_floating(container) == enable) {
 		return;
@@ -936,7 +919,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_remove_child(container);
 		container_add_child(workspace->sway_workspace->floating, container);
 		if (container->type == C_VIEW) {
-			configure_floating_view(container->sway_view);
+			view_autoconfigure(container->sway_view);
 		}
 		seat_set_focus(seat, seat_get_focus_inactive(seat, container));
 		container_reap_empty_recursive(workspace);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -949,15 +949,6 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 	con->height = top + view->height + border_width;
 }
 
-bool container_self_or_parent_floating(struct sway_container *container) {
-	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
-	if (!workspace) {
-		return false;
-	}
-	return container_has_anscestor(container,
-			workspace->sway_workspace->floating);
-}
-
 bool container_is_floating(struct sway_container *container) {
 	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
 	if (!workspace) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -680,26 +680,6 @@ static struct sway_container *get_swayc_in_output_direction(
 	return ws;
 }
 
-static void get_layout_center_position(struct sway_container *container,
-		int *x, int *y) {
-	// FIXME view coords are inconsistently referred to in layout/output systems
-	if (container->type == C_OUTPUT) {
-		*x = container->x + container->width/2;
-		*y = container->y + container->height/2;
-	} else {
-		struct sway_container *output = container_parent(container, C_OUTPUT);
-		if (container->type == C_WORKSPACE) {
-			// Workspace coordinates are actually wrong/arbitrary, but should
-			// be same as output.
-			*x = output->x;
-			*y = output->y;
-		} else {
-			*x = output->x + container->x;
-			*y = output->y + container->y;
-		}
-	}
-}
-
 static struct sway_container *sway_output_from_wlr(struct wlr_output *output) {
 	if (output == NULL) {
 		return NULL;
@@ -755,8 +735,8 @@ struct sway_container *container_get_in_direction(
 						"got invalid direction: %d", dir)) {
 				return NULL;
 			}
-			int lx, ly;
-			get_layout_center_position(container, &lx, &ly);
+			int lx = container->x + container->width / 2;
+			int ly = container->y + container->height / 2;
 			struct wlr_output_layout *layout =
 				root_container.sway_root->output_layout;
 			struct wlr_output *wlr_adjacent =

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -154,7 +154,7 @@ void container_move_to(struct sway_container *container,
 			|| container_has_ancestor(container, destination)) {
 		return;
 	}
-	if (container->is_floating) {
+	if (container_is_floating(container)) {
 		// TODO
 		return;
 	}
@@ -718,7 +718,7 @@ struct sway_container *container_get_in_direction(
 		enum movement_direction dir) {
 	struct sway_container *parent = container->parent;
 
-	if (container->is_floating) {
+	if (container_is_floating(container)) {
 		return NULL;
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -139,7 +139,7 @@ static void view_autoconfigure_floating(struct sway_view *view) {
 	int ly = output->y + (ws->height - height) / 2;
 
 	view->border_left = view->border_right = view->border_bottom = true;
-	view_set_maximized(view, false);
+	view_set_tiled(view, false);
 	view_configure(view, lx, ly, width, height);
 }
 
@@ -257,9 +257,9 @@ void view_set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-void view_set_maximized(struct sway_view *view, bool maximized) {
-	if (view->impl->set_maximized) {
-		view->impl->set_maximized(view, maximized);
+void view_set_tiled(struct sway_view *view, bool tiled) {
+	if (view->impl->set_tiled) {
+		view->impl->set_tiled(view, tiled);
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -554,13 +554,12 @@ void view_update_position(struct sway_view *view, double lx, double ly) {
 	if (view->x == lx && view->y == ly) {
 		return;
 	}
-	if (!container_is_floating(view->swayc)) {
-		return;
-	}
 	container_damage_whole(view->swayc);
 	view->x = lx;
 	view->y = ly;
-	container_set_geometry_from_floating_view(view->swayc);
+	if (container_is_floating(view->swayc)) {
+		container_set_geometry_from_floating_view(view->swayc);
+	}
 	container_damage_whole(view->swayc);
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -274,6 +274,10 @@ void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen) {
 			view_set_fullscreen(workspace->sway_workspace->fullscreen, false);
 		}
 		workspace->sway_workspace->fullscreen = view;
+		view->saved_x = view->x;
+		view->saved_y = view->y;
+		view->saved_width = view->width;
+		view->saved_height = view->height;
 		view->swayc->saved_x = view->swayc->x;
 		view->swayc->saved_y = view->swayc->y;
 		view->swayc->saved_width = view->swayc->width;
@@ -296,11 +300,12 @@ void view_set_fullscreen_raw(struct sway_view *view, bool fullscreen) {
 		}
 	} else {
 		workspace->sway_workspace->fullscreen = NULL;
-		view->swayc->width = view->swayc->saved_width;
-		view->swayc->height = view->swayc->saved_height;
 		if (container_is_floating(view->swayc)) {
-			view->swayc->x = view->swayc->saved_x;
-			view->swayc->y = view->swayc->saved_y;
+			view_configure(view, view->saved_x, view->saved_y,
+					view->saved_width, view->saved_height);
+		} else {
+			view->swayc->width = view->swayc->saved_width;
+			view->swayc->height = view->swayc->saved_height;
 			view_autoconfigure(view);
 		}
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -458,7 +458,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	}
 	// If we're about to launch the view into the floating container, then
 	// launch it as a tiled view in the root of the workspace instead.
-	if (focus->is_floating) {
+	if (container_is_floating(focus)) {
 		focus = focus->parent->parent;
 	}
 	free(criterias);
@@ -531,7 +531,7 @@ void view_unmap(struct sway_view *view) {
 }
 
 void view_update_position(struct sway_view *view, double lx, double ly) {
-	if (!view->swayc->is_floating) {
+	if (!container_is_floating(view->swayc)) {
 		return;
 	}
 	container_damage_whole(view->swayc);
@@ -548,7 +548,7 @@ void view_update_size(struct sway_view *view, int width, int height) {
 	container_damage_whole(view->swayc);
 	view->width = width;
 	view->height = height;
-	if (view->swayc->is_floating) {
+	if (container_is_floating(view->swayc)) {
 		container_set_geometry_from_view(view->swayc);
 	}
 	container_damage_whole(view->swayc);
@@ -904,15 +904,15 @@ bool view_is_visible(struct sway_view *view) {
 		container_parent(view->swayc, C_WORKSPACE);
 	// Determine if view is nested inside a floating container which is sticky.
 	// A simple floating view will have this ancestry:
-	// C_VIEW (is_floating=true) -> floating -> workspace
+	// C_VIEW -> floating -> workspace
 	// A more complex ancestry could be:
-	// C_VIEW -> C_CONTAINER (tabbed and is_floating) -> floating -> workspace
+	// C_VIEW -> C_CONTAINER (tabbed) -> floating -> workspace
 	struct sway_container *floater = view->swayc;
 	while (floater->parent->type != C_WORKSPACE
 			&& floater->parent->parent->type != C_WORKSPACE) {
 		floater = floater->parent;
 	}
-	bool is_sticky = floater->is_floating && floater->is_sticky;
+	bool is_sticky = container_is_floating(floater) && floater->is_sticky;
 	// Check view isn't in a tabbed or stacked container on an inactive tab
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *container = view->swayc;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -138,7 +138,6 @@ static void view_autoconfigure_floating(struct sway_view *view) {
 	int ly = ws->y + (ws->height - height) / 2;
 
 	view->border_left = view->border_right = view->border_bottom = true;
-	view_set_tiled(view, false);
 	view_configure(view, lx, ly, width, height);
 }
 
@@ -252,12 +251,6 @@ void view_autoconfigure(struct sway_view *view) {
 void view_set_activated(struct sway_view *view, bool activated) {
 	if (view->impl->set_activated) {
 		view->impl->set_activated(view, activated);
-	}
-}
-
-void view_set_tiled(struct sway_view *view, bool tiled) {
-	if (view->impl->set_tiled) {
-		view->impl->set_tiled(view, tiled);
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -567,7 +567,7 @@ void view_update_position(struct sway_view *view, double lx, double ly) {
 	container_damage_whole(view->swayc);
 	view->x = lx;
 	view->y = ly;
-	container_set_geometry_from_view(view->swayc);
+	container_set_geometry_from_floating_view(view->swayc);
 	container_damage_whole(view->swayc);
 }
 
@@ -579,7 +579,7 @@ void view_update_size(struct sway_view *view, int width, int height) {
 	view->width = width;
 	view->height = height;
 	if (container_is_floating(view->swayc)) {
-		container_set_geometry_from_view(view->swayc);
+		container_set_geometry_from_floating_view(view->swayc);
 	}
 	container_damage_whole(view->swayc);
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -119,10 +119,10 @@ const char *view_get_shell(struct sway_view *view) {
 	return "unknown";
 }
 
-void view_configure(struct sway_view *view, double ox, double oy, int width,
+void view_configure(struct sway_view *view, double lx, double ly, int width,
 		int height) {
 	if (view->impl->configure) {
-		view->impl->configure(view, ox, oy, width, height);
+		view->impl->configure(view, lx, ly, width, height);
 	}
 }
 
@@ -134,9 +134,8 @@ static void view_autoconfigure_floating(struct sway_view *view) {
 		view->natural_width > max_width ? max_width : view->natural_width;
 	int height =
 		view->natural_height > max_height ? max_height : view->natural_height;
-	struct sway_container *output = ws->parent;
-	int lx = output->x + (ws->width - width) / 2;
-	int ly = output->y + (ws->height - height) / 2;
+	int lx = ws->x + (ws->width - width) / 2;
+	int ly = ws->y + (ws->height - height) / 2;
 
 	view->border_left = view->border_right = view->border_bottom = true;
 	view_set_tiled(view, false);
@@ -152,8 +151,7 @@ void view_autoconfigure(struct sway_view *view) {
 	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
 
 	if (view->is_fullscreen) {
-		view_configure(view, 0, 0, output->width, output->height);
-		view->x = view->y = 0;
+		view_configure(view, output->x, output->y, output->width, output->height);
 		return;
 	}
 
@@ -560,6 +558,9 @@ void view_unmap(struct sway_view *view) {
 }
 
 void view_update_position(struct sway_view *view, double lx, double ly) {
+	if (view->x == lx && view->y == ly) {
+		return;
+	}
 	if (!container_is_floating(view->swayc)) {
 		return;
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -387,13 +387,37 @@ bool workspace_switch(struct sway_container *workspace) {
 		strcpy(prev_workspace_name, active_ws->name);
 	}
 
-	// TODO: Deal with sticky containers
+	// Move sticky containers to new workspace
+	struct sway_container *next_output = workspace->parent;
+	struct sway_container *next_output_prev_ws =
+		seat_get_active_child(seat, next_output);
+	struct sway_container *floating =
+		next_output_prev_ws->sway_workspace->floating;
+	bool has_sticky = false;
+	for (int i = 0; i < floating->children->length; ++i) {
+		struct sway_container *floater = floating->children->items[i];
+		if (floater->is_sticky) {
+			has_sticky = true;
+			container_remove_child(floater);
+			container_add_child(workspace->sway_workspace->floating, floater);
+		}
+	}
 
 	wlr_log(L_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);
 	struct sway_container *next = seat_get_focus_inactive(seat, workspace);
 	if (next == NULL) {
 		next = workspace;
+	}
+	if (has_sticky) {
+		// If there's a sticky container, we might be setting focus to the same
+		// container that's already focused, so seat_set_focus is effectively a
+		// no op. We therefore need to send the IPC event and clean up the old
+		// workspace here.
+		ipc_event_workspace(active_ws, workspace, "focus");
+		if (!workspace_is_visible(active_ws) && workspace_is_empty(active_ws)) {
+			container_destroy(active_ws);
+		}
 	}
 	seat_set_focus(seat, next);
 	struct sway_container *output = container_parent(workspace, C_OUTPUT);
@@ -418,8 +442,13 @@ bool workspace_is_empty(struct sway_container *ws) {
 	if (ws->children->length) {
 		return false;
 	}
-	if (ws->sway_workspace->floating->children->length) {
-		return false;
+	// Sticky views are not considered to be part of this workspace
+	struct sway_container *floating = ws->sway_workspace->floating;
+	for (int i = 0; i < floating->children->length; ++i) {
+		struct sway_container *floater = floating->children->items[i];
+		if (!floater->is_sticky) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -12,6 +12,7 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"
+#include "list.h"
 #include "log.h"
 #include "util.h"
 
@@ -64,6 +65,7 @@ struct sway_container *workspace_create(struct sway_container *output,
 		return NULL;
 	}
 	swayws->swayc = workspace;
+	swayws->floating = create_list();
 	workspace->sway_workspace = swayws;
 
 	container_add_child(output, workspace);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -65,7 +65,9 @@ struct sway_container *workspace_create(struct sway_container *output,
 		return NULL;
 	}
 	swayws->swayc = workspace;
-	swayws->floating = create_list();
+	swayws->floating = container_create(C_CONTAINER);
+	swayws->floating->parent = swayws->swayc;
+	swayws->floating->reapable = false;
 	workspace->sway_workspace = swayws;
 
 	container_add_child(output, workspace);
@@ -407,4 +409,17 @@ bool workspace_is_visible(struct sway_container *ws) {
 		focus = container_parent(focus, C_WORKSPACE);
 	}
 	return focus == ws;
+}
+
+bool workspace_is_empty(struct sway_container *ws) {
+	if (!sway_assert(ws->type == C_WORKSPACE, "Expected a workspace")) {
+		return false;
+	}
+	if (ws->children->length) {
+		return false;
+	}
+	if (ws->sway_workspace->floating->children->length) {
+		return false;
+	}
+	return true;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -67,7 +67,7 @@ struct sway_container *workspace_create(struct sway_container *output,
 	swayws->swayc = workspace;
 	swayws->floating = container_create(C_CONTAINER);
 	swayws->floating->parent = swayws->swayc;
-	swayws->floating->reapable = false;
+	swayws->floating->layout = L_FLOATING;
 	workspace->sway_workspace = swayws;
 
 	container_add_child(output, workspace);


### PR DESCRIPTION
This implements basic floating features. You can float views, unfloat views, make them sticky and unsticky, and click to focus/unfocus them. You cannot move or resize them.

I was going to make it so you can float `C_CONTAINER`s in this PR, but there were some issues and I wanted to get this in front of everyone for review, so I blocked off that functionality. There's still bits in the code where it handles `C_CONTAINER`s being floated though.

This PR has a known issue with floating xdg_shell views when using multiple outputs. If floating the view on the left output, I'm experiencing a flickering copy of the container at the same output-local position on the right output. This does not happen for xwayland views. I can't see what I'm doing wrong, so if someone can assist me with that then that would be appreciated.

I went with the approach of having a `sway_workspace->floating` property, but I made it a `struct sway_container *` rather than a `list_t`. Using a container makes it easier to pass to functions that expect to be given a container. This `floating` container is created at workspace creation, destroyed at workspace destruction, and is immune to reaping. The type of this container is `C_CONTAINER` and the layout is irrelevant and never used.

Each view implementation has a new `wants_floating` function, which allows the implementation to inspect the view and determine if it should be floating or not. There's a basic/terrible implementation for xwayland already done, but there needs to be some discussion on how to do this properly. Perhaps wlroots should expose its own list of window types so we don't have to use the xcb library. At the moment I'm using magic numbers, but this is a temporary solution.

Test plan:

* Use as daily driver
* Float and unfloat things
* Make things sticky and unsticky
* Use multiple outputs

My preference is to implement the move/resize commands and floating `C_CONTAINER`s as separate PRs.