### PR TITLE
Fix config buffer overflow and logic

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -561,12 +561,17 @@ static char *expand_line(const char *block, const char *line, bool add_brace) {
 bool read_config(FILE *file, struct sway_config *config) {
 	bool reading_main_config = false;
 	char *this_config = NULL;
-	unsigned long config_size = 0;
+	size_t config_size = 0;
 	if (config->current_config == NULL) {
 		reading_main_config = true;
 
-		fseek(file, 0, SEEK_END);
-		config_size = ftell(file);
+		int ret_seek = fseek(file, 0, SEEK_END);
+		long ret_tell = ftell(file);
+		if (ret_seek == -1 || ret_tell == -1) {
+			wlr_log(WLR_ERROR, "Unable to get size of config file");
+			return false;
+		}
+		config_size = ret_tell;
 		rewind(file);
 
 		config->current_config = this_config = calloc(1, config_size + 1);


### PR DESCRIPTION
When I originally wrote the code to read the config file, I set the struct variable early and used the null check to see whether it was reading the main config or an included config. Later on, I changed my mind so that it would attach it late, which negated the null check without me realising, leading to a whole bunch of problems.

Hopefully, this fixes that, as well as making the logic a bit better. I also added in a check so that if somehow, improbably, it reads in more than it thought it needed, it just aborts. I thought about resizing the buffer but was still a bit paranoid about race conditions.

Would appreciate feedback.