### PR TITLE
Move floating windows to front when focused

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "log.h"
 
 list_t *create_list(void) {
 	list_t *list = malloc(sizeof(list_t));
@@ -80,6 +81,20 @@ void list_swap(list_t *list, int src, int dest) {
 	void *tmp = list->items[src];
 	list->items[src] = list->items[dest];
 	list->items[dest] = tmp;
+}
+
+void list_move_to_end(list_t *list, void *item) {
+	int i;
+	for (i = 0; i < list->length; ++i) {
+		if (list->items[i] == item) {
+			break;
+		}
+	}
+	if (!sway_assert(i < list->length, "Item not found in list")) {
+		return;
+	}
+	list_del(list, i);
+	list_add(list, item);
 }
 
 static void list_rotate(list_t *list, int from, int to) {

--- a/include/list.h
+++ b/include/list.h
@@ -24,4 +24,6 @@ int list_seq_find(list_t *list, int compare(const void *item, const void *cmp_to
 void list_stable_sort(list_t *list, int compare(const void *a, const void *b));
 // swap two elements in a list
 void list_swap(list_t *list, int src, int dest);
+// move item to end of list
+void list_move_to_end(list_t *list, void *item);
 #endif

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -666,6 +666,14 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		container_damage_whole(container->parent);
 	}
 
+	// If we've focused a floating container, bring it to the front.
+	// We do this by putting it at the end of the floating list.
+	// This must happen for both the pending and current children lists.
+	if (container_is_floating(container)) {
+		list_move_to_end(container->parent->children, container);
+		list_move_to_end(container->parent->current.children, container);
+	}
+
 	// clean up unfocused empty workspace on new output
 	if (new_output_last_ws) {
 		if (!workspace_is_visible(new_output_last_ws)


### PR DESCRIPTION
To test, open two floating windows and position them (eg. using `move position mouse`) in a way that they overlap. Click each one and observe it move to be in front of the other one.