### PR TITLE
Support i3's legacy force_focus_wrapping command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -109,6 +109,7 @@ sway_cmd cmd_focus_follows_mouse;
 sway_cmd cmd_focus_wrapping;
 sway_cmd cmd_font;
 sway_cmd cmd_for_window;
+sway_cmd cmd_force_focus_wrapping;
 sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
 sway_cmd cmd_hide_edge_borders;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -109,6 +109,7 @@ static struct cmd_handler handlers[] = {
 	{ "focus_wrapping", cmd_focus_wrapping },
 	{ "font", cmd_font },
 	{ "for_window", cmd_for_window },
+	{ "force_focus_wrapping", cmd_force_focus_wrapping },
 	{ "fullscreen", cmd_fullscreen },
 	{ "hide_edge_borders", cmd_hide_edge_borders },
 	{ "include", cmd_include },

--- a/sway/commands/force_focus_wrapping.c
+++ b/sway/commands/force_focus_wrapping.c
@@ -1,0 +1,22 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
+	struct cmd_results *error =
+		checkarg(argc, "force_focus_wrapping", EXPECTED_EQUAL_TO, 1);
+	if (error) {
+		return error;
+	}
+
+	if (strcasecmp(argv[0], "no") == 0) {
+		config->focus_wrapping = WRAP_YES;
+	} else if (strcasecmp(argv[0], "yes") == 0) {
+		config->focus_wrapping = WRAP_FORCE;
+	} else {
+		return cmd_results_new(CMD_INVALID, "force_focus_wrapping",
+				"Expected 'force_focus_wrapping yes|no'");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -41,6 +41,7 @@ sway_sources = files(
 	'commands/focus_wrapping.c',
 	'commands/font.c',
 	'commands/for_window.c',
+	'commands/force_focus_wrapping.c',
 	'commands/fullscreen.c',
 	'commands/hide_edge_borders.c',
 	'commands/kill.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -344,6 +344,12 @@ The default colors are:
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.
 
+*force\_focus\_wrapping* yes|no
+	This option is a wrapper to support i3's legacy syntax. _no_ is equivalent
+	to _focus\_wrapping yes_ and _yes_ is equivalent to
+	_focus\_wrapping force_. This is only available for convenience. Please
+	use _focus\_wrapping_ instead when possible.
+
 *gaps* edge\_gaps on|off|toggle
 	When _on_, gaps will be added between windows and workspace edges if the
 	inner gap is nonzero. When _off_, gaps will only be added between views.


### PR DESCRIPTION
Implements support for i3's legacy `force_focus_wrapping yes|no` command.

This is a follow-up to #2060. @SirCmpwn commented after the merge that he wants support for this legacy command.