### PR TITLE
xdg_shell: make view floating if a parent has been set

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -120,11 +120,12 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 static bool wants_floating(struct sway_view *view) {
-	struct wlr_xdg_toplevel_state *state =
-		&view->wlr_xdg_surface->toplevel->current;
-	return state->min_width != 0 && state->min_height != 0
+	struct wlr_xdg_toplevel *toplevel = view->wlr_xdg_surface->toplevel;
+	struct wlr_xdg_toplevel_state *state = &toplevel->current;
+	return (state->min_width != 0 && state->min_height != 0
 		&& state->min_width == state->max_width
-		&& state->min_height == state->max_height;
+		&& state->min_height == state->max_height)
+		|| toplevel->parent;
 }
 
 static void for_each_surface(struct sway_view *view,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -119,11 +119,13 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 }
 
 static bool wants_floating(struct sway_view *view) {
-	struct wlr_xdg_toplevel_v6_state *state =
-		&view->wlr_xdg_surface_v6->toplevel->current;
-	return state->min_width != 0 && state->min_height != 0
+	struct wlr_xdg_toplevel_v6 *toplevel =
+		view->wlr_xdg_surface_v6->toplevel;
+	struct wlr_xdg_toplevel_v6_state *state = &toplevel->current;
+	return (state->min_width != 0 && state->min_height != 0
 		&& state->min_width == state->max_width
-		&& state->min_height == state->max_height;
+		&& state->min_height == state->max_height)
+		|| toplevel->parent;
 }
 
 static void for_each_surface(struct sway_view *view,


### PR DESCRIPTION
Prompts e.g. authentication request from firefox-wayland ought to be
floating.

This is a bit coarse but just fixed size is not enough, here is what
firefox does:
[1285461.363]  -> xdg_wm_base@18.get_xdg_surface(new id xdg_surface@68, wl_surface@71)
[1285461.508]  -> xdg_surface@68.get_toplevel(new id xdg_toplevel@67)
[1285461.571]  -> xdg_toplevel@67.set_parent(xdg_toplevel@37)
[1285461.630]  -> xdg_toplevel@67.set_title("Authentication Required")
[1285461.736]  -> xdg_toplevel@67.set_app_id("firefox")
...
[1285476.549] xdg_toplevel@67.configure(0, 0, array)
...
[1285502.080]  -> xdg_toplevel@67.set_min_size(299, 187)
[1285502.140]  -> xdg_toplevel@67.set_max_size(1920, 32767)

This can also be observed with e.g. the open window of gedit
(gedit->open->other documents)