### PR TITLE
Don't return pending children in seat_get_active_current_child

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -832,12 +832,12 @@ struct sway_container *seat_get_active_child(struct sway_seat *seat,
 
 struct sway_container *seat_get_active_current_child(struct sway_seat *seat,
 		struct sway_container *container) {
-	struct sway_container *child = seat_get_active_child(seat, container);
-	if (child) {
-		return child;
-	}
-	if (container->current.children->length == 1) {
-		return container->current.children->items[0];
+	struct sway_seat_container *current = NULL;
+	wl_list_for_each(current, &seat->focus_stack, link) {
+		if (current->container->current.parent == container &&
+				current->container->current.layout != L_FLOATING) {
+			return current->container;
+		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
Fixes #2192.

`seat_get_active_current_child` is intended to return a **current** child of the given container (ie. a child which has finished its mapping transaction and is able to be rendered on screen). The previous implementation was capable of returning a pending child, which caused a child of a tabbed or stacked view to be rendered prematurely while it was mapping.