### PR TITLE
Implement no_focus command

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -6,9 +6,10 @@
 #include "tree/view.h"
 
 enum criteria_type {
-	CT_COMMAND = 1 << 0,
-	CT_ASSIGN_OUTPUT = 1 << 1,
+	CT_COMMAND          = 1 << 0,
+	CT_ASSIGN_OUTPUT    = 1 << 1,
 	CT_ASSIGN_WORKSPACE = 1 << 2,
+	CT_NO_FOCUS         = 1 << 3,
 };
 
 struct criteria {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -114,6 +114,7 @@ static struct cmd_handler handlers[] = {
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },
 	{ "mouse_warping", cmd_mouse_warping },
+	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },

--- a/sway/commands/no_focus.c
+++ b/sway/commands/no_focus.c
@@ -1,0 +1,26 @@
+#define _XOPEN_SOURCE 500
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/criteria.h"
+#include "list.h"
+#include "log.h"
+
+struct cmd_results *cmd_no_focus(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "no_focus", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	char *err_str = NULL;
+	struct criteria *criteria = criteria_parse(argv[0], &err_str);
+	if (!criteria) {
+		error = cmd_results_new(CMD_INVALID, "no_focus", err_str);
+		free(err_str);
+		return error;
+	}
+
+	criteria->type = CT_NO_FOCUS;
+	list_add(config->criteria, criteria);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -59,6 +59,7 @@ sway_sources = files(
 	'commands/mode.c',
 	'commands/mouse_warping.c',
 	'commands/move.c',
+	'commands/no_focus.c',
 	'commands/output.c',
 	'commands/reload.c',
 	'commands/rename.c',

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -504,15 +504,13 @@ void view_execute_criteria(struct sway_view *view) {
 		}
 		wlr_log(WLR_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
 				criteria->raw, view, criteria->cmdlist);
+		seat_set_focus(seat, view->swayc);
 		list_add(view->executed_criteria, criteria);
 		struct cmd_results *res = execute_command(criteria->cmdlist, NULL);
 		if (res->status != CMD_SUCCESS) {
 			wlr_log(WLR_ERROR, "Command '%s' failed: %s", res->input, res->error);
 		}
 		free_cmd_results(res);
-		// view must be focused for commands to affect it,
-		// so always refocus in-between command lists
-		seat_set_focus(seat, view->swayc);
 	}
 	list_free(criterias);
 	seat_set_focus(seat, prior_focus);


### PR DESCRIPTION
i3 docs: https://i3wm.org/docs/userguide.html#no_focus

Example config: `no_focus [class="Firefox"]`

Note that if you've focused an empty workspace when the view maps, the view should receive focus regardless of any `no_focus` directive.