### PR TITLE
Set pool_buffers busy when handing them out

### DIFF
--- a/client/pool-buffer.c
+++ b/client/pool-buffer.c
@@ -144,5 +144,6 @@ struct pool_buffer *get_next_buffer(struct wl_shm *shm,
 			return NULL;
 		}
 	}
+	buffer->busy = true;
 	return buffer;
 }


### PR DESCRIPTION
Pool buffers keep track of whether the compositor is still using them, so we don't step on its toes. They never got marked as such, though, so toe-stepping could be occurring.