### PR TITLE
fix tabbed titlebar widths

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -599,7 +599,8 @@ static void render_container_tabbed(struct sway_output *output,
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 	struct sway_container_state *pstate = &con->current;
 
-	int tab_width = pstate->swayc_width / pstate->children->length;
+    double width_gap_adjustment = 2 * pstate->current_gaps;
+	int tab_width = (pstate->swayc_width - width_gap_adjustment) / pstate->children->length;
 
 	// Render tabs
 	for (int i = 0; i < pstate->children->length; ++i) {
@@ -628,7 +629,7 @@ static void render_container_tabbed(struct sway_output *output,
 
 		// Make last tab use the remaining width of the parent
 		if (i == pstate->children->length - 1) {
-			tab_width = pstate->swayc_width - tab_width * i;
+			tab_width = (pstate->swayc_width - width_gap_adjustment) - tab_width * i;
 		}
 
 		render_titlebar(output, damage, child, x, cstate->swayc_y, tab_width,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -631,7 +631,7 @@ static void render_container_tabbed(struct sway_output *output,
 		// Make last tab use the remaining width of the parent
 		if (i == pstate->children->length - 1) {
 			tab_width =
-				(pstate->swayc_width - width_gap_adjustment) - tab_width * i;
+				pstate->swayc_width - width_gap_adjustment - tab_width * i;
 		}
 
 		render_titlebar(output, damage, child, x, cstate->swayc_y, tab_width,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -599,7 +599,7 @@ static void render_container_tabbed(struct sway_output *output,
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 	struct sway_container_state *pstate = &con->current;
 
-    double width_gap_adjustment = 2 * pstate->current_gaps;
+	double width_gap_adjustment = 2 * pstate->current_gaps;
 	int tab_width = (pstate->swayc_width - width_gap_adjustment) / pstate->children->length;
 
 	// Render tabs

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -600,7 +600,8 @@ static void render_container_tabbed(struct sway_output *output,
 	struct sway_container_state *pstate = &con->current;
 
 	double width_gap_adjustment = 2 * pstate->current_gaps;
-	int tab_width = (pstate->swayc_width - width_gap_adjustment) / pstate->children->length;
+	int tab_width =
+		(pstate->swayc_width - width_gap_adjustment) / pstate->children->length;
 
 	// Render tabs
 	for (int i = 0; i < pstate->children->length; ++i) {
@@ -629,7 +630,8 @@ static void render_container_tabbed(struct sway_output *output,
 
 		// Make last tab use the remaining width of the parent
 		if (i == pstate->children->length - 1) {
-			tab_width = (pstate->swayc_width - width_gap_adjustment) - tab_width * i;
+			tab_width =
+				(pstate->swayc_width - width_gap_adjustment) - tab_width * i;
 		}
 
 		render_titlebar(output, damage, child, x, cstate->swayc_y, tab_width,


### PR DESCRIPTION
using tabs with gaps causes the title bar to hang over the container on the right side
![sway_tabbed_gaps_issue](https://user-images.githubusercontent.com/6980201/42548493-25bb46b6-847c-11e8-93c9-c942efd1552e.png)

this fixes the title bar width under tabbed mode by factoring gaps into the calculation.