### PR TITLE
Don't send frame done to surfaces behind lockscreen

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -54,4 +54,8 @@ void output_damage_whole_container(struct sway_output *output,
 struct sway_container *output_by_name(const char *name);
 
 void output_enable(struct sway_output *output);
+
+bool output_has_opaque_lockscreen(struct sway_output *output,
+		struct sway_seat *seat);
+
 #endif

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -934,7 +934,7 @@ bool output_has_opaque_lockscreen(struct sway_output *output,
 			.x2 = output->swayc->current.swayc_width,
 			.y2 = output->swayc->current.swayc_height,
 		};
-		if (pixman_region32_contains_rectangle(&wlr_surface->current->opaque,
+		if (pixman_region32_contains_rectangle(&wlr_surface->current.opaque,
 					&output_box)) {
 			return true;
 		}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -930,16 +930,13 @@ bool output_has_opaque_lockscreen(struct sway_output *output,
 		if (wlr_surface->resource->client != seat->exclusive_client) {
 			continue;
 		}
-		int nrects;
-		pixman_box32_t *rects =
-			pixman_region32_rectangles(&wlr_surface->current->opaque, &nrects);
-		for (int i = 0; i < nrects; ++i) {
-			pixman_box32_t *rect = &rects[i];
-			if (rect->x1 <= 0 && rect->y1 <= 0 &&
-					rect->x2 >= output->swayc->current.swayc_width &&
-					rect->y2 >= output->swayc->current.swayc_height) {
-				return true;
-			}
+		pixman_box32_t output_box = {
+			.x2 = output->swayc->current.swayc_width,
+			.y2 = output->swayc->current.swayc_height,
+		};
+		if (pixman_region32_contains_rectangle(&wlr_surface->current->opaque,
+					&output_box)) {
+			return true;
 		}
 	}
 	return false;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -978,15 +978,6 @@ static void render_output(struct sway_output *output, struct timespec *when,
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 
 	if (output_has_opaque_lockscreen(output, seat)) {
-		float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
-
-		int nrects;
-		pixman_box32_t *rects = pixman_region32_rectangles(damage, &nrects);
-		for (int i = 0; i < nrects; ++i) {
-			scissor_output(wlr_output, &rects[i]);
-			wlr_renderer_clear(renderer, clear_color);
-		}
-
 		struct wlr_layer_surface *wlr_layer_surface = seat->focused_layer;
 		struct sway_layer_surface *sway_layer_surface =
 			layer_from_wlr_layer_surface(seat->focused_layer);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -930,12 +930,21 @@ bool output_has_opaque_lockscreen(struct sway_output *output,
 		if (wlr_surface->resource->client != seat->exclusive_client) {
 			continue;
 		}
+		struct sway_layer_surface *sway_layer_surface =
+			layer_from_wlr_layer_surface(wlr_layer_surface);
 		pixman_box32_t output_box = {
 			.x2 = output->swayc->current.swayc_width,
 			.y2 = output->swayc->current.swayc_height,
 		};
-		if (pixman_region32_contains_rectangle(&wlr_surface->current.opaque,
-					&output_box)) {
+		pixman_region32_t surface_opaque_box;
+		pixman_region32_init(&surface_opaque_box);
+		pixman_region32_copy(&surface_opaque_box, &wlr_surface->current.opaque);
+		pixman_region32_translate(&surface_opaque_box,
+				sway_layer_surface->geo.x, sway_layer_surface->geo.y);
+		bool contains = pixman_region32_contains_rectangle(
+				&wlr_surface->current.opaque, &output_box);
+		pixman_region32_fini(&surface_opaque_box);
+		if (contains) {
 			return true;
 		}
 	}

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -84,8 +84,11 @@ static const struct zwlr_layer_surface_v1_listener layer_surface_listener;
 static cairo_surface_t *select_image(struct swaylock_state *state,
 		struct swaylock_surface *surface);
 
-static bool image_is_opaque(cairo_surface_t *image) {
-	return cairo_surface_get_content(image) == CAIRO_CONTENT_COLOR;
+static bool surface_is_opaque(struct swaylock_surface *surface) {
+	if (surface->image) {
+		return cairo_surface_get_content(surface->image) == CAIRO_CONTENT_COLOR;
+	}
+	return (surface->state->args.color & 0xff) == 0xff;
 }
 
 static void create_layer_surface(struct swaylock_surface *surface) {
@@ -113,7 +116,7 @@ static void create_layer_surface(struct swaylock_surface *surface) {
 	zwlr_layer_surface_v1_add_listener(surface->layer_surface,
 			&layer_surface_listener, surface);
 
-	if (image_is_opaque(surface->image) &&
+	if (surface_is_opaque(surface) &&
 			surface->state->args.mode != BACKGROUND_MODE_CENTER &&
 			surface->state->args.mode != BACKGROUND_MODE_FIT) {
 		struct wl_region *region =


### PR DESCRIPTION
Also, when rendering, don't descend into the tree if the lockscreen is active. Just render the lockscreen's surfaces.

This makes an assumption that an `exclusive_client` will always be a lockscreen. This assumption is also made when handling `bindsym --locked` so I think it's a safe assumption.

This PR paints black behind the lockscreen, so if your lockscreen uses transparency or doesn't cover the whole layout for some reason then you'll just see black there. I know some people like to have their lock shortcut take a screenshot, blur it and apply it as the lockscreen background, and this is still possible.

Maybe my fans will spin down when my computer is locked now.