### PR TITLE
Allow outputs to be re-enabled

### DIFF
--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -6,6 +6,7 @@
 
 json_object *ipc_json_get_version();
 
+json_object *ipc_json_describe_disabled_output(struct sway_output *o);
 json_object *ipc_json_describe_container(struct sway_container *c);
 json_object *ipc_json_describe_container_recursive(struct sway_container *c);
 json_object *ipc_json_describe_input(struct sway_input_device *device);

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -29,6 +29,8 @@ struct sway_output {
 	struct wl_listener damage_destroy;
 	struct wl_listener damage_frame;
 
+	struct wl_list link;
+
 	pid_t bg_pid;
 };
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -45,4 +45,5 @@ void output_damage_whole_container(struct sway_output *output,
 
 struct sway_container *output_by_name(const char *name);
 
+void output_enable(struct sway_output *output);
 #endif

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -31,7 +31,7 @@ struct sway_root {
 
 	struct wlr_texture *debug_tree;
 
-	list_t *outputs;
+	struct wl_list outputs; // sway_output::link
 
 	struct {
 		struct wl_signal new_container;

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -31,6 +31,8 @@ struct sway_root {
 
 	struct wlr_texture *debug_tree;
 
+	list_t *outputs;
+
 	struct {
 		struct wl_signal new_container;
 	} events;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -82,9 +82,8 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	// will be applied during normal "new output" event from wlroots.
 	char identifier[128];
 	bool all = strcmp(output->name, "*") == 0;
-	list_t *sway_outputs = root_container.sway_root->outputs;
-	for (int i = 0; i < sway_outputs->length; ++i) {
-		struct sway_output *sway_output = sway_outputs->items[i];
+	struct sway_output *sway_output;
+	wl_list_for_each(sway_output, &root_container.sway_root->outputs, link) {
 		output_get_identifier(identifier, sizeof(identifier), sway_output);
 		wlr_log(L_DEBUG, "Checking identifier %s", identifier);
 		if (all || strcmp(sway_output->wlr_output->name, output->name) == 0

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -131,11 +131,13 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 	struct wlr_output *wlr_output = output->sway_output->wlr_output;
 
 	if (oc && oc->enabled == 0) {
+		struct sway_output *sway_output = output->sway_output;
 		if (output->sway_output->bg_pid != 0) {
 			terminate_swaybg(output->sway_output->bg_pid);
 			output->sway_output->bg_pid = 0;
 		}
 		container_destroy(output);
+		sway_output->swayc = NULL;
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);
 		return;

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -252,7 +252,7 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 		return;
 	}
 	struct sway_output *output = wlr_output->data;
-	if (output == NULL) {
+	if (output == NULL || output->swayc == NULL) {
 		return;
 	}
 	output_damage_surface(output, sway_layer->geo.x, sway_layer->geo.y,
@@ -279,7 +279,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&sway_layer->surface_commit.link);
 	if (sway_layer->layer_surface->output != NULL) {
 		struct sway_output *output = sway_layer->layer_surface->output->data;
-		if (output != NULL) {
+		if (output != NULL && output->swayc != NULL) {
 			arrange_layers(output);
 		}
 		wl_list_remove(&sway_layer->output_destroy.link);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1157,6 +1157,10 @@ void output_damage_whole_container(struct sway_output *output,
 	wlr_output_damage_add_box(output->damage, &box);
 }
 
+static int find_output(const void *output1, const void *output2) {
+	return output1 == output2 ? 0 : 1;
+}
+
 static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output =
 		wl_container_of(listener, output, damage_destroy);
@@ -1165,7 +1169,19 @@ static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, destroy);
-	container_destroy(output->swayc);
+	if (output->swayc) {
+		container_destroy(output->swayc);
+	}
+	int index = list_seq_find(root_container.sway_root->outputs, find_output,
+			output);
+	if (index >= 0 && index < root_container.sway_root->outputs->length) {
+		wlr_log(L_DEBUG, "Removing %s from outputs list",
+				output->wlr_output->name);
+		list_del(root_container.sway_root->outputs, index);
+		wl_list_remove(&output->destroy.link);
+		output->wlr_output = NULL;
+		free(output);
+	}
 }
 
 static void handle_mode(struct wl_listener *listener, void *data) {
@@ -1203,6 +1219,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->wlr_output = wlr_output;
 	wlr_output->data = output;
 	output->server = server;
+	list_add(root_container.sway_root->outputs, output);
 
 	if (!wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *mode =
@@ -1210,11 +1227,23 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		wlr_output_set_mode(wlr_output, mode);
 	}
 
-	output->damage = wlr_output_damage_create(wlr_output);
+	output_enable(output);
+}
+
+void output_enable(struct sway_output *output) {
+	struct wlr_output *wlr_output = output->wlr_output;
+
+	if (!wlr_output->data) {
+		wlr_output->data = output;
+	}
+
+	if (!output->damage) {
+		output->damage = wlr_output_damage_create(wlr_output);
+	}
 
 	output->swayc = output_create(output);
 	if (!output->swayc) {
-		free(output);
+		// Output is disabled
 		return;
 	}
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1221,6 +1221,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->server = server;
 	list_add(root_container.sway_root->outputs, output);
 
+	output->damage = wlr_output_damage_create(wlr_output);
+
 	if (!wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *mode =
 			wl_container_of(wlr_output->modes.prev, mode, link);
@@ -1232,14 +1234,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 void output_enable(struct sway_output *output) {
 	struct wlr_output *wlr_output = output->wlr_output;
-
-	if (!wlr_output->data) {
-		wlr_output->data = output;
-	}
-
-	if (!output->damage) {
-		output->damage = wlr_output_damage_create(wlr_output);
-	}
 
 	output->swayc = output_create(output);
 	if (!output->swayc) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -139,6 +139,26 @@ static void ipc_json_describe_output(struct sway_container *container, json_obje
 	json_object_object_add(object, "layout", json_object_new_string("output"));
 }
 
+json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
+	struct wlr_output *wlr_output = output->wlr_output;
+	
+	json_object *object = json_object_new_object();
+
+	json_object_object_add(object, "type", json_object_new_string("output"));
+	json_object_object_add(object, "name",
+			wlr_output->name ? json_object_new_string(wlr_output->name) : NULL);
+	json_object_object_add(object, "active", json_object_new_boolean(false));
+	json_object_object_add(object, "make",
+			json_object_new_string(wlr_output->make));
+	json_object_object_add(object, "model",
+			json_object_new_string(wlr_output->model));
+	json_object_object_add(object, "serial",
+			json_object_new_string(wlr_output->serial));
+	json_object_object_add(object, "modes", json_object_new_array());
+
+	return object;
+}
+
 static void ipc_json_describe_workspace(struct sway_container *workspace,
 		json_object *object) {
 	int num = isdigit(workspace->name[0]) ? atoi(workspace->name) : -1;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -19,6 +19,7 @@
 #include "sway/commands.h"
 #include "sway/ipc-json.h"
 #include "sway/ipc-server.h"
+#include "sway/output.h"
 #include "sway/server.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -486,6 +487,14 @@ void ipc_client_handle_command(struct ipc_client *client) {
 			if (container->type == C_OUTPUT) {
 				json_object_array_add(outputs,
 					ipc_json_describe_container(container));
+			}
+		}
+		for (int i = 0; i < root_container.sway_root->outputs->length; ++i) {
+			struct sway_output *output =
+				root_container.sway_root->outputs->items[i];
+			if (!output->swayc) {
+				json_object_array_add(outputs,
+						ipc_json_describe_disabled_output(output));
 			}
 		}
 		const char *json_string = json_object_to_json_string(outputs);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -489,9 +489,8 @@ void ipc_client_handle_command(struct ipc_client *client) {
 					ipc_json_describe_container(container));
 			}
 		}
-		for (int i = 0; i < root_container.sway_root->outputs->length; ++i) {
-			struct sway_output *output =
-				root_container.sway_root->outputs->items[i];
+		struct sway_output *output;
+		wl_list_for_each(output, &root_container.sway_root->outputs, link) {
 			if (!output->swayc) {
 				json_object_array_add(outputs,
 						ipc_json_describe_disabled_output(output));

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -262,8 +262,6 @@ static struct sway_container *container_output_destroy(
 	wl_list_remove(&output->sway_output->damage_destroy.link);
 	wl_list_remove(&output->sway_output->damage_frame.link);
 
-	// clear the wlr_output reference to this container
-	output->sway_output->wlr_output->data = NULL;
 	output->sway_output->swayc = NULL;
 
 	wlr_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -255,7 +255,6 @@ static struct sway_container *container_output_destroy(
 		}
 	}
 
-	wl_list_remove(&output->sway_output->destroy.link);
 	wl_list_remove(&output->sway_output->mode.link);
 	wl_list_remove(&output->sway_output->transform.link);
 	wl_list_remove(&output->sway_output->scale.link);
@@ -265,6 +264,7 @@ static struct sway_container *container_output_destroy(
 
 	// clear the wlr_output reference to this container
 	output->sway_output->wlr_output->data = NULL;
+	output->sway_output->swayc = NULL;
 
 	wlr_log(L_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
 	_container_destroy(output);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -35,7 +35,7 @@ void layout_init(void) {
 
 	root_container.sway_root = calloc(1, sizeof(*root_container.sway_root));
 	root_container.sway_root->output_layout = wlr_output_layout_create();
-	root_container.sway_root->outputs = create_list();
+	wl_list_init(&root_container.sway_root->outputs);
 	wl_list_init(&root_container.sway_root->xwayland_unmanaged);
 	wl_signal_init(&root_container.sway_root->events.new_container);
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -35,6 +35,7 @@ void layout_init(void) {
 
 	root_container.sway_root = calloc(1, sizeof(*root_container.sway_root));
 	root_container.sway_root->output_layout = wlr_output_layout_create();
+	root_container.sway_root->outputs = create_list();
 	wl_list_init(&root_container.sway_root->xwayland_unmanaged);
 	wl_signal_init(&root_container.sway_root->events.new_container);
 

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -174,26 +174,35 @@ static void pretty_print_output(json_object *o) {
 	json_object *modes;
 	json_object_object_get_ex(o, "modes", &modes);
 
-	printf(
-		"Output %s '%s %s %s'%s%s\n"
-		"  Current mode: %dx%d @ %f Hz\n"
-		"  Position: %d,%d\n"
-		"  Scale factor: %dx\n"
-		"  Transform: %s\n"
-		"  Workspace: %s\n",
-		json_object_get_string(name),
-		json_object_get_string(make),
-		json_object_get_string(model),
-		json_object_get_string(serial),
-		json_object_get_boolean(focused) ? " (focused)" : "",
-		!json_object_get_boolean(active) ? " (inactive)" : "",
-		json_object_get_int(width), json_object_get_int(height),
-		(float)json_object_get_int(refresh) / 1000,
-		json_object_get_int(x), json_object_get_int(y),
-		json_object_get_int(scale),
-		json_object_get_string(transform),
-		json_object_get_string(ws)
-	);
+	if (json_object_get_boolean(active)) {
+		printf(
+			"Output %s '%s %s %s'%s\n"
+			"  Current mode: %dx%d @ %f Hz\n"
+			"  Position: %d,%d\n"
+			"  Scale factor: %dx\n"
+			"  Transform: %s\n"
+			"  Workspace: %s\n",
+			json_object_get_string(name),
+			json_object_get_string(make),
+			json_object_get_string(model),
+			json_object_get_string(serial),
+			json_object_get_boolean(focused) ? " (focused)" : "",
+			json_object_get_int(width), json_object_get_int(height),
+			(float)json_object_get_int(refresh) / 1000,
+			json_object_get_int(x), json_object_get_int(y),
+			json_object_get_int(scale),
+			json_object_get_string(transform),
+			json_object_get_string(ws)
+		);
+	} else {
+		printf(
+			"Output %s '%s %s %s' (inactive)",
+			json_object_get_string(name),
+			json_object_get_string(make),
+			json_object_get_string(model),
+			json_object_get_string(serial)
+		);
+	}
 
 	size_t modes_len = json_object_array_length(modes);
 	if (modes_len > 0) {


### PR DESCRIPTION
Fixes #1887

When an output is:
- _connected_ - the sway_output stored in a `list_t` in `struct sway_root`
- _disabled_ - the container is destroyed
- _enabled_ - the container is (re-)created
- _disconnected_ - the sway_output is removed from the `list_t` in `struct sway_root` and freed

Additionally, I added disabled outputs to the output of `swaymsg -t get_outputs`.