### PR TITLE
Fix moving out of tab/stack when only child

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -315,7 +315,7 @@ static void move_out_of_tabs_stacks(struct sway_container *container,
 	if (container->parent == current->parent
 			&& current->parent->children->length == 1) {
 		wlr_log(L_DEBUG, "Changing layout of %zd", current->parent->id);
-		current->parent->layout = move_dir =
+		current->parent->layout = move_dir ==
 			MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT;
 		if (current->parent->type == C_WORKSPACE) {
 			arrange_workspace(current->parent);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -312,6 +312,19 @@ static void workspace_rejigger(struct sway_container *ws,
 static void move_out_of_tabs_stacks(struct sway_container *container,
 		struct sway_container *current, enum movement_direction move_dir,
 		int offs) {
+	if (container->parent == current->parent
+			&& current->parent->children->length == 1) {
+		wlr_log(L_DEBUG, "Changing layout of %zd", current->parent->id);
+		current->parent->layout = move_dir =
+			MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT;
+		if (current->parent->type == C_WORKSPACE) {
+			arrange_workspace(current->parent);
+		} else {
+			arrange_children_of(current->parent);
+		}
+		return;
+	}
+
 	wlr_log(L_DEBUG, "Moving out of tab/stack into a split");
 	bool is_workspace = current->parent->type == C_WORKSPACE;
 	struct sway_container *old_parent = current->parent->parent;


### PR DESCRIPTION
Fixes #2078 

This handles moving out of a tab/stack when the container is the only child.