### PR TITLE
Sorted binding lists

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -147,3 +147,61 @@ void list_stable_sort(list_t *list, int compare(const void *a, const void *b)) {
 		list_inplace_sort(list, 0, list->length - 1, compare);
 	}
 }
+
+void list_sortedset_insert(list_t *list, void *item,
+		int compare(const void *item_left, const void *item_right),
+		void *replace(void *old_item, void* new_item)) {
+	if (list->length <= 0) {
+		list_add(list, item);
+		return;
+	}
+
+	size_t lower = 0;
+	size_t upper = (size_t)list->length - 1;
+	while (lower <= upper && upper != (size_t)-1) {
+		size_t div = (lower + upper) / 2;
+		int cv = compare(list->items[div], item);
+		if (cv < 0) {
+			lower = div + 1;
+		} else if (cv > 0) {
+			upper = div - 1;
+		} else {
+			list->items[div] = replace(list->items[div], item);
+			return;
+		}
+	}
+	list_insert(list, lower, item);
+}
+
+int list_sortedset_find(list_t *list,
+		int compare(const void *item, const void *cmp_to),
+		const void *cmp_to) {
+	if (list->length <= 0) {
+		return -1;
+	}
+
+	size_t lower = 0;
+	size_t upper = (size_t)list->length - 1;
+	while (lower <= upper && upper != (size_t)-1) {
+		size_t div = (lower + upper) / 2;
+		int cv = compare(list->items[div], cmp_to);
+		if (cv < 0) {
+			lower = div + 1;
+		} else if (cv > 0) {
+			upper = div - 1;
+		} else {
+			return div;
+		}
+	}
+	return -1;
+}
+
+int list_is_sortedset(list_t *list,
+		int compare(const void *left, const void *right)) {
+	for (size_t i = 1; i < (size_t)list->length; i++) {
+		if (compare(list->items[i - 1], list->items[i]) >= 0) {
+			return 0;
+		}
+	}
+	return 1;
+}

--- a/include/list.h
+++ b/include/list.h
@@ -12,6 +12,12 @@ void list_free(list_t *list);
 void list_foreach(list_t *list, void (*callback)(void* item));
 void list_add(list_t *list, void *item);
 void list_insert(list_t *list, int index, void *item);
+// Insert an item into the list which is already sorted strictly ascending
+// according to 'compare'. 'replace' is called when displacing an old item
+// and returns the item which will take its place.
+void list_sortedset_insert(list_t *list, void* item,
+		int compare(const void *item_left, const void *item_right),
+		void *replace(void *old_item, void* new_item));
 void list_del(list_t *list, int index);
 void list_cat(list_t *list, list_t *source);
 // See qsort. Remember to use *_qsort functions as compare functions,
@@ -20,6 +26,11 @@ void list_qsort(list_t *list, int compare(const void *left, const void *right));
 // Return index for first item in list that returns 0 for given compare
 // function or -1 if none matches.
 int list_seq_find(list_t *list, int compare(const void *item, const void *cmp_to), const void *cmp_to);
+// Requires a list sorted strictly ascending according to 'compare';
+// returns the index of the matching item, or -1 is no such item exists
+int list_sortedset_find(list_t *list, int compare(const void *item, const void *cmp_to), const void *cmp_to);
+// Check if a list is sorted strictly ascending according to compare
+int list_is_sortedset(list_t *list, int compare(const void *left, const void *right));
 // stable sort since qsort is not guaranteed to be stable
 void list_stable_sort(list_t *list, int compare(const void *a, const void *b));
 // swap two elements in a list

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -26,12 +26,14 @@ struct sway_variable {
  * A key binding and an associated command.
  */
 struct sway_binding {
-	int order;
-	bool release;
-	bool locked;
-	bool bindcode;
-	list_t *keys; // sorted in ascending order
+	// key part
+	uint32_t *keys; // sorted in ascending order
+	size_t length;
 	uint32_t modifiers;
+	bool release;
+	// value part
+	int order;
+	bool locked;
 	char *command;
 };
 
@@ -467,13 +469,7 @@ int workspace_output_cmp_workspace(const void *a, const void *b);
 
 int sway_binding_cmp(const void *a, const void *b);
 
-int sway_binding_cmp_qsort(const void *a, const void *b);
-
-int sway_binding_cmp_keys(const void *a, const void *b);
-
 void free_sway_binding(struct sway_binding *sb);
-
-struct sway_binding *sway_binding_dup(struct sway_binding *sb);
 
 void load_swaybars();
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -106,6 +106,88 @@ static bool workspace_valid_on_output(const char *output_name,
 	return true;
 }
 
+static void workspace_name_from_binding(const struct sway_binding * binding,
+		const char* output_name, int *min_order, char **earliest_name) {
+	char *cmdlist = strdup(binding->command);
+	char *dup = cmdlist;
+	char *name = NULL;
+
+	// workspace n
+	char *cmd = argsep(&cmdlist, " ");
+	if (cmdlist) {
+		name = argsep(&cmdlist, ",;");
+	}
+
+	if (strcmp("workspace", cmd) == 0 && name) {
+		char *_target = strdup(name);
+		_target = do_var_replacement(_target);
+		strip_quotes(_target);
+		while (isspace(*_target)) {
+			memmove(_target, _target+1, strlen(_target+1));
+		}
+		wlr_log(WLR_DEBUG, "Got valid workspace command for target: '%s'",
+				_target);
+
+		// Make sure that the command references an actual workspace
+		// not a command about workspaces
+		if (strcmp(_target, "next") == 0 ||
+			strcmp(_target, "prev") == 0 ||
+			strcmp(_target, "next_on_output") == 0 ||
+			strcmp(_target, "prev_on_output") == 0 ||
+			strcmp(_target, "number") == 0 ||
+			strcmp(_target, "back_and_forth") == 0 ||
+			strcmp(_target, "current") == 0)
+		{
+			free(_target);
+			free(dup);
+			return;
+		}
+
+		// If the command is workspace number <name>, isolate the name
+		if (strncmp(_target, "number ", strlen("number ")) == 0) {
+			size_t length = strlen(_target) - strlen("number ") + 1;
+			char *temp = malloc(length);
+			strncpy(temp, _target + strlen("number "), length - 1);
+			temp[length - 1] = '\0';
+			free(_target);
+			_target = temp;
+			wlr_log(WLR_DEBUG, "Isolated name from workspace number: '%s'", _target);
+
+			// Make sure the workspace number doesn't already exist
+			if (workspace_by_number(_target)) {
+				free(_target);
+				free(dup);
+				return;
+			}
+		}
+
+		// Make sure that the workspace doesn't already exist
+		if (workspace_by_name(_target)) {
+			free(_target);
+			free(dup);
+			return;
+		}
+
+		// make sure that the workspace can appear on the given
+		// output
+		if (!workspace_valid_on_output(output_name, _target)) {
+			free(_target);
+			free(dup);
+			return;
+		}
+
+		if (binding->order < *min_order) {
+			*min_order = binding->order;
+			free(*earliest_name);
+			*earliest_name = _target;
+			wlr_log(WLR_DEBUG, "Workspace: Found free name %s", _target);
+		} else {
+			free(_target);
+		}
+	}
+	free(dup);
+}
+
 char *workspace_next_name(const char *output_name) {
 	wlr_log(WLR_DEBUG, "Workspace: Generating new workspace name for output %s",
 			output_name);
@@ -113,89 +195,15 @@ char *workspace_next_name(const char *output_name) {
 	// if none are found/available then default to a number
 	struct sway_mode *mode = config->current_mode;
 
-	// TODO: iterate over keycode bindings too
 	int order = INT_MAX;
 	char *target = NULL;
 	for (int i = 0; i < mode->keysym_bindings->length; ++i) {
-		struct sway_binding *binding = mode->keysym_bindings->items[i];
-		char *cmdlist = strdup(binding->command);
-		char *dup = cmdlist;
-		char *name = NULL;
-
-		// workspace n
-		char *cmd = argsep(&cmdlist, " ");
-		if (cmdlist) {
-			name = argsep(&cmdlist, ",;");
-		}
-
-		if (strcmp("workspace", cmd) == 0 && name) {
-			char *_target = strdup(name);
-			_target = do_var_replacement(_target);
-			strip_quotes(_target);
-			while (isspace(*_target)) {
-				memmove(_target, _target+1, strlen(_target+1));
-			}
-			wlr_log(WLR_DEBUG, "Got valid workspace command for target: '%s'",
-					_target);
-
-			// Make sure that the command references an actual workspace
-			// not a command about workspaces
-			if (strcmp(_target, "next") == 0 ||
-				strcmp(_target, "prev") == 0 ||
-				strcmp(_target, "next_on_output") == 0 ||
-				strcmp(_target, "prev_on_output") == 0 ||
-				strcmp(_target, "number") == 0 ||
-				strcmp(_target, "back_and_forth") == 0 ||
-				strcmp(_target, "current") == 0)
-			{
-				free(_target);
-				free(dup);
-				continue;
-			}
-
-			// If the command is workspace number <name>, isolate the name
-			if (strncmp(_target, "number ", strlen("number ")) == 0) {
-				size_t length = strlen(_target) - strlen("number ") + 1;
-				char *temp = malloc(length);
-				strncpy(temp, _target + strlen("number "), length - 1);
-				temp[length - 1] = '\0';
-				free(_target);
-				_target = temp;
-				wlr_log(WLR_DEBUG, "Isolated name from workspace number: '%s'", _target);
-
-				// Make sure the workspace number doesn't already exist
-				if (workspace_by_number(_target)) {
-					free(_target);
-					free(dup);
-					continue;
-				}
-			}
-
-			// Make sure that the workspace doesn't already exist
-			if (workspace_by_name(_target)) {
-				free(_target);
-				free(dup);
-				continue;
-			}
-
-			// make sure that the workspace can appear on the given
-			// output
-			if (!workspace_valid_on_output(output_name, _target)) {
-				free(_target);
-				free(dup);
-				continue;
-			}
-
-			if (binding->order < order) {
-				order = binding->order;
-				free(target);
-				target = _target;
-				wlr_log(WLR_DEBUG, "Workspace: Found free name %s", _target);
-			} else {
-				free(_target);
-			}
-		}
-		free(dup);
+		workspace_name_from_binding(mode->keysym_bindings->items[i],
+				output_name, &order, &target);
+	}
+	for (int i = 0; i < mode->keycode_bindings->length; ++i) {
+		workspace_name_from_binding(mode->keycode_bindings->items[i],
+				output_name, &order, &target);
 	}
 	if (target != NULL) {
 		return target;


### PR DESCRIPTION
The motivation for this pull request is that binding lookup was O(n) per key press, and duplicated some of the code involved in checking for duplicate bindings. This PR ensures that the lists of bindings remain sorted, so that `get_active_binding` can use binary search instead of a linear scan.

As a rule of thumb, for low-cost comparisons, binary search is faster than linear search around 32 elements. With a configuration involving ~60 bindsyms, binding search time drops from 4us to 3us. This change most likely does slow down modes with <10 bindsyms. but in exchange can handle even 100000 bindsyms in 6us rather than e.g. 2ms. Using e.g. an AVL tree ([tree.c.txt](https://github.com/swaywm/sway/files/2195857/tree.c.txt), [tree.h.txt](https://github.com/swaywm/sway/files/2195858/tree.h.txt)) guarantees O(n log n) loading, but yields slower lookups for <100 bindsyms, and introduces too much complexity.

The PR also resolves a TODO in `sway/tree/workspace.c`, by extracting the first workspace name from bindcode expressions as well.

~~I'm not entirely certain on naming, especially with `list_sortedset_insert` ,  `list_sortedset_find`,  and `find_workspace_name` (e.g. is `extract_binding_workspace_name` clearer?).~~ (Edit: the former two aren't pretty, but one can guess the meaning from the name, and `workspace_name_from_binding` better describes the last one.)







