### PR TITLE
Implement swaylock configuration file parsing

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -789,13 +789,16 @@ int main(int argc, char **argv) {
 	wlr_log_init(WLR_DEBUG, NULL);
 
 	char *config_path = NULL;
-	for (int i = 0; i < argc; i++) {
-		if (strcmp(argv[i], "-C") == 0 || strcmp(argv[i], "--config") == 0) {
-			if (i + 1 == argc) {
-				wlr_log(WLR_ERROR, "Config file path is missing");
-				return 1;
-			}
-			config_path = strdup(argv[i + 1]);
+	static struct option long_options[] = {
+		{"config", required_argument, NULL, 'C'},
+		{0, 0, 0, 0},
+	};
+	while (1) {
+		int c = getopt_long(argc, argv, "C:", long_options, NULL);
+		if (c == -1) {
+			break;
+		} else if (c == 'C') {
+			config_path = strdup(optarg);
 			break;
 		}
 	}

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -716,7 +716,7 @@ static char *get_config_path(void) {
 
 	wordexp_t p;
 	char *path;
-	for (size_t i = 0; i < (int)(sizeof(config_paths) / sizeof(char *)); ++i) {
+	for (size_t i = 0; i < (sizeof(config_paths) / sizeof(char *)); ++i) {
 		if (wordexp(config_paths[i], &p, 0) == 0) {
 			path = strdup(p.we_wordv[0]);
 			wordfree(&p);

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -716,7 +716,7 @@ static char *get_config_path(void) {
 
 	wordexp_t p;
 	char *path;
-	for (size_t i = 0; i < (sizeof(config_paths) / sizeof(char *)); ++i) {
+	for (size_t i = 0; i < sizeof(config_paths) / sizeof(char *); ++i) {
 		if (wordexp(config_paths[i], &p, 0) == 0) {
 			path = strdup(p.we_wordv[0]);
 			wordfree(&p);

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -716,7 +716,7 @@ static char *get_config_path(void) {
 
 	wordexp_t p;
 	char *path;
-	for (int i = 0; i < (int)(sizeof(config_paths) / sizeof(char *)); ++i) {
+	for (size_t i = 0; i < (int)(sizeof(config_paths) / sizeof(char *)); ++i) {
 		if (wordexp(config_paths[i], &p, 0) == 0) {
 			path = strdup(p.we_wordv[0]);
 			wordfree(&p);

--- a/swaylock/swaylock.1.scd
+++ b/swaylock/swaylock.1.scd
@@ -12,6 +12,15 @@ Locks your Wayland session.
 
 # OPTIONS
 
+*-C, --config* <path>
+	The config file to use. By default, the following paths are checked:
+	_$HOME/.swaylock/config_, _$XDG\_CONFIG\_HOME/swaylock/config_, and
+	_SYSCONFDIR/swaylock/config_. All flags aside from this one are valid
+	options in the configuration file using the format _long-option=value_.
+	For options such as _ignore-empty-password_, just supply the _long-option_.
+	All leading dashes should be omitted and the equals sign is required for
+	flags that take an argument.
+
 *-c, --color* <rrggbb[aa]>
 	Turn the screen into the given color. If -i is used, this sets the
 	background of the image to the given color. Defaults to white (FFFFFF), or


### PR DESCRIPTION
Closes #1962 

Allows for `swaylock` to be configured from file. All long options are valid using the format `long-option[=value]`. Ex. `color=111111FF` or `ignore-empty-password`. If requested, I can add support for short options, but they are currently not supported in the config file.

The default configuration file paths are `$HOME/.swaylock/config`, `$XDG_CONFIG_HOME/swaylock/config`, and `SYSCONFDIR/swaylock/config`. The configuration file can also be manually specified using `-C, --config`.

I decided that instead of duplicating the code for configuring via the command line and a config file, to just reuse the same code and treat each line of the config file as a single argument for parsing. This makes it so that options do not need to be implemented/parsed in two locations and ensures that when an option is added/changed/removed, it effects both config methods.

Any option set on the command line will override the option read from the config file.