### PR TITLE
Clean up container title functions

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -55,6 +55,20 @@ void strip_quotes(char *str) {
 	*end = '\0';
 }
 
+char *lenient_strcat(char *dest, const char *src) {
+	if (dest && src) {
+		return strcat(dest, src);
+	}
+	return dest;
+}
+
+char *lenient_strncat(char *dest, const char *src, size_t len) {
+	if (dest && src) {
+		return strncat(dest, src, len);
+	}
+	return dest;
+}
+
 // strcmp that also handles null pointers.
 int lenient_strcmp(char *a, char *b) {
 	if (a == b) {

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -1,5 +1,6 @@
 #ifndef _SWAY_STRINGOP_H
 #define _SWAY_STRINGOP_H
+#include <stdlib.h>
 #include "list.h"
 
 #if !HAVE_DECL_SETENV
@@ -13,6 +14,10 @@ extern const char whitespace[];
 char *strip_whitespace(char *str);
 char *strip_comments(char *str);
 void strip_quotes(char *str);
+
+// strcat that does nothing if dest or src is NULL
+char *lenient_strcat(char *dest, const char *src);
+char *lenient_strncat(char *dest, const char *src, size_t len);
 
 // strcmp that also handles null pointers.
 int lenient_strcmp(char *a, char *b);

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -216,7 +216,11 @@ void container_update_title_textures(struct sway_container *container);
  */
 void container_calculate_title_height(struct sway_container *container);
 
-void container_notify_child_title_changed(struct sway_container *container);
+/**
+ * Notify a container that a tree modification has changed in its children,
+ * so the container can update its tree representation.
+ */
+void container_notify_subtree_changed(struct sway_container *container);
 
 /**
  * Return the height of a regular title bar.

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -52,6 +52,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 	}
 
+	container_notify_subtree_changed(parent);
 	arrange_children_of(parent);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -149,7 +149,7 @@ struct sway_container *container_remove_child(struct sway_container *child) {
 		}
 	}
 	child->parent = NULL;
-	container_notify_child_title_changed(parent);
+	container_notify_subtree_changed(parent);
 
 	return parent;
 }
@@ -184,8 +184,8 @@ void container_move_to(struct sway_container *container,
 		container_sort_workspaces(new_parent);
 		seat_set_focus(seat, new_parent);
 	}
-	container_notify_child_title_changed(old_parent);
-	container_notify_child_title_changed(new_parent);
+	container_notify_subtree_changed(old_parent);
+	container_notify_subtree_changed(new_parent);
 	if (old_parent) {
 		if (old_parent->type == C_OUTPUT) {
 			arrange_output(old_parent);
@@ -497,8 +497,8 @@ void container_move(struct sway_container *container,
 		}
 	}
 
-	container_notify_child_title_changed(old_parent);
-	container_notify_child_title_changed(container->parent);
+	container_notify_subtree_changed(old_parent);
+	container_notify_subtree_changed(container->parent);
 
 	if (old_parent) {
 		seat_set_focus(config->handler_context.seat, old_parent);
@@ -847,7 +847,7 @@ struct sway_container *container_split(struct sway_container *child,
 		container_add_child(cont, child);
 	}
 
-	container_notify_child_title_changed(cont);
+	container_notify_subtree_changed(cont);
 
 	return cont;
 }


### PR DESCRIPTION
This is mostly a code cleanup PR. The only functional change is fixing a minor bug (5th bullet point).

* Add and use `lenient_strcat` and `lenient_strncat` functions
* Rename `concatenate_child_titles` function as that's no longer what it does
* Rename `container_notify_child_title_changed` because we only need to notify that the tree structure has changed, not titles
* Don't notify parents when a child changes its title
* Update ancestor titles when changing a container's layout
    * Eg. create nested tabs and change the inner container to stacking
* No need to store tree presentation in both `container->name` and `container->formatted_title`