### PR TITLE
swaybar/bg: Fix crash on DPMS off

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -503,6 +503,9 @@ void render_frame(struct swaybar *bar, struct swaybar_output *output) {
 				output->buffers,
 				output->width * output->scale,
 				output->height * output->scale);
+		if (!output->current_buffer) {
+			return;
+		}
 		cairo_t *shm = output->current_buffer->cairo;
 
 		cairo_save(shm);

--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -68,6 +68,9 @@ static void render_frame(struct swaybg_state *state) {
 		buffer_height = state->height * state->scale;
 	state->current_buffer = get_next_buffer(state->shm,
 			state->buffers, buffer_width, buffer_height);
+	if (!state->current_buffer) {
+		return;
+	}
 	cairo_t *cairo = state->current_buffer->cairo;
 	if (state->args->mode == BACKGROUND_MODE_SOLID_COLOR) {
 		cairo_set_source_u32(cairo, state->context.color);


### PR DESCRIPTION
When turning off displays via DPMS, swaybar and swaybg still tried to
render, but did not get a valid buffer, causing them to crash.

Not sure if that's a proper fix for the problem, but it does work