### PR TITLE
fix crash on floating windows

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -671,7 +671,9 @@ void seat_set_focus_warp(struct sway_seat *seat,
 	// This must happen for both the pending and current children lists.
 	if (container_is_floating(container)) {
 		list_move_to_end(container->parent->children, container);
-		list_move_to_end(container->parent->current.children, container);
+		if (container_has_ancestor(container, container->current.parent)) {
+			list_move_to_end(container->parent->current.children, container);
+		}
 	}
 
 	// clean up unfocused empty workspace on new output


### PR DESCRIPTION
https://github.com/swaywm/sway/commit/15dc5286e280ddd06e845dc57115243e72f2339e crashes sway when opening floating windows. The reason for this is because ``current.children`` can have a length of 0 thus causing `sway_assert` and `list_del` to fail. Since I don't think there's any purpose in moving items around in a zero-length list, I just added a return condition to ``list_move_to_end``.