### PR TITLE
IPC Events (1.0)

### DIFF
--- a/completions/bash/swaymsg
+++ b/completions/bash/swaymsg
@@ -14,7 +14,8 @@ _swaymsg()
     'get_marks'
     'get_bar_config'
     'get_version'
-    'get_clipboard'
+    'get_binding_modes'
+    'get_config'
   )
 
   short=(

--- a/completions/bash/swaymsg
+++ b/completions/bash/swaymsg
@@ -16,6 +16,7 @@ _swaymsg()
     'get_version'
     'get_binding_modes'
     'get_config'
+    'send_tick'
   )
 
   short=(

--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -24,6 +24,7 @@ types=(
 'get_version'
 'get_binding_modes'
 'get_config'
+'send_tick'
 )
 
 _arguments -s \

--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -22,6 +22,8 @@ types=(
 'get_marks'
 'get_bar_config'
 'get_version'
+'get_binding_modes'
+'get_config'
 )
 
 _arguments -s \

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -27,8 +27,9 @@ enum ipc_command_type {
 	IPC_EVENT_WINDOW = ((1<<31) | 3),
 	IPC_EVENT_BARCONFIG_UPDATE = ((1<<31) | 4),
 	IPC_EVENT_BINDING = ((1<<31) | 5),
-	IPC_EVENT_MODIFIER = ((1<<31) | 6),
-	IPC_EVENT_INPUT = ((1<<31) | 7),
+	IPC_EVENT_SHUTDOWN = ((1<<31) | 6),
+	IPC_EVENT_MODIFIER = ((1<<31) | 16),
+	IPC_EVENT_INPUT = ((1<<31) | 17),
 };
 
 #endif

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -30,8 +30,6 @@ enum ipc_command_type {
 	IPC_EVENT_BINDING = ((1<<31) | 5),
 	IPC_EVENT_SHUTDOWN = ((1<<31) | 6),
 	IPC_EVENT_TICK = ((1<<31) | 7),
-	IPC_EVENT_MODIFIER = ((1<<31) | 16),
-	IPC_EVENT_INPUT = ((1<<31) | 17),
 };
 
 #endif

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -15,6 +15,7 @@ enum ipc_command_type {
 	IPC_GET_VERSION = 7,
 	IPC_GET_BINDING_MODES = 8,
 	IPC_GET_CONFIG = 9,
+	IPC_SEND_TICK = 10,
 
 	// sway-specific command types
 	IPC_GET_INPUTS = 100,
@@ -28,6 +29,7 @@ enum ipc_command_type {
 	IPC_EVENT_BARCONFIG_UPDATE = ((1<<31) | 4),
 	IPC_EVENT_BINDING = ((1<<31) | 5),
 	IPC_EVENT_SHUTDOWN = ((1<<31) | 6),
+	IPC_EVENT_TICK = ((1<<31) | 7),
 	IPC_EVENT_MODIFIER = ((1<<31) | 16),
 	IPC_EVENT_INPUT = ((1<<31) | 17),
 };

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -488,8 +488,6 @@ int sway_binding_cmp_keys(const void *a, const void *b);
 
 void free_sway_binding(struct sway_binding *sb);
 
-struct sway_binding *sway_binding_dup(struct sway_binding *sb);
-
 void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding);
 
 void load_swaybars();

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -99,7 +99,7 @@ void seat_configure_xcursor(struct sway_seat *seat);
 void seat_set_focus(struct sway_seat *seat, struct sway_container *container);
 
 void seat_set_focus_warp(struct sway_seat *seat,
-		struct sway_container *container, bool warp);
+		struct sway_container *container, bool warp, bool notify);
 
 void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus);

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -17,5 +17,6 @@ void ipc_event_window(struct sway_container *window, const char *change);
 void ipc_event_barconfig_update(struct bar_config *bar);
 void ipc_event_mode(const char *mode, bool pango);
 void ipc_event_shutdown(const char *reason);
+void ipc_event_binding(struct sway_binding *binding);
 
 #endif

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -16,5 +16,6 @@ void ipc_event_workspace(struct sway_container *old,
 void ipc_event_window(struct sway_container *window, const char *change);
 void ipc_event_barconfig_update(struct bar_config *bar);
 void ipc_event_mode(const char *mode, bool pango);
+void ipc_event_shutdown(const char *reason);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -311,6 +311,8 @@ void view_clear_marks(struct sway_view *view);
 
 bool view_has_mark(struct sway_view *view, char *mark);
 
+void view_add_mark(struct sway_view *view, char *mark);
+
 void view_update_marks_textures(struct sway_view *view);
 
 /**

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -58,7 +58,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	view_find_and_unmark(mark);
 
 	if (!toggle || !had_mark) {
-		list_add(view->marks, strdup(mark));
+		view_add_mark(view, mark);
 	}
 
 	free(mark);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -98,7 +98,7 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 		container_move_to(current, destination);
 		struct sway_container *focus = seat_get_focus_inactive(
 				config->handler_context.seat, old_parent);
-		seat_set_focus(config->handler_context.seat, focus);
+		seat_set_focus_warp(config->handler_context.seat, focus, true, false);
 		container_reap_empty(old_parent);
 		container_reap_empty(destination->parent);
 
@@ -135,7 +135,7 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 		struct sway_container *old_parent = current->parent;
 		struct sway_container *old_ws = container_parent(current, C_WORKSPACE);
 		container_move_to(current, focus);
-		seat_set_focus(config->handler_context.seat, old_parent);
+		seat_set_focus_warp(config->handler_context.seat, old_parent, true, false);
 		container_reap_empty(old_parent);
 		container_reap_empty(focus->parent);
 

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -22,6 +22,7 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 	if (!load_main_config(config->current_config_path, true)) {
 		return cmd_results_new(CMD_FAILURE, "reload", "Error(s) reloading config.");
 	}
+	ipc_event_workspace(NULL, NULL, "reload");
 
 	load_swaybars();
 

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -1,17 +1,45 @@
+#define _XOPEN_SOURCE 500
+#include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/ipc-server.h"
 #include "sway/tree/arrange.h"
+#include "list.h"
 
 struct cmd_results *cmd_reload(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}
+
+	// store bar ids to check against new bars for barconfig_update events
+	list_t *bar_ids = create_list();
+	for (int i = 0; i < config->bars->length; ++i) {
+		struct bar_config *bar = config->bars->items[i];
+		list_add(bar_ids, strdup(bar->id));
+	}
+
 	if (!load_main_config(config->current_config_path, true)) {
 		return cmd_results_new(CMD_FAILURE, "reload", "Error(s) reloading config.");
 	}
 
 	load_swaybars();
+
+	for (int i = 0; i < config->bars->length; ++i) {
+		struct bar_config *bar = config->bars->items[i];
+		for (int j = 0; j < bar_ids->length; ++j) {
+			if (strcmp(bar->id, bar_ids->items[j]) == 0) {
+				ipc_event_barconfig_update(bar);
+				break;
+			}
+		}
+	}
+
+	for (int i = 0; i < bar_ids->length; ++i) {
+		free(bar_ids->items[i]);
+	}
+	list_free(bar_ids);
+
 	arrange_windows(&root_container);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -349,7 +349,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 				output = container_parent(c, C_OUTPUT);
 			}
 			if (output != focus) {
-				seat_set_focus_warp(seat, c, false);
+				seat_set_focus_warp(seat, c, false, true);
 			}
 		} else if (c->type == C_VIEW) {
 			// Focus c if the following are true:
@@ -359,13 +359,13 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			if (!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
 					c != prev_c &&
 					view_is_visible(c->sway_view)) {
-				seat_set_focus_warp(seat, c, false);
+				seat_set_focus_warp(seat, c, false, true);
 			} else {
 				struct sway_container *next_focus =
 					seat_get_focus_inactive(seat, &root_container);
 				if (next_focus && next_focus->type == C_VIEW &&
 						view_is_visible(next_focus->sway_view)) {
-					seat_set_focus_warp(seat, next_focus, false);
+					seat_set_focus_warp(seat, next_focus, false, true);
 				}
 			}
 		}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -617,7 +617,7 @@ static int handle_urgent_timeout(void *data) {
 }
 
 void seat_set_focus_warp(struct sway_seat *seat,
-		struct sway_container *container, bool warp) {
+		struct sway_container *container, bool warp, bool notify) {
 	if (seat->focused_layer) {
 		return;
 	}
@@ -739,7 +739,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 	if (last_focus) {
 		if (last_workspace) {
-			if (last_workspace != new_workspace) {
+			if (notify && last_workspace != new_workspace) {
 				 ipc_event_workspace(last_workspace, new_workspace, "focus");
 			}
 			if (!workspace_is_visible(last_workspace)
@@ -779,7 +779,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 void seat_set_focus(struct sway_seat *seat,
 		struct sway_container *container) {
-	seat_set_focus_warp(seat, container, true);
+	seat_set_focus_warp(seat, container, true, true);
 }
 
 void seat_set_focus_surface(struct sway_seat *seat,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -766,6 +766,10 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		}
 	}
 
+	if (container->type == C_VIEW) {
+		ipc_event_window(container, "focus");
+	}
+
 	seat->has_focus = (container != NULL);
 
 	update_debug_tree();

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -739,7 +739,9 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 	if (last_focus) {
 		if (last_workspace) {
-			ipc_event_workspace(last_workspace, container, "focus");
+			if (last_workspace != new_workspace) {
+				 ipc_event_workspace(last_workspace, new_workspace, "focus");
+			}
 			if (!workspace_is_visible(last_workspace)
 					&& workspace_is_empty(last_workspace)) {
 				if (last_workspace == last_focus) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -201,6 +201,15 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	bool urgent = c->type == C_VIEW ?
 		view_is_urgent(c->sway_view) : container_has_urgent_child(c);
 	json_object_object_add(object, "urgent", json_object_new_boolean(urgent));
+
+	if (c->type == C_VIEW) {
+		json_object *marks = json_object_new_array();
+		list_t *view_marks = c->sway_view->marks;
+		for (int i = 0; i < view_marks->length; ++i) {
+			json_object_array_add(marks, json_object_new_string(view_marks->items[i]));
+		}
+		json_object_object_add(object, "marks", marks);
+	}
 }
 
 static void focus_inactive_children_iterator(struct sway_container *c, void *data) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -353,6 +353,20 @@ void ipc_event_mode(const char *mode, bool pango) {
 	json_object_put(obj);
 }
 
+void ipc_event_shutdown(const char *reason) {
+	if (!ipc_has_event_listeners(IPC_EVENT_SHUTDOWN)) {
+		return;
+	}
+	wlr_log(WLR_DEBUG, "Sending shutdown::%s event", reason);
+
+	json_object *json = json_object_new_object();
+	json_object_object_add(json, "change", json_object_new_string(reason));
+
+	const char *json_string = json_object_to_json_string(json);
+	ipc_send_event(json_string, IPC_EVENT_SHUTDOWN);
+	json_object_put(json);
+}
+
 int ipc_client_handle_writable(int client_fd, uint32_t mask, void *data) {
 	struct ipc_client *client = data;
 
@@ -549,6 +563,8 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client->subscribed_events |= event_mask(IPC_EVENT_BARCONFIG_UPDATE);
 			} else if (strcmp(event_type, "mode") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_MODE);
+			} else if (strcmp(event_type, "shutdown") == 0) {
+				client->subscribed_events |= event_mask(IPC_EVENT_SHUTDOWN);
 			} else if (strcmp(event_type, "window") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_WINDOW);
 			} else if (strcmp(event_type, "modifier") == 0) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -664,8 +664,6 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client->subscribed_events |= event_mask(IPC_EVENT_SHUTDOWN);
 			} else if (strcmp(event_type, "window") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_WINDOW);
-			} else if (strcmp(event_type, "modifier") == 0) {
-				client->subscribed_events |= event_mask(IPC_EVENT_MODIFIER);
 			} else if (strcmp(event_type, "binding") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_BINDING);
 			} else if (strcmp(event_type, "tick") == 0) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -298,13 +298,11 @@ void ipc_event_workspace(struct sway_container *old,
 	wlr_log(WLR_DEBUG, "Sending workspace::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
-	if (strcmp("focus", change) == 0) {
-		if (old) {
-			json_object_object_add(obj, "old",
-					ipc_json_describe_container_recursive(old));
-		} else {
-			json_object_object_add(obj, "old", NULL);
-		}
+	if (old) {
+		json_object_object_add(obj, "old",
+				ipc_json_describe_container_recursive(old));
+	} else {
+		json_object_object_add(obj, "old", NULL);
 	}
 
 	if (new) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -36,6 +36,7 @@ struct sway_server server;
 void sway_terminate(int exit_code) {
 	terminate_request = true;
 	exit_value = exit_code;
+	ipc_event_shutdown("exit");
 	wl_display_terminate(server.wl_display);
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -283,7 +283,7 @@ static struct sway_container *container_output_destroy(
 				container_remove_child(workspace);
 				if (!workspace_is_empty(workspace)) {
 					container_add_child(new_output, workspace);
-					ipc_event_workspace(workspace, NULL, "move");
+					ipc_event_workspace(NULL, workspace, "move");
 				} else {
 					container_destroy(workspace);
 				}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -64,6 +64,8 @@ void container_create_notify(struct sway_container *container) {
 
 	if (container->type == C_VIEW || container->type == C_CONTAINER) {
 		ipc_event_window(container, "new");
+	} else if (container->type == C_WORKSPACE) {
+		ipc_event_workspace(NULL, container, "init");
 	}
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -62,7 +62,7 @@ void container_create_notify(struct sway_container *container) {
 	// TODO send ipc event type based on the container type
 	wl_signal_emit(&root_container.sway_root->events.new_container, container);
 
-	if (container->type == C_VIEW || container->type == C_CONTAINER) {
+	if (container->type == C_VIEW) {
 		ipc_event_window(container, "new");
 	} else if (container->type == C_WORKSPACE) {
 		ipc_event_workspace(NULL, container, "init");

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -325,6 +325,8 @@ static struct sway_container *container_destroy_noreaping(
 	// emit IPC event
 	if (con->type == C_VIEW) {
 		ipc_event_window(con, "close");
+	} else if (con->type == C_WORKSPACE) {
+		ipc_event_workspace(NULL, con, "empty");
 	}
 
 	// The below functions move their children to somewhere else.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -321,7 +321,11 @@ static struct sway_container *container_destroy_noreaping(
 	}
 
 	wl_signal_emit(&con->events.destroy, con);
-	ipc_event_window(con, "close");
+
+	// emit IPC event
+	if (con->type == C_VIEW) {
+		ipc_event_window(con, "close");
+	}
 
 	// The below functions move their children to somewhere else.
 	if (con->type == C_OUTPUT) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -218,6 +218,8 @@ void container_move_to(struct sway_container *container,
 		seat_set_focus(seat, new_parent);
 		workspace_output_raise_priority(container, old_parent, new_parent);
 		ipc_event_workspace(NULL, container, "move");
+	} else if (container->type == C_VIEW) {
+		ipc_event_window(container, "move");
 	}
 	container_notify_subtree_changed(old_parent);
 	container_notify_subtree_changed(new_parent);
@@ -577,6 +579,10 @@ void container_move(struct sway_container *container,
 
 	container_notify_subtree_changed(old_parent);
 	container_notify_subtree_changed(container->parent);
+
+	if (container->type == C_VIEW) {
+		ipc_event_window(container, "move");
+	}
 
 	if (old_parent) {
 		seat_set_focus(config->handler_context.seat, old_parent);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -1001,13 +1001,13 @@ static void swap_focus(struct sway_container *con1,
 		if (focus == con1 && (con2->parent->layout == L_TABBED
 					|| con2->parent->layout == L_STACKED)) {
 			if (workspace_is_visible(ws2)) {
-				seat_set_focus_warp(seat, con2, false);
+				seat_set_focus_warp(seat, con2, false, true);
 			}
 			seat_set_focus(seat, ws1 != ws2 ? con2 : con1);
 		} else if (focus == con2 && (con1->parent->layout == L_TABBED
 					|| con1->parent->layout == L_STACKED)) {
 			if (workspace_is_visible(ws1)) {
-				seat_set_focus_warp(seat, con1, false);
+				seat_set_focus_warp(seat, con1, false, true);
 			}
 			seat_set_focus(seat, ws1 != ws2 ? con1 : con2);
 		} else if (ws1 != ws2) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -217,7 +217,7 @@ void container_move_to(struct sway_container *container,
 		container_sort_workspaces(new_parent);
 		seat_set_focus(seat, new_parent);
 		workspace_output_raise_priority(container, old_parent, new_parent);
-		ipc_event_workspace(container, NULL, "move");
+		ipc_event_workspace(NULL, container, "move");
 	}
 	container_notify_subtree_changed(old_parent);
 	container_notify_subtree_changed(new_parent);

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -598,7 +598,7 @@ void container_move(struct sway_container *container,
 		next_ws = container_parent(next_ws, C_WORKSPACE);
 	}
 	if (last_ws && next_ws && last_ws != next_ws) {
-		ipc_event_workspace(last_ws, container, "focus");
+		ipc_event_workspace(last_ws, next_ws, "focus");
 		workspace_detect_urgent(last_ws);
 		workspace_detect_urgent(next_ws);
 	}

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -22,7 +22,7 @@ static void restore_workspaces(struct sway_container *output) {
 			if (highest == output) {
 				container_remove_child(ws);
 				container_add_child(output, ws);
-				ipc_event_workspace(ws, NULL, "move");
+				ipc_event_workspace(NULL, ws, "move");
 				j--;
 			}
 		}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -888,6 +888,7 @@ bool view_find_and_unmark(char *mark) {
 			free(view_mark);
 			list_del(view->marks, i);
 			view_update_marks_textures(view);
+			ipc_event_window(container, "mark");
 			return true;
 		}
 	}
@@ -895,11 +896,10 @@ bool view_find_and_unmark(char *mark) {
 }
 
 void view_clear_marks(struct sway_view *view) {
-	for (int i = 0; i < view->marks->length; ++i) {
-		free(view->marks->items[i]);
+	while (view->marks->length) {
+		list_del(view->marks, 0);
+		ipc_event_window(view->swayc, "mark");
 	}
-	list_free(view->marks);
-	view->marks = create_list();
 }
 
 bool view_has_mark(struct sway_view *view, char *mark) {
@@ -910,6 +910,11 @@ bool view_has_mark(struct sway_view *view, char *mark) {
 		}
 	}
 	return false;
+}
+
+void view_add_mark(struct sway_view *view, char *mark) {
+	list_add(view->marks, strdup(mark));
+	ipc_event_window(view->swayc, "mark");
 }
 
 static void update_marks_texture(struct sway_view *view,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -864,6 +864,8 @@ void view_update_title(struct sway_view *view, bool force) {
 
 	// Update title after the global font height is updated
 	container_update_title_textures(view->swayc);
+
+	ipc_event_window(view->swayc, "title");
 }
 
 static bool find_by_mark_iterator(struct sway_container *con,

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -250,9 +250,13 @@ static void pretty_print(int type, json_object *resp) {
 	if (type != IPC_COMMAND && type != IPC_GET_WORKSPACES &&
 			type != IPC_GET_INPUTS && type != IPC_GET_OUTPUTS &&
 			type != IPC_GET_VERSION && type != IPC_GET_SEATS &&
-			type != IPC_GET_CONFIG) {
+			type != IPC_GET_CONFIG && type != IPC_SEND_TICK) {
 		printf("%s\n", json_object_to_json_string_ext(resp,
 			JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
+		return;
+	}
+
+	if (type == IPC_SEND_TICK) {
 		return;
 	}
 
@@ -384,6 +388,8 @@ int main(int argc, char **argv) {
 		type = IPC_GET_BINDING_MODES;
 	} else if (strcasecmp(cmdtype, "get_config") == 0) {
 		type = IPC_GET_CONFIG;
+	} else if (strcasecmp(cmdtype, "send_tick") == 0) {
+		type = IPC_SEND_TICK;
 	} else {
 		sway_abort("Unknown message type %s", cmdtype);
 	}

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -64,3 +64,6 @@ _swaymsg_ [options...] [message]
 
 *get\_config*
 	Gets a JSON-encoded copy of the current configuration.
+
+*send\_tick*
+	Sends a tick event to all subscribed clients.


### PR DESCRIPTION
Fixes #1730 

- [x] workspace
    - [x] focus - not satisfied with the hack in the last commit, but also not happy with old behaviour
    - [x] init
    - [x] empty
    - [x] urgent (added in #2276)
    - [x] reload
    - [x] rename (already implemented)
    - [x] ~~restored~~
    - [x] move (already implemented but I haven't tested them yet)
- [x] output (no valid events for them currently)
- [x] mode (already implemented)
- [x] window
    - [x] new (already implemented)
    - [x] close
    - [x] focus
    - [x] title
    - [x] fullscreen_mode (already implemented)
    - [x] move
    - [x] floating (already implemented)
    - [x] urgent (added in #2276)
    - [x] mark - ~I'm not satisfied with its implementation, but with the current api it's hard to work out the best places to add the events~ rewrote it to better conform to i3 behaviour
- [x] barconfig_update
    - [x] on config update
- [x] binding
    - [x] mouse binding
- [x] shutdown - though there are some timing issues, since the server seems to shut down before it can emit the shutdown event
    - [x] ~~restart~~
- [x] tick