### PR TITLE
Fix floating views not receiving frame events

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -948,7 +948,7 @@ bool view_is_visible(struct sway_view *view) {
 	// Check view isn't in a tabbed or stacked container on an inactive tab
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *container = view->swayc;
-	while (container->type != C_WORKSPACE) {
+	while (container->type != C_WORKSPACE && container->layout != L_FLOATING) {
 		if (container->parent->layout == L_TABBED ||
 				container->parent->layout == L_STACKED) {
 			if (seat_get_active_child(seat, container->parent) != container) {


### PR DESCRIPTION
That happened when they were in tabbed or stacked containers.

Fixes #2161