### PR TITLE
sway/config: fix use-after-free for end of block

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -626,13 +626,13 @@ bool read_config(FILE *file, struct sway_config *config) {
 				success = false;
 				break;
 			}
-			wlr_log(L_DEBUG, "Exiting block '%s'", block);
-			list_del(stack, 0);
-			free(block);
-
 			if (strcmp(block, "bar") == 0) {
 				config->current_bar = NULL;
 			}
+
+			wlr_log(L_DEBUG, "Exiting block '%s'", block);
+			list_del(stack, 0);
+			free(block);
 			memset(&config->handler_context, 0,
 					sizeof(config->handler_context));
 		default:;


### PR DESCRIPTION
Introduced in 7c810dc344c28d1876c5ee158cb0806289d0f813