### PR TITLE
Perform (partial) server initialization before dropping privileges.

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -47,6 +47,8 @@ struct sway_server {
 
 struct sway_server server;
 
+/* Prepares an unprivileged server_init by performing all privileged operations in advance */
+bool server_privileged_prepare(struct sway_server *server);
 bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);
 void server_run(struct sway_server *server);

--- a/sway/main.c
+++ b/sway/main.c
@@ -359,6 +359,11 @@ int main(int argc, char **argv) {
 
 	executable_sanity_check();
 	bool suid = false;
+
+	if (!server_privileged_prepare(&server)) {
+		return 1;
+	}
+
 #ifdef __linux__
 	if (getuid() != geteuid() || getgid() != getegid()) {
 		// Retain capabilities after setuid()

--- a/sway/server.c
+++ b/sway/server.c
@@ -25,9 +25,8 @@
 #include "sway/tree/layout.h"
 
 
-bool server_init(struct sway_server *server) {
-	wlr_log(L_DEBUG, "Initializing Wayland server");
-
+bool server_privileged_prepare(struct sway_server *server) {
+	wlr_log(L_DEBUG, "Preparing Wayland server initialization");
 	server->wl_display = wl_display_create();
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 	server->backend = wlr_backend_autocreate(server->wl_display, NULL);
@@ -36,6 +35,12 @@ bool server_init(struct sway_server *server) {
 		wlr_log(L_ERROR, "Unable to create backend");
 		return false;
 	}
+	return true;
+}
+
+bool server_init(struct sway_server *server) {
+	wlr_log(L_DEBUG, "Initializing Wayland server");
+
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(server->backend);
 	assert(renderer);
 


### PR DESCRIPTION
Some operations during backend creation (e.g. becoming DRM master)
require CAP_SYS_ADMIN privileges. At this point, sway has dropped them
already, though. This patch splits the privileged part of server_init
into its own function and calls it before dropping its privileges.
This fixes the bug with minimal security implications.