### PR TITLE
Make command block implementation generic

### DIFF
--- a/common/readline.c
+++ b/common/readline.c
@@ -58,7 +58,7 @@ char *peek_line(FILE *file, int offset, long *position) {
 		if (read < 0) {
 			break;
 		}
-		if (line[read - 1] == '\n') {
+		if (read > 0 && line[read - 1] == '\n') {
 			line[read - 1] = '\0';
 		}
 	}

--- a/common/readline.c
+++ b/common/readline.c
@@ -56,6 +56,8 @@ char *peek_line(FILE *file, int line_offset, long *position) {
 	for (int i = 0; i <= line_offset; i++) {
 		ssize_t read = getline(&line, &length, file);
 		if (read < 0) {
+			free(line);
+			line = NULL;
 			break;
 		}
 		if (read > 0 && line[read - 1] == '\n') {

--- a/common/readline.c
+++ b/common/readline.c
@@ -48,6 +48,20 @@ char *read_line(FILE *file) {
 	return string;
 }
 
+char *peek_line(FILE *file, int offset) {
+	int pos = ftell(file);
+	char *line = NULL;
+	for (int i = 0; i <= offset; i++) {
+		free(line);
+		line = read_line(file);
+		if (!line) {
+			break;
+		}
+	}
+	fseek(file, pos, SEEK_SET);
+	return line;
+}
+
 char *read_line_buffer(FILE *file, char *string, size_t string_len) {
 	size_t length = 0;
 	if (!string) {

--- a/common/readline.c
+++ b/common/readline.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include "readline.h"
 #include "log.h"
 #include <stdlib.h>
@@ -48,15 +49,21 @@ char *read_line(FILE *file) {
 	return string;
 }
 
-char *peek_line(FILE *file, int offset) {
-	int pos = ftell(file);
-	char *line = NULL;
+char *peek_line(FILE *file, int offset, long *position) {
+	long pos = ftell(file);
+	size_t length = 1;
+	char *line = calloc(1, length);
 	for (int i = 0; i <= offset; i++) {
-		free(line);
-		line = read_line(file);
-		if (!line) {
+		ssize_t read = getline(&line, &length, file);
+		if (read < 0) {
 			break;
 		}
+		if (line[read - 1] == '\n') {
+			line[read - 1] = '\0';
+		}
+	}
+	if (position) {
+		*position = ftell(file);
 	}
 	fseek(file, pos, SEEK_SET);
 	return line;

--- a/common/readline.c
+++ b/common/readline.c
@@ -49,11 +49,11 @@ char *read_line(FILE *file) {
 	return string;
 }
 
-char *peek_line(FILE *file, int offset, long *position) {
+char *peek_line(FILE *file, int line_offset, long *position) {
 	long pos = ftell(file);
-	size_t length = 1;
-	char *line = calloc(1, length);
-	for (int i = 0; i <= offset; i++) {
+	size_t length = 0;
+	char *line = NULL;
+	for (int i = 0; i <= line_offset; i++) {
 		ssize_t read = getline(&line, &length, file);
 		if (read < 0) {
 			break;

--- a/include/readline.h
+++ b/include/readline.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 char *read_line(FILE *file);
-char *peek_line(FILE *file, int offset);
+char *peek_line(FILE *file, int offset, long *position);
 char *read_line_buffer(FILE *file, char *string, size_t string_len);
 
 #endif

--- a/include/readline.h
+++ b/include/readline.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 char *read_line(FILE *file);
+char *peek_line(FILE *file, int offset);
 char *read_line_buffer(FILE *file, char *string, size_t string_len);
 
 #endif

--- a/include/readline.h
+++ b/include/readline.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 char *read_line(FILE *file);
-char *peek_line(FILE *file, int offset, long *position);
+char *peek_line(FILE *file, int line_offset, long *position);
 char *read_line_buffer(FILE *file, char *string, size_t string_len);
 
 #endif

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -3,6 +3,13 @@
 
 #include "config.h"
 
+typedef struct cmd_results *sway_cmd(int argc, char **argv);
+
+struct cmd_handler {
+	char *command;
+	sway_cmd *handle;
+};
+
 /**
  * Indicates the result of a command's execution.
  */
@@ -11,16 +18,9 @@ enum cmd_status {
 	CMD_FAILURE,		/**< The command resulted in an error */
 	CMD_INVALID, 		/**< Unknown command or parser error */
 	CMD_DEFER,		/**< Command execution deferred */
-	// Config Blocks
-	CMD_BLOCK_END,
-	CMD_BLOCK_MODE,
-	CMD_BLOCK_BAR,
-	CMD_BLOCK_BAR_COLORS,
-	CMD_BLOCK_INPUT,
-	CMD_BLOCK_SEAT,
+	CMD_BLOCK,
 	CMD_BLOCK_COMMANDS,
-	CMD_BLOCK_IPC,
-	CMD_BLOCK_IPC_EVENTS,
+	CMD_BLOCK_END
 };
 
 /**
@@ -45,6 +45,8 @@ enum expected_args {
 struct cmd_results *checkarg(int argc, const char *name,
 		enum expected_args type, int val);
 
+struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
+		int handlers_size);
 /**
  * Parse and executes a command.
  */
@@ -54,7 +56,12 @@ struct cmd_results *execute_command(char *command,  struct sway_seat *seat);
  *
  * Do not use this under normal conditions.
  */
-struct cmd_results *config_command(char *command, enum cmd_status block);
+struct cmd_results *config_command(char *command);
+/**
+ * Parse and handle a sub command
+ */
+struct cmd_results *subcommand(char **argv, int argc,
+		struct cmd_handler *handlers, int handlers_size);
 /*
  * Parses a command policy rule.
  */
@@ -76,8 +83,6 @@ const char *cmd_results_to_json(struct cmd_results *results);
 
 struct cmd_results *add_color(const char *name,
 		char *buffer, const char *color);
-
-typedef struct cmd_results *sway_cmd(int argc, char **argv);
 
 sway_cmd cmd_assign;
 sway_cmd cmd_bar;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -60,8 +60,8 @@ struct cmd_results *config_command(char *command);
 /**
  * Parse and handle a sub command
  */
-struct cmd_results *subcommand(char **argv, int argc,
-		struct cmd_handler *handlers, int handlers_size);
+struct cmd_results *config_subcommand(char **argv, int argc,
+		struct cmd_handler *handlers, size_t handlers_size);
 /*
  * Parses a command policy rule.
  */

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -403,8 +403,6 @@ bool read_config(FILE *file, struct sway_config *config);
  */
 void free_config(struct sway_config *config);
 
-void config_clear_handler_context(struct sway_config *config);
-
 void free_sway_variable(struct sway_variable *var);
 
 /**

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -376,8 +376,8 @@ cleanup:
 	return results;
 }
 
-struct cmd_results *subcommand(char **argv, int argc,
-		struct cmd_handler *handlers, int handlers_size) {
+struct cmd_results *config_subcommand(char **argv, int argc,
+		struct cmd_handler *handlers, size_t handlers_size) {
 	char *command = join_args(argv, argc);
 	wlr_log(L_DEBUG, "Subcommand: %s", command);
 	free(command);

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 500
 #include <string.h>
 #include <strings.h>
 #include <wlr/util/log.h>
@@ -5,53 +6,110 @@
 #include "sway/config.h"
 #include "util.h"
 
+// Must be in alphabetical order for bsearch
+static struct cmd_handler bar_handlers[] = {
+	{ "activate_button", bar_cmd_activate_button },
+	{ "binding_mode_indicator", bar_cmd_binding_mode_indicator },
+	{ "bindsym", bar_cmd_bindsym },
+	{ "colors", bar_cmd_colors },
+	{ "context_button", bar_cmd_context_button },
+	{ "font", bar_cmd_font },
+	{ "height", bar_cmd_height },
+	{ "hidden_state", bar_cmd_hidden_state },
+	{ "icon_theme", bar_cmd_icon_theme },
+	{ "id", bar_cmd_id },
+	{ "mode", bar_cmd_mode },
+	{ "modifier", bar_cmd_modifier },
+	{ "output", bar_cmd_output },
+	{ "pango_markup", bar_cmd_pango_markup },
+	{ "position", bar_cmd_position },
+	{ "secondary_button", bar_cmd_secondary_button },
+	{ "separator_symbol", bar_cmd_separator_symbol },
+	{ "status_command", bar_cmd_status_command },
+	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
+	{ "swaybar_command", bar_cmd_swaybar_command },
+	{ "tray_output", bar_cmd_tray_output },
+	{ "tray_padding", bar_cmd_tray_padding },
+	{ "workspace_buttons", bar_cmd_workspace_buttons },
+	{ "wrap_scroll", bar_cmd_wrap_scroll },
+};
+
+// Must be in alphabetical order for bsearch
+static struct cmd_handler bar_config_handlers[] = {
+	{ "hidden_state", bar_cmd_hidden_state },
+	{ "mode", bar_cmd_mode }
+};
+
 struct cmd_results *cmd_bar(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "bar", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
-	if (config->reading && strcmp("{", argv[0]) != 0) {
-		return cmd_results_new(CMD_INVALID, "bar",
-				"Expected '{' at start of bar config definition.");
-	}
-
 	if (!config->reading) {
-		if (argc > 1) {
-			if (strcasecmp("mode", argv[0]) == 0) {
-				return bar_cmd_mode(argc-1, argv + 1);
-			}
+		if (!find_handler(argv[0], bar_config_handlers,
+					sizeof(bar_config_handlers))) {
+			return cmd_results_new(CMD_FAILURE, "bar",
+					"Can only be used in config file.");
+		}
+		return subcommand(argv, argc, bar_config_handlers,
+				sizeof(bar_config_handlers));
+	}
 
-			if (strcasecmp("hidden_state", argv[0]) == 0) {
-				return bar_cmd_hidden_state(argc-1, argv + 1);
+	if (argc > 1) {
+		struct bar_config *bar = NULL;
+		if (!find_handler(argv[0], bar_handlers, sizeof(bar_handlers))
+				&& find_handler(argv[1], bar_handlers, sizeof(bar_handlers))) {
+			for (int i = 0; i < config->bars->length; ++i) {
+				struct bar_config *item = config->bars->items[i];
+				if (strcmp(item->id, argv[0]) == 0) {
+					wlr_log(L_DEBUG, "Selecting bar: %s", argv[0]);
+					bar = item;
+					break;
+				}
+			}
+			if (!bar) {
+				wlr_log(L_DEBUG, "Creating bar: %s", argv[0]);
+				bar = default_bar_config();
+				if (!bar) {
+					return cmd_results_new(CMD_FAILURE, "bar",
+							"Unable to allocate bar state");
+				}
+
+				bar->id = strdup(argv[0]);
+			}
+			config->current_bar = bar;
+			++argv; --argc;
+		}
+	}
+
+	if (!config->current_bar) {
+		// Create new bar with default values
+		struct bar_config *bar = default_bar_config();
+		if (!bar) {
+			return cmd_results_new(CMD_FAILURE, "bar",
+					"Unable to allocate bar state");
+		}
+
+		// set bar id
+		for (int i = 0; i < config->bars->length; ++i) {
+			if (bar == config->bars->items[i]) {
+				const int len = 5 + numlen(i); // "bar-" + i + \0
+				bar->id = malloc(len * sizeof(char));
+				if (bar->id) {
+					snprintf(bar->id, len, "bar-%d", i);
+				} else {
+					return cmd_results_new(CMD_FAILURE,
+							"bar", "Unable to allocate bar ID");
+				}
+				break;
 			}
 		}
-		return cmd_results_new(CMD_FAILURE, "bar", "Can only be used in config file.");
+
+		// Set current bar
+		config->current_bar = bar;
+		wlr_log(L_DEBUG, "Creating bar %s", bar->id);
 	}
 
-	// Create new bar with default values
-	struct bar_config *bar = default_bar_config();
-	if (!bar) {
-		return cmd_results_new(CMD_FAILURE, "bar", "Unable to allocate bar state");
-	}
-
-	// set bar id
-	for (int i = 0; i < config->bars->length; ++i) {
-		if (bar == config->bars->items[i]) {
-			const int len = 5 + numlen(i); // "bar-" + i + \0
-			bar->id = malloc(len * sizeof(char));
-			if (bar->id) {
-				snprintf(bar->id, len, "bar-%d", i);
-			} else {
-				return cmd_results_new(CMD_FAILURE,
-						"bar", "Unable to allocate bar ID");
-			}
-			break;
-		}
-	}
-
-	// Set current bar
-	config->current_bar = bar;
-	wlr_log(L_DEBUG, "Configuring bar %s", bar->id);
-	return cmd_results_new(CMD_BLOCK_BAR, NULL, NULL);
+	return subcommand(argv, argc, bar_handlers, sizeof(bar_handlers));
 }

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -52,7 +52,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 			return cmd_results_new(CMD_FAILURE, "bar",
 					"Can only be used in config file.");
 		}
-		return subcommand(argv, argc, bar_config_handlers,
+		return config_subcommand(argv, argc, bar_config_handlers,
 				sizeof(bar_config_handlers));
 	}
 
@@ -111,5 +111,5 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		wlr_log(L_DEBUG, "Creating bar %s", bar->id);
 	}
 
-	return subcommand(argv, argc, bar_handlers, sizeof(bar_handlers));
+	return config_subcommand(argv, argc, bar_handlers, sizeof(bar_handlers));
 }

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -52,7 +52,7 @@ static struct cmd_results *parse_three_colors(char ***colors,
 }
 
 struct cmd_results *bar_cmd_colors(int argc, char **argv) {
-	return subcommand(argv, argc, bar_colors_handlers,
+	return config_subcommand(argv, argc, bar_colors_handlers,
 			sizeof(bar_colors_handlers));
 }
 

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -1,6 +1,21 @@
 #include <string.h>
 #include "sway/commands.h"
 
+// Must be in alphabetical order for bsearch
+static struct cmd_handler bar_colors_handlers[] = {
+	{ "active_workspace", bar_colors_cmd_active_workspace },
+	{ "background", bar_colors_cmd_background },
+	{ "binding_mode", bar_colors_cmd_binding_mode },
+	{ "focused_background", bar_colors_cmd_focused_background },
+	{ "focused_separator", bar_colors_cmd_focused_separator },
+	{ "focused_statusline", bar_colors_cmd_focused_statusline },
+	{ "focused_workspace", bar_colors_cmd_focused_workspace },
+	{ "inactive_workspace", bar_colors_cmd_inactive_workspace },
+	{ "separator", bar_colors_cmd_separator },
+	{ "statusline", bar_colors_cmd_statusline },
+	{ "urgent_workspace", bar_colors_cmd_urgent_workspace },
+};
+
 static struct cmd_results *parse_single_color(char **color,
 		const char *cmd_name, int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -37,15 +52,8 @@ static struct cmd_results *parse_three_colors(char ***colors,
 }
 
 struct cmd_results *bar_cmd_colors(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "colors", EXPECTED_EQUAL_TO, 1))) {
-		return error;
-	}
-	if (strcmp("{", argv[0]) != 0) {
-		return cmd_results_new(CMD_INVALID, "colors",
-				"Expected '{' at the start of colors config definition.");
-	}
-	return cmd_results_new(CMD_BLOCK_BAR_COLORS, NULL, NULL);
+	return subcommand(argv, argc, bar_colors_handlers,
+			sizeof(bar_colors_handlers));
 }
 
 struct cmd_results *bar_colors_cmd_active_workspace(int argc, char **argv) {

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -11,6 +11,9 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 
 	const char *name = argv[0];
 	const char *oldname = config->current_bar->id;
+	if (strcmp(name, oldname) == 0) {
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);  // NOP
+	}
 	// check if id is used by a previously defined bar
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *find = config->bars->items[i];

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -42,8 +42,8 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
 	}
 
-	struct cmd_results *res = subcommand(argv + 1, argc - 1, input_handlers,
-			sizeof(input_handlers));
+	struct cmd_results *res = config_subcommand(argv + 1, argc - 1,
+			input_handlers, sizeof(input_handlers));
 
 	free_input_config(config->handler_context.input_config);
 	config->handler_context.input_config = NULL;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -3,85 +3,50 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 #include "log.h"
+#include "stringop.h"
+
+// must be in order for the bsearch
+static struct cmd_handler input_handlers[] = {
+	{ "accel_profile", input_cmd_accel_profile },
+	{ "click_method", input_cmd_click_method },
+	{ "drag_lock", input_cmd_drag_lock },
+	{ "dwt", input_cmd_dwt },
+	{ "events", input_cmd_events },
+	{ "left_handed", input_cmd_left_handed },
+	{ "map_from_region", input_cmd_map_from_region },
+	{ "map_to_output", input_cmd_map_to_output },
+	{ "middle_emulation", input_cmd_middle_emulation },
+	{ "natural_scroll", input_cmd_natural_scroll },
+	{ "pointer_accel", input_cmd_pointer_accel },
+	{ "repeat_delay", input_cmd_repeat_delay },
+	{ "repeat_rate", input_cmd_repeat_rate },
+	{ "scroll_method", input_cmd_scroll_method },
+	{ "tap", input_cmd_tap },
+	{ "xkb_layout", input_cmd_xkb_layout },
+	{ "xkb_model", input_cmd_xkb_model },
+	{ "xkb_options", input_cmd_xkb_options },
+	{ "xkb_rules", input_cmd_xkb_rules },
+	{ "xkb_variant", input_cmd_xkb_variant },
+};
 
 struct cmd_results *cmd_input(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 2))) {
+	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
-	if (config->reading && strcmp("{", argv[1]) == 0) {
-		free_input_config(config->handler_context.input_config);
-		config->handler_context.input_config = new_input_config(argv[0]);
-		if (!config->handler_context.input_config) {
-			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
-		}
-		wlr_log(L_DEBUG, "entering input block: %s", argv[0]);
-		return cmd_results_new(CMD_BLOCK_INPUT, NULL, NULL);
+	wlr_log(L_DEBUG, "entering input block: %s", argv[0]);
+
+	config->handler_context.input_config = new_input_config(argv[0]);
+	if (!config->handler_context.input_config) {
+		return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
 	}
 
-	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 3))) {
-		return error;
-	}
+	struct cmd_results *res = subcommand(argv + 1, argc - 1, input_handlers,
+			sizeof(input_handlers));
 
-	bool has_context = (config->handler_context.input_config != NULL);
-	if (!has_context) {
-		// caller did not give a context so create one just for this command
-		config->handler_context.input_config = new_input_config(argv[0]);
-		if (!config->handler_context.input_config) {
-			return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
-		}
-	}
-
-	int argc_new = argc-2;
-	char **argv_new = argv+2;
-
-	struct cmd_results *res;
-	if (strcasecmp("accel_profile", argv[1]) == 0) {
-		res = input_cmd_accel_profile(argc_new, argv_new);
-	} else if (strcasecmp("click_method", argv[1]) == 0) {
-		res = input_cmd_click_method(argc_new, argv_new);
-	} else if (strcasecmp("drag_lock", argv[1]) == 0) {
-		res = input_cmd_drag_lock(argc_new, argv_new);
-	} else if (strcasecmp("dwt", argv[1]) == 0) {
-		res = input_cmd_dwt(argc_new, argv_new);
-	} else if (strcasecmp("events", argv[1]) == 0) {
-		res = input_cmd_events(argc_new, argv_new);
-	} else if (strcasecmp("left_handed", argv[1]) == 0) {
-		res = input_cmd_left_handed(argc_new, argv_new);
-	} else if (strcasecmp("middle_emulation", argv[1]) == 0) {
-		res = input_cmd_middle_emulation(argc_new, argv_new);
-	} else if (strcasecmp("natural_scroll", argv[1]) == 0) {
-		res = input_cmd_natural_scroll(argc_new, argv_new);
-	} else if (strcasecmp("pointer_accel", argv[1]) == 0) {
-		res = input_cmd_pointer_accel(argc_new, argv_new);
-	} else if (strcasecmp("repeat_delay", argv[1]) == 0) {
-		res = input_cmd_repeat_delay(argc_new, argv_new);
-	} else if (strcasecmp("repeat_rate", argv[1]) == 0) {
-		res = input_cmd_repeat_rate(argc_new, argv_new);
-	} else if (strcasecmp("scroll_method", argv[1]) == 0) {
-		res = input_cmd_scroll_method(argc_new, argv_new);
-	} else if (strcasecmp("tap", argv[1]) == 0) {
-		res = input_cmd_tap(argc_new, argv_new);
-	} else if (strcasecmp("xkb_layout", argv[1]) == 0) {
-		res = input_cmd_xkb_layout(argc_new, argv_new);
-	} else if (strcasecmp("xkb_model", argv[1]) == 0) {
-		res = input_cmd_xkb_model(argc_new, argv_new);
-	} else if (strcasecmp("xkb_options", argv[1]) == 0) {
-		res = input_cmd_xkb_options(argc_new, argv_new);
-	} else if (strcasecmp("xkb_rules", argv[1]) == 0) {
-		res = input_cmd_xkb_rules(argc_new, argv_new);
-	} else if (strcasecmp("xkb_variant", argv[1]) == 0) {
-		res = input_cmd_xkb_variant(argc_new, argv_new);
-	} else {
-		res = cmd_results_new(CMD_INVALID, "input <device>", "Unknown command %s", argv[1]);
-	}
-
-	if (!has_context) {
-		// clean up the context we created earlier
-		free_input_config(config->handler_context.input_config);
-		config->handler_context.input_config = NULL;
-	}
+	free_input_config(config->handler_context.input_config);
+	config->handler_context.input_config = NULL;
 
 	return res;
 }

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -65,8 +65,8 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 	}
 
 	// Create binding
-	struct cmd_results *result = subcommand(argv + 1, argc - 1, mode_handlers,
-			sizeof(mode_handlers));
+	struct cmd_results *result = config_subcommand(argv + 1, argc - 1,
+			mode_handlers, sizeof(mode_handlers));
 	config->current_mode = config->modes->items[0];
 
 	return result;

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -7,6 +7,13 @@
 #include "sway/ipc-server.h"
 #include "list.h"
 #include "log.h"
+#include "stringop.h"
+
+// Must be in order for the bsearch
+static struct cmd_handler mode_handlers[] = {
+	{ "bindcode", cmd_bindcode },
+	{ "bindsym", cmd_bindsym }
+};
 
 struct cmd_results *cmd_mode(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -14,12 +21,12 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		return error;
 	}
 
-	const char *mode_name = argv[0];
-	bool new_mode = (argc == 2 && strcmp(argv[1], "{") == 0);
-	if (new_mode && !config->reading) {
+	if (argc > 1 && !config->reading) {
 		return cmd_results_new(CMD_FAILURE,
 				"mode", "Can only be used in config file.");
 	}
+
+	const char *mode_name = argv[0];
 	struct sway_mode *mode = NULL;
 	// Find mode
 	for (int i = 0; i < config->modes->length; ++i) {
@@ -30,7 +37,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		}
 	}
 	// Create mode if it doesn't exist
-	if (!mode && new_mode) {
+	if (!mode && argc > 1) {
 		mode = calloc(1, sizeof(struct sway_mode));
 		if (!mode) {
 			return cmd_results_new(CMD_FAILURE,
@@ -46,14 +53,21 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 				"mode", "Unknown mode `%s'", mode_name);
 		return error;
 	}
-	if ((config->reading && new_mode) || (!config->reading && !new_mode)) {
+	if ((config->reading && argc > 1) || (!config->reading && argc == 1)) {
 		wlr_log(L_DEBUG, "Switching to mode `%s'",mode->name);
 	}
 	// Set current mode
 	config->current_mode = mode;
-	if (!new_mode) {
+	if (argc == 1) {
 		// trigger IPC mode event
 		ipc_event_mode(config->current_mode->name);
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
-	return cmd_results_new(new_mode ? CMD_BLOCK_MODE : CMD_SUCCESS, NULL, NULL);
+
+	// Create binding
+	struct cmd_results *result = subcommand(argv + 1, argc - 1, mode_handlers,
+			sizeof(mode_handlers));
+	config->current_mode = config->modes->items[0];
+
+	return result;
 }

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -3,59 +3,32 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 #include "log.h"
+#include "stringop.h"
+
+// must be in order for the bsearch
+static struct cmd_handler seat_handlers[] = {
+	{ "attach", seat_cmd_attach },
+	{ "cursor", seat_cmd_cursor },
+	{ "fallback", seat_cmd_fallback },
+};
 
 struct cmd_results *cmd_seat(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 2))) {
+	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
-	if (config->reading && strcmp("{", argv[1]) == 0) {
-		free_seat_config(config->handler_context.seat_config);
-		config->handler_context.seat_config = new_seat_config(argv[0]);
-		if (!config->handler_context.seat_config) {
-			return cmd_results_new(CMD_FAILURE, NULL,
-					"Couldn't allocate config");
-		}
-		wlr_log(L_DEBUG, "entering seat block: %s", argv[0]);
-		return cmd_results_new(CMD_BLOCK_SEAT, NULL, NULL);
+	config->handler_context.seat_config = new_seat_config(argv[0]);
+	if (!config->handler_context.seat_config) {
+		return cmd_results_new(CMD_FAILURE, NULL,
+				"Couldn't allocate config");
 	}
 
-	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 3))) {
-		return error;
-	}
+	struct cmd_results *res = subcommand(argv + 1, argc - 1, seat_handlers,
+			sizeof(seat_handlers));
 
-	bool has_context = (config->handler_context.seat_config != NULL);
-	if (!has_context) {
-		config->handler_context.seat_config = new_seat_config(argv[0]);
-		if (!config->handler_context.seat_config) {
-			return cmd_results_new(CMD_FAILURE, NULL,
-					"Couldn't allocate config");
-		}
-	}
-
-	int argc_new = argc-2;
-	char **argv_new = argv+2;
-
-	struct cmd_results *res;
-	if (strcasecmp("attach", argv[1]) == 0) {
-		res = seat_cmd_attach(argc_new, argv_new);
-	} else if (strcasecmp("cursor", argv[1]) == 0) {
-		res = seat_cmd_cursor(argc_new, argv_new);
-	} else if (strcasecmp("fallback", argv[1]) == 0) {
-		res = seat_cmd_fallback(argc_new, argv_new);
-	} else {
-		res =
-			cmd_results_new(CMD_INVALID,
-				"seat <name>", "Unknown command %s",
-				argv[1]);
-	}
-
-	if (!has_context) {
-		// clean up the context we created earlier
-		free_seat_config(config->handler_context.seat_config);
-		config->handler_context.seat_config = NULL;
-	}
+	free_seat_config(config->handler_context.seat_config);
+	config->handler_context.seat_config = NULL;
 
 	return res;
 }

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -24,8 +24,8 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 				"Couldn't allocate config");
 	}
 
-	struct cmd_results *res = subcommand(argv + 1, argc - 1, seat_handlers,
-			sizeof(seat_handlers));
+	struct cmd_results *res = config_subcommand(argv + 1, argc - 1,
+			seat_handlers, sizeof(seat_handlers));
 
 	free_seat_config(config->handler_context.seat_config);
 	config->handler_context.seat_config = NULL;

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -98,7 +98,6 @@ static void keyboard_execute_command(struct sway_keyboard *keyboard,
 		struct sway_binding *binding) {
 	wlr_log(L_DEBUG, "running command for binding: %s",
 		binding->command);
-	config_clear_handler_context(config);
 	config->handler_context.seat = keyboard->seat_device->sway_seat;
 	struct cmd_results *results = execute_command(binding->command, NULL);
 	if (results->status != CMD_SUCCESS) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -469,7 +469,6 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	switch (client->current_command) {
 	case IPC_COMMAND:
 	{
-		config_clear_handler_context(config);
 		struct cmd_results *results = execute_command(buf, NULL);
 		const char *json = cmd_results_to_json(results);
 		char reply[256];


### PR DESCRIPTION
Overview
-------------
Fixes #547 - Generic Code Blocks
Fixed #1034 - Braces on following line
Fixes #1753 - Output Block

This allows for any command to be given in either block form or expanded form. All commands should be working now.

`bar` command
----
For `bar`, the following syntax structures should be working:
1. Block with optional id subcommand (currently in master)
     ```
    bar {
        id bar-one
        <bar-command>
    }
    # - or, if you prefer the brace on the following line --
    bar
    {
        id bar-one
        <bar-command>
    }
    ```
2. Identifier block (similar to input and seat in master)
    ```
    bar bar-one {
        <bar-command>
    }
    ```
3. Nested
    ```
    bar {
        bar-one {
            <bar-command>
        }
        bar-two {
            <bar-command>
        }
        bar-three <bar-command>
    }
    ```
4. Expanded with identifier
    ```
    bar bar-one <bar-commad>
    ``` 
5. Expanded with identifier on bar change
    ```
    bar bar-one <bar-command>
    bar <bar-command>
    bar bar-two <bar-command>
    bar <bar-command>
    ```

TODO
----------------------------------------------
- [X] Restructure functions to support any command being a given as a block or single line
- [X] Update current blocks to work again
    - [X] `mode`
    - [X] `bar` (See Above)
    - [X] `bar colors`
    - [X] `input`
    - [X] `seat`
- [X] Test all commands and update as necessary