### PR TITLE
Implement tap_button_map for input devices

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -210,6 +210,7 @@ sway_cmd input_cmd_repeat_rate;
 sway_cmd input_cmd_scroll_button;
 sway_cmd input_cmd_scroll_method;
 sway_cmd input_cmd_tap;
+sway_cmd input_cmd_tap_button_map;
 sway_cmd input_cmd_xkb_layout;
 sway_cmd input_cmd_xkb_model;
 sway_cmd input_cmd_xkb_options;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -79,6 +79,7 @@ struct input_config {
 	int scroll_method;
 	int send_events;
 	int tap;
+	int tap_button_map;
 
 	char *xkb_layout;
 	char *xkb_model;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -23,6 +23,7 @@ static struct cmd_handler input_handlers[] = {
 	{ "scroll_button", input_cmd_scroll_button },
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
+	{ "tap_button_map", input_cmd_tap_button_map },
 	{ "xkb_layout", input_cmd_xkb_layout },
 	{ "xkb_model", input_cmd_xkb_model },
 	{ "xkb_options", input_cmd_xkb_options },

--- a/sway/commands/input/tap_button_map.c
+++ b/sway/commands/input/tap_button_map.c
@@ -1,0 +1,33 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+
+struct cmd_results *input_cmd_tap_button_map(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "tap_button_map", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *current_input_config =
+		config->handler_context.input_config;
+	if (!current_input_config) {
+		return cmd_results_new(CMD_FAILURE, "tap_button_map",
+				"No input device defined.");
+	}
+	struct input_config *new_config =
+		new_input_config(current_input_config->identifier);
+
+	if (strcasecmp(argv[0], "lrm") == 0) {
+		new_config->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LRM;
+	} else if (strcasecmp(argv[0], "lmr") == 0) {
+		new_config->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LMR;
+	} else {
+		free_input_config(new_config);
+		return cmd_results_new(CMD_INVALID, "tap_button_map",
+			"Expected 'tap_button_map <lrm|lmr>'");
+	}
+
+	apply_input_config(new_config);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -19,6 +19,7 @@ struct input_config *new_input_config(const char* identifier) {
 	}
 
 	input->tap = INT_MIN;
+	input->tap_button_map = INT_MIN;
 	input->drag_lock = INT_MIN;
 	input->dwt = INT_MIN;
 	input->send_events = INT_MIN;
@@ -79,6 +80,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->tap != INT_MIN) {
 		dst->tap = src->tap;
+	}
+	if (src->tap_button_map != INT_MIN) {
+		dst->tap_button_map = src->tap_button_map;
 	}
 	if (src->xkb_layout) {
 		free(dst->xkb_layout);

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -181,6 +181,12 @@ static void input_manager_libinput_config_pointer(
 			ic->identifier, ic->tap);
 		libinput_device_config_tap_set_enabled(libinput_device, ic->tap);
 	}
+	if (ic->tap_button_map != INT_MIN) {
+		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) tap_set_button_map(%d)",
+			ic->identifier, ic->tap);
+		libinput_device_config_tap_set_button_map(libinput_device,
+			ic->tap_button_map);
+	}
 }
 
 static void handle_device_destroy(struct wl_listener *listener, void *data) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -121,6 +121,7 @@ sway_sources = files(
 	'commands/input/scroll_button.c',
 	'commands/input/scroll_method.c',
 	'commands/input/tap.c',
+	'commands/input/tap_button_map.c',
 	'commands/input/xkb_layout.c',
 	'commands/input/xkb_model.c',
 	'commands/input/xkb_options.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -100,6 +100,12 @@ For more information on these xkb configuration options, see
 *input* <identifier> tap enabled|disabled
 	Enables or disables tap for specified input device.
 
+*input* <identifier> tap_button_map lrm|lmr
+	Specifies which button mapping to use for tapping. _lrm_ treats 1 finger as
+	left click, 2 fingers as right click, and 3 fingers as middle click. _lmr_
+	treats 1 finger as left click, 2 fingers as middle click, and 3 fingers as
+	right click.
+
 ## SEAT CONFIGURATION
 
 Configure options for multiseat mode. sway-seat commands must be used inside a


### PR DESCRIPTION
Closes #1569 

Implements `input <identifier> tap_button_map lmr|lrm`. This allows for the number of fingers used to be remapped to different buttons when using tap to click. There are only two options allowed by libinput: `lmr` (1=left, 2=middle, 3=right) and `lrm` (1=left, 2=right, 3=middle).