### PR TITLE
xdg_shell: listen to fullscreen request on map

### DIFF
--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -198,6 +198,29 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
 	popup_create(wlr_popup, &xdg_shell_v6_view->view);
 }
 
+static void handle_request_fullscreen(struct wl_listener *listener, void *data) {
+	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
+		wl_container_of(listener, xdg_shell_v6_view, request_fullscreen);
+	struct wlr_xdg_toplevel_v6_set_fullscreen_event *e = data;
+	struct wlr_xdg_surface_v6 *xdg_surface =
+		xdg_shell_v6_view->view.wlr_xdg_surface_v6;
+	struct sway_view *view = &xdg_shell_v6_view->view;
+
+	if (!sway_assert(xdg_surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL,
+				"xdg_shell_v6 requested fullscreen of surface with role %i",
+				xdg_surface->role)) {
+		return;
+	}
+	if (!xdg_surface->mapped) {
+		return;
+	}
+
+	view_set_fullscreen(view, e->fullscreen);
+
+	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+	arrange_and_commit(ws);
+}
+
 static void handle_unmap(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, unmap);
@@ -211,6 +234,7 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 
 	wl_list_remove(&xdg_shell_v6_view->commit.link);
 	wl_list_remove(&xdg_shell_v6_view->new_popup.link);
+	wl_list_remove(&xdg_shell_v6_view->request_fullscreen.link);
 }
 
 static void handle_map(struct wl_listener *listener, void *data) {
@@ -243,6 +267,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xdg_shell_v6_view->new_popup.notify = handle_new_popup;
 	wl_signal_add(&xdg_surface->events.new_popup,
 		&xdg_shell_v6_view->new_popup);
+
+	xdg_shell_v6_view->request_fullscreen.notify = handle_request_fullscreen;
+	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
+			&xdg_shell_v6_view->request_fullscreen);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -252,32 +280,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_v6_view->destroy.link);
 	wl_list_remove(&xdg_shell_v6_view->map.link);
 	wl_list_remove(&xdg_shell_v6_view->unmap.link);
-	wl_list_remove(&xdg_shell_v6_view->request_fullscreen.link);
 	view->wlr_xdg_surface_v6 = NULL;
 	view_destroy(view);
-}
-
-static void handle_request_fullscreen(struct wl_listener *listener, void *data) {
-	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
-		wl_container_of(listener, xdg_shell_v6_view, request_fullscreen);
-	struct wlr_xdg_toplevel_v6_set_fullscreen_event *e = data;
-	struct wlr_xdg_surface_v6 *xdg_surface =
-		xdg_shell_v6_view->view.wlr_xdg_surface_v6;
-	struct sway_view *view = &xdg_shell_v6_view->view;
-
-	if (!sway_assert(xdg_surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL,
-				"xdg_shell_v6 requested fullscreen of surface with role %i",
-				xdg_surface->role)) {
-		return;
-	}
-	if (!xdg_surface->mapped) {
-		return;
-	}
-
-	view_set_fullscreen(view, e->fullscreen);
-
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	arrange_and_commit(ws);
 }
 
 struct sway_view *view_from_wlr_xdg_surface_v6(
@@ -319,10 +323,6 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 
 	xdg_shell_v6_view->destroy.notify = handle_destroy;
 	wl_signal_add(&xdg_surface->events.destroy, &xdg_shell_v6_view->destroy);
-
-	xdg_shell_v6_view->request_fullscreen.notify = handle_request_fullscreen;
-	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
-			&xdg_shell_v6_view->request_fullscreen);
 
 	xdg_surface->data = xdg_shell_v6_view;
 }


### PR DESCRIPTION
That event comes from the toplevel and not the surface, so would cause
a use-after-free on destroy if the toplevel got destroyed first:

```
==5454==ERROR: AddressSanitizer: heap-use-after-free on address 0x6110001ed198 at pc 0x000000472d10 bp 0x7ffc19070a80 sp 0x7ffc19070a70
WRITE of size 8 at 0x6110001ed198 thread T0
    #0 0x472d0f in wl_list_remove ../common/list.c:157
    #1 0x42e159 in handle_destroy ../sway/desktop/xdg_shell_v6.c:243
    #2 0x7fa9e5b28ce8 in wlr_signal_emit_safe ../util/signal.c:29
    #3 0x7fa9e5afd6b1 in destroy_xdg_surface_v6 ../types/xdg_shell_v6/wlr_xdg_surface_v6.c:101
    #4 0x7fa9e5d98025 in destroy_resource src/wayland-server.c:688
    #5 0x7fa9e5d98091 in wl_resource_destroy src/wayland-server.c:705
    #6 0x7fa9e27f103d in ffi_call_unix64 (/lib64/libffi.so.6+0x603d)
    #7 0x7fa9e27f09fe in ffi_call (/lib64/libffi.so.6+0x59fe)
    #8 0x7fa9e5d9bf2c  (/lib64/libwayland-server.so.0+0xbf2c)
    #9 0x7fa9e5d983de in wl_client_connection_data src/wayland-server.c:420
    #10 0x7fa9e5d99f01 in wl_event_loop_dispatch src/event-loop.c:641
    #11 0x7fa9e5d98601 in wl_display_run src/wayland-server.c:1260
    #12 0x40a2f4 in main ../sway/main.c:433
    #13 0x7fa9e527318a in __libc_start_main ../csu/libc-start.c:308
    #14 0x40b749 in _start (/opt/wayland/bin/sway+0x40b749)

0x6110001ed198 is located 152 bytes inside of 240-byte region [0x6110001ed100,0x6110001ed1f0)
freed by thread T0 here:
    #0 0x7fa9e7c89880 in __interceptor_free (/lib64/libasan.so.5+0xee880)
    #1 0x7fa9e5affce9 in destroy_xdg_toplevel_v6 ../types/xdg_shell_v6/wlr_xdg_toplevel_v6.c:23
    #2 0x7fa9e5d98025 in destroy_resource src/wayland-server.c:688

previously allocated by thread T0 here:
    #0 0x7fa9e7c89e50 in calloc (/lib64/libasan.so.5+0xeee50)
    #1 0x7fa9e5b00eea in create_xdg_toplevel_v6 ../types/xdg_shell_v6/wlr_xdg_toplevel_v6.c:427
    #2 0x7fa9e27f103d in ffi_call_unix64 (/lib64/libffi.so.6+0x603d)
```

The toplevel only notifies the compositor on destroy if it was mapped,
so only listen to events at map time.


I commited that ages ago and was waiting for transactions to be merged (small conflict as I moved the function around), can't recall what client reproduces that :/ since it says toplevel_v6 on the stack probably something with konsole on quit... As it's in wl_list_remove you need valgrind to see that (or a hack like me for ASAN)