### PR TITLE
Use saved buffer when fullscreen view is in a transaction

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -844,7 +844,11 @@ void output_render(struct sway_output *output, struct timespec *when,
 		}
 
 		// TODO: handle views smaller than the output
-		render_view_surfaces(fullscreen_view, output, damage, 1.0f);
+		if (fullscreen_view->swayc->instructions->length) {
+			render_saved_view(fullscreen_view, output, damage, 1.0f);
+		} else {
+			render_view_surfaces(fullscreen_view, output, damage, 1.0f);
+		}
 
 		if (fullscreen_view->type == SWAY_VIEW_XWAYLAND) {
 			render_unmanaged(output, damage,


### PR DESCRIPTION
Fixes #2237.

To test, launch mpv, fullscreen the video then unfullscreen it. When unfullscreening, it continued to render the live buffer while the other views were resizing, which meant you can get some frames of smaller video despite being fullscreen.

An easier way to test is to set `TRANSACTION_DEBUG` and increase the `TIMEOUT_MS` to 1000 or so.