### PR TITLE
Fix popups

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -174,13 +174,6 @@ struct sway_container *container_at(struct sway_container *workspace,
 		double *sx, double *sy);
 
 /**
- * Same as container_at, but only checks for popups only.
- */
-struct sway_container *popup_at(struct sway_container *workspace,
-		double lx, double ly, struct wlr_surface **surface,
-		double *sx, double *sy);
-
-/**
  * Apply the function for each descendant of the container breadth first.
  */
 void container_for_each_descendant_bfs(struct sway_container *container,

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -169,16 +169,16 @@ struct sway_container *container_parent(struct sway_container *container,
  * surface-local coordinates of the given layout coordinates if the container
  * is a view and the view contains a surface at those coordinates.
  */
-struct sway_container *container_at(struct sway_container *container,
-		double ox, double oy, struct wlr_surface **surface,
+struct sway_container *container_at(struct sway_container *workspace,
+		double lx, double ly, struct wlr_surface **surface,
 		double *sx, double *sy);
 
 /**
- * Same as container_at, but only checks floating views and expects coordinates
- * to be layout coordinates, as that's what floating views use.
+ * Same as container_at, but only checks for popups only.
  */
-struct sway_container *floating_container_at(double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
+struct sway_container *popup_at(struct sway_container *workspace,
+		double lx, double ly, struct wlr_surface **surface,
+		double *sx, double *sy);
 
 /**
  * Apply the function for each descendant of the container breadth first.

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -219,11 +219,6 @@ damage_finish:
 }
 
 static bool surface_is_popup(struct wlr_surface *surface) {
-	if (wlr_surface_is_xwayland_surface(surface)) {
-		struct wlr_xwayland_surface *xsurface =
-			wlr_xwayland_surface_from_wlr_surface(surface);
-		return wlr_xwayland_surface_is_unmanaged(xsurface);
-	}
 	if (wlr_surface_is_xdg_surface(surface)) {
 		struct wlr_xdg_surface *xdg_surface =
 			wlr_xdg_surface_from_wlr_surface(surface);
@@ -234,7 +229,10 @@ static bool surface_is_popup(struct wlr_surface *surface) {
 			wlr_xdg_surface_v6_from_wlr_surface(surface);
 		return xdg_surface_v6->role == WLR_XDG_SURFACE_V6_ROLE_POPUP;
 	}
-	// Layer surface
+	// Anything else will either be a layer surface, an xwayland managed surface
+	// or an xwayland unmanaged surface. Xwayland unmanaged surfaces are
+	// rendered specially and expect the surface to NOT identify as a popup.
+	// The other two are not popups.
 	return false;
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -108,9 +108,6 @@ static struct sway_container *container_at_coords(
 	}
 
 	struct sway_container *c;
-	if ((c = popup_at(ws, lx, ly, surface, sx, sy))) {
-		return c;
-	}
 	if ((c = container_at(ws, lx, ly, surface, sx, sy))) {
 		return c;
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -108,7 +108,7 @@ static struct sway_container *container_at_coords(
 	}
 
 	struct sway_container *c;
-	if ((c = floating_container_at(lx, ly, surface, sx, sy))) {
+	if ((c = popup_at(ws, lx, ly, surface, sx, sy))) {
 		return c;
 	}
 	if ((c = container_at(ws, lx, ly, surface, sx, sy))) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -474,9 +474,9 @@ struct sway_container *container_parent(struct sway_container *container,
 	return container;
 }
 
-static struct sway_container *container_at_view(struct sway_container *swayc,
-		double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy) {
+static struct sway_container *surface_at_view(struct sway_container *swayc,
+		double lx, double ly, struct wlr_surface **surface,
+		double *sx, double *sy, bool only_popups) {
 	if (!sway_assert(swayc->type == C_VIEW, "Expected a view")) {
 		return NULL;
 	}
@@ -490,6 +490,13 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 	case SWAY_VIEW_XWAYLAND:
 		_surface = wlr_surface_surface_at(sview->surface,
 				view_sx, view_sy, &_sx, &_sy);
+		if (_surface && only_popups) {
+			struct wlr_xwayland_surface *xsurface =
+				wlr_xwayland_surface_from_wlr_surface(_surface);
+			if (!wlr_xwayland_surface_is_unmanaged(xsurface)) {
+				return NULL;
+			}
+		}
 		break;
 	case SWAY_VIEW_XDG_SHELL_V6:
 		// the top left corner of the sway container is the
@@ -500,6 +507,13 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 		_surface = wlr_xdg_surface_v6_surface_at(
 				sview->wlr_xdg_surface_v6,
 				view_sx, view_sy, &_sx, &_sy);
+		if (_surface && only_popups) {
+			struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+				wlr_xdg_surface_v6_from_wlr_surface(_surface);
+			if (xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_POPUP) {
+				return NULL;
+			}
+		}
 		break;
 	case SWAY_VIEW_XDG_SHELL:
 		// the top left corner of the sway container is the
@@ -510,6 +524,13 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 		_surface = wlr_xdg_surface_surface_at(
 				sview->wlr_xdg_surface,
 				view_sx, view_sy, &_sx, &_sy);
+		if (_surface && only_popups) {
+			struct wlr_xdg_surface *xdg_surface =
+				wlr_xdg_surface_from_wlr_surface(_surface);
+			if (xdg_surface->role != WLR_XDG_SURFACE_ROLE_POPUP) {
+				return NULL;
+			}
+		}
 		break;
 	}
 	if (_surface) {
@@ -517,8 +538,15 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 		*sy = _sy;
 		*surface = _surface;
 	}
+	if (only_popups && !_surface) {
+		return NULL;
+	}
 	return swayc;
 }
+
+static struct sway_container *container_at_container(
+		struct sway_container *parent, double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * container_at for a container with layout L_TABBED.
@@ -546,7 +574,7 @@ static struct sway_container *container_at_tabbed(struct sway_container *parent,
 	// Surfaces
 	struct sway_container *current = seat_get_active_child(seat, parent);
 
-	return container_at(current, lx, ly, surface, sx, sy);
+	return container_at_container(current, lx, ly, surface, sx, sy);
 }
 
 /**
@@ -571,7 +599,7 @@ static struct sway_container *container_at_stacked(
 	// Surfaces
 	struct sway_container *current = seat_get_active_child(seat, parent);
 
-	return container_at(current, lx, ly, surface, sx, sy);
+	return container_at_container(current, lx, ly, surface, sx, sy);
 }
 
 /**
@@ -589,21 +617,17 @@ static struct sway_container *container_at_linear(struct sway_container *parent,
 			.height = child->height,
 		};
 		if (wlr_box_contains_point(&box, lx, ly)) {
-			return container_at(child, lx, ly, surface, sx, sy);
+			return container_at_container(child, lx, ly, surface, sx, sy);
 		}
 	}
 	return NULL;
 }
 
-struct sway_container *container_at(struct sway_container *parent,
-		double lx, double ly,
+static struct sway_container *container_at_container(
+		struct sway_container *parent, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
-	if (!sway_assert(parent->type >= C_WORKSPACE,
-				"Expected workspace or deeper")) {
-		return NULL;
-	}
 	if (parent->type == C_VIEW) {
-		return container_at_view(parent, lx, ly, surface, sx, sy);
+		return surface_at_view(parent, lx, ly, surface, sx, sy, false);
 	}
 	if (!parent->children->length) {
 		return NULL;
@@ -623,34 +647,73 @@ struct sway_container *container_at(struct sway_container *parent,
 	case L_NONE:
 		return NULL;
 	}
-
 	return NULL;
 }
 
-struct sway_container *floating_container_at(double lx, double ly,
+struct sway_container *container_at(struct sway_container *workspace,
+		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *output = root_container.children->items[i];
-		for (int j = 0; j < output->children->length; ++j) {
-			struct sway_container *workspace = output->children->items[j];
-			struct sway_workspace *ws = workspace->sway_workspace;
-			if (!workspace_is_visible(workspace)) {
-				continue;
-			}
-			for (int k = 0; k < ws->floating->children->length; ++k) {
-				struct sway_container *floater =
-					ws->floating->children->items[k];
-				struct wlr_box box = {
-					.x = floater->x,
-					.y = floater->y,
-					.width = floater->width,
-					.height = floater->height,
-				};
-				if (wlr_box_contains_point(&box, lx, ly)) {
-					return container_at(floater, lx, ly, surface, sx, sy);
-				}
+	if (!sway_assert(workspace->type == C_WORKSPACE, "Expected a workspace")) {
+		return NULL;
+	}
+	struct sway_container *floating = workspace->sway_workspace->floating;
+	struct sway_container *c;
+	// Floating
+	for (int i = 0; i < floating->children->length; ++i) {
+		struct sway_container *floater = floating->children->items[i];
+		if ((c = container_at_container(floater, lx, ly, surface, sx, sy))) {
+			return c;
+		}
+	}
+	// Tiling
+	if ((c = container_at_container(workspace, lx, ly, surface, sx, sy))) {
+		return c;
+	}
+	return NULL;
+}
+
+static struct sway_container *popup_at_container(struct sway_container *parent,
+		double lx, double ly, struct wlr_surface **surface,
+		double *sx, double *sy) {
+	if (parent->type == C_VIEW) {
+		return surface_at_view(parent, lx, ly, surface, sx, sy, true);
+	}
+	if (parent->layout == L_TABBED || parent->layout == L_STACKED) {
+		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		struct sway_container *child = seat_get_active_child(seat, parent);
+		struct sway_container *c =
+			popup_at_container(child, lx, ly, surface, sx, sy);
+		if (c) {
+			return c;
+		}
+	} else {
+		for (int i = 0; i < parent->children->length; ++i) {
+			struct sway_container *child = parent->children->items[i];
+			struct sway_container *c =
+				popup_at_container(child, lx, ly, surface, sx, sy);
+			if (c) {
+				return c;
 			}
 		}
+	}
+	return NULL;
+}
+
+struct sway_container *popup_at(struct sway_container *workspace,
+		double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy) {
+	if (!sway_assert(workspace->type == C_WORKSPACE, "Expected a workspace")) {
+		return NULL;
+	}
+	struct sway_container *c;
+	// Floating popups
+	if ((c = popup_at_container(workspace->sway_workspace->floating, lx, ly,
+				surface, sx, sy))) {
+		return c;
+	}
+	// Tiling poups
+	if ((c = popup_at_container(workspace, lx, ly, surface, sx, sy))) {
+		return c;
 	}
 	return NULL;
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -655,6 +655,20 @@ static struct sway_container *floating_container_at(double lx, double ly,
 	return NULL;
 }
 
+static bool surface_is_popup(struct wlr_surface *surface) {
+	if (wlr_surface_is_xdg_surface(surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(surface);
+		return xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP;
+	}
+	if (wlr_surface_is_xdg_surface_v6(surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(surface);
+		return xdg_surface_v6->role == WLR_XDG_SURFACE_V6_ROLE_POPUP;
+	}
+	return false;
+}
+
 struct sway_container *container_at(struct sway_container *workspace,
 		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
@@ -668,8 +682,7 @@ struct sway_container *container_at(struct sway_container *workspace,
 		seat_get_focus_inactive(seat, &root_container);
 	if (focus && focus->type == C_VIEW) {
 		c = surface_at_view(focus, lx, ly, surface, sx, sy);
-		if (*surface && *surface == focus->sway_view->surface) {
-			// Not a popup
+		if (*surface && !surface_is_popup(*surface)) {
 			*surface = NULL;
 		} else if (c) {
 			return c;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -681,10 +681,12 @@ static struct sway_container *popup_at_container(struct sway_container *parent,
 	if (parent->layout == L_TABBED || parent->layout == L_STACKED) {
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
 		struct sway_container *child = seat_get_active_child(seat, parent);
-		struct sway_container *c =
-			popup_at_container(child, lx, ly, surface, sx, sy);
-		if (c) {
-			return c;
+		if (child) {
+			struct sway_container *c =
+				popup_at_container(child, lx, ly, surface, sx, sy);
+			if (c) {
+				return c;
+			}
 		}
 	} else {
 		for (int i = 0; i < parent->children->length; ++i) {


### PR DESCRIPTION
This adds proper support for popups overhanging the bounds of their swayc.

An example of the problem this solves:

* Place a gedit and a terminal side by side with gedit on the left.
* Right click near the right edge of gedit, so the popup overlaps the terminal.
* Before this PR, the terminal would be rendered on top of the popup and you wouldn't be able to hover or click the popup's overhanging part.

The same problem is evident with floating views showing a popup outside the bounds of the floating swayc.

For locating a surface at a given coordinate, the new logic is to iterate all the floating popups first, then floating toplevels and decorations, then tiled popups, then tiled toplevels and decorations.

For rendering popups, it renders all toplevels and decorations first, then popups afterwards.

Some discussion points:
* If you have a tabbed container, open a popup that overhangs the tabbed container, then switch to a different tab, I've made the popup disappear until you tab back. I assume this is desired?
* We might find performance gains if we store a list of mapped popups somewhere global such as `sway_server`, rather than iterating through the tree multiple times when using `container_at` and when rendering.
* When a popup is unmapped, only the swayc's bounds are damaged. I'd like to make this a separate PR because it's not a result of my doing, and I'd rather work on atomic for now.