### PR TITLE
swaylock: fix the displaying of "verified"

### DIFF
--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -97,7 +97,20 @@ void swaylock_handle_key(struct swaylock_state *state,
 	case XKB_KEY_Return:
 		state->auth_state = AUTH_STATE_VALIDATING;
 		damage_state(state);
-		wl_display_roundtrip(state->display);
+		while (wl_display_dispatch(state->display) != -1 && state->run_display) {
+			bool ok = 1;
+			struct swaylock_surface *surface;
+			wl_list_for_each(surface, &state->surfaces, link) {
+				if (surface->dirty) {
+					ok = 0;
+				}
+			}
+			if (ok) {
+				break;
+			}
+		}
+		wl_display_flush(state->display);
+
 		if (attempt_password(&state->password)) {
 			state->run_display = false;
 			break;


### PR DESCRIPTION
Displaying verified after damaging state needs more than one roundtrip,
so keep looping until surfaces are not dirty anymore

I had this commit laying around for testing since we talked about it in #2112,
might as well use that since the author closed the original PR.
(I don't remember why the flush is needed after the loop, but I said it's needed so it probably was...)