### PR TITLE
Fix focus related damage

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -663,7 +663,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		}
 
 		seat_send_focus(container, seat);
-		container_damage_whole(container);
+		container_damage_whole(container->parent);
 	}
 
 	// clean up unfocused empty workspace on new output


### PR DESCRIPTION
When you have an unfocused container (so one view is focused_inactive), and you focus any other view in that container, the view with focused_inactive was not damaged. This is because we damaged the
previous focus and new focus, but needed to damage the parent of the new focus.

For example, create layout `H[view 1, V[view 2, view 3]]` and set focus to view 2. `focus left` to focus view 1, so view 2 becomes focused_inactive. Then use the mouse to focus view 3. Do this a couple of times and you'll see damage issues.