### PR TITLE
Fix xwayland floating views unclickable

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -283,9 +283,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	if (view->swayc->instructions->length) {
 		transaction_notify_view_ready_by_size(view,
 				surface_state->width, surface_state->height);
-	}
-
-	if (container_is_floating(view->swayc)) {
+	} else if (container_is_floating(view->swayc)) {
 		view_update_size(view, surface_state->width, surface_state->height);
 	}
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -284,6 +284,11 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		transaction_notify_view_ready_by_size(view,
 				surface_state->width, surface_state->height);
 	}
+
+	if (container_is_floating(view->swayc)) {
+		view_update_size(view, surface_state->width, surface_state->height);
+	}
+
 	view_damage_from(view);
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -574,6 +574,8 @@ void view_update_position(struct sway_view *view, double lx, double ly) {
 	container_damage_whole(view->swayc);
 	view->x = lx;
 	view->y = ly;
+	view->swayc->current.view_x = lx;
+	view->swayc->current.view_y = ly;
 	if (container_is_floating(view->swayc)) {
 		container_set_geometry_from_floating_view(view->swayc);
 	}
@@ -587,6 +589,8 @@ void view_update_size(struct sway_view *view, int width, int height) {
 	container_damage_whole(view->swayc);
 	view->width = width;
 	view->height = height;
+	view->swayc->current.view_width = width;
+	view->swayc->current.view_height = height;
 	if (container_is_floating(view->swayc)) {
 		container_set_geometry_from_floating_view(view->swayc);
 	}


### PR DESCRIPTION
Some xwayland views are first configured with a 1x1 size, and then
resized. Since the view size isn't updated, they are unclickable.

Fixes #2195