### PR TITLE
Fix deferred command handling

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -56,6 +56,7 @@ struct sway_server server;
 bool server_privileged_prepare(struct sway_server *server);
 bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);
+bool server_start_backend(struct sway_server *server);
 void server_run(struct sway_server *server);
 
 void handle_new_output(struct wl_listener *listener, void *data);

--- a/sway/config.c
+++ b/sway/config.c
@@ -649,7 +649,6 @@ bool read_config(FILE *file, struct sway_config *config) {
 		} else {
 			res = config_command(expanded);
 		}
-		free(expanded);
 		switch(res->status) {
 		case CMD_FAILURE:
 		case CMD_INVALID:
@@ -660,7 +659,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 
 		case CMD_DEFER:
 			wlr_log(WLR_DEBUG, "Deferring command `%s'", line);
-			list_add(config->cmd_queue, strdup(line));
+			list_add(config->cmd_queue, strdup(expanded));
 			break;
 
 		case CMD_BLOCK_COMMANDS:
@@ -693,6 +692,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 					sizeof(config->handler_context));
 		default:;
 		}
+		free(expanded);
 		free(line);
 		free_cmd_results(res);
 	}

--- a/sway/main.c
+++ b/sway/main.c
@@ -429,9 +429,16 @@ int main(int argc, char **argv) {
 
 	security_sanity_check();
 
-	config->active = true;
 	setenv("WAYLAND_DISPLAY", server.socket, true);
+	if (!terminate_request) {
+		if (!server_start_backend(&server)) {
+			sway_terminate(EXIT_FAILURE);
+		}
+	}
+
+	config->active = true;
 	// Execute commands until there are none left
+	wlr_log(WLR_DEBUG, "Running deferred commands");
 	while (config->cmd_queue->length) {
 		char *line = config->cmd_queue->items[0];
 		struct cmd_results *res = execute_command(line, NULL);

--- a/sway/server.c
+++ b/sway/server.c
@@ -137,13 +137,19 @@ void server_fini(struct sway_server *server) {
 	list_free(server->transactions);
 }
 
-void server_run(struct sway_server *server) {
-	wlr_log(WLR_INFO, "Running compositor on wayland display '%s'",
+bool server_start_backend(struct sway_server *server) {
+	wlr_log(WLR_INFO, "Starting backend on wayland display '%s'",
 			server->socket);
 	if (!wlr_backend_start(server->backend)) {
 		wlr_log(WLR_ERROR, "Failed to start backend");
 		wlr_backend_destroy(server->backend);
-		return;
+		return false;
 	}
+	return true;
+}
+
+void server_run(struct sway_server *server) {
+	wlr_log(WLR_INFO, "Running compositor on wayland display '%s'",
+			server->socket);
 	wl_display_run(server->wl_display);
 }


### PR DESCRIPTION
Fixes #2298 

Deferred commands were being run before the backend was started. This meant that there were no globals available yet. Since all deferred commands require globals (either directly or indirectly), this was causing deferred commands to fail.

This PR splits the `server_run` function in two: `server_start_backend` and `server_run`. The first starts the backend, which allows for the globals to be processed. The second does the call to `wl_display_run`. The deferred commands are being run between the two calls.

I also fixed a minor issue that was adding the raw line to the command queue instead of the expanded one. Off the top of my head, I'm not sure of anything used in a block that would be deferred, but that does not mean that one does not exist or will not exist in the future.