### PR TITLE
Fix potential crash when destroying workspace

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -204,8 +204,16 @@ static struct sway_container *container_workspace_destroy(
 		}
 	}
 
-	free(workspace->sway_workspace);
+	struct sway_workspace *sway_workspace = workspace->sway_workspace;
+
+	// This emits the destroy event and also destroys the swayc.
 	_container_destroy(workspace);
+
+	// Clean up the floating container
+	sway_workspace->floating->parent = NULL;
+	_container_destroy(sway_workspace->floating);
+
+	free(sway_workspace);
 
 	if (output) {
 		output_damage_whole(output->sway_output);


### PR DESCRIPTION
`_container_destroy` emits a `destroy` event, and any listener for this event should have access to the full container, not a half destroyed one.

`_container_destroy` also destroys the swayc, so we have to grab a reference to the sway_workspace so we can free it afterwards.

This also fixes a memory leak where the floating container wasn't freed.

Fixes #2092.