### PR TITLE
swaymsg: Fix exit code

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -19,13 +19,26 @@ void sway_terminate(int exit_code) {
 	exit(exit_code);
 }
 
+// Iterate results array and return false if any of them failed
 static bool success(json_object *r, bool fallback) {
-	json_object *success;
-	if (!json_object_object_get_ex(r, "success", &success)) {
+	if (!json_object_is_type(r, json_type_array)) {
 		return fallback;
-	} else {
-		return json_object_get_boolean(success);
 	}
+	size_t results_len = json_object_array_length(r);
+	if (!results_len) {
+		return fallback;
+	}
+	for (size_t i = 0; i < results_len; ++i) {
+		json_object *result = json_object_array_get_idx(r, i);
+		json_object *success;
+		if (!json_object_object_get_ex(result, "success", &success)) {
+			return false;
+		}
+		if (!json_object_get_boolean(success)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 static void pretty_print_cmd(json_object *r) {


### PR DESCRIPTION
When executing commands via IPC, sway returns the result in a JSON array. swaymsg expected the result to be in the root of the JSON object, wouldn't find the `success` boolean, and would always return the fallback which is `true`.

This changes swaymsg to look in the array rather than the root, and return false if any of the commands failed.

Note that sway only ever returns an array of one item (the last executed command), but that's out of scope of this PR.

To test, run `swaymsg lol; echo $?`