### PR TITLE
Comment floating_modifier to avoid run time warning

### DIFF
--- a/config.in
+++ b/config.in
@@ -75,7 +75,8 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
     # Despite the name, also works for non-floating windows.
     # Change normal to inverse to use left mouse button for resizing and right
     # mouse button for dragging.
-    floating_modifier $mod normal
+    # TODO: reenable when floating_modifier has been reimplemented.
+    #floating_modifier $mod normal
 
     # reload the configuration file
     bindsym $mod+Shift+c reload


### PR DESCRIPTION
Sway cannot parse config option floating_modifier.

It appears that this config option has existed before, and is currently
waiting to be reimplemented.

In the meantime commment the config option, so that the user does not
get confused if the config parsing gets halted half-way though or not.