### PR TITLE
Fix movement crashes/issues

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -412,19 +412,15 @@ void container_move(struct sway_container *container,
 		}
 		case C_WORKSPACE:
 			if (!is_parallel(current->layout, move_dir)) {
-				if (current->children->length > 2) {
+				if (current->children->length >= 2) {
 					wlr_log(L_DEBUG, "Rejiggering the workspace (%d kiddos)",
 							current->children->length);
 					workspace_rejigger(current, container, move_dir);
-				} else if (current->children->length == 2) {
-					wlr_log(L_DEBUG, "Changing workspace layout");
-					current->layout =
-						move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ?
-						L_HORIZ : L_VERT;
-					container_insert_child(current, container, offs < 0 ? 0 : 1);
-					arrange_workspace(current);
+					return;
+				} else {
+					wlr_log(L_DEBUG, "Selecting output");
+					current = current->parent;
 				}
-				return;
 			} else if (current->layout == L_TABBED
 					|| current->layout == L_STACKED) {
 				wlr_log(L_DEBUG, "Rejiggering out of tabs/stacks");
@@ -520,7 +516,7 @@ void container_move(struct sway_container *container,
 				wlr_log(L_DEBUG, "Reparenting container (perpendicular)");
 				struct sway_container *focus_inactive = seat_get_focus_inactive(
 						config->handler_context.seat, sibling);
-				if (focus_inactive) {
+				if (focus_inactive && focus_inactive != sibling) {
 					while (focus_inactive->parent != sibling) {
 						focus_inactive = focus_inactive->parent;
 					}


### PR DESCRIPTION
Fixes #2105 

For the first and second issue in #2105, the issue was the `focus_inactive` loop. In both cases, `focus_inactive == sibling` so 
```
while (focus_inactive->parent == sibling) {
    focus_inactive = focus_inactive->parent;
}
```
was going until it was trying to access the `parent` of `NULL`.

For the third issue, if the movement direction was perpendicular to the workspace layout and the layout was `L_HORIZ` or `L_VERT`, it was never escalated to the output level.

I also fixed a fourth issue that I noticed when making sure nothing broke. If you created the representation `H[view#1 V[view#2 view#3]]` and focused `view#2` and executed move up, the representation would be `V[view#1 view#2 V[view#3]]`. This is fixed by rejiggering the workspace with two containers instead of having the special optimized case that seemingly only works with two views.