### PR TITLE
Check if command input has at least 2 arguments

### DIFF
--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -31,7 +31,7 @@ static struct cmd_handler input_handlers[] = {
 
 struct cmd_results *cmd_input(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 2))) {
 		return error;
 	}
 


### PR DESCRIPTION
Using `swaymsg "input identifier"`, was making sway crashing, no matter the validity or not of the input identifier. According to `sway-input(5)`, all input commands have the following format : `input identifier subcmd arg1 [args]`, so at least 3 arguments are expected (identifier, subcmd, and arg1).