### PR TITLE
Fix tab split focus bug

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -649,6 +649,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		while (parent) {
 			wl_list_remove(&parent->link);
 			wl_list_insert(&seat->focus_stack, &parent->link);
+			container_set_dirty(parent->container);
 
 			parent =
 				seat_container_from_container(seat,


### PR DESCRIPTION
Fixes a bug where if you have a tab containing a split, then switch from a non-split tab to the split tab, focus is not changed properly.

To test, create layout `T[view, V[view, view focused]]` then `focus left` then `focus right`.