### PR TITLE
Switch workspace if required when mapping a view

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -438,10 +438,11 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	// Check if there's any `assign` criteria for the view
 	list_t *criterias = criteria_for_view(view,
 			CT_ASSIGN_WORKSPACE | CT_ASSIGN_OUTPUT);
+	struct sway_container *workspace = NULL;
 	if (criterias->length) {
 		struct criteria *criteria = criterias->items[0];
 		if (criteria->type == CT_ASSIGN_WORKSPACE) {
-			struct sway_container *workspace = workspace_by_name(criteria->target);
+			workspace = workspace_by_name(criteria->target);
 			if (!workspace) {
 				workspace = workspace_create(NULL, criteria->target);
 			}
@@ -468,6 +469,9 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 
 	arrange_children_of(cont->parent);
 	input_manager_set_focus(input_manager, cont);
+	if (workspace) {
+		workspace_switch(workspace);
+	}
 
 	view_update_title(view, false);
 	container_notify_child_title_changed(view->swayc->parent);


### PR DESCRIPTION
Fixes #1879.

Have something like this in your config:

    assign [class="Firefox"] web
    workspace web output X11-2

Then launch sway with two outputs, focus output X11-1, and launch Firefox. The web workspace will be created on X11-2, Firefox will be created there and focused, the IPC workspace event will be sent, but Firefox wouldn't actually render because you hadn't switched to the workspace.