### PR TITLE
Send reparent events in container_split

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -327,7 +327,6 @@ static void move_out_of_tabs_stacks(struct sway_container *container,
 
 	wlr_log(L_DEBUG, "Moving out of tab/stack into a split");
 	bool is_workspace = current->parent->type == C_WORKSPACE;
-	struct sway_container *old_parent = current->parent->parent;
 	struct sway_container *new_parent = container_split(current->parent,
 		move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT);
 	if (is_workspace) {
@@ -337,7 +336,6 @@ static void move_out_of_tabs_stacks(struct sway_container *container,
 		container_reap_empty_recursive(new_parent->parent);
 		container_flatten(new_parent->parent);
 	}
-	wl_signal_emit(&container->events.reparent, old_parent);
 	container_create_notify(new_parent);
 	if (is_workspace) {
 		arrange_workspace(new_parent->parent);
@@ -902,6 +900,7 @@ struct sway_container *container_split(struct sway_container *child,
 			struct sway_container *ws_child = workspace->children->items[0];
 			container_remove_child(ws_child);
 			container_add_child(cont, ws_child);
+			wl_signal_emit(&ws_child->events.reparent, workspace);
 		}
 
 		container_add_child(workspace, cont);
@@ -913,9 +912,11 @@ struct sway_container *container_split(struct sway_container *child,
 			seat_set_focus(seat, cont);
 		}
 	} else {
+		struct sway_container *old_parent = child->parent;
 		cont->layout = layout;
 		container_replace_child(child, cont);
 		container_add_child(cont, child);
+		wl_signal_emit(&child->events.reparent, old_parent);
 	}
 
 	container_notify_subtree_changed(cont);


### PR DESCRIPTION
Fixes #2077 

I was sending the reparent event for the wrong container, which may have been freed by `container_flatten`. It was supposed to be for the container being split (`container_insert_child` already handles it for the container being moved out of the tab/stack). 

I decided the correct solution was not to send the reparent event after `container_split`, but in the `container_split` function itself.