### PR TITLE
Schedule a frame even if damage is empty

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1066,6 +1066,8 @@ static void damage_surface_iterator(struct wlr_surface *surface, int sx, int sy,
 		wlr_box_rotated_bounds(&box, rotation, &box);
 		wlr_output_damage_add_box(output->damage, &box);
 	}
+
+	wlr_output_schedule_frame(output->wlr_output);
 }
 
 void output_damage_surface(struct sway_output *output, double ox, double oy,


### PR DESCRIPTION
This fixes clients scheduling a frame by committing without damaging anything like so:

```
callback = wl_surface_frame(surface);
wl_surface_commit(surface);
```