### PR TITLE
Make focus part of transactions

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -119,17 +119,6 @@ struct sway_container *seat_get_active_child(struct sway_seat *seat,
 		struct sway_container *container);
 
 /**
- * Return the immediate child of container which was most recently focused, with
- * fallback to selecting the child in the parent's `current` (rendered) children
- * list.
- *
- * This is useful for when a tabbed container and its children are destroyed but
- * still being rendered, and we have to render an appropriate child.
- */
-struct sway_container *seat_get_active_current_child(struct sway_seat *seat,
-		struct sway_container *container);
-
-/**
  * Iterate over the focus-inactive children of the container calling the
  * function on each.
  */

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -68,6 +68,9 @@ struct sway_container_state {
 	struct sway_container *parent;
 	list_t *children;
 
+	struct sway_container *focused_inactive_child;
+	bool focused;
+
 	// View properties
 	double view_x, view_y;
 	double view_width, view_height;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -9,7 +9,6 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/criteria.h"
-#include "sway/desktop/transaction.h"
 #include "sway/security.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -323,7 +322,6 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat) {
 cleanup:
 	free(exec);
 	free(views);
-	transaction_commit_dirty();
 	if (!results) {
 		results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_idle.h>
 #include "list.h"
 #include "log.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/layers.h"
 #include "sway/output.h"
@@ -219,6 +220,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		struct sway_drag_icon *drag_icon = wlr_drag_icon->data;
 		drag_icon_update_position(drag_icon);
 	}
+	transaction_commit_dirty();
 }
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {
@@ -278,6 +280,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	wlr_seat_pointer_notify_button(cursor->seat->wlr_seat,
 			time_msec, button, state);
+	transaction_commit_dirty();
 }
 
 static void handle_cursor_button(struct wl_listener *listener, void *data) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -3,6 +3,7 @@
 #include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_idle.h>
+#include "sway/desktop/transaction.h"
 #include "sway/input/seat.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/input-manager.h"
@@ -126,6 +127,7 @@ static void keyboard_execute_command(struct sway_keyboard *keyboard,
 		binding->command);
 	config->handler_context.seat = keyboard->seat_device->sway_seat;
 	struct cmd_results *results = execute_command(binding->command, NULL);
+	transaction_commit_dirty();
 	if (results->status != CMD_SUCCESS) {
 		wlr_log(WLR_DEBUG, "could not run command for binding: %s (%s)",
 			binding->command, results->error);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -661,9 +661,13 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		if (last_focus) {
 			seat_send_unfocus(last_focus, seat);
 		}
-
 		seat_send_focus(container, seat);
-		container_damage_whole(container->parent);
+
+		container_set_dirty(container);
+		container_set_dirty(container->parent); // for focused_inactive_child
+		if (last_focus) {
+			container_set_dirty(last_focus);
+		}
 	}
 
 	// If we've focused a floating container, bring it to the front.
@@ -715,10 +719,6 @@ void seat_set_focus_warp(struct sway_seat *seat,
 				}
 			}
 		}
-	}
-
-	if (last_focus) {
-		container_damage_whole(last_focus);
 	}
 
 	if (last_workspace && last_workspace != new_workspace) {
@@ -834,18 +834,6 @@ struct sway_container *seat_get_active_child(struct sway_seat *seat,
 	wl_list_for_each(current, &seat->focus_stack, link) {
 		if (current->container->parent == container &&
 				current->container->layout != L_FLOATING) {
-			return current->container;
-		}
-	}
-	return NULL;
-}
-
-struct sway_container *seat_get_active_current_child(struct sway_seat *seat,
-		struct sway_container *container) {
-	struct sway_seat_container *current = NULL;
-	wl_list_for_each(current, &seat->focus_stack, link) {
-		if (current->container->current.parent == container &&
-				current->container->current.layout != L_FLOATING) {
 			return current->container;
 		}
 	}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -18,6 +18,7 @@
 #include <wayland-server.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/desktop/transaction.h"
 #include "sway/ipc-json.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
@@ -484,6 +485,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_COMMAND:
 	{
 		struct cmd_results *results = execute_command(buf, NULL);
+		transaction_commit_dirty();
 		char *json = cmd_results_to_json(results);
 		int length = strlen(json);
 		client_valid = ipc_send_reply(client, json, (uint32_t)length);

--- a/sway/main.c
+++ b/sway/main.c
@@ -20,6 +20,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/debug.h"
+#include "sway/desktop/transaction.h"
 #include "sway/server.h"
 #include "sway/tree/layout.h"
 #include "sway/ipc-server.h"
@@ -441,6 +442,7 @@ int main(int argc, char **argv) {
 		free(line);
 		list_del(config->cmd_queue, 0);
 	}
+	transaction_commit_dirty();
 
 	if (!terminate_request) {
 		server_run(&server);


### PR DESCRIPTION
Rather than maintain copies of the entire focus stack, this PR transactionises the focus by introducing two new properties to the container state and using those when rendering.

* `bool focused` means this container has actual focus. Only one container should have this equalling true in its current state.
* `struct sway_container *focus_inactive_child` points to the immediate child that was most recently focused (eg. for tabbed and stacked containers).

While implementing this PR I discovered `transaction_commit_dirty` needs to be called even earlier than in `execute_command`, so it's now called from IPC, bindsym handling, etc. The reason for this is that a mapping view with criteria would call `execute_command` which created a second/nested transaction, which when combined with the new focus code making containers dirty would ultimately cause rendering issues. This isn't a problem in the simplify-transactions PR because the focus code in that PR doesn't make containers dirty.

Because transactions must be used when focus is changed, `transaction_commit_dirty` is now called in a few more places, such as when handling cursor motion and buttons.

Another negative net LOC PR :)

To test, use the transaction debug feature:

* Open views and observe that the focus styling is preserved on the previous view until the new one appears.
* Close views and observe that the focus styling is preserved on the closing view until it disappears.
* Create tabbed and stacked containers and open and close views within them. Prior to this PR, it would render something it shouldn't during the transaction.