### PR TITLE
Fix move perpendicular segfault

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -521,7 +521,6 @@ void container_move(struct sway_container *container,
 				sibling = NULL;
 			} else {
 				wlr_log(L_DEBUG, "Reparenting container (perpendicular)");
-				container_remove_child(container);
 				struct sway_container *focus_inactive = seat_get_focus_inactive(
 						config->handler_context.seat, sibling);
 				if (focus_inactive) {
@@ -534,9 +533,11 @@ void container_move(struct sway_container *container,
 					continue;
 				} else if (sibling->children->length) {
 					wlr_log(L_DEBUG, "No focus-inactive, adding arbitrarily");
+					container_remove_child(container);
 					container_add_sibling(sibling->children->items[0], container);
 				} else {
 					wlr_log(L_DEBUG, "No kiddos, adding container alone");
+					container_remove_child(container);
 					container_add_child(sibling, container);
 				}
 				container->width = container->height = 0;


### PR DESCRIPTION
Fixes the `SEGV on unknown address 0x000000000060` issue @martinetd found when testing #2081.

```
==2950==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000060 (pc 0x000000457a0d bp 0x7ffe81407ae0 sp 0x7ffe8
1407ac0 T0)
==2950==The signal is caused by a READ memory access.
==2950==Hint: address points to the zero page.
    #0 0x457a0c in container_remove_child ../sway/tree/layout.c:145
    #1 0x45b06d in container_move ../sway/tree/layout.c:522
    #2 0x44350b in cmd_move ../sway/commands/move.c:178
    #3 0x40e414 in execute_command ../sway/commands.c:369
    #4 0x435f7d in keyboard_execute_command ../sway/input/keyboard.c:100
    #5 0x43636e in keyboard_execute_bindsym ../sway/input/keyboard.c:168
    #6 0x437590 in handle_keyboard_key ../sway/input/keyboard.c:380
    #7 0x7f48a54d8948 in wlr_signal_emit_safe ../util/signal.c:29
    #8 0x7f48a54ba08f in wlr_keyboard_notify_key ../types/wlr_keyboard.c:125
    #9 0x7f48a547b64a in handle_keyboard_key ../backend/libinput/keyboard.c:73
    #10 0x7f48a547a0ca in handle_libinput_readable ../backend/libinput/backend.c:35
    #11 0x7f48a5746f01 in wl_event_loop_dispatch src/event-loop.c:641
    #12 0x7f48a5745601 in wl_display_run src/wayland-server.c:1260
    #13 0x409da6 in main ../sway/main.c:428
    #14 0x7f48a4c2818a in __libc_start_main (/lib64/libc.so.6+0x2318a)
    #15 0x40b049 in _start (/opt/wayland/bin/sway+0x40b049)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ../sway/tree/layout.c:145 in container_remove_child
==2950==ABORTING
```

The issue occurs in the `Reparenting container (perpendicular)` section. The `container` was being removed from it's parent (and parent set to `NULL`), then the `sibling` pointer was being changed and due to the `continue` starting back at the top. The second time around, it would segfault when attempting to remove `container` from it's parent, which is now `NULL`.

I was able to reproduce with the starting representation of `H[view#1 V[view#2 V[view#3 view#4]]]`. With `view#3` focused, move left twice, and then move right twice. On the second move right, it would segfault.