### PR TITLE
feature: scroll button option for input devices

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -207,6 +207,7 @@ sway_cmd input_cmd_natural_scroll;
 sway_cmd input_cmd_pointer_accel;
 sway_cmd input_cmd_repeat_delay;
 sway_cmd input_cmd_repeat_rate;
+sway_cmd input_cmd_scroll_button;
 sway_cmd input_cmd_scroll_method;
 sway_cmd input_cmd_tap;
 sway_cmd input_cmd_xkb_layout;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -75,6 +75,7 @@ struct input_config {
 	float pointer_accel;
 	int repeat_delay;
 	int repeat_rate;
+	int scroll_button;
 	int scroll_method;
 	int send_events;
 	int tap;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -20,6 +20,7 @@ static struct cmd_handler input_handlers[] = {
 	{ "pointer_accel", input_cmd_pointer_accel },
 	{ "repeat_delay", input_cmd_repeat_delay },
 	{ "repeat_rate", input_cmd_repeat_rate },
+	{ "scroll_button", input_cmd_scroll_button },
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
 	{ "xkb_layout", input_cmd_xkb_layout },

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <strings.h>
+#include <errno.h>
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
@@ -18,12 +19,18 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
+	errno = 0;
 	char *endptr;
-	long scroll_button = strtol(*argv, &endptr, 10);
+	int scroll_button = strtol(*argv, &endptr, 10);
 	if (endptr == *argv && scroll_button == 0) {
 		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
 				"Scroll button identifier must be an integer.");
+	}
+	if (errno == ERANGE) {
+		free_input_config(new_config);
+		return cmd_results_new(CMD_INVALID, "scroll_button",
+				"Scroll button identifier out of range.");
 	}
 	if (scroll_button < 0) {
 		free_input_config(new_config);

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -19,10 +19,10 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 		new_input_config(current_input_config->identifier);
 
 	int scroll_button = atoi(argv[0]);
-	if (scroll_button < 0 || scroll_button > 1000) {
+	if (scroll_button < 0) {
 		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
-				"Input out of range [1, 10]");
+				"Scroll button identifier cannot be negative");
 	}
 	new_config->scroll_button = scroll_button;
 

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -19,7 +19,7 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 		new_input_config(current_input_config->identifier);
 
 	int scroll_button = atoi(argv[0]);
-	if (scroll_button < 1 || scroll_button > 10) {
+	if (scroll_button < 0 || scroll_button > 1000) {
 		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
 				"Input out of range [1, 10]");

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -18,11 +18,17 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	int scroll_button = atoi(argv[0]);
+	char *endptr;
+	long scroll_button = strtol(*argv, &endptr, 10);
+	if (endptr == *argv && scroll_button == 0) {
+		free_input_config(new_config);
+		return cmd_results_new(CMD_INVALID, "scroll_button",
+				"Scroll button identifier must be an integer.");
+	}
 	if (scroll_button < 0) {
 		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
-				"Scroll button identifier cannot be negative");
+				"Scroll button identifier cannot be negative.");
 	}
 	new_config->scroll_button = scroll_button;
 

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -1,0 +1,31 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+
+struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "scroll_button", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
+	if (!current_input_config) {
+		return cmd_results_new(CMD_FAILURE, "scroll_button",
+			"No input device defined.");
+	}
+	struct input_config *new_config =
+		new_input_config(current_input_config->identifier);
+
+	int scroll_button = atoi(argv[0]);
+	if (scroll_button < 1 || scroll_button > 10) {
+		free_input_config(new_config);
+		return cmd_results_new(CMD_INVALID, "scroll_button",
+				"Input out of range [1, 10]");
+	}
+	new_config->scroll_button = scroll_button;
+
+	apply_input_config(new_config);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -27,8 +27,8 @@ struct input_config *new_input_config(const char* identifier) {
 	input->natural_scroll = INT_MIN;
 	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
-	input->scroll_method = INT_MIN;
 	input->scroll_button = INT_MIN;
+	input->scroll_method = INT_MIN;
 	input->left_handed = INT_MIN;
 	input->repeat_delay = INT_MIN;
 	input->repeat_rate = INT_MIN;
@@ -72,7 +72,7 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 		dst->scroll_method = src->scroll_method;
 	}
 	if (src->scroll_button != INT_MIN) {
-		dst->scroll_button= src->scroll_button;
+		dst->scroll_button = src->scroll_button;
 	}
 	if (src->send_events != INT_MIN) {
 		dst->send_events = src->send_events;

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -28,6 +28,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
 	input->scroll_method = INT_MIN;
+	input->scroll_button = INT_MIN;
 	input->left_handed = INT_MIN;
 	input->repeat_delay = INT_MIN;
 	input->repeat_rate = INT_MIN;
@@ -69,6 +70,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->scroll_method != INT_MIN) {
 		dst->scroll_method = src->scroll_method;
+	}
+	if (src->scroll_button != INT_MIN) {
+		dst->scroll_button= src->scroll_button;
 	}
 	if (src->send_events != INT_MIN) {
 		dst->send_events = src->send_events;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -158,6 +158,12 @@ static void input_manager_libinput_config_pointer(
 		libinput_device_config_accel_set_speed(libinput_device,
 			ic->pointer_accel);
 	}
+	if (ic->scroll_button != INT_MIN) {
+		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_button(%d)",
+			ic->identifier, ic->scroll_button);
+		libinput_device_config_scroll_set_button(libinput_device,
+			ic->scroll_button);
+	}
 	if (ic->scroll_method != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
 			ic->identifier, ic->scroll_method);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -118,6 +118,7 @@ sway_sources = files(
 	'commands/input/pointer_accel.c',
 	'commands/input/repeat_delay.c',
 	'commands/input/repeat_rate.c',
+	'commands/input/scroll_button.c',
 	'commands/input/scroll_method.c',
 	'commands/input/tap.c',
 	'commands/input/xkb_layout.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -92,6 +92,11 @@ For more information on these xkb configuration options, see
 *input* <identifier> scroll\_method none|two\_finger|edge|on\_button\_down
 	Changes the scroll method for the specified input device.
 
+*input* <identifier> scroll\_button <button\_identifier>
+	Sets button used for scroll\_method on\_button\_down. The button identifier
+	can be obtained from `libinput debug-events`.
+	If set to 0, it disables the scroll\_button on\_button\_down.
+
 *input* <identifier> tap enabled|disabled
 	Enables or disables tap for specified input device.
 


### PR DESCRIPTION
Hello!

I missed in sway an option to set a scrolling button for my trackball Logitech M570, so I decided to implement it myself.

This patch adds support for `scroll_button` command in user's config file. Below is an example of my working config:
```
input "1133:4136:Logitech_M570" {
	scroll_method on_button_down
	scroll_button 273
}
```
In result I can scroll with holding the right button instead of default middle button.

The scroll button identifier is the same as in `libinput debug-events`.

I decided to set min and max value of button identifier to 0 and 1000, because I don't really know how the situation will be with other input devices. I am sure, that the minimum possible value must be set to 0, because libinput accepts it and disables the `on_button_down` scroll method. [(source)](https://wayland.freedesktop.org/libinput/doc/latest/group__config.html#gac95a25055b22c3631e3c10c0463ca332)
