### PR TITLE
Remove suspicious unconditional return

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -160,7 +160,6 @@ static void log_distro() {
 }
 
 static void log_kernel() {
-	return;
 	FILE *f = popen("uname -a", "r");
 	if (!f) {
 		wlr_log(L_INFO, "Unable to determine kernel version");


### PR DESCRIPTION
This return effectively disables the log_kernel function. I don't think this is intended. Git blame suggests this was accidentally commited in 9eecbb5d8a988a0dded57ead1982dd0121071454.