### PR TITLE
Fix crash when moving workspace to output

### DIFF
--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -232,7 +232,9 @@ void container_move_to(struct sway_container *container,
 	}
 	if (new_workspace != old_workspace) {
 		workspace_detect_urgent(new_workspace);
-		workspace_detect_urgent(old_workspace);
+		if (old_workspace) {
+			workspace_detect_urgent(old_workspace);
+		}
 	}
 }
 


### PR DESCRIPTION
To test, run something like `move workspace to output right`.