### PR TITLE
Fix memory leaks and reference to uninitialized 

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -24,6 +24,7 @@
 #include "sway/input/seat.h"
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/criteria.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/layout.h"
 #include "sway/tree/workspace.h"
@@ -105,7 +106,12 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->seat_configs);
 	}
-	list_free(config->criteria);
+	if (config->criteria) {
+		for (int i = 0; i < config->criteria->length; ++i) {
+			criteria_destroy(config->criteria->items[i]);
+		}
+		list_free(config->criteria);
+	}
 	list_free(config->no_focus);
 	list_free(config->active_bar_modifiers);
 	list_free(config->config_chain);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -37,7 +37,7 @@ void criteria_destroy(struct criteria *criteria) {
 	pcre_free(criteria->con_mark);
 	pcre_free(criteria->window_role);
 	free(criteria->workspace);
-
+	free(criteria->cmdlist);
 	free(criteria->raw);
 	free(criteria);
 }

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -67,6 +67,7 @@ struct sway_idle_inhibit_manager_v1 *sway_idle_inhibit_manager_v1_create(
 
 	manager->wlr_manager = wlr_idle_inhibit_v1_create(wl_display);
 	if (!manager->wlr_manager) {
+		free(manager);
 		return NULL;
 	}
 	manager->idle = idle;

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -325,12 +325,6 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 		layer_surface->client_pending.margin.bottom,
 		layer_surface->client_pending.margin.left);
 
-	struct sway_layer_surface *sway_layer =
-		calloc(1, sizeof(struct sway_layer_surface));
-	if (!sway_layer) {
-		return;
-	}
-
 	if (!layer_surface->output) {
 		// Assign last active output
 		struct sway_container *output = NULL;
@@ -350,6 +344,12 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 			output = container_parent(output, C_OUTPUT);
 		}
 		layer_surface->output = output->sway_output->wlr_output;
+	}
+
+	struct sway_layer_surface *sway_layer =
+		calloc(1, sizeof(struct sway_layer_surface));
+	if (!sway_layer) {
+		return;
 	}
 
 	sway_layer->surface_commit.notify = handle_surface_commit;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -621,16 +621,16 @@ void view_unmap(struct sway_view *view) {
 		view->urgent_timer = NULL;
 	}
 
-	struct sway_container *parent;
 	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
 
+	struct sway_container *parent;
 	if (view->is_fullscreen) {
 		ws->sway_workspace->fullscreen = NULL;
 		parent = container_destroy(view->swayc);
 
 		arrange_windows(ws->parent);
 	} else {
-		struct sway_container *parent = container_destroy(view->swayc);
+		parent = container_destroy(view->swayc);
 		arrange_windows(parent);
 	}
 	if (parent->type >= C_WORKSPACE) { // if the workspace still exists


### PR DESCRIPTION
Found using Cppcheck and AddressSanitizer. (FYI, Cppcheck also indicates

     [sway/common/stringop.c:150]: (error) Common realloc mistake: 'argv' nulled but not freed upon failure

but the file is full of unchecked allocations anyway.)