### PR TITLE
Implement bindsym/bindcode --locked

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -28,6 +28,7 @@ struct sway_variable {
 struct sway_binding {
 	int order;
 	bool release;
+	bool locked;
 	bool bindcode;
 	list_t *keys;
 	uint32_t modifiers;

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -83,20 +83,26 @@ struct cmd_results *cmd_bindsym(int argc, char **argv) {
 	binding->keys = create_list();
 	binding->modifiers = 0;
 	binding->release = false;
+	binding->locked = false;
 	binding->bindcode = false;
 
-	// Handle --release
-	if (strcmp("--release", argv[0]) == 0) {
-		if (argc >= 3) {
+	// Handle --release and --locked
+	while (argc > 0) {
+		if (strcmp("--release", argv[0]) == 0) {
 			binding->release = true;
-			argv++;
-			argc--;
+		} else if (strcmp("--locked", argv[0]) == 0) {
+			binding->locked = true;
 		} else {
-			free_sway_binding(binding);
-			return cmd_results_new(CMD_FAILURE, "bindsym",
-				"Invalid bindsym command "
-				"(expected more than 2 arguments, got %d)", argc);
+			break;
 		}
+		argv++;
+		argc--;
+	}
+	if (argc < 2) {
+		free_sway_binding(binding);
+		return cmd_results_new(CMD_FAILURE, "bindsym",
+			"Invalid bindsym command "
+			"(expected at least 2 non-option arguments, got %d)", argc);
 	}
 
 	binding->command = join_args(argv + 1, argc - 1);
@@ -176,20 +182,26 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 	binding->keys = create_list();
 	binding->modifiers = 0;
 	binding->release = false;
+	binding->locked = false;
 	binding->bindcode = true;
 
-	// Handle --release
-	if (strcmp("--release", argv[0]) == 0) {
-		if (argc >= 3) {
+	// Handle --release and --locked
+	while (argc > 0) {
+		if (strcmp("--release", argv[0]) == 0) {
 			binding->release = true;
-			argv++;
-			argc--;
+		} else if (strcmp("--locked", argv[0]) == 0) {
+			binding->locked = true;
 		} else {
-			free_sway_binding(binding);
-			return cmd_results_new(CMD_FAILURE, "bindcode",
-				"Invalid bindcode command "
-				"(expected more than 2 arguments, got %d)", argc);
+			break;
 		}
+		argv++;
+		argc--;
+	}
+	if (argc < 2) {
+		free_sway_binding(binding);
+		return cmd_results_new(CMD_FAILURE, "bindcode",
+			"Invalid bindcode command "
+			"(expected at least 2 non-option arguments, got %d)", argc);
 	}
 
 	binding->command = join_args(argv + 1, argc - 1);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -186,17 +186,20 @@ runtime.
 
 		for\_window <criteria> move container to workspace <workspace>
 
-*bindsym* <key combo> <command>
+*bindsym* [--release|--locked] <key combo> <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
+	With the flag _--release_, the command is executed when the key combo is
+	released. Unless the flag _--locked_ is set, the command will not be run
+	when a screen locking program is active.
 
 	Example:
 
 		# Execute firefox when alt, shift, and f are pressed together
 		bindsym Mod1+Shift+f exec firefox
 
-	*bindcode* <code> <command> is also available for binding with key codes
-	instead of key names.
+	*bindcode* [--release|--locked] <code> <command> is also available for
+	binding with key codes instead of key names.
 
 *client.<class>* <border> <background> <text> <indicator> <child\_border>
 	Configures the color of window borders and title bars. All 5 colors are


### PR DESCRIPTION
Adds the --locked flag to bindsym and bindcode commands.

When a keyboard's associated seat has an exclusive client
(i.e, a screenlocker), then bindings are only executed if
they have the locked flag. When there is no such client,
this restriction is lifted.

-------

This should resolve #592. As my development system only has one screen, I haven't 
tested e.g. how this will interact with seat or keyboard additions while a screenlocker
is active, or with multiple screens. Example usage:

    bindsym --locked XF86AudioMute exec amixer sset Master toggle
    bindsym XF86AudioMicMute exec  amixer sset Capture toggle





