### PR TITLE
Implement mode --pango_markup

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -50,6 +50,7 @@ struct sway_mode {
 	char *name;
 	list_t *keysym_bindings;
 	list_t *keycode_bindings;
+	bool pango;
 };
 
 struct input_config_mapped_from_region {

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -15,6 +15,6 @@ void ipc_event_workspace(struct sway_container *old,
 		struct sway_container *new, const char *change);
 void ipc_event_window(struct sway_container *window, const char *change);
 void ipc_event_barconfig_update(struct bar_config *bar);
-void ipc_event_mode(const char *mode);
+void ipc_event_mode(const char *mode, bool pango);
 
 #endif

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -26,7 +26,17 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 				"mode", "Can only be used in config file.");
 	}
 
-	const char *mode_name = argv[0];
+	bool pango = strcmp(*argv, "--pango_markup") == 0;
+	if (pango) {
+		argc--; argv++;
+		if (argc == 0) {
+			return cmd_results_new(CMD_FAILURE, "mode",
+					"Mode name is missing");
+		}
+	}
+
+	char *mode_name = *argv;
+	strip_quotes(mode_name);
 	struct sway_mode *mode = NULL;
 	// Find mode
 	for (int i = 0; i < config->modes->length; ++i) {
@@ -46,6 +56,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		mode->name = strdup(mode_name);
 		mode->keysym_bindings = create_list();
 		mode->keycode_bindings = create_list();
+		mode->pango = pango;
 		list_add(config->modes, mode);
 	}
 	if (!mode) {
@@ -54,13 +65,15 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		return error;
 	}
 	if ((config->reading && argc > 1) || (!config->reading && argc == 1)) {
-		wlr_log(L_DEBUG, "Switching to mode `%s'",mode->name);
+		wlr_log(L_DEBUG, "Switching to mode `%s' (pango=%d)",
+				mode->name, mode->pango);
 	}
 	// Set current mode
 	config->current_mode = mode;
 	if (argc == 1) {
 		// trigger IPC mode event
-		ipc_event_mode(config->current_mode->name);
+		ipc_event_mode(config->current_mode->name,
+				config->current_mode->pango);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -332,13 +332,15 @@ void ipc_event_barconfig_update(struct bar_config *bar) {
 	json_object_put(json);
 }
 
-void ipc_event_mode(const char *mode) {
+void ipc_event_mode(const char *mode, bool pango) {
 	if (!ipc_has_event_listeners(IPC_EVENT_MODE)) {
 		return;
 	}
 	wlr_log(L_DEBUG, "Sending mode::%s event", mode);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(mode));
+	json_object_object_add(obj, "pango_markup",
+			json_object_new_boolean(pango));
 
 	const char *json_string = json_object_to_json_string(obj);
 	ipc_send_event(json_string, IPC_EVENT_MODE);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -413,10 +413,12 @@ The default colors are:
 *mode* <mode>
 	Switches to the specified mode. The default mode _default_.
 
-*mode* <mode> *{* <commands...> *}*
+*mode* [--pango\_markup] <mode> *{* <commands...> *}*
 	_commands..._ after *{* will be added to the specified mode. A newline is
 	required between *{* and the first command, and *}* must be alone on a
 	line. Only *bindsym* and *bindcode* commands are permitted in mode blocks.
+	If _--pango\_markup_ is given, then _mode_ will be interpreted as pango
+	markup.
 
 *mouse\_warping* output|none
 	If _output_ is specified, the mouse will be moved to new outputs as you

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -298,7 +298,8 @@ static uint32_t render_binding_mode_indicator(cairo_t *cairo,
 
 	int text_width, text_height;
 	get_text_size(cairo, config->font, &text_width, &text_height,
-			output->scale, config->pango_markup, "%s", mode);
+			output->scale, config->mode_pango_markup,
+			"%s", mode);
 
 	int ws_vertical_padding = WS_VERTICAL_PADDING * output->scale;
 	int ws_horizontal_padding = WS_HORIZONTAL_PADDING * output->scale;
@@ -329,7 +330,7 @@ static uint32_t render_binding_mode_indicator(cairo_t *cairo,
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_set_source_u32(cairo, config->colors.binding_mode.text);
 	cairo_move_to(cairo, x + width / 2 - text_width / 2, (int)floor(text_y));
-	pango_printf(cairo, config->font, output->scale, config->pango_markup,
+	pango_printf(cairo, config->font, output->scale, config->mode_pango_markup,
 			"%s", mode);
 	return surface_height;
 }


### PR DESCRIPTION
Fixes #663

This implements the `--pango_markup` flag for the `mode` command. For anything listening for IPC events, `mode::pango_markup` is sent along with `mode::change`.