### PR TITLE
Add some missing ipc message types from i3

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -14,6 +14,7 @@ enum ipc_command_type {
 	IPC_GET_BAR_CONFIG = 6,
 	IPC_GET_VERSION = 7,
 	IPC_GET_BINDING_MODES = 8,
+	IPC_GET_CONFIG = 9,
 
 	// sway-specific command types
 	IPC_GET_INPUTS = 100,

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -13,6 +13,7 @@ enum ipc_command_type {
 	IPC_GET_MARKS = 5,
 	IPC_GET_BAR_CONFIG = 6,
 	IPC_GET_VERSION = 7,
+	IPC_GET_BINDING_MODES = 8,
 
 	// sway-specific command types
 	IPC_GET_INPUTS = 100,

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -341,6 +341,7 @@ struct sway_config {
 	int gaps_outer;
 
 	list_t *config_chain;
+	const char *current_config_path;
 	const char *current_config;
 
 	enum sway_container_border border;
@@ -495,8 +496,5 @@ void config_update_font_height(bool recalculate);
 
 /* Global config singleton. */
 extern struct sway_config *config;
-
-/* Config file currently being read */
-extern const char *current_config_path;
 
 #endif

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -80,7 +80,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		if (config->reading && *src != '/') {
 			// src file is inside configuration dir
 
-			char *conf = strdup(config->current_config);
+			char *conf = strdup(config->current_config_path);
 			if (!conf) {
 				wlr_log(WLR_ERROR, "Failed to duplicate string");
 				free(src);

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -7,7 +7,7 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 	if ((error = checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}
-	if (!load_main_config(config->current_config, true)) {
+	if (!load_main_config(config->current_config_path, true)) {
 		return cmd_results_new(CMD_FAILURE, "reload", "Error(s) reloading config.");
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include "log.h"
+#include "sway/config.h"
 #include "sway/ipc-json.h"
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"
@@ -41,6 +42,7 @@ json_object *ipc_json_get_version() {
 	json_object_object_add(version, "major", json_object_new_int(major));
 	json_object_object_add(version, "minor", json_object_new_int(minor));
 	json_object_object_add(version, "patch", json_object_new_int(patch));
+	json_object_object_add(version, "loaded_config_file_name", json_object_new_string(config->current_config_path));
 
 	return version;
 }

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -667,6 +667,20 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		goto exit_cleanup;
 	}
 
+	case IPC_GET_BINDING_MODES:
+	{
+		json_object *modes = json_object_new_array();
+		for (int i = 0; i < config->modes->length; i++) {
+			struct sway_mode *mode = config->modes->items[i];
+			json_object_array_add(modes, json_object_new_string(mode->name));
+		}
+		const char *json_string = json_object_to_json_string(modes);
+		client_valid =
+			ipc_send_reply(client, json_string, (uint32_t)strlen(json_string));
+		json_object_put(modes); // free
+		goto exit_cleanup;
+	}
+
 	default:
 		wlr_log(WLR_INFO, "Unknown IPC command type %i", client->current_command);
 		goto exit_cleanup;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <wayland-server.h>
 #include "sway/commands.h"
+#include "sway/config.h"
 #include "sway/ipc-json.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
@@ -680,6 +681,17 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		json_object_put(modes); // free
 		goto exit_cleanup;
 	}
+
+	case IPC_GET_CONFIG:
+	{
+		json_object *json = json_object_new_object();
+		json_object_object_add(json, "config", json_object_new_string(config->current_config));
+		const char *json_string = json_object_to_json_string(json);
+		client_valid =
+			ipc_send_reply(client, json_string, (uint32_t)strlen(json_string));
+		json_object_put(json); // free
+		goto exit_cleanup;
+    }
 
 	default:
 		wlr_log(WLR_INFO, "Unknown IPC command type %i", client->current_command);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -240,6 +240,12 @@ static void pretty_print_version(json_object *v) {
 	printf("sway version %s\n", json_object_get_string(ver));
 }
 
+static void pretty_print_config(json_object *c) {
+	json_object *config;
+	json_object_object_get_ex(c, "config", &config);
+	printf("%s\n", json_object_get_string(config));
+}
+
 static void pretty_print_clipboard(json_object *v) {
 	if (success(v, true)) {
 		if (json_object_is_type(v, json_type_array)) {
@@ -277,7 +283,7 @@ static void pretty_print(int type, json_object *resp) {
 	if (type != IPC_COMMAND && type != IPC_GET_WORKSPACES &&
 			type != IPC_GET_INPUTS && type != IPC_GET_OUTPUTS &&
 			type != IPC_GET_VERSION && type != IPC_GET_CLIPBOARD &&
-			type != IPC_GET_SEATS) {
+			type != IPC_GET_SEATS && type != IPC_GET_CONFIG) {
 		printf("%s\n", json_object_to_json_string_ext(resp,
 			JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
 		return;
@@ -285,6 +291,11 @@ static void pretty_print(int type, json_object *resp) {
 
 	if (type == IPC_GET_VERSION) {
 		pretty_print_version(resp);
+		return;
+	}
+
+	if (type == IPC_GET_CONFIG) {
+		pretty_print_config(resp);
 		return;
 	}
 
@@ -409,6 +420,8 @@ int main(int argc, char **argv) {
 		type = IPC_GET_VERSION;
 	} else if (strcasecmp(cmdtype, "get_binding_modes") == 0) {
 		type = IPC_GET_BINDING_MODES;
+	} else if (strcasecmp(cmdtype, "get_config") == 0) {
+		type = IPC_GET_CONFIG;
 	} else if (strcasecmp(cmdtype, "get_clipboard") == 0) {
 		type = IPC_GET_CLIPBOARD;
 	} else {

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -407,6 +407,8 @@ int main(int argc, char **argv) {
 		type = IPC_GET_BAR_CONFIG;
 	} else if (strcasecmp(cmdtype, "get_version") == 0) {
 		type = IPC_GET_VERSION;
+	} else if (strcasecmp(cmdtype, "get_binding_modes") == 0) {
+		type = IPC_GET_BINDING_MODES;
 	} else if (strcasecmp(cmdtype, "get_clipboard") == 0) {
 		type = IPC_GET_CLIPBOARD;
 	} else {

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -62,6 +62,9 @@ _swaymsg_ [options...] [message]
 *get\_binding\_modes*
 	Gets a JSON-encoded list of currently configured binding modes.
 
+*get\_config*
+	Gets a JSON-encoded copy of the current configuration.
+
 *get\_clipboard*
 	Get JSON-encoded information about the clipboard.
 	Returns the current clipboard mime-types if called without

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -59,6 +59,9 @@ _swaymsg_ [options...] [message]
 *get\_version*
 	Get JSON-encoded version information for the running instance of sway.
 
+*get\_binding\_modes*
+	Gets a JSON-encoded list of currently configured binding modes.
+
 *get\_clipboard*
 	Get JSON-encoded information about the clipboard.
 	Returns the current clipboard mime-types if called without


### PR DESCRIPTION
Namely get_binding_modes and get_config, though I'm not sure how well the latter has been implemented, would appreciate feedback on it.

Note: the config also doesn't expand includes, and I'm not sure whether that would be wanted, but it would definitely be a bit more work to add.