### PR TITLE
Reduce work duplication in keyboard and binding code

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -6,7 +6,20 @@
 #define SWAY_KEYBOARD_PRESSED_KEYS_CAP 32
 
 struct sway_shortcut_state {
+	/**
+	 * A list of pressed key ids (either keysyms or keycodes),
+	 * including duplicates when different keycodes produce the same key id.
+	 *
+	 * Each key id is associated with the keycode (in `pressed_keycodes`)
+	 * whose press generated it, so that the key id can be removed on
+	 * keycode release without recalculating the transient link between
+	 * keycode and key id at the time of the key press.
+	 */
 	uint32_t pressed_keys[SWAY_KEYBOARD_PRESSED_KEYS_CAP];
+	/**
+	 * The list of keycodes associated to currently pressed key ids,
+	 * including duplicates when a keycode generates multiple key ids.
+	 */
 	uint32_t pressed_keycodes[SWAY_KEYBOARD_PRESSED_KEYS_CAP];
 	int last_key_index;
 };

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -3,7 +3,13 @@
 
 #include "sway/input/seat.h"
 
-#define SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP 32
+#define SWAY_KEYBOARD_PRESSED_KEYS_CAP 32
+
+struct sway_shortcut_state {
+	uint32_t pressed_keys[SWAY_KEYBOARD_PRESSED_KEYS_CAP];
+	uint32_t pressed_keycodes[SWAY_KEYBOARD_PRESSED_KEYS_CAP];
+	int last_key_index;
+};
 
 struct sway_keyboard {
 	struct sway_seat_device *seat_device;
@@ -13,11 +19,11 @@ struct sway_keyboard {
 	struct wl_listener keyboard_key;
 	struct wl_listener keyboard_modifiers;
 
-	xkb_keysym_t pressed_keysyms_translated[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
-	uint32_t modifiers_translated;
-
-	xkb_keysym_t pressed_keysyms_raw[SWAY_KEYBOARD_PRESSED_KEYSYMS_CAP];
-	uint32_t modifiers_raw;
+	struct sway_shortcut_state state_keysyms_translated;
+	struct sway_shortcut_state state_keysyms_raw;
+	struct sway_shortcut_state state_keycodes;
+	struct sway_binding *held_binding;
+	uint32_t last_modifiers;
 };
 
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -69,8 +69,9 @@ bool binding_key_compare(struct sway_binding *binding_a,
 	return true;
 }
 
-static struct cmd_results * cmd_bindsym_or_bindcode(int argc, char **argv, bool bindcode) {
-	const char* bindtype = bindcode ? "bindcode" : "bindsym";
+static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
+		bool bindcode) {
+	const char *bindtype = bindcode ? "bindcode" : "bindsym";
 
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, bindtype, EXPECTED_MORE_THAN, 1))) {
@@ -149,7 +150,7 @@ static struct cmd_results * cmd_bindsym_or_bindcode(int argc, char **argv, bool 
 				return ret;
 			}
 		}
-		uint32_t *key = calloc(1, sizeof(xkb_keysym_t));
+		uint32_t *key = calloc(1, sizeof(uint32_t));
 		if (!key) {
 			free_sway_binding(binding);
 			free_flat_list(split);
@@ -158,9 +159,9 @@ static struct cmd_results * cmd_bindsym_or_bindcode(int argc, char **argv, bool 
 		}
 
 		if (bindcode) {
-			*key = (uint32_t) keycode;
+			*key = (uint32_t)keycode;
 		} else {
-			*key = (uint32_t) keysym;
+			*key = (uint32_t)keysym;
 		}
 
 		list_add(binding->keys, key);

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -158,7 +158,7 @@ static struct cmd_results * cmd_bindsym_or_bindcode(int argc, char **argv, bool 
 		}
 
 		if (bindcode) {
-			*key = (uint32_t) (keycode - 8);
+			*key = (uint32_t) keycode;
 		} else {
 			*key = (uint32_t) keysym;
 		}

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -86,7 +86,7 @@ static struct cmd_results * cmd_bindsym_or_bindcode(int argc, char **argv, bool 
 	binding->modifiers = 0;
 	binding->release = false;
 	binding->locked = false;
-	binding->bindcode = false;
+	binding->bindcode = bindcode;
 
 	// Handle --release and --locked
 	while (argc > 0) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -12,10 +12,9 @@
 /**
  * Update the shortcut model state in response to new input
  */
-static void update_shortcut_model(struct sway_shortcut_state* state,
-				  struct wlr_event_keyboard_key * event,
-				  uint32_t new_key,
-				  bool last_key_was_a_modifier) {
+static void update_shortcut_model(struct sway_shortcut_state *state,
+		struct wlr_event_keyboard_key *event, uint32_t new_key,
+		bool last_key_was_a_modifier) {
 	if (event->state == WLR_KEY_PRESSED) {
 		if (last_key_was_a_modifier && state->last_key_index >= 0) {
 			// Last pressed key before this one was a modifier. We nullify
@@ -26,7 +25,7 @@ static void update_shortcut_model(struct sway_shortcut_state* state,
 		}
 
 		// Add current key to set; there may be duplicates
-		for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; i++) {
+		for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; ++i) {
 			if (!state->pressed_keys[i]) {
 				state->pressed_keys[i] = new_key;
 				state->pressed_keycodes[i] = event->keycode;
@@ -35,7 +34,7 @@ static void update_shortcut_model(struct sway_shortcut_state* state,
 			}
 		}
 	} else {
-		for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; i++) {
+		for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; ++i) {
 			// The same keycode may match multiple keysyms.
 			if (state->pressed_keycodes[i] == event->keycode) {
 				state->pressed_keys[i] = 0;
@@ -50,11 +49,11 @@ static void update_shortcut_model(struct sway_shortcut_state* state,
  * Returns a binding which matches the shortcut model state (ignoring the
  * `release` flag).
  */
-static struct sway_binding* check_shortcut_model(
-		struct sway_shortcut_state* state, list_t* bindings,
+static struct sway_binding *check_shortcut_model(
+		struct sway_shortcut_state *state, list_t *bindings,
 		uint32_t modifiers, bool locked) {
 	int npressed_keys = 0;
-	for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; i++) {
+	for (size_t i = 0; i < SWAY_KEYBOARD_PRESSED_KEYS_CAP; ++i) {
 		if (state->pressed_keys[i]) {
 			++npressed_keys;
 		}
@@ -70,10 +69,10 @@ static struct sway_binding* check_shortcut_model(
 
 		bool match = true;
 		for (int j = 0; j < binding->keys->length; ++j) {
-			uint32_t key = *(uint32_t*)binding->keys->items[j];
+			uint32_t key = *(uint32_t *)binding->keys->items[j];
 
 			bool key_found = false;
-			for (int k = 0; k < SWAY_KEYBOARD_PRESSED_KEYS_CAP; k++) {
+			for (int k = 0; k < SWAY_KEYBOARD_PRESSED_KEYS_CAP; ++k) {
 				if (state->pressed_keys[k] == key) {
 					key_found = true;
 					break;
@@ -216,13 +215,13 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 
 	// Update shortcut models
 	update_shortcut_model(&keyboard->state_keycodes, event,
-			      (uint32_t)keycode, last_key_was_a_modifier);
-	for (size_t i=0;i<translated_keysyms_len;i++) {
+			(uint32_t)keycode, last_key_was_a_modifier);
+	for (size_t i = 0; i < translated_keysyms_len; ++i) {
 		update_shortcut_model(&keyboard->state_keysyms_translated,
 				event, (uint32_t)translated_keysyms[i],
 				last_key_was_a_modifier);
 	}
-	for (size_t i=0;i<raw_keysyms_len;i++) {
+	for (size_t i = 0; i < raw_keysyms_len; ++i) {
 		update_shortcut_model(&keyboard->state_keysyms_raw,
 				event, (uint32_t)raw_keysyms[i],
 				last_key_was_a_modifier);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -12,7 +12,7 @@
 /**
  * Update the shortcut model state in response to new input
  */
-static void update_shortcut_model(struct sway_shortcut_state *state,
+static void update_shortcut_state(struct sway_shortcut_state *state,
 		struct wlr_event_keyboard_key *event, uint32_t new_key,
 		bool last_key_was_a_modifier) {
 	if (event->state == WLR_KEY_PRESSED) {
@@ -213,16 +213,16 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	bool last_key_was_a_modifier = code_modifiers != keyboard->last_modifiers;
 	keyboard->last_modifiers = code_modifiers;
 
-	// Update shortcut models
-	update_shortcut_model(&keyboard->state_keycodes, event,
+	// Update shortcut model state
+	update_shortcut_state(&keyboard->state_keycodes, event,
 			(uint32_t)keycode, last_key_was_a_modifier);
 	for (size_t i = 0; i < translated_keysyms_len; ++i) {
-		update_shortcut_model(&keyboard->state_keysyms_translated,
+		update_shortcut_state(&keyboard->state_keysyms_translated,
 				event, (uint32_t)translated_keysyms[i],
 				last_key_was_a_modifier);
 	}
 	for (size_t i = 0; i < raw_keysyms_len; ++i) {
-		update_shortcut_model(&keyboard->state_keysyms_raw,
+		update_shortcut_state(&keyboard->state_keysyms_raw,
 				event, (uint32_t)raw_keysyms[i],
 				last_key_was_a_modifier);
 	}

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -17,9 +17,8 @@ static void update_shortcut_state(struct sway_shortcut_state *state,
 		bool last_key_was_a_modifier) {
 	if (event->state == WLR_KEY_PRESSED) {
 		if (last_key_was_a_modifier && state->last_key_index >= 0) {
-			// Last pressed key before this one was a modifier. We nullify
-			// the key id but not the keycode (as that is used for erasure
-			// on release)
+			// Last pressed key before this one was a modifier
+			state->pressed_keycodes[state->last_key_index] = 0;
 			state->pressed_keys[state->last_key_index] = 0;
 			state->last_key_index = -1;
 		}
@@ -62,8 +61,8 @@ static struct sway_binding *get_active_binding(
 		struct sway_binding *binding = bindings->items[i];
 
 		if (modifiers ^ binding->modifiers ||
-			npressed_keys != binding->keys->length ||
-			locked > binding->locked) {
+				npressed_keys != binding->keys->length ||
+				locked > binding->locked) {
 			continue;
 		}
 
@@ -219,12 +218,12 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	for (size_t i = 0; i < translated_keysyms_len; ++i) {
 		update_shortcut_state(&keyboard->state_keysyms_translated,
 				event, (uint32_t)translated_keysyms[i],
-				last_key_was_a_modifier);
+				last_key_was_a_modifier && i == 0);
 	}
 	for (size_t i = 0; i < raw_keysyms_len; ++i) {
 		update_shortcut_state(&keyboard->state_keysyms_raw,
 				event, (uint32_t)raw_keysyms[i],
-				last_key_was_a_modifier);
+				last_key_was_a_modifier && i == 0);
 	}
 
 	// identify which binding should be executed.

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -49,7 +49,7 @@ static void update_shortcut_model(struct sway_shortcut_state *state,
  * Returns a binding which matches the shortcut model state (ignoring the
  * `release` flag).
  */
-static struct sway_binding *check_shortcut_model(
+static struct sway_binding *get_active_binding(
 		struct sway_shortcut_state *state, list_t *bindings,
 		uint32_t modifiers, bool locked) {
 	int npressed_keys = 0;
@@ -228,11 +228,11 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	}
 
 	// identify which binding should be executed.
-	struct sway_binding *binding = check_shortcut_model(
+	struct sway_binding *binding = get_active_binding(
 			&keyboard->state_keycodes,
 			config->current_mode->keycode_bindings,
 			code_modifiers, input_inhibited);
-	struct sway_binding *translated_binding = check_shortcut_model(
+	struct sway_binding *translated_binding = get_active_binding(
 			&keyboard->state_keysyms_translated,
 			config->current_mode->keysym_bindings,
 			translated_modifiers, input_inhibited);
@@ -242,7 +242,7 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 		wlr_log(L_DEBUG, "encountered duplicate bindings %d and %d",
 			binding->order, translated_binding->order);
 	}
-	struct sway_binding *raw_binding = check_shortcut_model(
+	struct sway_binding *raw_binding = get_active_binding(
 			&keyboard->state_keysyms_raw,
 			config->current_mode->keysym_bindings,
 			raw_modifiers, input_inhibited);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -229,33 +229,29 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	}
 
 	// identify which binding should be executed.
-	struct sway_binding *binding =
-		check_shortcut_model(&keyboard->state_keycodes,
-				 config->current_mode->keycode_bindings,
-				 code_modifiers, input_inhibited);
-	for (size_t i=0;i<translated_keysyms_len;i++) {
-		struct sway_binding *translated_binding =
-			check_shortcut_model(&keyboard->state_keysyms_translated,
-				 config->current_mode->keysym_bindings,
-				 translated_modifiers, input_inhibited);
-		if (translated_binding && !binding) {
-			binding = translated_binding;
-		} else if (binding && translated_binding && binding != translated_binding) {
-			wlr_log(L_DEBUG, "encountered duplicate bindings %d and %d",
-				binding->order, translated_binding->order);
-		}
+	struct sway_binding *binding = check_shortcut_model(
+			&keyboard->state_keycodes,
+			config->current_mode->keycode_bindings,
+			code_modifiers, input_inhibited);
+	struct sway_binding *translated_binding = check_shortcut_model(
+			&keyboard->state_keysyms_translated,
+			config->current_mode->keysym_bindings,
+			translated_modifiers, input_inhibited);
+	if (translated_binding && !binding) {
+		binding = translated_binding;
+	} else if (binding && translated_binding && binding != translated_binding) {
+		wlr_log(L_DEBUG, "encountered duplicate bindings %d and %d",
+			binding->order, translated_binding->order);
 	}
-	for (size_t i=0;i<raw_keysyms_len;i++) {
-		struct sway_binding *raw_binding =
-			check_shortcut_model(&keyboard->state_keysyms_raw,
-				config->current_mode->keysym_bindings,
-				raw_modifiers, input_inhibited);
-		if (raw_binding && !binding) {
-			binding = raw_binding;
-		} else if (binding && raw_binding && binding != raw_binding) {
-			wlr_log(L_DEBUG, "encountered duplicate bindings %d and %d",
-				binding->order, raw_binding->order);
-		}
+	struct sway_binding *raw_binding = check_shortcut_model(
+			&keyboard->state_keysyms_raw,
+			config->current_mode->keysym_bindings,
+			raw_modifiers, input_inhibited);
+	if (raw_binding && !binding) {
+		binding = raw_binding;
+	} else if (binding && raw_binding && binding != raw_binding) {
+		wlr_log(L_DEBUG, "encountered duplicate bindings %d and %d",
+			binding->order, raw_binding->order);
 	}
 
 	bool handled = false;


### PR DESCRIPTION
This pull request first simplifies the bindcode and bindsym generation code, 
so that the binding generated are identical in form up to the ids used to identify
the set of pressed keys; as most of the code between `cmd_bindsym` and `cmd_bindcode`
is shared, the two functions have been merged.

(Keycode numbering is briefly adjusted to match the XKB numbering scheme, like i3 seems to. (?))

The next large change is a rewrite of the shortcut handling, which should preserve the same behavior
except in edge cases. A single shortcut model is used for keycodes, raw keysyms, and translated keysyms. Release flag shortcuts are now identified on the preceding keypress, triggered if the next keyrelease breaks the shortcut condition, and kept if the next key event doesn't change shortcut state. The hardcoded list of modifier keys has been replaced by a retroactive test.

This pull request closes  #1844 . It interferes with PR #2064, as it uses a slightly different solution to solve the same issue (#2020).

I have not yet, but probably should, seen what happens with dead, compose, or latch keys. `bindsym --release Control_L` does work, and I haven't yet discovered any bugs with my existing setup.

