### PR TITLE
startup: move setenv WAYLAND_DISPLAY before config execs

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -416,6 +416,7 @@ int main(int argc, char **argv) {
 	security_sanity_check();
 
 	config->active = true;
+	setenv("WAYLAND_DISPLAY", server.socket, true);
 	// Execute commands until there are none left
 	while (config->cmd_queue->length) {
 		char *line = config->cmd_queue->items[0];

--- a/sway/server.c
+++ b/sway/server.c
@@ -143,7 +143,6 @@ void server_fini(struct sway_server *server) {
 void server_run(struct sway_server *server) {
 	wlr_log(L_INFO, "Running compositor on wayland display '%s'",
 			server->socket);
-	setenv("WAYLAND_DISPLAY", server->socket, true);
 	if (!wlr_backend_start(server->backend)) {
 		wlr_log(L_ERROR, "Failed to start backend");
 		wlr_backend_destroy(server->backend);


### PR DESCRIPTION
We would previously run all config commands without the environment,
which would appear to work as our socket name is the default one, but
wayland clients would start up in the wrong sway session.

(This explains why 'sometimes' my swayidle processes wouldn't die with
sway, as they weren't listening to the correct socket)