### PR TITLE
Remove code that was nullifying output_config

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -170,8 +170,6 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 		int i = list_seq_find(config->output_configs, output_name_cmp, "*");
 		if (i >= 0) {
 			oc = config->output_configs->items[i];
-		} else {
-			oc = NULL;
 		}
 	}
 


### PR DESCRIPTION
Code which loaded a '*' config for backgrounds was wrongly nullifying output_config, breaking dpms commands for specific displays.