### PR TITLE
Fix seat_get_active_child

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -728,14 +728,14 @@ struct sway_container *seat_get_focus_inactive(struct sway_seat *seat,
 
 struct sway_container *seat_get_active_child(struct sway_seat *seat,
 		struct sway_container *container) {
-	struct sway_container *focus = seat_get_focus_inactive(seat, container);
-	if (!focus) {
-		return NULL;
+	struct sway_seat_container *current = NULL;
+	wl_list_for_each(current, &seat->focus_stack, link) {
+		if (current->container->parent == container &&
+				current->container->layout != L_FLOATING) {
+			return current->container;
+		}
 	}
-	while (focus->parent != container) {
-		focus = focus->parent;
-	}
-	return focus;
+	return NULL;
 }
 
 struct sway_container *seat_get_focus(struct sway_seat *seat) {


### PR DESCRIPTION
`seat_get_active_child` is used for tabbed and stacked containers to get the active child. The previous implementation used `seat_get_focus_inactive` then ascended the tree to the child of the tabbed/stacked container, but this fails when the workspace itself is stacked or tabbed and the most recently active child is floating.

The new implementation takes a more simple approach, where it directly scans the focus stack for the first immediate child which isn't the floating container.

Fixes #2098.