### PR TITLE
Add extended debugging flags

### DIFF
--- a/include/sway/debug.h
+++ b/include/sway/debug.h
@@ -1,7 +1,15 @@
 #ifndef SWAY_DEBUG_H
 #define SWAY_DEBUG_H
 
+// Tree
 extern bool enable_debug_tree;
 void update_debug_tree();
+
+// Damage
+extern const char *damage_debug;
+
+// Transactions
+extern int txn_timeout_ms;
+extern bool txn_debug;
 
 #endif

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -15,6 +15,7 @@
 #include <wlr/util/region.h>
 #include "log.h"
 #include "sway/config.h"
+#include "sway/debug.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/layers.h"
@@ -786,6 +787,8 @@ static void render_floating(struct sway_output *soutput,
 	}
 }
 
+const char *damage_debug = NULL;
+
 void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
@@ -805,7 +808,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 		goto renderer_end;
 	}
 
-	const char *damage_debug = getenv("SWAY_DAMAGE_DEBUG");
 	if (damage_debug != NULL) {
 		if (strcmp(damage_debug, "highlight") == 0) {
 			wlr_renderer_clear(renderer, (float[]){1, 1, 0, 1});

--- a/sway/main.c
+++ b/sway/main.c
@@ -251,6 +251,18 @@ static void drop_permissions(bool keep_caps) {
 #endif
 }
 
+void enable_debug_flag(const char *flag) {
+	if (strcmp(flag, "render-tree") == 0) {
+		enable_debug_tree = true;
+	} else if (strncmp(flag, "damage=", 7) == 0) {
+		damage_debug = &flag[7];
+	} else if (strcmp(flag, "txn-debug") == 0) {
+		txn_debug = true;
+	} else if (strncmp(flag, "txn-timeout=", 12) == 0) {
+		txn_timeout_ms = atoi(&flag[12]);
+	}
+}
+
 int main(int argc, char **argv) {
 	static int verbose = 0, debug = 0, validate = 0;
 
@@ -290,7 +302,7 @@ int main(int argc, char **argv) {
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hCdDvVc:", long_options, &option_index);
+		c = getopt_long(argc, argv, "hCdD:vVc:", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
@@ -309,7 +321,7 @@ int main(int argc, char **argv) {
 			debug = 1;
 			break;
 		case 'D': // extended debug options
-			enable_debug_tree = true;
+			enable_debug_flag(optarg);
 			break;
 		case 'v': // version
 			fprintf(stdout, "sway version " SWAY_VERSION "\n");


### PR DESCRIPTION
We currently have several ways of setting debug flags, including command
line arguments, environment variables, and compile-time macros. This
replaces the lot with command line flags.