### PR TITLE
Fix border weirdness

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -935,7 +935,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_add_child(workspace->sway_workspace->floating, container);
 		if (container->type == C_VIEW) {
 			view_init_floating(container->sway_view);
-			view_set_tiled(container->sway_view, true);
+			view_set_tiled(container->sway_view, false);
 		}
 		seat_set_focus(seat, seat_get_focus_inactive(seat, container));
 		container_reap_empty_recursive(workspace);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -935,6 +935,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_add_child(workspace->sway_workspace->floating, container);
 		if (container->type == C_VIEW) {
 			view_init_floating(container->sway_view);
+			view_set_tiled(container->sway_view, true);
 		}
 		seat_set_focus(seat, seat_get_focus_inactive(seat, container));
 		container_reap_empty_recursive(workspace);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -164,9 +164,6 @@ void view_init_floating(struct sway_view *view) {
 	view->border_left = view->border_right = true;
 
 	container_set_geometry_from_floating_view(view->swayc);
-
-	// Don't maximize floating windows
-	view_set_tiled(view, false);
 }
 
 void view_autoconfigure(struct sway_view *view) {
@@ -278,7 +275,6 @@ void view_autoconfigure(struct sway_view *view) {
 	view->y = y;
 	view->width = width;
 	view->height = height;
-	view_set_tiled(view, true);
 }
 
 void view_set_activated(struct sway_view *view, bool activated) {


### PR DESCRIPTION
I don't know why that line is there, but it effectively forces `B_NORMAL` for all tiled views, even if I run `border toggle`. It also disables borders for floating views.