### PR TITLE
Fix top border when a view is initially floating

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -137,7 +137,10 @@ static void view_autoconfigure_floating(struct sway_view *view) {
 	int lx = ws->x + (ws->width - width) / 2;
 	int ly = ws->y + (ws->height - height) / 2;
 
-	view->border_left = view->border_right = view->border_bottom = true;
+	// If the view's border is B_NONE then these properties are ignored.
+	view->border_top = view->border_bottom = true;
+	view->border_left = view->border_right = true;
+
 	view_configure(view, lx, ly, width, height);
 }
 


### PR DESCRIPTION
Fixes #2085.

Those properties control whether the individual borders are rendered, and only take effect if the view's border is not `B_NONE`. Therefore it's safe to set them all to true. It initialises the values if the view is initially floating, and undoes any `hide_edge_borders` effects if the view was previously tiled.