### PR TITLE
Update cursor on focus change

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -738,7 +738,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		}
 	}
 
-	if (last_workspace && last_workspace != new_workspace) {
+	if (last_focus != NULL) {
 		cursor_send_pointer_motion(seat->cursor, 0, true);
 	}
 


### PR DESCRIPTION
This allows to send wl_pointer.enter when switching between views
in a split/tabbed layout for instance. This (1) updates the cursor
image accordingly (2) makes it unnecessary to move the mouse before
scrolling. It's harmless to always call cursor_send_pointer_motion
because in case the focused surface hasn't changed this is a no-op.

The `last_focus != NULL` condition is required otherwise
cursor_send_pointer_motion will crash when sway starts up (the
sway_output doesn't yet have a workspace).