### PR TITLE
Fix initial workspace orientation on a rotated output

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -8,10 +8,6 @@
 
 struct sway_container *output_create(
 		struct sway_output *sway_output) {
-	struct wlr_box size;
-	wlr_output_effective_resolution(sway_output->wlr_output, &size.width,
-		&size.height);
-
 	const char *name = sway_output->wlr_output->name;
 	char identifier[128];
 	output_get_identifier(identifier, sizeof(identifier), sway_output);
@@ -53,6 +49,12 @@ struct sway_container *output_create(
 	apply_output_config(oc, output);
 	container_add_child(&root_container, output);
 	load_swaybars();
+
+	struct wlr_box size;
+	wlr_output_effective_resolution(sway_output->wlr_output, &size.width,
+		&size.height);
+	output->width = size.width;
+	output->height = size.height;
 
 	// Create workspace
 	char *ws_name = workspace_next_name(output->name);


### PR DESCRIPTION
When launching on DRM with an output rotated 90 or 270 (ie. portrait), the first workspace on that output would incorrectly have an `L_HORIZ` layout. This is because the workspace was being created before the output's dimensions were assigned, and the workspace's layout is chosen when it is created.

The PR assigns the output's dimensions before creating the workspace.