### PR TITLE
 fix accidently removing borders on XCB_CONFIGURE_REQUEST 

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -335,9 +335,9 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		return;
 	}
 	if (container_is_floating(view->swayc)) {
-		configure(view, view->swayc->x, view->swayc->y, ev->width, ev->height);
+		configure(view, view->x, view->y, ev->width, ev->height);
 	} else {
-		configure(view, view->swayc->x, view->swayc->y,
+		configure(view, view->x, view->y,
 			view->width, view->height);
 	}
 }


### PR DESCRIPTION
The view was configured with the container coordinates.
Although they were right on the first configure, they
changed after a XCB_CONFIGURE_REQUEST, when the
border was already drawn.

May fix #1925 