### PR TITLE
Clean up keyboard handling code

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -30,7 +30,7 @@ struct sway_binding {
 	bool release;
 	bool locked;
 	bool bindcode;
-	list_t *keys;
+	list_t *keys; // sorted in ascending order
 	uint32_t modifiers;
 	char *command;
 };

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -21,7 +21,9 @@ struct sway_shortcut_state {
 	 * including duplicates when a keycode generates multiple key ids.
 	 */
 	uint32_t pressed_keycodes[SWAY_KEYBOARD_PRESSED_KEYS_CAP];
-	int last_key_index;
+	uint32_t last_keycode;
+	uint32_t last_raw_modifiers;
+	size_t npressed;
 };
 
 struct sway_keyboard {
@@ -36,7 +38,6 @@ struct sway_keyboard {
 	struct sway_shortcut_state state_keysyms_raw;
 	struct sway_shortcut_state state_keycodes;
 	struct sway_binding *held_binding;
-	uint32_t last_modifiers;
 };
 
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,


### PR DESCRIPTION
To quote the commit messages:
* Sort the list comprising the set of keys for the binding in ascending order. (Keyboard shortcuts depend only on the set of simultaneously pressed keys, not their order, so this change should have no external effect.) This simplifies comparisons between bindings.
* Ensure that modifier keys are identified even when the next key does  not produce a keysym. This requires that modifier change tracking  be done for each sway_shortcut_state.
* Permit regular and --release shortcuts on the same key combination. Distinct bindings are identified for press and release cases; note that the release binding needs to be identified for both key press and key release events.
* Maintain ascending sort order for the shortcut state list, and keep track of the number of pressed key ids, for simpler (and hence faster) searching of the list of key bindings.
* Move binding duplicate detection into get_active_binding to avoid duplicating error messages.

----

Code which may be useful to verify how this works:

	// Debug. Print pressed keysyms
	fprintf(stderr, "%s Trl %04x %02d:", event->state==WLR_KEY_PRESSED ? "press" : "rel. ", translated_modifiers, keyboard->state_keysyms_translated.npressed);
	for (int i=0;i<keyboard->state_keysyms_translated.npressed;i++) {
		char buf[256];
		xkb_keysym_get_name(keyboard->state_keysyms_translated.pressed_keys[i], buf, 255);
		fprintf(stderr, " %s", buf);
	}
	fprintf(stderr, "\n");
	fprintf(stderr, "%s Raw %04x %02d:", event->state==WLR_KEY_PRESSED ? "press" : "rel. ", raw_modifiers, keyboard->state_keysyms_raw.npressed);
	for (int i=0;i<keyboard->state_keysyms_raw.npressed;i++) {
		char buf[256];
		xkb_keysym_get_name(keyboard->state_keysyms_raw.pressed_keys[i], buf, 255);
		fprintf(stderr, " %s", buf);
	}
	fprintf(stderr, "\n");
	fprintf(stderr, "%s Kcd %04x %02d:", event->state==WLR_KEY_PRESSED ? "press" : "rel. ", raw_modifiers, keyboard->state_keysyms_raw.npressed);
	for (int i=0;i<keyboard->state_keycodes.npressed;i++) {
		fprintf(stderr, " %d", keyboard->state_keycodes.pressed_keys[i]);
	}
	fprintf(stderr, "\n");

----

This does not change dead/compose key behavior,  i.e.  `Ctrl+Multi_Key+1+2`,  `Alt+dead_acute+a`, are still usable translated shortcut specifications. Latching modifiers still do not work, precisely as described by #1451. Distinct press and release bindings were tested with

    bindsym Ctrl+a exec echo "Press"
    bindsym --release Ctrl+a exec echo "Release"

The changes in this pull request make it easier to order bindings and hence to switch to a more appropriate data structure to store them (such as an rbtree map) which can load/query shortcuts faster than `ϴ(n^2)`/`O(n)`.

If changes are necessary and there are style fix commits, please remind me to rebase at the end.

