### PR TITLE
Fix view title update order

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -790,8 +790,10 @@ void view_update_title(struct sway_view *view, bool force) {
 		view->swayc->formatted_title = NULL;
 	}
 	container_calculate_title_height(view->swayc);
-	container_update_title_textures(view->swayc);
 	config_update_font_height(false);
+
+	// Update title after the global font height is updated
+	container_update_title_textures(view->swayc);
 }
 
 static bool find_by_mark_iterator(struct sway_container *con,


### PR DESCRIPTION
The first view renders its title text incorrectly in case any font is set in the config file.

The `font` command calls `config_update_font_height(true)`, which resets `config->font_height` to 0 before iterating through child containers, but `config->font_height` is not updated anymore, because at this point there is only the root container with empty `formatted_title`.

When a new view is created after that, it relies on `config->font_height` to render its title, however it gets updated after the title is already rendered.

This commit changes the order, so that a newly created view uses the relevant font height.