### PR TITLE
Remove strip quoting and fix strncpy-overlap

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -274,7 +274,6 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 			for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
 				argv[i] = do_var_replacement(argv[i]);
 				unescape_string(argv[i]);
-				strip_quotes(argv[i]);
 			}
 
 			if (!config->handler_context.using_criteria) {

--- a/sway/config.c
+++ b/sway/config.c
@@ -660,7 +660,7 @@ char *do_var_replacement(char *str) {
 		// Unescape double $ and move on
 		if (find[1] == '$') {
 			size_t length = strlen(find + 1);
-			strncpy(find, find + 1, length);
+			memmove(find, find + 1, length);
 			find[length] = '\0';
 			++find;
 			continue;


### PR DESCRIPTION
Fixes #2117 

This also fixes a strncpy--param-overlap error by replacing strncpy with memmove.