### PR TITLE
Fix a bunch of leaks

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -79,7 +79,7 @@ void free_cmd_results(struct cmd_results *results);
  *
  * Free the JSON string later on.
  */
-const char *cmd_results_to_json(struct cmd_results *results);
+char *cmd_results_to_json(struct cmd_results *results);
 
 struct cmd_results *add_color(const char *name,
 		char *buffer, const char *color);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -527,7 +527,7 @@ void free_cmd_results(struct cmd_results *results) {
 	free(results);
 }
 
-const char *cmd_results_to_json(struct cmd_results *results) {
+char *cmd_results_to_json(struct cmd_results *results) {
 	json_object *result_array = json_object_new_array();
 	json_object *root = json_object_new_object();
 	json_object_object_add(root, "success",
@@ -542,9 +542,9 @@ const char *cmd_results_to_json(struct cmd_results *results) {
 	}
 	json_object_array_add(result_array, root);
 	const char *json = json_object_to_json_string(result_array);
-	free(result_array);
-	free(root);
-	return json;
+	char *res = strdup(json);
+	json_object_put(result_array);
+	return res;
 }
 
 /**

--- a/sway/config.c
+++ b/sway/config.c
@@ -87,7 +87,12 @@ void free_config(struct sway_config *config) {
 	list_free(config->cmd_queue);
 	list_free(config->workspace_outputs);
 	list_free(config->pid_workspaces);
-	list_free(config->output_configs);
+	if (config->output_configs) {
+		for (int i = 0; i < config->output_configs->length; i++) {
+			free_output_config(config->output_configs->items[i]);
+		}
+		list_free(config->output_configs);
+	}
 	if (config->input_configs) {
 		for (int i = 0; i < config->input_configs->length; i++) {
 			free_input_config(config->input_configs->items[i]);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -30,6 +30,7 @@ void free_bar_config(struct bar_config *bar) {
 	if (!bar) {
 		return;
 	}
+	free(bar->id);
 	free(bar->mode);
 	free(bar->position);
 	free(bar->hidden_state);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -420,6 +420,9 @@ void sway_keyboard_destroy(struct sway_keyboard *keyboard) {
 	if (!keyboard) {
 		return;
 	}
+	if (keyboard->keymap) {
+		xkb_keymap_unref(keyboard->keymap);
+	}
 	wl_list_remove(&keyboard->keyboard_key.link);
 	wl_list_remove(&keyboard->keyboard_modifiers.link);
 	free(keyboard);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -481,11 +481,10 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_COMMAND:
 	{
 		struct cmd_results *results = execute_command(buf, NULL);
-		const char *json = cmd_results_to_json(results);
-		char reply[256];
-		int length = snprintf(reply, sizeof(reply), "%s", json);
+		char *json = cmd_results_to_json(results);
+		int length = strlen(json);
+		client_valid = ipc_send_reply(client, json, (uint32_t)length);
 		free(json);
-		client_valid = ipc_send_reply(client, reply, (uint32_t)length);
 		free_cmd_results(results);
 		goto exit_cleanup;
 	}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -64,6 +64,10 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	close(ipc_socket);
 	unlink(ipc_sockaddr->sun_path);
 
+	while (ipc_client_list->length) {
+		struct ipc_client *client = ipc_client_list->items[0];
+		ipc_client_disconnect(client);
+	}
 	list_free(ipc_client_list);
 
 	if (ipc_sockaddr) {
@@ -480,6 +484,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		const char *json = cmd_results_to_json(results);
 		char reply[256];
 		int length = snprintf(reply, sizeof(reply), "%s", json);
+		free(json);
 		client_valid = ipc_send_reply(client, reply, (uint32_t)length);
 		free_cmd_results(results);
 		goto exit_cleanup;

--- a/sway/main.c
+++ b/sway/main.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200112L
 #include <getopt.h>
+#include <pango/pangocairo.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -440,6 +441,8 @@ int main(int argc, char **argv) {
 	if (config) {
 		free_config(config);
 	}
+
+	pango_cairo_font_map_set_default(NULL);
 
 	return exit_value;
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -151,6 +151,7 @@ void container_free(struct sway_container *cont) {
 		return;
 	}
 	free(cont->name);
+	free(cont->formatted_title);
 	wlr_texture_destroy(cont->title_focused);
 	wlr_texture_destroy(cont->title_focused_inactive);
 	wlr_texture_destroy(cont->title_unfocused);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -514,7 +514,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	if (container_is_floating(focus)) {
 		focus = focus->parent->parent;
 	}
-	free(criterias);
+	list_free(criterias);
 	cont = container_view_create(focus, view);
 
 	view->surface = wlr_surface;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -191,6 +191,8 @@ char *workspace_next_name(const char *output_name) {
 				free(target);
 				target = _target;
 				wlr_log(L_DEBUG, "Workspace: Found free name %s", _target);
+			} else {
+				free(_target);
 			}
 		}
 		free(dup);


### PR DESCRIPTION
This PR depends on #2203 as it touches the same function.

I'm pretty sure I'm still missing some here, I got a couple of crashes while trying to "produce activity" so I got annoyed and very likely missing some as I didn't check various patterns. This should still be a good start.

There also is tons of fontconfig stuff that seems to be alloc'd by cairo but I have no idea where that comes from, hopefully it's really just fontconfig's cache and won't grow endlessly.

wrt. what I said on IRC earlier for swaybar (bar leaking ~250 bytes every 5s) it would seem that this only happens with ASAN, so I guess that's just how much memory ASAN needs to keep track of the... 913 (!) indirect alloc/malloc calls that swaybar does every 5 seconds according to perf record. I guess I'll live with that for now but that means I won't be able to keep ASAN if I seriously start to use sway...