### PR TITLE
sway views: add helpers to get view and layer from wlr_surface

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -22,4 +22,7 @@ struct sway_layer_surface {
 struct sway_output;
 void arrange_layers(struct sway_output *output);
 
+struct sway_layer_surface *layer_from_wlr_layer_surface(
+	struct wlr_layer_surface *layer_surface);
+
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -260,6 +260,16 @@ void view_child_init(struct sway_view_child *child,
 
 void view_child_destroy(struct sway_view_child *child);
 
+
+struct sway_view *view_from_wlr_xdg_surface(
+	struct wlr_xdg_surface *xdg_surface);
+struct sway_view *view_from_wlr_xdg_surface_v6(
+	struct wlr_xdg_surface_v6 *xdg_surface_v6);
+struct sway_view *view_from_wlr_xwayland_surface(
+	struct wlr_xwayland_surface *xsurface);
+
+struct sway_view *view_from_wlr_surface(struct wlr_surface *surface);
+
 /**
  * Re-read the view's title property and update any relevant title bars.
  * The force argument makes it recreate the title bars even if the title hasn't

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -307,6 +307,11 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	unmap(sway_layer);
 }
 
+struct sway_layer_surface *layer_from_wlr_layer_surface(
+		struct wlr_layer_surface *layer_surface) {
+	return layer_surface->data;
+}
+
 void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	struct wlr_layer_surface *layer_surface = data;
 	struct sway_server *server =

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1302,6 +1302,10 @@ static void handle_scale(struct wl_listener *listener, void *data) {
 	arrange_and_commit(output->swayc);
 }
 
+struct sway_output *output_from_wlr_output(struct wlr_output *wlr_output) {
+	return wlr_output->data;
+}
+
 void handle_new_output(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -289,6 +289,11 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 	arrange_and_commit(ws);
 }
 
+struct sway_view *view_from_wlr_xdg_surface(
+		struct wlr_xdg_surface *xdg_surface) {
+	return xdg_surface->data;
+}
+
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server,
 		xdg_shell_surface);
@@ -327,4 +332,6 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	xdg_shell_view->request_fullscreen.notify = handle_request_fullscreen;
 	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
 			&xdg_shell_view->request_fullscreen);
+
+	xdg_surface->data = xdg_shell_view;
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -280,6 +280,11 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 	arrange_and_commit(ws);
 }
 
+struct sway_view *view_from_wlr_xdg_surface_v6(
+		struct wlr_xdg_surface_v6 *xdg_surface_v6) {
+       return xdg_surface_v6->data;
+}
+
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server,
 		xdg_shell_v6_surface);
@@ -318,4 +323,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	xdg_shell_v6_view->request_fullscreen.notify = handle_request_fullscreen;
 	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
 			&xdg_shell_v6_view->request_fullscreen);
+
+	xdg_surface->data = xdg_shell_v6_view;
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -417,6 +417,11 @@ static void handle_set_window_type(struct wl_listener *listener, void *data) {
 	view_execute_criteria(view);
 }
 
+struct sway_view *view_from_wlr_xwayland_surface(
+		struct wlr_xwayland_surface *xsurface) {
+	return xsurface->data;
+}
+
 void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server,
 		xwayland_surface);
@@ -470,6 +475,8 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 
 	wl_signal_add(&xsurface->events.map, &xwayland_view->map);
 	xwayland_view->map.notify = handle_map;
+
+	xsurface->data = xwayland_view;
 }
 
 void handle_xwayland_ready(struct wl_listener *listener, void *data) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -694,6 +694,36 @@ void view_child_destroy(struct sway_view_child *child) {
 	}
 }
 
+struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
+	if (wlr_surface_is_xdg_surface(wlr_surface)) {
+		struct wlr_xdg_surface *xdg_surface =
+			wlr_xdg_surface_from_wlr_surface(wlr_surface);
+		return view_from_wlr_xdg_surface(xdg_surface);
+	}
+	if (wlr_surface_is_xdg_surface_v6(wlr_surface)) {
+		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface);
+		return view_from_wlr_xdg_surface_v6(xdg_surface_v6);
+	}
+	if (wlr_surface_is_xwayland_surface(wlr_surface)) {
+		struct wlr_xwayland_surface *xsurface =
+			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
+		return view_from_wlr_xwayland_surface(xsurface);
+	}
+	if (wlr_surface_is_subsurface(wlr_surface)) {
+		struct wlr_subsurface *subsurface =
+			wlr_subsurface_from_wlr_surface(wlr_surface);
+		return view_from_wlr_surface(subsurface->parent);
+	}
+	if (wlr_surface_is_layer_surface(wlr_surface)) {
+		return NULL;
+	}
+
+	wlr_log(L_DEBUG, "Surface of unknown type (role %s): %p",
+		wlr_surface->role, wlr_surface);
+	return NULL;
+}
+
 static size_t append_prop(char *buffer, const char *value) {
 	if (!value) {
 		return 0;


### PR DESCRIPTION
As discussed on IRC a few days ago with @emersion, get the appropriate wlr shell type depending on the surface type with wlr_surface_is_x then get the view through that `->data` field.

This is a prerequisite for idle inhibit to properly toggle itself on/off depending on surface visibility as the inhibitor only has a wlr_surface to deal with - I have an implementation that uses this and it appears to work but some of the rest depends on atomic transactions (e.g. when to check if view is still visible) so that'll hold off until atomic stuff is merged... But I wanted to get feedbacks on this first anyway.