### PR TITLE
Add config parser for workspace_layout

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -169,6 +169,7 @@ static struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "set", cmd_set },
 	{ "swaybg_command", cmd_swaybg_command },
+	{ "workspace_layout", cmd_workspace_layout },
 };
 
 /* Runtime-only commands. Keep alphabetized */

--- a/sway/commands/workspace_layout.c
+++ b/sway/commands/workspace_layout.c
@@ -1,0 +1,21 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+
+struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_layout", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	if (strcasecmp(argv[0], "default") == 0) {
+		config->default_layout = L_NONE;
+	} else if (strcasecmp(argv[0], "stacking") == 0) {
+		config->default_layout = L_STACKED;
+	} else if (strcasecmp(argv[0], "tabbed") == 0) {
+		config->default_layout = L_TABBED;
+	} else {
+		return cmd_results_new(CMD_INVALID, "workspace_layout",
+				"Expected 'workspace_layout <default|stacking|tabbed>'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -69,6 +69,7 @@ sway_sources = files(
 	'commands/title_format.c',
 	'commands/unmark.c',
 	'commands/workspace.c',
+	'commands/workspace_layout.c',
 	'commands/ws_auto_back_and_forth.c',
 
 	'commands/bar/activate_button.c',


### PR DESCRIPTION
Adds config parser for `workspace_layout default|stacking|tabbed`. The rest of the parts are already in master.

Tests:
1. Horizontal layout
    - Have `workspace_layout default` and `default_orientation horizontal` in the config
       - Having just `default_orientation horizontal` or neither should be the same
    - Open two views and observe a horizontal split
2. Vertical layout
    - Have `workspace_layout default` and `default_orientation vertical` in the config
        - Having just `default_orientation vertical` should be the same
    - Open two views and observe a vertical split
3. Tabbed layout
    - Have `workspace_layout tabbed` in the config
    - Open two views and observe a tabbed container
4. Stacking layout
    - Have `workspace_layout stacking` in the config
    - Open two views and observe a stacked container