### PR TITLE
ipc-server: add display destroy listener

### DIFF
--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -9,8 +9,6 @@ struct sway_server;
 
 void ipc_init(struct sway_server *server);
 
-void ipc_terminate(void);
-
 struct sockaddr_un *ipc_user_sockaddr(void);
 
 void ipc_event_workspace(struct sway_container *old,

--- a/sway/main.c
+++ b/sway/main.c
@@ -437,8 +437,6 @@ int main(int argc, char **argv) {
 
 	server_fini(&server);
 
-	ipc_terminate();
-
 	if (config) {
 		free_config(config);
 	}


### PR DESCRIPTION
`wl_event_source_remove()` is illegal after display has been destroyed

```
==20392==ERROR: AddressSanitizer: heap-use-after-free on address 0x607000001240 at pc 0x00000048e86e bp 0x7ffe4b557e00 sp 0x7ffe4b557df0
READ of size 8 at 0x607000001240 thread T0
    #0 0x48e86d in wl_list_insert ../common/list.c:149
    #1 0x7fdf673d4d7d in wl_event_source_remove src/event-loop.c:487
    #2 0x41b742 in ipc_terminate ../sway/ipc-server.c:94
    #3 0x40b1ad in main ../sway/main.c:440
    #4 0x7fdf6664c18a in __libc_start_main ../csu/libc-start.c:308
    #5 0x409359 in _start (/opt/wayland/bin/sway+0x409359)

0x607000001240 is located 48 bytes inside of 72-byte region [0x607000001210,0x607000001258)
freed by thread T0 here:
    #0 0x7fdf692c4880 in __interceptor_free (/lib64/libasan.so.5+0xee880)
    #1 0x7fdf673d371a in wl_display_destroy src/wayland-server.c:1097

previously allocated by thread T0 here:
    #0 0x7fdf692c4c48 in malloc (/lib64/libasan.so.5+0xeec48)
    #1 0x7fdf673d4d9e in wl_event_loop_create src/event-loop.c:522
    #2 0x40acb2 in main ../sway/main.c:363
    #3 0x7fdf6664c18a in __libc_start_main ../csu/libc-start.c:308
```

Alternative fix would be to, like, just not call `wl_event_source_remove` as we're exiting sway anyway but might as well do this somewhat cleanly (static globals, meh)

Open question though: shall handle_display_destroy do more and we could just remove the `ipc_terminate` call in main?