### PR TITLE
swaylock: implement a proper render loop

### DIFF
--- a/include/swaylock/swaylock.h
+++ b/include/swaylock/swaylock.h
@@ -56,6 +56,7 @@ struct swaylock_surface {
 	struct zwlr_layer_surface_v1 *layer_surface;
 	struct pool_buffer buffers[2];
 	struct pool_buffer *current_buffer;
+	bool frame_pending, dirty;
 	uint32_t width, height;
 	int32_t scale;
 	char *output_name;
@@ -74,5 +75,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint);
 void render_frame(struct swaylock_surface *surface);
 void render_frames(struct swaylock_state *state);
+void damage_surface(struct swaylock_surface *surface);
+void damage_state(struct swaylock_state *state);
 
 #endif

--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -93,58 +93,58 @@ static void append_ch(struct swaylock_password *pw, uint32_t codepoint) {
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
 	switch (keysym) {
-		case XKB_KEY_KP_Enter: /* fallthrough */
-		case XKB_KEY_Return:
-			state->auth_state = AUTH_STATE_VALIDATING;
-			render_frames(state);
-			wl_display_roundtrip(state->display);
-			if (attempt_password(&state->password)) {
-				state->run_display = false;
-				break;
-			}
-			state->auth_state = AUTH_STATE_INVALID;
-			render_frames(state);
+	case XKB_KEY_KP_Enter: /* fallthrough */
+	case XKB_KEY_Return:
+		state->auth_state = AUTH_STATE_VALIDATING;
+		damage_state(state);
+		wl_display_roundtrip(state->display);
+		if (attempt_password(&state->password)) {
+			state->run_display = false;
 			break;
-		case XKB_KEY_Delete:
-		case XKB_KEY_BackSpace:
-			if (backspace(&state->password)) {
-				state->auth_state = AUTH_STATE_BACKSPACE;
-			} else {
-				state->auth_state = AUTH_STATE_CLEAR;
-			}
-			render_frames(state);
-			break;
-		case XKB_KEY_Escape: 
-			clear_password_buffer(&state->password);
+		}
+		state->auth_state = AUTH_STATE_INVALID;
+		damage_state(state);
+		break;
+	case XKB_KEY_Delete:
+	case XKB_KEY_BackSpace:
+		if (backspace(&state->password)) {
+			state->auth_state = AUTH_STATE_BACKSPACE;
+		} else {
 			state->auth_state = AUTH_STATE_CLEAR;
-			render_frames(state);
-			break;
-		case XKB_KEY_Caps_Lock:
-			/* The state is getting active after this
-			 * so we need to manually toggle it */
-			state->xkb.caps_lock = !state->xkb.caps_lock;
-			state->auth_state = AUTH_STATE_INPUT_NOP;
-			render_frames(state);
-			break;
-		case XKB_KEY_Shift_L:
-		case XKB_KEY_Shift_R:
-		case XKB_KEY_Control_L:
-		case XKB_KEY_Control_R:
-		case XKB_KEY_Meta_L:
-		case XKB_KEY_Meta_R:
-		case XKB_KEY_Alt_L:
-		case XKB_KEY_Alt_R:
-		case XKB_KEY_Super_L:
-		case XKB_KEY_Super_R:
-			state->auth_state = AUTH_STATE_INPUT_NOP;
-			render_frames(state);
-			break;
-		default:
-			if (codepoint) {
-				append_ch(&state->password, codepoint);
-				state->auth_state = AUTH_STATE_INPUT;
-				render_frames(state);
-			}
-			break;
+		}
+		damage_state(state);
+		break;
+	case XKB_KEY_Escape:
+		clear_password_buffer(&state->password);
+		state->auth_state = AUTH_STATE_CLEAR;
+		damage_state(state);
+		break;
+	case XKB_KEY_Caps_Lock:
+		/* The state is getting active after this
+		 * so we need to manually toggle it */
+		state->xkb.caps_lock = !state->xkb.caps_lock;
+		state->auth_state = AUTH_STATE_INPUT_NOP;
+		damage_state(state);
+		break;
+	case XKB_KEY_Shift_L:
+	case XKB_KEY_Shift_R:
+	case XKB_KEY_Control_L:
+	case XKB_KEY_Control_R:
+	case XKB_KEY_Meta_L:
+	case XKB_KEY_Meta_R:
+	case XKB_KEY_Alt_L:
+	case XKB_KEY_Alt_R:
+	case XKB_KEY_Super_L:
+	case XKB_KEY_Super_R:
+		state->auth_state = AUTH_STATE_INPUT_NOP;
+		damage_state(state);
+		break;
+	default:
+		if (codepoint) {
+			append_ch(&state->password, codepoint);
+			state->auth_state = AUTH_STATE_INPUT;
+			damage_state(state);
+		}
+		break;
 	}
 }

--- a/swaylock/render.c
+++ b/swaylock/render.c
@@ -23,6 +23,10 @@ void render_frame(struct swaylock_surface *surface) {
 
 	surface->current_buffer = get_next_buffer(state->shm,
 			surface->buffers, buffer_width, buffer_height);
+	if (surface->current_buffer == NULL) {
+		return;
+	}
+
 	cairo_t *cairo = surface->current_buffer->cairo;
 	cairo_identity_matrix(cairo);
 


### PR DESCRIPTION
This is an attempt to fix #2031. I cannot reproduce this issue, so please test.

If I typed too fast, I experienced tearing. This PR fixes it by implementing a proper render loop.