### PR TITLE
Fix compilation errors related to disabled outputs

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -83,7 +83,8 @@ static const char *ipc_json_get_output_transform(enum wl_output_transform transf
 	return NULL;
 }
 
-static void ipc_json_describe_output(struct sway_container *container, json_object *object) {
+static void ipc_json_describe_output(struct sway_container *container,
+		json_object *object) {
 	struct wlr_output *wlr_output = container->sway_output->wlr_output;
 	json_object_object_add(object, "type",
 			json_object_new_string("output"));
@@ -141,12 +142,12 @@ static void ipc_json_describe_output(struct sway_container *container, json_obje
 
 json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	struct wlr_output *wlr_output = output->wlr_output;
-	
+
 	json_object *object = json_object_new_object();
 
 	json_object_object_add(object, "type", json_object_new_string("output"));
 	json_object_object_add(object, "name",
-			wlr_output->name ? json_object_new_string(wlr_output->name) : NULL);
+			json_object_new_string(wlr_output->name));
 	json_object_object_add(object, "active", json_object_new_boolean(false));
 	json_object_object_add(object, "make",
 			json_object_new_string(wlr_output->make));


### PR DESCRIPTION
```
FAILED: sway/sway@@sway@exe/desktop_output.c.o 
clang -Isway/sway@@sway@exe -Isway -I../sway -Iinclude -I../include -Isubprojects/wlroots/include -I../subprojects/wlroots/include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/uuid -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/json-c -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/libdrm -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-unused-parameter -Wno-unused-function -Wno-unused-result '-DSYSCONFDIR="/etc"' '-DSWAY_VERSION="1.0-alpha.2-266-g22c1c4be (" __DATE__ ", branch '"'"'master'"'"')"' -pthread  -MD -MQ 'sway/sway@@sway@exe/desktop_output.c.o' -MF 'sway/sway@@sway@exe/desktop_output.c.o.d' -o 'sway/sway@@sway@exe/desktop_output.c.o' -c ../sway/desktop/output.c
../sway/desktop/output.c:1172:15: error: address of 'output->link' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
        if (&output->link) {
        ~~   ~~~~~~~~^~~~
1 error generated.
[3/131] Compiling C object 'sway/sway@@sway@exe/ipc-json.c.o'.
FAILED: sway/sway@@sway@exe/ipc-json.c.o 
clang -Isway/sway@@sway@exe -Isway -I../sway -Iinclude -I../include -Isubprojects/wlroots/include -I../subprojects/wlroots/include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/uuid -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/json-c -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/libdrm -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-unused-parameter -Wno-unused-function -Wno-unused-result '-DSYSCONFDIR="/etc"' '-DSWAY_VERSION="1.0-alpha.2-266-g22c1c4be (" __DATE__ ", branch '"'"'master'"'"')"' -pthread  -MD -MQ 'sway/sway@@sway@exe/ipc-json.c.o' -MF 'sway/sway@@sway@exe/ipc-json.c.o.d' -o 'sway/sway@@sway@exe/ipc-json.c.o' -c ../sway/ipc-json.c
../sway/ipc-json.c:149:16: error: address of array 'wlr_output->name' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
                        wlr_output->name ? json_object_new_string(wlr_output->name) : NULL);
                        ~~~~~~~~~~~~^~~~ ~
1 error generated.
```