### PR TITLE
Refactor parse_title_format

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -641,6 +641,14 @@ void view_child_destroy(struct sway_view_child *child) {
 	}
 }
 
+static size_t append_prop(char *buffer, const char *value) {
+	if (!value) {
+		return 0;
+	}
+	lenient_strcat(buffer, value);
+	return strlen(value);
+}
+
 /**
  * Calculate and return the length of the formatted title.
  * If buffer is not NULL, also populate the buffer with the formatted title.
@@ -653,16 +661,6 @@ static size_t parse_title_format(struct sway_view *view, char *buffer) {
 		}
 		return title ? strlen(title) : 0;
 	}
-	const char *title = view_get_title(view);
-	const char *app_id = view_get_app_id(view);
-	const char *class = view_get_class(view);
-	const char *instance = view_get_instance(view);
-	const char *shell = view_get_shell(view);
-	size_t title_len = title ? strlen(title) : 0;
-	size_t app_id_len = app_id ? strlen(app_id) : 0;
-	size_t class_len = class ? strlen(class) : 0;
-	size_t instance_len = instance ? strlen(instance) : 0;
-	size_t shell_len = shell ? strlen(shell) : 0;
 
 	size_t len = 0;
 	char *format = view->title_format;
@@ -674,24 +672,19 @@ static size_t parse_title_format(struct sway_view *view, char *buffer) {
 		format = next;
 
 		if (strncmp(next, "%title", 6) == 0) {
-			lenient_strcat(buffer, title);
-			len += title_len;
+			len += append_prop(buffer, view_get_title(view));
 			format += 6;
 		} else if (strncmp(next, "%app_id", 7) == 0) {
-			lenient_strcat(buffer, app_id);
-			len += app_id_len;
+			len += append_prop(buffer, view_get_app_id(view));
 			format += 7;
 		} else if (strncmp(next, "%class", 6) == 0) {
-			lenient_strcat(buffer, class);
-			len += class_len;
+			len += append_prop(buffer, view_get_class(view));
 			format += 6;
 		} else if (strncmp(next, "%instance", 9) == 0) {
-			lenient_strcat(buffer, instance);
-			len += instance_len;
+			len += append_prop(buffer, view_get_instance(view));
 			format += 9;
 		} else if (strncmp(next, "%shell", 6) == 0) {
-			lenient_strcat(buffer, shell);
-			len += shell_len;
+			len += append_prop(buffer, view_get_shell(view));
 			format += 6;
 		} else {
 			lenient_strcat(buffer, "%");


### PR DESCRIPTION
Don't read properties until needed, and do it with less lines of code.