### PR TITLE
Fix titles when container titles contain UTF-8 characters

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -783,7 +783,7 @@ static void update_title_texture(struct sway_container *con,
 
 	double scale = output->sway_output->wlr_output->scale;
 	int width = 0;
-	int height = config->font_height * scale;
+	int height = con->title_height * scale;
 
 	cairo_t *c = cairo_create(NULL);
 	get_text_size(c, config->font, &width, NULL, scale, config->pango_markup,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -923,7 +923,7 @@ static void update_marks_texture(struct sway_view *view,
 
 	double scale = output->sway_output->wlr_output->scale;
 	int width = 0;
-	int height = config->font_height * scale;
+	int height = view->swayc->title_height * scale;
 
 	cairo_t *c = cairo_create(NULL);
 	get_text_size(c, config->font, &width, NULL, scale, false, "%s", buffer);


### PR DESCRIPTION
The title and marks textures would have their height set from the config's computed max font height, but the textures were not regenerated when the config's max font height changed which made a gap appear. Rather than making it regenerate the title textures every time the config font height was changed, I've changed it to just make the textures the height of the title itself and fill any gap when rendering.

Also, the `title_width` and `marks_width` variables have been renamed to make it more obvious that they are in output-buffer-local coordinates.

To test, visit [this YouTube video](https://www.youtube.com/watch?v=kfgFcMz-VnM) or [search for "grilled pork ginger" in Japanese](https://duckduckgo.com/?q=%E8%B1%9A%E3%81%AE%E7%94%9F%E5%A7%9C%E7%84%BC%E3%81%8D+&t=ffab&ia=web).

Fixes #1936.