### PR TITLE
Idle inhibit

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -1,0 +1,13 @@
+
+#ifndef _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
+#define _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
+#include <wlr/types/wlr_idle_inhibit_v1.h>
+#include "sway/server.h"
+
+struct sway_idle_inhibitor_v1 {
+	struct sway_server *server;
+
+	struct wl_listener destroy;
+};
+
+#endif

--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -6,8 +6,12 @@
 
 struct sway_idle_inhibitor_v1 {
 	struct sway_server *server;
+	struct sway_view *view;
 
+	struct wl_list link;
 	struct wl_listener destroy;
 };
+
+void idle_inhibit_v1_check_active(struct sway_server *server);
 
 #endif

--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -1,17 +1,28 @@
-
 #ifndef _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
 #define _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
 #include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_idle.h>
 #include "sway/server.h"
 
+struct sway_idle_inhibit_manager_v1 {
+	struct wlr_idle_inhibit_manager_v1 *wlr_manager;
+	struct wl_listener new_idle_inhibitor_v1;
+	struct wl_list inhibitors;
+
+	struct wlr_idle *idle;
+};
+
 struct sway_idle_inhibitor_v1 {
-	struct sway_server *server;
+	struct sway_idle_inhibit_manager_v1 *manager;
 	struct sway_view *view;
 
 	struct wl_list link;
 	struct wl_listener destroy;
 };
 
-void idle_inhibit_v1_check_active(struct sway_server *server);
+void idle_inhibit_v1_check_active(
+	struct sway_idle_inhibit_manager_v1 *manager);
 
+struct sway_idle_inhibit_manager_v1 *sway_idle_inhibit_manager_v1_create(
+	struct wl_display *wl_display, struct wlr_idle *idle);
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -23,16 +23,13 @@ struct sway_server {
 
 	struct wlr_compositor *compositor;
 	struct wlr_data_device_manager *data_device_manager;
-	struct wlr_idle *idle;
-	struct wlr_idle_inhibit_manager_v1 *idle_inhibit;
 
 	struct sway_input_manager *input;
 
 	struct wl_listener new_output;
 
-	struct wlr_idle_inhibit_manager_v1 *idle_inhibit_v1;
-	struct wl_listener new_idle_inhibitor_v1;
-	struct wl_list idle_inhibitors_v1;
+	struct wlr_idle *idle;
+	struct sway_idle_inhibit_manager_v1 *idle_inhibit_manager_v1;
 
 	struct wlr_layer_shell *layer_shell;
 	struct wl_listener layer_shell_surface;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -24,10 +24,14 @@ struct sway_server {
 	struct wlr_compositor *compositor;
 	struct wlr_data_device_manager *data_device_manager;
 	struct wlr_idle *idle;
+	struct wlr_idle_inhibit_manager_v1 *idle_inhibit;
 
 	struct sway_input_manager *input;
 
 	struct wl_listener new_output;
+
+	struct wlr_idle_inhibit_manager_v1 *idle_inhibit_v1;
+	struct wl_listener new_idle_inhibitor_v1;
 
 	struct wlr_layer_shell *layer_shell;
 	struct wl_listener layer_shell_surface;
@@ -61,6 +65,7 @@ void server_run(struct sway_server *server);
 
 void handle_new_output(struct wl_listener *listener, void *data);
 
+void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);
 void handle_layer_shell_surface(struct wl_listener *listener, void *data);
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -32,6 +32,7 @@ struct sway_server {
 
 	struct wlr_idle_inhibit_manager_v1 *idle_inhibit_v1;
 	struct wl_listener new_idle_inhibitor_v1;
+	struct wl_list idle_inhibitors_v1;
 
 	struct wlr_layer_shell *layer_shell;
 	struct wl_listener layer_shell_surface;

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include <wlr/types/wlr_idle.h>
+#include "log.h"
+#include "sway/desktop/idle_inhibit_v1.h"
+#include "sway/server.h"
+
+
+static void handle_destroy(struct wl_listener *listener, void *data) {
+	struct sway_idle_inhibitor_v1 *inhibitor =
+		wl_container_of(listener, inhibitor, destroy);
+	wlr_log(L_DEBUG, "Sway idle inhibitor destroyed");
+	wlr_idle_set_enabled(inhibitor->server->idle, NULL, true);
+	wl_list_remove(&inhibitor->destroy.link);
+	free(inhibitor);
+}
+
+void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
+	struct wlr_idle_inhibitor_v1 *wlr_inhibitor = data;
+	struct sway_server *server =
+		wl_container_of(listener, server, new_idle_inhibitor_v1);
+	wlr_log(L_DEBUG, "New sway idle inhibitor");
+
+	struct sway_idle_inhibitor_v1 *inhibitor =
+		calloc(1, sizeof(struct sway_idle_inhibitor_v1));
+	if (!inhibitor) {
+		return;
+	}
+
+	inhibitor->server = server;
+
+	inhibitor->destroy.notify = handle_destroy;
+	wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->destroy);
+
+	wlr_idle_set_enabled(server->idle, NULL, false);
+}

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -2,6 +2,7 @@
 #include <wlr/types/wlr_idle.h>
 #include "log.h"
 #include "sway/desktop/idle_inhibit_v1.h"
+#include "sway/tree/view.h"
 #include "sway/server.h"
 
 
@@ -10,6 +11,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, inhibitor, destroy);
 	wlr_log(L_DEBUG, "Sway idle inhibitor destroyed");
 	wlr_idle_set_enabled(inhibitor->server->idle, NULL, true);
+	wl_list_remove(&inhibitor->link);
 	wl_list_remove(&inhibitor->destroy.link);
 	free(inhibitor);
 }
@@ -27,9 +29,29 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 	}
 
 	inhibitor->server = server;
+	inhibitor->view = view_from_wlr_surface(wlr_inhibitor->surface);
+	wl_list_insert(&server->idle_inhibitors_v1, &inhibitor->link);
+
 
 	inhibitor->destroy.notify = handle_destroy;
 	wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->destroy);
 
 	wlr_idle_set_enabled(server->idle, NULL, false);
+}
+
+void idle_inhibit_v1_check_active(struct sway_server *server) {
+	struct sway_idle_inhibitor_v1 *inhibitor;
+	bool inhibited = false;
+	wl_list_for_each(inhibitor, &server->idle_inhibitors_v1, link) {
+		if (!inhibitor->view) {
+			/* Cannot guess if view is visible so assume it is */
+			inhibited = true;
+			break;
+		}
+		if (view_is_visible(inhibitor->view)) {
+			inhibited = true;
+			break;
+		}
+	}
+	wlr_idle_set_enabled(server->idle, NULL, !inhibited);
 }

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -10,16 +10,16 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_idle_inhibitor_v1 *inhibitor =
 		wl_container_of(listener, inhibitor, destroy);
 	wlr_log(L_DEBUG, "Sway idle inhibitor destroyed");
-	wlr_idle_set_enabled(inhibitor->server->idle, NULL, true);
 	wl_list_remove(&inhibitor->link);
 	wl_list_remove(&inhibitor->destroy.link);
+	idle_inhibit_v1_check_active(inhibitor->manager);
 	free(inhibitor);
 }
 
 void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 	struct wlr_idle_inhibitor_v1 *wlr_inhibitor = data;
-	struct sway_server *server =
-		wl_container_of(listener, server, new_idle_inhibitor_v1);
+	struct sway_idle_inhibit_manager_v1 *manager =
+		wl_container_of(listener, manager, new_idle_inhibitor_v1);
 	wlr_log(L_DEBUG, "New sway idle inhibitor");
 
 	struct sway_idle_inhibitor_v1 *inhibitor =
@@ -28,21 +28,22 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	inhibitor->server = server;
+	inhibitor->manager = manager;
 	inhibitor->view = view_from_wlr_surface(wlr_inhibitor->surface);
-	wl_list_insert(&server->idle_inhibitors_v1, &inhibitor->link);
+	wl_list_insert(&manager->inhibitors, &inhibitor->link);
 
 
 	inhibitor->destroy.notify = handle_destroy;
 	wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->destroy);
 
-	wlr_idle_set_enabled(server->idle, NULL, false);
+	idle_inhibit_v1_check_active(manager);
 }
 
-void idle_inhibit_v1_check_active(struct sway_server *server) {
+void idle_inhibit_v1_check_active(
+		struct sway_idle_inhibit_manager_v1 *manager) {
 	struct sway_idle_inhibitor_v1 *inhibitor;
 	bool inhibited = false;
-	wl_list_for_each(inhibitor, &server->idle_inhibitors_v1, link) {
+	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
 		if (!inhibitor->view) {
 			/* Cannot guess if view is visible so assume it is */
 			inhibited = true;
@@ -53,5 +54,26 @@ void idle_inhibit_v1_check_active(struct sway_server *server) {
 			break;
 		}
 	}
-	wlr_idle_set_enabled(server->idle, NULL, !inhibited);
+	wlr_idle_set_enabled(manager->idle, NULL, !inhibited);
+}
+
+struct sway_idle_inhibit_manager_v1 *sway_idle_inhibit_manager_v1_create(
+		struct wl_display *wl_display, struct wlr_idle *idle) {
+	struct sway_idle_inhibit_manager_v1 *manager =
+		calloc(1, sizeof(struct sway_idle_inhibit_manager_v1));
+	if (!manager) {
+		return NULL;
+	}
+
+	manager->wlr_manager = wlr_idle_inhibit_v1_create(wl_display);
+	if (!manager->wlr_manager) {
+		return NULL;
+	}
+	manager->idle = idle;
+	wl_signal_add(&manager->wlr_manager->events.new_inhibitor,
+		&manager->new_idle_inhibitor_v1);
+	manager->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
+	wl_list_init(&manager->inhibitors);
+
+	return manager;
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_linux_dmabuf.h>
 #include "sway/debug.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/desktop/transaction.h"
 #include "sway/output.h"
 #include "sway/tree/container.h"
@@ -245,6 +246,7 @@ static void transaction_progress_queue() {
 		transaction_destroy(transaction);
 	}
 	server.transactions->length = 0;
+	idle_inhibit_v1_check_active(&server);
 }
 
 static int handle_timeout(void *data) {
@@ -320,6 +322,7 @@ void transaction_commit(struct sway_transaction *transaction) {
 		wlr_log(L_DEBUG, "Transaction %p has nothing to wait for", transaction);
 		transaction_apply(transaction);
 		transaction_destroy(transaction);
+		idle_inhibit_v1_check_active(&server);
 		return;
 	}
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -246,7 +246,7 @@ static void transaction_progress_queue() {
 		transaction_destroy(transaction);
 	}
 	server.transactions->length = 0;
-	idle_inhibit_v1_check_active(&server);
+	idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
 }
 
 static int handle_timeout(void *data) {
@@ -322,7 +322,7 @@ void transaction_commit(struct sway_transaction *transaction) {
 		wlr_log(L_DEBUG, "Transaction %p has nothing to wait for", transaction);
 		transaction_apply(transaction);
 		transaction_destroy(transaction);
-		idle_inhibit_v1_check_active(&server);
+		idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
 		return;
 	}
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -10,6 +10,7 @@ sway_sources = files(
 	'security.c',
 
 	'desktop/desktop.c',
+	'desktop/idle_inhibit_v1.c',
 	'desktop/layer_shell.c',
 	'desktop/output.c',
 	'desktop/transaction.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -10,7 +10,6 @@
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_gamma_control.h>
 #include <wlr/types/wlr_idle.h>
-#include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_layer_shell.h>
 #include <wlr/types/wlr_linux_dmabuf.h>
 #include <wlr/types/wlr_primary_selection.h>
@@ -23,6 +22,7 @@
 // TODO WLR: make Xwayland optional
 #include "list.h"
 #include "sway/config.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
 #include "sway/server.h"
 #include "sway/tree/layout.h"
@@ -53,7 +53,6 @@ bool server_init(struct sway_server *server) {
 	server->data_device_manager =
 		wlr_data_device_manager_create(server->wl_display);
 
-	server->idle = wlr_idle_create(server->wl_display);
 	wlr_screenshooter_create(server->wl_display);
 	wlr_gamma_control_manager_create(server->wl_display);
 	wlr_primary_selection_device_manager_create(server->wl_display);
@@ -64,11 +63,9 @@ bool server_init(struct sway_server *server) {
 	wlr_xdg_output_manager_create(server->wl_display,
 			root_container.sway_root->output_layout);
 
-	server->idle_inhibit = wlr_idle_inhibit_v1_create(server->wl_display);
-	wl_signal_add(&server->idle_inhibit->events.new_inhibitor,
-		&server->new_idle_inhibitor_v1);
-	server->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
-	wl_list_init(&server->idle_inhibitors_v1);
+	server->idle = wlr_idle_create(server->wl_display);
+	server->idle_inhibit_manager_v1 =
+		sway_idle_inhibit_manager_v1_create(server->wl_display, server->idle);
 
 	server->layer_shell = wlr_layer_shell_create(server->wl_display);
 	wl_signal_add(&server->layer_shell->events.new_surface,

--- a/sway/server.c
+++ b/sway/server.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_gamma_control.h>
 #include <wlr/types/wlr_idle.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_layer_shell.h>
 #include <wlr/types/wlr_linux_dmabuf.h>
 #include <wlr/types/wlr_primary_selection.h>
@@ -62,6 +63,11 @@ bool server_init(struct sway_server *server) {
 
 	wlr_xdg_output_manager_create(server->wl_display,
 			root_container.sway_root->output_layout);
+
+	server->idle_inhibit = wlr_idle_inhibit_v1_create(server->wl_display);
+	wl_signal_add(&server->idle_inhibit->events.new_inhibitor,
+		&server->new_idle_inhibitor_v1);
+	server->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
 
 	server->layer_shell = wlr_layer_shell_create(server->wl_display);
 	wl_signal_add(&server->layer_shell->events.new_surface,

--- a/sway/server.c
+++ b/sway/server.c
@@ -68,6 +68,7 @@ bool server_init(struct sway_server *server) {
 	wl_signal_add(&server->idle_inhibit->events.new_inhibitor,
 		&server->new_idle_inhibitor_v1);
 	server->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
+	wl_list_init(&server->idle_inhibitors_v1);
 
 	server->layer_shell = wlr_layer_shell_create(server->wl_display);
 	wl_signal_add(&server->layer_shell->events.new_surface,


### PR DESCRIPTION
Implements idle inhibit, and make it toggle when the surface goes "invisible" (hooks on every transition so whenever layouts change or workspace change)

It should be easy to adjust when the idle protocol works per-output, just need to make view_is_visible return a list of outputs where the thing is visible and disable idle for these specifically.


One thing I'm not totally happy about is I'm taking a pointer to the server struct everywhere in the idle inhibit code... To end up using the global server object in transition -_-
Should I just always use the global?
Also not happy storing the list of idle inhibitors directly in servers struct, I might want to encompass things in a sway_idle_inhibit_manager_v1 or something