### PR TITLE
swaylock: implement ^U to clear buffer

### DIFF
--- a/include/swaylock/seat.h
+++ b/include/swaylock/seat.h
@@ -2,36 +2,12 @@
 #define _SWAYLOCK_SEAT_H
 #include <xkbcommon/xkbcommon.h>
 
-enum mod_bit {
-	MOD_SHIFT = 1<<0,
-	MOD_CAPS = 1<<1,
-	MOD_CTRL = 1<<2,
-	MOD_ALT = 1<<3,
-	MOD_MOD2 = 1<<4,
-	MOD_MOD3 = 1<<5,
-	MOD_LOGO = 1<<6,
-	MOD_MOD5 = 1<<7,
-};
-
-enum mask {
-	MASK_SHIFT,
-	MASK_CAPS,
-	MASK_CTRL,
-	MASK_ALT,
-	MASK_MOD2,
-	MASK_MOD3,
-	MASK_LOGO,
-	MASK_MOD5,
-	MASK_LAST
-};
-
 struct swaylock_xkb {
-	uint32_t modifiers;
 	bool caps_lock;
+	bool control;
 	struct xkb_state *state;
 	struct xkb_context *context;
 	struct xkb_keymap *keymap;
-	xkb_mod_mask_t masks[MASK_LAST];
 };
 
 extern const struct wl_seat_listener seat_listener;

--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -139,6 +139,14 @@ void swaylock_handle_key(struct swaylock_state *state,
 		state->auth_state = AUTH_STATE_INPUT_NOP;
 		damage_state(state);
 		break;
+	case XKB_KEY_u:
+		if (state->xkb.control) {
+			clear_password_buffer(&state->password);
+			state->auth_state = AUTH_STATE_CLEAR;
+			damage_state(state);
+			break;
+		}
+		// fallthrough
 	default:
 		if (codepoint) {
 			append_ch(&state->password, codepoint);

--- a/swaylock/seat.c
+++ b/swaylock/seat.c
@@ -7,28 +7,6 @@
 #include "swaylock/swaylock.h"
 #include "swaylock/seat.h"
 
-const char *XKB_MASK_NAMES[MASK_LAST] = {
-	XKB_MOD_NAME_SHIFT,
-	XKB_MOD_NAME_CAPS,
-	XKB_MOD_NAME_CTRL,
-	XKB_MOD_NAME_ALT,
-	"Mod2",
-	"Mod3",
-	XKB_MOD_NAME_LOGO,
-	"Mod5",
-};
-
-const enum mod_bit XKB_MODS[MASK_LAST] = {
-	MOD_SHIFT,
-	MOD_CAPS,
-	MOD_CTRL,
-	MOD_ALT,
-	MOD_MOD2,
-	MOD_MOD3,
-	MOD_LOGO,
-	MOD_MOD5
-};
-
 static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t format, int32_t fd, uint32_t size) {
 	struct swaylock_state *state = data;
@@ -84,16 +62,13 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t mods_locked, uint32_t group) {
 	struct swaylock_state *state = data;
 	xkb_state_update_mask(state->xkb.state,
-			mods_depressed, mods_latched, mods_locked, 0, 0, group);
-	xkb_mod_mask_t mask = xkb_state_serialize_mods(state->xkb.state,
-			XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
-	state->xkb.modifiers = 0;
-	state->xkb.caps_lock = xkb_state_mod_name_is_active(state->xkb.state, XKB_MOD_NAME_CAPS, XKB_STATE_MODS_LOCKED);
-	for (uint32_t i = 0; i < MASK_LAST; ++i) {
-		if (mask & state->xkb.masks[i]) {
-			state->xkb.modifiers |= XKB_MODS[i];
-		}
-	}
+		mods_depressed, mods_latched, mods_locked, 0, 0, group);
+	state->xkb.caps_lock = xkb_state_mod_name_is_active(state->xkb.state,
+		XKB_MOD_NAME_CAPS, XKB_STATE_MODS_LOCKED);
+	state->xkb.control = xkb_state_mod_name_is_active(state->xkb.state,
+		XKB_MOD_NAME_CTRL,
+		XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
+
 }
 
 static void keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,


### PR DESCRIPTION
The whole state->xcb.modifiers thing didn't work at all (always 0)

The xkb doc says "[xkb_state_serialize_mods] should not be used in
regular clients; please use the xkb_state_mod_*_is_active API instead"
so here it is

The final result is still rather messy so happy to get rebuked, please give me a better idea to do it though.