### PR TITLE
Restore workspaces to output when re-enabled

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -9,6 +9,7 @@ struct sway_workspace {
 	struct sway_container *swayc;
 	struct sway_view *fullscreen;
 	struct sway_container *floating;
+	list_t *output_priority;
 };
 
 extern char *prev_workspace_name;
@@ -33,4 +34,12 @@ bool workspace_is_visible(struct sway_container *ws);
 
 bool workspace_is_empty(struct sway_container *ws);
 
+void workspace_output_raise_priority(struct sway_container *workspace,
+		struct sway_container *old_output, struct sway_container *new_output);
+
+void workspace_output_add_priority(struct sway_container *workspace,
+		struct sway_container *output);
+
+struct sway_container *workspace_output_get_highest_available(
+		struct sway_container *ws, struct sway_container *exclude);
 #endif

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -445,9 +445,6 @@ void container_descendants(struct sway_container *root,
 			func(item, data);
 		}
 		container_descendants(item, type, func, data);
-		if (i < root->children->length && root->children->items[i] != item) {
-			--i;
-		}
 	}
 }
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -184,6 +184,7 @@ void container_move_to(struct sway_container *container,
 		container_sort_workspaces(new_parent);
 		seat_set_focus(seat, new_parent);
 		workspace_output_raise_priority(container, old_parent, new_parent);
+		ipc_event_workspace(container, NULL, "move");
 	}
 	container_notify_subtree_changed(old_parent);
 	container_notify_subtree_changed(new_parent);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -183,6 +183,7 @@ void container_move_to(struct sway_container *container,
 		}
 		container_sort_workspaces(new_parent);
 		seat_set_focus(seat, new_parent);
+		workspace_output_raise_priority(container, old_parent, new_parent);
 	}
 	container_notify_subtree_changed(old_parent);
 	container_notify_subtree_changed(new_parent);


### PR DESCRIPTION
**This is forked from #2108 so that needs to be merged first**

In #2108, it was requested that workspaces be restored to their outputs when re-enabled as discussed in swaywm/wlroots#479. This PR implements that request.
