### PR TITLE
Arrange views after flattening the parent

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -327,9 +327,11 @@ void container_move(struct sway_container *container,
 		current = container_parent(container, C_OUTPUT);
 	}
 
-	if (parent != container_flatten(parent)) {
+	struct sway_container *new_parent = container_flatten(parent);
+	if (new_parent != parent) {
 		// Special case: we were the last one in this container, so flatten it
 		// and leave
+		arrange_children_of(new_parent);
 		update_debug_tree();
 		return;
 	}


### PR DESCRIPTION
Fixes #2029.

To test:

* Created a tabbed layout with some views
* Focus a view and run `splitv` or `splith` (tree should be something like `T[view, view, V[view]]`)
* Run `move left` (tree should be `T[view, view, view]`)

Before the PR, the view would be offset from the title bar until the tabbed container is next arranged. After the PR, it shows correctly as a regular tab.