### PR TITLE
Fix compilation on Debian

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ prefix = get_option('prefix')
 
 swayidle_deps = []
 
-jsonc          = dependency('json-c', version: '>=0.13')
+jsonc          = dependency('json-c', version: '>=0.12')
 pcre           = dependency('libpcre')
 wlroots        = dependency('wlroots', fallback: ['wlroots', 'wlroots'])
 wayland_server = dependency('wayland-server')

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -524,7 +524,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 
 		// parse requested event types
-		for (size_t i = 0; i < json_object_array_length(request); i++) {
+		for (int i = 0; i < json_object_array_length(request); i++) {
 			const char *event_type = json_object_get_string(json_object_array_get_idx(request, i));
 			if (strcmp(event_type, "workspace") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_WORKSPACE);

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -32,7 +32,7 @@ static bool i3bar_parse_json(struct status_line *status, const char *text) {
 		return false;
 	}
 	wlr_log(L_DEBUG, "Got i3bar json: '%s'", text);
-	for (size_t i = 0; i < json_object_array_length(results); ++i) {
+	for (int i = 0; i < json_object_array_length(results); ++i) {
 		json_object *full_text, *short_text, *color, *min_width, *align, *urgent;
 		json_object *name, *instance, *separator, *separator_block_width;
 		json_object *background, *border, *border_top, *border_bottom;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -270,7 +270,7 @@ static void ipc_get_outputs(struct swaybar *bar) {
 	char *res = ipc_single_command(bar->ipc_socketfd,
 			IPC_GET_OUTPUTS, NULL, &len);
 	json_object *outputs = json_tokener_parse(res);
-	for (size_t i = 0; i < json_object_array_length(outputs); ++i) {
+	for (int i = 0; i < json_object_array_length(outputs); ++i) {
 		json_object *output = json_object_array_get_idx(outputs, i);
 		json_object *output_name, *output_active;
 		json_object_object_get_ex(output, "name", &output_name);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -233,7 +233,7 @@ static void pretty_print_version(json_object *v) {
 static void pretty_print_clipboard(json_object *v) {
 	if (success(v, true)) {
 		if (json_object_is_type(v, json_type_array)) {
-			for (size_t i = 0; i < json_object_array_length(v); ++i) {
+			for (int i = 0; i < json_object_array_length(v); ++i) {
 				json_object *o = json_object_array_get_idx(v, i);
 				printf("%s\n", json_object_get_string(o));
 			}


### PR DESCRIPTION
json-c 0.13 isn't required.
The size_t -> int changes are more correct as that's what the json functions return.