### PR TITLE
Focus fixes

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -257,6 +257,11 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 	}
 	output_damage_surface(output, sway_layer->geo.x, sway_layer->geo.y,
 		sway_layer->layer_surface->surface, true);
+
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	if (seat->focused_layer == sway_layer->layer_surface) {
+		seat_set_focus_layer(seat, NULL);
+	}
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -79,14 +79,17 @@ static void unmanaged_handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&surface->commit.link);
 
 	if (!wlr_xwayland_surface_is_unmanaged(xsurface)) {
-		// Restore focus
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		struct sway_container *previous =
-			seat_get_focus_inactive(seat, &root_container);
-		if (previous) {
-			// Hack to get seat to re-focus the return value of get_focus
-			seat_set_focus(seat, previous->parent);
-			seat_set_focus(seat, previous);
+		if (seat->wlr_seat->keyboard_state.focused_surface ==
+				xsurface->surface) {
+			// Restore focus
+			struct sway_container *previous =
+				seat_get_focus_inactive(seat, &root_container);
+			if (previous) {
+				// Hack to get seat to re-focus the return value of get_focus
+				seat_set_focus(seat, previous->parent);
+				seat_set_focus(seat, previous);
+			}
 		}
 	}
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -77,6 +77,18 @@ static void unmanaged_handle_unmap(struct wl_listener *listener, void *data) {
 	desktop_damage_surface(xsurface->surface, xsurface->x, xsurface->y, true);
 	wl_list_remove(&surface->link);
 	wl_list_remove(&surface->commit.link);
+
+	if (!wlr_xwayland_surface_is_unmanaged(xsurface)) {
+		// Restore focus
+		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		struct sway_container *previous =
+			seat_get_focus_inactive(seat, &root_container);
+		if (previous) {
+			// Hack to get seat to re-focus the return value of get_focus
+			seat_set_focus(seat, previous->parent);
+			seat_set_focus(seat, previous);
+		}
+	}
 }
 
 static void unmanaged_handle_destroy(struct wl_listener *listener, void *data) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -264,7 +264,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		if (new_ws != old_ws) {
 			seat_set_focus(cursor->seat, cont);
 		}
-	} else {
+	} else if (cont) {
 		seat_set_focus(cursor->seat, cont);
 	}
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -658,7 +658,8 @@ void seat_set_focus_layer(struct sway_seat *seat,
 		struct wlr_layer_surface *layer) {
 	if (!layer && seat->focused_layer) {
 		seat->focused_layer = NULL;
-		struct sway_container *previous = seat_get_focus(seat);
+		struct sway_container *previous =
+			seat_get_focus_inactive(seat, &root_container);
 		if (previous) {
 			wlr_log(L_DEBUG, "Returning focus to %p %s '%s'", previous,
 					container_type_to_str(previous->type), previous->name);


### PR DESCRIPTION
This PR fixes three focus related issues.

1. Restore focus when unmapping unmanaged xwayland surfaces. To test:

    * Open a terminal and run i3-input.
    * Cancel the prompt by pressing escape.
    * Focus should be returned to the terminal.

2. Restore focus when unmapping layer shell surfaces. To test:

    * Open a view.
    * Lock the screen with swaylock.
    * Unlock the screen.
    * Focus should be returned to the view.

3. Don't set focus to NULL when clicking a surface which has no container. To test:

    * Launch chromium and configure it so the bookmarks bar is visible and it contains a bookmark.
    * Right click on a bookmark.
    * swaybar should show that the workspace has focus.

There is one thing I'm not sure about, and that's the `wlr_xwayland_surface_is_unmanaged` check in `unmanaged_handle_unmap`. I copied it from `unmanaged_handle_map` but it seems backwards to me. Not only does the check seem to be incorrectly negated, but wouldn't the surface always be unmanaged at that point anyway?