### PR TITLE
Fix cmd_workspace crash when a surface has focus

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -90,13 +90,6 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			free(name);
 		}
 		workspace_switch(ws);
-		current_container =
-			seat_get_focus(config->handler_context.seat);
-		struct sway_container *new_output = container_parent(current_container, C_OUTPUT);
-
-		if (config->mouse_warping && old_output != new_output) {
-			// TODO: Warp mouse
-		}
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }


### PR DESCRIPTION
Fixes #1976 
Fixes #1957 

Switching workspaces would cause a crash when a layer surface has focus, such as swaylock. This is due to the seat not having focus so `seat_get_focus` returns `NULL`, which fails the assert in `container_parent` on the following line.

The only reason why `seat_get_focus` was called was to handle mouse warping. This is already handled by the `seat_set_focus` call in `workspace_switch` though so it can be removed entirely