### PR TITLE
Implement urgency base functionality

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -152,6 +152,7 @@ sway_cmd cmd_swaybg_command;
 sway_cmd cmd_swap;
 sway_cmd cmd_title_format;
 sway_cmd cmd_unmark;
+sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;
 sway_cmd cmd_ws_auto_back_and_forth;
 sway_cmd cmd_workspace_layout;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -316,4 +316,6 @@ void container_floating_move_to(struct sway_container *con,
  */
 void container_set_dirty(struct sway_container *container);
 
+bool container_has_urgent_child(struct sway_container *container);
+
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -70,6 +70,10 @@ struct sway_view {
 	bool border_left;
 	bool border_right;
 
+	struct timespec urgent;
+	bool allow_request_urgent;
+	struct wl_event_source *urgent_timer;
+
 	bool destroying;
 
 	list_t *executed_criteria; // struct criteria *
@@ -304,5 +308,9 @@ void view_update_marks_textures(struct sway_view *view);
  * Intended for damage tracking.
  */
 bool view_is_visible(struct sway_view *view);
+
+void view_set_urgent(struct sway_view *view, bool enable);
+
+bool view_is_urgent(struct sway_view *view);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -10,6 +10,7 @@ struct sway_workspace {
 	struct sway_view *fullscreen;
 	struct sway_container *floating;
 	list_t *output_priority;
+	bool urgent;
 };
 
 extern char *prev_workspace_name;
@@ -43,6 +44,6 @@ void workspace_output_add_priority(struct sway_container *workspace,
 struct sway_container *workspace_output_get_highest_available(
 		struct sway_container *ws, struct sway_container *exclude);
 
-bool workspace_is_urgent(struct sway_container *workspace);
+void workspace_detect_urgent(struct sway_container *workspace);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -42,4 +42,7 @@ void workspace_output_add_priority(struct sway_container *workspace,
 
 struct sway_container *workspace_output_get_highest_available(
 		struct sway_container *ws, struct sway_container *exclude);
+
+bool workspace_is_urgent(struct sway_container *workspace);
+
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -153,6 +153,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "swap", cmd_swap },
 	{ "title_format", cmd_title_format },
 	{ "unmark", cmd_unmark },
+	{ "urgent", cmd_urgent },
 };
 
 static int handler_compare(const void *_a, const void *_b) {

--- a/sway/commands/urgent.c
+++ b/sway/commands/urgent.c
@@ -1,0 +1,36 @@
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "sway/tree/layout.h"
+
+struct cmd_results *cmd_urgent(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "urgent", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	struct sway_container *container =
+		config->handler_context.current_container;
+	if (container->type != C_VIEW) {
+		return cmd_results_new(CMD_INVALID, "urgent",
+				"Only views can be urgent");
+	}
+	struct sway_view *view = container->sway_view;
+
+	if (strcmp(argv[0], "enable") == 0) {
+		view_set_urgent(view, true);
+	} else if (strcmp(argv[0], "disable") == 0) {
+		view_set_urgent(view, false);
+	} else if (strcmp(argv[0], "allow") == 0) {
+		view->allow_request_urgent = true;
+	} else if (strcmp(argv[0], "deny") == 0) {
+		view->allow_request_urgent = false;
+	} else {
+		return cmd_results_new(CMD_INVALID, "urgent",
+				"Expected 'urgent <enable|disable|allow|deny>'");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -46,6 +46,31 @@ static int regex_cmp(const char *item, const pcre *regex) {
 	return pcre_exec(regex, NULL, item, strlen(item), 0, 0, NULL, 0);
 }
 
+static int cmp_urgent(const void *_a, const void *_b) {
+	struct sway_view *a = *(void **)_a;
+	struct sway_view *b = *(void **)_b;
+
+	if (a->urgent.tv_sec < b->urgent.tv_sec) {
+		return -1;
+	} else if (a->urgent.tv_sec > b->urgent.tv_sec) {
+		return 1;
+	}
+	if (a->urgent.tv_nsec < b->urgent.tv_nsec) {
+		return -1;
+	} else if (a->urgent.tv_nsec > b->urgent.tv_nsec) {
+		return 1;
+	}
+	return 0;
+}
+
+static void find_urgent_iterator(struct sway_container *swayc, void *data) {
+	if (swayc->type != C_VIEW || !view_is_urgent(swayc->sway_view)) {
+		return;
+	}
+	list_t *urgent_views = data;
+	list_add(urgent_views, swayc->sway_view);
+}
+
 static bool criteria_matches_view(struct criteria *criteria,
 		struct sway_view *view) {
 	if (criteria->title) {
@@ -133,8 +158,23 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->urgent) {
-		// TODO
-		return false;
+		if (!view_is_urgent(view)) {
+			return false;
+		}
+		list_t *urgent_views = create_list();
+		container_for_each_descendant_dfs(&root_container,
+				find_urgent_iterator, urgent_views);
+		list_stable_sort(urgent_views, cmp_urgent);
+		struct sway_view *target;
+		if (criteria->urgent == 'o') { // oldest
+			target = urgent_views->items[0];
+		} else { // latest
+			target = urgent_views->items[urgent_views->length - 1];
+		}
+		list_free(urgent_views);
+		if (view != target) {
+			return false;
+		}
 	}
 
 	if (criteria->workspace) {

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -611,11 +611,13 @@ static void render_container_tabbed(struct sway_output *output,
 		struct border_colors *colors;
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
+		bool urgent = view ?
+			view_is_urgent(view) : container_has_urgent_child(child);
 
-		if (view && view_is_urgent(view)) {
+		if (urgent) {
 			colors = &config->border_colors.urgent;
 			title_texture = child->title_urgent;
-			marks_texture = view->marks_urgent;
+			marks_texture = view ? view->marks_urgent : NULL;
 		} else if (cstate->focused || parent_focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;
@@ -678,11 +680,13 @@ static void render_container_stacked(struct sway_output *output,
 		struct border_colors *colors;
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
+		bool urgent = view ?
+			view_is_urgent(view) : container_has_urgent_child(child);
 
-		if (view && view_is_urgent(view)) {
+		if (urgent) {
 			colors = &config->border_colors.urgent;
 			title_texture = child->title_urgent;
-			marks_texture = view->marks_urgent;
+			marks_texture = view ? view->marks_urgent : NULL;
 		} else if (cstate->focused || parent_focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -553,7 +553,11 @@ static void render_container_simple(struct sway_output *output,
 			struct wlr_texture *marks_texture;
 			struct sway_container_state *state = &child->current;
 
-			if (state->focused || parent_focused) {
+			if (view_is_urgent(view)) {
+				colors = &config->border_colors.urgent;
+				title_texture = child->title_urgent;
+				marks_texture = view->marks_urgent;
+			} else if (state->focused || parent_focused) {
 				colors = &config->border_colors.focused;
 				title_texture = child->title_focused;
 				marks_texture = view->marks_focused;
@@ -608,7 +612,11 @@ static void render_container_tabbed(struct sway_output *output,
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
 
-		if (cstate->focused || parent_focused) {
+		if (view && view_is_urgent(view)) {
+			colors = &config->border_colors.urgent;
+			title_texture = child->title_urgent;
+			marks_texture = view->marks_urgent;
+		} else if (cstate->focused || parent_focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;
 			marks_texture = view ? view->marks_focused : NULL;
@@ -671,7 +679,11 @@ static void render_container_stacked(struct sway_output *output,
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
 
-		if (cstate->focused || parent_focused) {
+		if (view && view_is_urgent(view)) {
+			colors = &config->border_colors.urgent;
+			title_texture = child->title_urgent;
+			marks_texture = view->marks_urgent;
+		} else if (cstate->focused || parent_focused) {
 			colors = &config->border_colors.focused;
 			title_texture = child->title_focused;
 			marks_texture = view ? view->marks_focused : NULL;
@@ -731,7 +743,11 @@ static void render_floating_container(struct sway_output *soutput,
 		struct wlr_texture *title_texture;
 		struct wlr_texture *marks_texture;
 
-		if (con->current.focused) {
+		if (view_is_urgent(view)) {
+			colors = &config->border_colors.urgent;
+			title_texture = con->title_urgent;
+			marks_texture = view->marks_urgent;
+		} else if (con->current.focused) {
 			colors = &config->border_colors.focused;
 			title_texture = con->title_focused;
 			marks_texture = view->marks_focused;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -297,6 +297,10 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	}
 
 	view_damage_from(view);
+
+	if (view->allow_request_urgent) {
+		view_set_urgent(view, (bool)xsurface->hints_urgency);
+	}
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -594,6 +594,12 @@ static void seat_send_unfocus(struct sway_container *container,
 	}
 }
 
+static int handle_urgent_timeout(void *data) {
+	struct sway_view *view = data;
+	view_set_urgent(view, false);
+	return 0;
+}
+
 void seat_set_focus_warp(struct sway_seat *seat,
 		struct sway_container *container, bool warp) {
 	if (seat->focused_layer) {
@@ -668,6 +674,16 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		if (last_focus) {
 			container_set_dirty(last_focus);
 		}
+	}
+
+	// If urgent, start a timer to unset it
+	if (container && container->type == C_VIEW &&
+			view_is_urgent(container->sway_view) &&
+			!container->sway_view->urgent_timer) {
+		struct sway_view *view = container->sway_view;
+		view->urgent_timer = wl_event_loop_add_timer(server.wl_event_loop,
+				handle_urgent_timeout, view);
+		wl_event_source_timer_update(view->urgent_timer, 1000);
 	}
 
 	// If we've focused a floating container, bring it to the front.

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -198,8 +198,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 			json_object_new_string(ipc_json_layout_description(c->layout)));
 	}
 
-	json_object_object_add(object, "urgent",
-			json_object_new_boolean(view_is_urgent(c->sway_view)));
+	if (c->type == C_VIEW) {
+		json_object_object_add(object, "urgent",
+				json_object_new_boolean(view_is_urgent(c->sway_view)));
+	}
 }
 
 static void focus_inactive_children_iterator(struct sway_container *c, void *data) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -197,6 +197,9 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 		json_object_object_add(object, "layout",
 			json_object_new_string(ipc_json_layout_description(c->layout)));
 	}
+
+	json_object_object_add(object, "urgent",
+			json_object_new_boolean(view_is_urgent(c->sway_view)));
 }
 
 static void focus_inactive_children_iterator(struct sway_container *c, void *data) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -170,7 +170,8 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 	json_object_object_add(object, "output", workspace->parent ?
 			json_object_new_string(workspace->parent->name) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
-	json_object_object_add(object, "urgent", json_object_new_boolean(false));
+	json_object_object_add(object, "urgent",
+			json_object_new_boolean(workspace_is_urgent(workspace)));
 	json_object_object_add(object, "representation", workspace->formatted_title ?
 			json_object_new_string(workspace->formatted_title) : NULL);
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -171,7 +171,7 @@ static void ipc_json_describe_workspace(struct sway_container *workspace,
 			json_object_new_string(workspace->parent->name) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
 	json_object_object_add(object, "urgent",
-			json_object_new_boolean(workspace_is_urgent(workspace)));
+			json_object_new_boolean(workspace->sway_workspace->urgent));
 	json_object_object_add(object, "representation", workspace->formatted_title ?
 			json_object_new_string(workspace->formatted_title) : NULL);
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -198,10 +198,9 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 			json_object_new_string(ipc_json_layout_description(c->layout)));
 	}
 
-	if (c->type == C_VIEW) {
-		json_object_object_add(object, "urgent",
-				json_object_new_boolean(view_is_urgent(c->sway_view)));
-	}
+	bool urgent = c->type == C_VIEW ?
+		view_is_urgent(c->sway_view) : container_has_urgent_child(c);
+	json_object_object_add(object, "urgent", json_object_new_boolean(urgent));
 }
 
 static void focus_inactive_children_iterator(struct sway_container *c, void *data) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -76,6 +76,7 @@ sway_sources = files(
 	'commands/swap.c',
 	'commands/title_format.c',
 	'commands/unmark.c',
+	'commands/urgent.c',
 	'commands/workspace.c',
 	'commands/workspace_layout.c',
 	'commands/ws_auto_back_and_forth.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -499,6 +499,11 @@ config after the others, or it will be matched instead of the others.
 	*unmark* will remove _identifier_ from the list of current marks on a
 	window. If _identifier_ is omitted, all marks are removed.
 
+*urgent* enable|disable|allow|deny
+	Using _enable_ or _disable_ manually sets or unsets the window's urgent
+	state. Using _allow_ or _deny_ controls the window's ability to set itself
+	as urgent. By default, windows are allowed to set their own urgency.
+
 *workspace* [number] <name>
 	Switches to the specified workspace. The string "number" is optional and is
 	used to sort workspaces.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1082,3 +1082,12 @@ void container_set_dirty(struct sway_container *container) {
 	container->dirty = true;
 	list_add(server.dirty_containers, container);
 }
+
+static bool find_urgent_iterator(struct sway_container *con,
+		void *data) {
+	return con->type == C_VIEW && view_is_urgent(con->sway_view);
+}
+
+bool container_has_urgent_child(struct sway_container *container) {
+	return container_find(container, find_urgent_iterator, NULL);
+}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -674,16 +674,23 @@ struct sway_container *floating_container_at(double lx, double ly,
 void container_for_each_descendant_dfs(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data),
 		void *data) {
-	if (container) {
-		if (container->children)  {
-			for (int i = 0; i < container->children->length; ++i) {
-				struct sway_container *child =
-					container->children->items[i];
-				container_for_each_descendant_dfs(child, f, data);
-			}
-		}
-		f(container, data);
+	if (!container) {
+		return;
 	}
+	if (container->children)  {
+		for (int i = 0; i < container->children->length; ++i) {
+			struct sway_container *child = container->children->items[i];
+			container_for_each_descendant_dfs(child, f, data);
+		}
+	}
+	if (container->type == C_WORKSPACE)  {
+		struct sway_container *floating = container->sway_workspace->floating;
+		for (int i = 0; i < floating->children->length; ++i) {
+			struct sway_container *child = floating->children->items[i];
+			container_for_each_descendant_dfs(child, f, data);
+		}
+	}
+	f(container, data);
 }
 
 void container_for_each_descendant_bfs(struct sway_container *con,

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1070,6 +1070,8 @@ void container_floating_move_to(struct sway_container *con,
 		container_add_child(new_workspace->sway_workspace->floating, con);
 		arrange_windows(old_workspace);
 		arrange_windows(new_workspace);
+		workspace_detect_urgent(old_workspace);
+		workspace_detect_urgent(new_workspace);
 	}
 }
 

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -225,6 +225,15 @@ void container_move_to(struct sway_container *container,
 			}
 		}
 	}
+	// Update workspace urgent state
+	struct sway_container *old_workspace = old_parent;
+	if (old_workspace->type != C_WORKSPACE) {
+		old_workspace = container_parent(old_workspace, C_WORKSPACE);
+	}
+	if (new_workspace != old_workspace) {
+		workspace_detect_urgent(new_workspace);
+		workspace_detect_urgent(old_workspace);
+	}
 }
 
 static bool sway_dir_to_wlr(enum movement_direction dir,
@@ -548,6 +557,8 @@ void container_move(struct sway_container *container,
 	}
 	if (last_ws && next_ws && last_ws != next_ws) {
 		ipc_event_workspace(last_ws, container, "focus");
+		workspace_detect_urgent(last_ws);
+		workspace_detect_urgent(next_ws);
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1070,8 +1070,10 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 	}
 	container_damage_whole(view->swayc);
 
+	ipc_event_window(view->swayc, "urgent");
+
 	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	ipc_event_workspace(ws, NULL, "urgent");
+	ipc_event_workspace(NULL, ws, "urgent");
 }
 
 bool view_is_urgent(struct sway_view *view) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -25,6 +25,7 @@ void view_init(struct sway_view *view, enum sway_view_type type,
 	view->impl = impl;
 	view->executed_criteria = create_list();
 	view->marks = create_list();
+	view->allow_request_urgent = true;
 	wl_signal_init(&view->events.unmap);
 }
 
@@ -589,6 +590,11 @@ void view_unmap(struct sway_view *view) {
 	wl_list_remove(&view->surface_new_subsurface.link);
 	wl_list_remove(&view->container_reparent.link);
 
+	if (view->urgent_timer) {
+		wl_event_source_remove(view->urgent_timer);
+		view->urgent_timer = NULL;
+	}
+
 	if (view->is_fullscreen) {
 		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
 		ws->sway_workspace->fullscreen = NULL;
@@ -1046,4 +1052,28 @@ bool view_is_visible(struct sway_view *view) {
 		return workspace_is_visible(workspace);
 	}
 	return true;
+}
+
+void view_set_urgent(struct sway_view *view, bool enable) {
+	if (enable) {
+		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		if (seat_get_focus(seat) == view->swayc) {
+			return;
+		}
+		clock_gettime(CLOCK_MONOTONIC, &view->urgent);
+	} else {
+		view->urgent = (struct timespec){ 0 };
+		if (view->urgent_timer) {
+			wl_event_source_remove(view->urgent_timer);
+			view->urgent_timer = NULL;
+		}
+	}
+	container_damage_whole(view->swayc);
+
+	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+	ipc_event_workspace(ws, NULL, "urgent");
+}
+
+bool view_is_urgent(struct sway_view *view) {
+	return view->urgent.tv_sec || view->urgent.tv_nsec;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -520,13 +520,8 @@ struct sway_container *workspace_output_get_highest_available(
 	return NULL;
 }
 
-static bool find_urgent_iterator(struct sway_container *con,
-		void *data) {
-	return con->type == C_VIEW && view_is_urgent(con->sway_view);
-}
-
 void workspace_detect_urgent(struct sway_container *workspace) {
-	bool new_urgent = container_find(workspace, find_urgent_iterator, NULL);
+	bool new_urgent = container_has_urgent_child(workspace);
 
 	if (workspace->sway_workspace->urgent != new_urgent) {
 		workspace->sway_workspace->urgent = new_urgent;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -11,6 +11,7 @@
 #include "sway/ipc-server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
+#include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "list.h"
 #include "log.h"
@@ -517,4 +518,13 @@ struct sway_container *workspace_output_get_highest_available(
 	}
 
 	return NULL;
+}
+
+static bool find_urgent_iterator(struct sway_container *con,
+		void *data) {
+	return con->type == C_VIEW && view_is_urgent(con->sway_view);
+}
+
+bool workspace_is_urgent(struct sway_container *workspace) {
+	return container_find(workspace, find_urgent_iterator, NULL);
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -526,5 +526,6 @@ void workspace_detect_urgent(struct sway_container *workspace) {
 	if (workspace->sway_workspace->urgent != new_urgent) {
 		workspace->sway_workspace->urgent = new_urgent;
 		ipc_event_workspace(NULL, workspace, "urgent");
+		container_damage_whole(workspace);
 	}
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -525,6 +525,11 @@ static bool find_urgent_iterator(struct sway_container *con,
 	return con->type == C_VIEW && view_is_urgent(con->sway_view);
 }
 
-bool workspace_is_urgent(struct sway_container *workspace) {
-	return container_find(workspace, find_urgent_iterator, NULL);
+void workspace_detect_urgent(struct sway_container *workspace) {
+	bool new_urgent = container_find(workspace, find_urgent_iterator, NULL);
+
+	if (workspace->sway_workspace->urgent != new_urgent) {
+		workspace->sway_workspace->urgent = new_urgent;
+		ipc_event_workspace(NULL, workspace, "urgent");
+	}
 }

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -115,6 +115,18 @@ static void ipc_parse_colors(
 		config->colors.inactive_workspace.text = parse_color(
 				json_object_get_string(inactive_workspace_text));
 	}
+	if (urgent_workspace_border) {
+		config->colors.urgent_workspace.border = parse_color(
+				json_object_get_string(urgent_workspace_border));
+	}
+	if (urgent_workspace_bg) {
+		config->colors.urgent_workspace.background = parse_color(
+				json_object_get_string(urgent_workspace_bg));
+	}
+	if (urgent_workspace_text) {
+		config->colors.urgent_workspace.text = parse_color(
+				json_object_get_string(urgent_workspace_text));
+	}
 	if (binding_mode_border) {
 		config->colors.binding_mode.border = parse_color(
 				json_object_get_string(binding_mode_border));


### PR DESCRIPTION
Introduces a command to manually set urgency, as well as rendering of urgent views, sending the IPC event, removing urgency one second after focus, and matching urgent views via criteria.

To test, run something like `swaymsg [class="Firefox"] urgent enable`.

Try it with Firefox on a different workspace too, and notice the swaybar indicator working.

Note that urgency is not yet implemented when xwayland views request it, nor when a view requests focus (depending on the value of `focus_on_window_activation`). I feel like that's out of scope for this PR.

Closes #2258.