### PR TITLE
Send workspace::move in container_output_destroy

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -244,6 +244,7 @@ static struct sway_container *container_output_destroy(
 				container_remove_child(workspace);
 				if (workspace->children->length > 0) {
 					container_add_child(other_output, workspace);
+					ipc_event_workspace(workspace, NULL, "move");
 				} else {
 					container_workspace_destroy(workspace);
 				}


### PR DESCRIPTION
This sends the `workspace::move` IPC event in `container_output_destroy` when moving a workspace from one output to another. This notifies swaybar (and anything else subscribed to the IPC events) of the change.