### PR TITLE
Fix use after free in transaction code

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -377,7 +377,9 @@ static void set_instructions_ready(struct sway_view *view, int index) {
 	for (int i = 0; i <= index; ++i) {
 		struct sway_transaction_instruction *instruction =
 			view->swayc->instructions->items[i];
-		set_instruction_ready(instruction);
+		if (!instruction->ready) {
+			set_instruction_ready(instruction);
+		}
 	}
 }
 


### PR DESCRIPTION
If we set an instruction as ready twice, it decreases the transaction's num_waiting a second time and applies the transaction earlier than it should. This no doubt has undesired effects, probably resulting in a use after free.

Hopefully fixes the first part of #2207.