### PR TITLE
Implement default_floating_border command and adjust CSD behaviour

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -69,6 +69,7 @@ struct sway_view {
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
+	bool using_csd;
 
 	struct timespec urgent;
 	bool allow_request_urgent;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -98,6 +98,7 @@ static struct cmd_handler handlers[] = {
 	{ "client.unfocused", cmd_client_unfocused },
 	{ "client.urgent", cmd_client_urgent },
 	{ "default_border", cmd_default_border },
+	{ "default_floating_border", cmd_default_floating_border },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands/default_floating_border.c
+++ b/sway/commands/default_floating_border.c
@@ -1,0 +1,29 @@
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/container.h"
+
+struct cmd_results *cmd_default_floating_border(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "default_floating_border",
+					EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (strcmp(argv[0], "none") == 0) {
+		config->floating_border = B_NONE;
+	} else if (strcmp(argv[0], "normal") == 0) {
+		config->floating_border = B_NORMAL;
+	} else if (strcmp(argv[0], "pixel") == 0) {
+		config->floating_border = B_PIXEL;
+	} else {
+		return cmd_results_new(CMD_INVALID, "default_floating_border",
+				"Expected 'default_floating_border <none|normal|pixel>' "
+				"or 'default_floating_border <normal|pixel> <px>'");
+	}
+	if (argc == 2) {
+		config->floating_border_thickness = atoi(argv[1]);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -256,6 +256,10 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		render_view_surfaces(view, output, damage, view->swayc->alpha);
 	}
 
+	if (view->using_csd) {
+		return;
+	}
+
 	struct wlr_box box;
 	float output_scale = output->wlr_output->scale;
 	float color[4];
@@ -571,12 +575,14 @@ static void render_container_simple(struct sway_output *output,
 				marks_texture = view->marks_unfocused;
 			}
 
-			if (state->border == B_NORMAL) {
-				render_titlebar(output, damage, child, state->swayc_x,
-						state->swayc_y, state->swayc_width, colors,
-						title_texture, marks_texture);
-			} else {
-				render_top_border(output, damage, child, colors);
+			if (!view->using_csd) {
+				if (state->border == B_NORMAL) {
+					render_titlebar(output, damage, child, state->swayc_x,
+							state->swayc_y, state->swayc_width, colors,
+							title_texture, marks_texture);
+				} else {
+					render_top_border(output, damage, child, colors);
+				}
 			}
 			render_view(output, damage, child, colors);
 		} else {
@@ -761,12 +767,14 @@ static void render_floating_container(struct sway_output *soutput,
 			marks_texture = view->marks_unfocused;
 		}
 
-		if (con->current.border == B_NORMAL) {
-			render_titlebar(soutput, damage, con, con->current.swayc_x,
-					con->current.swayc_y, con->current.swayc_width, colors,
-					title_texture, marks_texture);
-		} else if (con->current.border != B_NONE) {
-			render_top_border(soutput, damage, con, colors);
+		if (!view->using_csd) {
+			if (con->current.border == B_NORMAL) {
+				render_titlebar(soutput, damage, con, con->current.swayc_x,
+						con->current.swayc_y, con->current.swayc_width, colors,
+						title_texture, marks_texture);
+			} else if (con->current.border != B_NONE) {
+				render_top_border(soutput, damage, con, colors);
+			}
 		}
 		render_view(soutput, damage, con, colors);
 	} else {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -35,6 +35,7 @@ sway_sources = files(
 	'commands/border.c',
 	'commands/client.c',
 	'commands/default_border.c',
+	'commands/default_floating_border.c',
 	'commands/default_orientation.c',
 	'commands/exit.c',
 	'commands/exec.c',

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -967,9 +967,14 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 		return;
 	}
 	struct sway_view *view = con->sway_view;
-	size_t border_width = view->border_thickness * (view->border != B_NONE);
-	size_t top =
-		view->border == B_NORMAL ? container_titlebar_height() : border_width;
+	size_t border_width = 0;
+	size_t top = 0;
+
+	if (!view->using_csd) {
+		border_width = view->border_thickness * (view->border != B_NONE);
+		top = view->border == B_NORMAL ?
+			container_titlebar_height() : border_width;
+	}
 
 	con->x = view->x - border_width;
 	con->y = view->y - top;


### PR DESCRIPTION
i3 docs: https://i3wm.org/docs/userguide.html#_default_border_style_for_new_windows

To test, you need to use something which floats by default and doesn't have CSD:

* Have `default_floating_border pixel 10` in config
* Open Firefox and press `Ctrl+O` to open the file open dialog

The existing code in `view_set_tiled` that set the border to `config->border` was causing issues. I've changed this so the border values are untouched, and it instead uses a `bool using_csd` in the view to determine whether the border values should be respected or not. This allows the previous border config to be reinstated easily when toggling between floating and tiling, and also means the user can't run an IPC command to mess with the borders while CSD is active.