### PR TITLE
Add tree representation to IPC workspace description

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -147,6 +147,8 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 			json_object_new_string(workspace->parent->name) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
 	json_object_object_add(object, "urgent", json_object_new_boolean(false));
+	json_object_object_add(object, "representation", workspace->formatted_title ?
+			json_object_new_string(workspace->formatted_title) : NULL);
 
 	const char *layout = ipc_json_layout_description(workspace->layout);
 	json_object_object_add(object, "layout", json_object_new_string(layout));

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -842,7 +842,7 @@ static size_t get_tree_representation(struct sway_container *parent, char *buffe
 }
 
 void container_notify_subtree_changed(struct sway_container *container) {
-	if (!container || container->type != C_CONTAINER) {
+	if (!container || container->type < C_WORKSPACE) {
 		return;
 	}
 	free(container->formatted_title);
@@ -856,9 +856,11 @@ void container_notify_subtree_changed(struct sway_container *container) {
 	get_tree_representation(container, buffer);
 
 	container->formatted_title = buffer;
-	container_calculate_title_height(container);
-	container_update_title_textures(container);
-	container_notify_subtree_changed(container->parent);
+	if (container->type != C_WORKSPACE) {
+		container_calculate_title_height(container);
+		container_update_title_textures(container);
+		container_notify_subtree_changed(container->parent);
+	}
 }
 
 size_t container_titlebar_height() {

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -53,24 +53,28 @@ static void pretty_print_cmd(json_object *r) {
 }
 
 static void pretty_print_workspace(json_object *w) {
-	json_object *name, *rect, *visible, *output, *urgent, *layout, *focused;
+	json_object *name, *rect, *visible, *output, *urgent, *layout,
+				*representation, *focused;
 	json_object_object_get_ex(w, "name", &name);
 	json_object_object_get_ex(w, "rect", &rect);
 	json_object_object_get_ex(w, "visible", &visible);
 	json_object_object_get_ex(w, "output", &output);
 	json_object_object_get_ex(w, "urgent", &urgent);
 	json_object_object_get_ex(w, "layout", &layout);
+	json_object_object_get_ex(w, "representation", &representation);
 	json_object_object_get_ex(w, "focused", &focused);
 	printf(
 		"Workspace %s%s%s%s\n"
 		"  Output: %s\n"
-		"  Layout: %s\n\n",
+		"  Layout: %s\n"
+		"  Representation: %s\n\n",
 		json_object_get_string(name),
 		json_object_get_boolean(focused) ? " (focused)" : "",
 		!json_object_get_boolean(visible) ? " (off-screen)" : "",
 		json_object_get_boolean(urgent) ? " (urgent)" : "",
 		json_object_get_string(output),
-		json_object_get_string(layout)
+		json_object_get_string(layout),
+		json_object_get_string(representation)
 	);
 }
 


### PR DESCRIPTION
This adds the tree representation to the IPC workspace description, which will make it easier for us to describe layouts to each other.

Run `swaymsg -t get_tree`. See something like:

    "type": "workspace",
    "representation": "H[URxvt V[URxvt URxvt]]",

Run `swaymsg -t get_workspaces`. See something like:

    Workspace 1 (focused)
      Output: X11-1
      Layout: splith
      Representation: H[URxvt V[URxvt URxvt]]