### PR TITLE
Fix focus bug when moving between outputs

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -586,11 +586,19 @@ static struct sway_container *get_swayc_in_output_direction(
 	if (ws->children->length > 0) {
 		switch (dir) {
 		case MOVE_LEFT:
-			// get most right child of new output
-			return ws->children->items[ws->children->length-1];
+			if (ws->layout == L_HORIZ || ws->layout == L_TABBED) {
+				// get most right child of new output
+				return ws->children->items[ws->children->length-1];
+			} else {
+				return seat_get_focus_inactive(seat, ws);
+			}
 		case MOVE_RIGHT:
-			// get most left child of new output
-			return ws->children->items[0];
+			if (ws->layout == L_HORIZ || ws->layout == L_TABBED) {
+				// get most left child of new output
+				return ws->children->items[0];
+			} else {
+				return seat_get_focus_inactive(seat, ws);
+			}
 		case MOVE_UP:
 		case MOVE_DOWN: {
 			struct sway_container *focused =


### PR DESCRIPTION
When moving focus left or right to an adjacent output, only select the first or last child in the new workspace if the workspace's layout is horizontalish. If it's a verticalish layout, use the last focused container.

To test:

* Have two outputs.
* On the left output, create two or more views in a vertical layout. Ensure the views are direct children of the workspace (eg. by creating two views then moving one of them down).
* Focus the topmost view.
* `focus right` to move focus to the right output (it doesn't matter if the right output is empty or has views).
* `focus left` to move back to the left output.
* Prior to the fix, sway would focus the bottom child in the left output. Because the layout is perpendicular to the movement direction, It should focus the last active child instead.