### PR TITLE
[WIP] Fix window geometry support

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -29,6 +29,7 @@ struct sway_view_impl {
 	const char *(*get_string_prop)(struct sway_view *view,
 			enum sway_view_prop prop);
 	uint32_t (*get_int_prop)(struct sway_view *view, enum sway_view_prop prop);
+	void (*get_geometry)(struct sway_view *view, struct wlr_box *box);
 	uint32_t (*configure)(struct sway_view *view, double lx, double ly,
 			int width, int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
@@ -249,10 +250,6 @@ void view_destroy(struct sway_view *view);
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface);
 
 void view_unmap(struct sway_view *view);
-
-void view_update_position(struct sway_view *view, double lx, double ly);
-
-void view_update_size(struct sway_view *view, int width, int height);
 
 void view_child_init(struct sway_view_child *child,
 	const struct sway_view_child_impl *impl, struct sway_view *view,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -74,7 +74,8 @@ static struct sway_xdg_shell_view *xdg_shell_view_from_view(
 	return (struct sway_xdg_shell_view *)view;
 }
 
-static const char *get_string_prop(struct sway_view *view, enum sway_view_prop prop) {
+static const char *get_string_prop(struct sway_view *view,
+		enum sway_view_prop prop) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return NULL;
 	}
@@ -86,6 +87,16 @@ static const char *get_string_prop(struct sway_view *view, enum sway_view_prop p
 	default:
 		return NULL;
 	}
+}
+
+static void get_geometry(struct sway_view *view, struct wlr_box *box) {
+	struct sway_xdg_shell_view *xdg_shell_view =
+		xdg_shell_view_from_view(view);
+	if (xdg_shell_view == NULL) {
+		return;
+	}
+	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
+	wlr_xdg_surface_get_geometry(surface, box);
 }
 
 static uint32_t configure(struct sway_view *view, double lx, double ly,
@@ -168,6 +179,7 @@ static void destroy(struct sway_view *view) {
 
 static const struct sway_view_impl view_impl = {
 	.get_string_prop = get_string_prop,
+	.get_geometry = get_geometry,
 	.configure = configure,
 	.set_activated = set_activated,
 	.set_tiled = set_tiled,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -126,8 +126,8 @@ static void set_tiled(struct sway_view *view, bool tiled) {
 	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
 	enum wlr_edges edges = WLR_EDGE_NONE;
 	if (tiled) {
-		edges = WLR_EDGE_LEFT | WLR_EDGE_RIGHT | WLR_EDGE_TOP |
-				WLR_EDGE_BOTTOM;
+		// edges = WLR_EDGE_LEFT | WLR_EDGE_RIGHT | WLR_EDGE_TOP |
+		// 		WLR_EDGE_BOTTOM;
 	}
 	wlr_xdg_toplevel_set_tiled(surface, edges);
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -288,6 +288,11 @@ void view_autoconfigure(struct sway_view *view) {
 		break;
 	}
 
+	struct wlr_box geo;
+	view_get_geometry(view, &geo);
+	x -= geo.x;
+	y -= geo.y;
+
 	view->x = x;
 	view->y = y;
 	view->width = width;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -129,7 +129,7 @@ uint32_t view_get_window_type(struct sway_view *view) {
 }
 
 const char *view_get_shell(struct sway_view *view) {
-	switch(view->type) {
+	switch (view->type) {
 	case SWAY_VIEW_XDG_SHELL_V6:
 		return "xdg_shell_v6";
 	case SWAY_VIEW_XDG_SHELL:
@@ -138,6 +138,20 @@ const char *view_get_shell(struct sway_view *view) {
 		return "xwayland";
 	}
 	return "unknown";
+}
+
+void view_get_geometry(struct sway_view *view, struct wlr_box *box) {
+	if (view->surface == NULL) {
+		box->x = box->y = box->width = box->height = 0;
+		return;
+	}
+	if (view->impl->get_geometry) {
+		view->impl->get_geometry(view, box);
+		return;
+	}
+	box->x = box->y = 0;
+	box->width = view->surface->current->width;
+	box->height = view->surface->current->height;
 }
 
 uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
@@ -567,32 +581,6 @@ void view_unmap(struct sway_view *view) {
 		arrange_and_commit(parent);
 	}
 	view->surface = NULL;
-}
-
-void view_update_position(struct sway_view *view, double lx, double ly) {
-	if (view->x == lx && view->y == ly) {
-		return;
-	}
-	container_damage_whole(view->swayc);
-	view->x = lx;
-	view->y = ly;
-	if (container_is_floating(view->swayc)) {
-		container_set_geometry_from_floating_view(view->swayc);
-	}
-	container_damage_whole(view->swayc);
-}
-
-void view_update_size(struct sway_view *view, int width, int height) {
-	if (view->width == width && view->height == height) {
-		return;
-	}
-	container_damage_whole(view->swayc);
-	view->width = width;
-	view->height = height;
-	if (container_is_floating(view->swayc)) {
-		container_set_geometry_from_floating_view(view->swayc);
-	}
-	container_damage_whole(view->swayc);
 }
 
 static void view_subsurface_create(struct sway_view *view,


### PR DESCRIPTION
Please try this and help me fix it.

Test plan: open `gnome-terminal`. Open its Preferences menu (floating).

```
22:54 <emersion> ryan-au: ideas on how to handle widnow geometry?
22:55 <emersion> i've been trying to implement it, but i failed
22:56 <emersion> it's basically a box inside which is the window contents
22:56 <emersion> so we want to crop everything outside it
22:57 <emersion> we basically want to offset view->{x,y,width,height}
22:57 <emersion> problem is, these are used when sending configures
22:58 <emersion> and configures don't include these offsets
22:59 <emersion> so i either get the window geometry right but rendering and input wrong
22:59 <emersion> or the other way around
```

Fixes #2178