### PR TITLE
Initialise previous cursor position.

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -480,6 +480,9 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 		return NULL;
 	}
 
+	cursor->previous.x = wlr_cursor->x;
+	cursor->previous.y = wlr_cursor->y;
+
 	cursor->seat = seat;
 	wlr_cursor_attach_output_layout(wlr_cursor,
 		root_container.sway_root->output_layout);


### PR DESCRIPTION
Fix the problem with focus jumping to the container under the cursor
when first starting sway.