### PR TITLE
Fix swaybar teardown when workspace buttons hidden

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -497,7 +497,7 @@ void render_frame(struct swaybar *bar, struct swaybar_output *output) {
 		// different height than what we asked for
 		wl_surface_commit(output->surface);
 		wl_display_roundtrip(bar->display);
-	} else {
+	} else if (height > 0) {
 		// Replay recording into shm and send it off
 		output->current_buffer = get_next_buffer(bar->shm,
 				output->buffers,


### PR DESCRIPTION
Fixes #2213

When workspace buttons are hidden, `wl_display_dispatch` was returning `-1` with `errno = 71`. Running `swaybar` with `WAYLAND_DEBUG=1` gave `wl_shm@4: error 1: invalid size (0)`. `max_height`was `0` on the first frame render due to the status line not being read yet.

~This PR prevents `max_height` from being `0`.~ This PR prevents rendering the bar if the `height` is not greater than `0`