### PR TITLE
sway/criteria: gcc string truncation warning fix

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -472,7 +472,9 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 			++head;
 		}
 		name = calloc(head - namestart + 1, 1);
-		strncpy(name, namestart, head - namestart);
+		if (head != namestart) {
+			strncpy(name, namestart, head - namestart);
+		}
 		// Parse token value
 		skip_spaces(&head);
 		value = NULL;


### PR DESCRIPTION
gcc complains about 0-length strncpy... it's fine anyway because calloc