### PR TITLE
Destroy empty workspace when destroying its output

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -204,16 +204,23 @@ static struct sway_container *container_workspace_destroy(
 		return NULL;
 	}
 
-	// Do not destroy this if it's the last workspace on this output
 	struct sway_container *output = container_parent(workspace, C_OUTPUT);
-	if (output && output->children->length == 1) {
+
+	// If we're destroying the output, it will be NULL here. Return the root so
+	// that it doesn't appear that the workspace has refused to be destoyed,
+	// which would leave it in a broken state with no parent.
+	if (output == NULL) {
+		return &root_container;
+	}
+
+	// Do not destroy this if it's the last workspace on this output
+	if (output->children->length == 1) {
 		return NULL;
 	}
 
 	wlr_log(L_DEBUG, "destroying workspace '%s'", workspace->name);
 
-	struct sway_container *parent = workspace->parent;
-	if (!workspace_is_empty(workspace) && output) {
+	if (!workspace_is_empty(workspace)) {
 		// Move children to a different workspace on this output
 		struct sway_container *new_workspace = NULL;
 		for (int i = 0; i < output->children->length; i++) {
@@ -235,7 +242,7 @@ static struct sway_container *container_workspace_destroy(
 		}
 	}
 
-	return parent;
+	return output;
 }
 
 static struct sway_container *container_output_destroy(


### PR DESCRIPTION
I discovered a crash that can be triggered with the following steps:
- Start a fresh sway in a two-output configuration
- Create at least one view on the first output
- Move the workspace from the first output to the second
    - Note that the original second output workspace sticks around even though it's empty, this is another bug
- Disconnect the second output
- :boom:

This appears to be due to the empty workspace on the second display. Because it is empty, `container_output_destroy` calls `container_destroy` on it instead of moving it to another output. However, at this point, the workspace has already been removed from its current output, leaving it without a parent. This causes the subsequent `container_workspace_destroy` to return NULL, as there is no parent output to look for another workspace on. This NULL is interpreted by `container_destroy_noreaping` as a refusal to be destroyed, which is not what was intended. That then also returns NULL, which causes `container_destroy` to not reap the workspace out of its output. Because it has been removed from its parent output, it is also not affected by that container's recursive reaping that occurs shortly after.

The ultimate effect of this is that there's a magical detached workspace sitting around somewhere, and the next time something tries to figure out where it is, it explodes.

The fix is to simply return some parent container instead of NULL when the workspace discovers that it no longer belongs to an output. I chose the root container. The value is never actually used.

Pinging @acrisci because I think he may have more insight into why the destroy functions return the parent container and whether this is a good idea.