### PR TITLE
layer shell: fix some use after free on destroy

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -32,6 +32,10 @@ struct sway_output {
 	struct wl_list link;
 
 	pid_t bg_pid;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
 };
 
 void output_damage_whole(struct sway_output *output);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -219,6 +219,8 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 	struct sway_layer_surface *sway_layer =
 		wl_container_of(listener, sway_layer, output_destroy);
 	wl_list_remove(&sway_layer->output_destroy.link);
+	wl_list_remove(&sway_layer->link);
+	wl_list_init(&sway_layer->link);
 	sway_layer->layer_surface->output = NULL;
 	wlr_layer_surface_close(sway_layer->layer_surface);
 }

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -352,10 +352,6 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&layer_surface->surface->events.commit,
 		&sway_layer->surface_commit);
 
-	sway_layer->output_destroy.notify = handle_output_destroy;
-	wl_signal_add(&layer_surface->output->events.destroy,
-		&sway_layer->output_destroy);
-
 	sway_layer->destroy.notify = handle_destroy;
 	wl_signal_add(&layer_surface->events.destroy, &sway_layer->destroy);
 	sway_layer->map.notify = handle_map;
@@ -368,6 +364,9 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	layer_surface->data = sway_layer;
 
 	struct sway_output *output = layer_surface->output->data;
+	sway_layer->output_destroy.notify = handle_output_destroy;
+	wl_signal_add(&output->events.destroy, &sway_layer->output_destroy);
+
 	wl_list_insert(&output->layers[layer_surface->layer], &sway_layer->link);
 
 	// Temporarily set the layer's current state to client_pending

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1199,6 +1199,8 @@ static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, destroy);
+	wl_signal_emit(&output->events.destroy, output);
+
 	if (output->swayc) {
 		container_destroy(output->swayc);
 	}
@@ -1277,6 +1279,7 @@ void output_enable(struct sway_output *output) {
 	for (size_t i = 0; i < len; ++i) {
 		wl_list_init(&output->layers[i]);
 	}
+	wl_signal_init(&output->events.destroy);
 
 	input_manager_configure_xcursor(input_manager);
 


### PR DESCRIPTION
Both commits revolve around the same idea that layer shells need to die and cleanup properly before sway's output.

First one is a simple not cleaning up properly on handler being called, but second one is more subtle: both layer shell and sway's output listen to wlr's output destroy event, but there is no ordering guarantee here so I added a new event from sway's output to artificially order them.