### PR TITLE
Remove superfluous IPC urgent events

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1080,6 +1080,9 @@ bool view_is_visible(struct sway_view *view) {
 }
 
 void view_set_urgent(struct sway_view *view, bool enable) {
+	if (view_is_urgent(view) == enable) {
+		return;
+	}
 	if (enable) {
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
 		if (seat_get_focus(seat) == view->swayc) {


### PR DESCRIPTION
When an xwayland view is mapped, the IPC urgent event ("this is/is-not urgent") was being sent on every surface commit.

I had intentionally ommitted the check because I figured an urgent surface could update its urgent timestamp by sending urgent a second time. But that's not how it works in xwayland's case, and it makes for more complicated code.