### PR TITLE
swaybar: Fix scroll handling on workspace buttons

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -29,10 +29,15 @@ enum x11_button {
 	FORWARD,
 };
 
+enum hotspot_event_handling {
+	HOTSPOT_IGNORE,
+	HOTSPOT_PROCESS,
+};
+
 struct swaybar_hotspot {
 	struct wl_list link;
 	int x, y, width, height;
-	void (*callback)(struct swaybar_output *output,
+	enum hotspot_event_handling (*callback)(struct swaybar_output *output,
 			int x, int y, enum x11_button button, void *data);
 	void (*destroy)(void *data);
 	void *data;

--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -71,7 +71,7 @@ void status_error(struct status_line *status, const char *text);
 bool status_handle_readable(struct status_line *status);
 void status_line_free(struct status_line *status);
 bool i3bar_handle_readable(struct status_line *status);
-void i3bar_block_send_click(struct status_line *status,
+enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, int x, int y, enum x11_button button);
 void i3bar_block_free(struct i3bar_block *block);
 enum x11_button wl_button_to_x11_button(uint32_t button);

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -146,8 +146,10 @@ static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 				&& y >= hotspot->y
 				&& x < hotspot->x + hotspot->width
 				&& y < hotspot->y + hotspot->height) {
-			hotspot->callback(output, pointer->x, pointer->y,
-					wl_button_to_x11_button(button), hotspot->data);
+			if (HOTSPOT_IGNORE == hotspot->callback(output, pointer->x, pointer->y,
+					wl_button_to_x11_button(button), hotspot->data)) {
+				return;
+			}
 		}
 	}
 }
@@ -169,9 +171,11 @@ static void wl_pointer_axis(void *data, struct wl_pointer *wl_pointer,
 				&& y >= hotspot->y
 				&& x < hotspot->x + hotspot->width
 				&& y < hotspot->y + hotspot->height) {
-			hotspot->callback(output, pointer->x, pointer->y,
-					wl_axis_to_x11_button(axis, value), hotspot->data);
-			return;
+			if (HOTSPOT_IGNORE == hotspot->callback(
+					output, pointer->x, pointer->y,
+					wl_axis_to_x11_button(axis, value), hotspot->data)) {
+				return;
+			}
 		}
 	}
 

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -192,11 +192,11 @@ bool i3bar_handle_readable(struct status_line *status) {
 	return redraw;
 }
 
-void i3bar_block_send_click(struct status_line *status,
+enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, int x, int y, enum x11_button button) {
 	wlr_log(WLR_DEBUG, "block %s clicked", block->name ? block->name : "(nil)");
 	if (!block->name || !status->i3bar_state.click_events) {
-		return;
+		return HOTSPOT_PROCESS;
 	}
 
 	struct json_object *event_json = json_object_new_object();
@@ -215,6 +215,7 @@ void i3bar_block_send_click(struct status_line *status,
 		status_error(status, "[failed to write click event]");
 	}
 	json_object_put(event_json);
+	return HOTSPOT_IGNORE;
 }
 
 enum x11_button wl_button_to_x11_button(uint32_t button) {

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -108,11 +108,11 @@ static void render_sharp_line(cairo_t *cairo, uint32_t color,
 	}
 }
 
-static void block_hotspot_callback(struct swaybar_output *output,
+static enum hotspot_event_handling block_hotspot_callback(struct swaybar_output *output,
 			int x, int y, enum x11_button button, void *data) {
 	struct i3bar_block *block = data;
 	struct status_line *status = output->bar->status;
-	i3bar_block_send_click(status, block, x, y, button);
+	return i3bar_block_send_click(status, block, x, y, button);
 }
 
 static uint32_t render_status_block(cairo_t *cairo,
@@ -348,9 +348,13 @@ static const char *strip_workspace_number(const char *ws_name) {
 	return ws_name;
 }
 
-static void workspace_hotspot_callback(struct swaybar_output *output,
+static enum hotspot_event_handling workspace_hotspot_callback(struct swaybar_output *output,
 			int x, int y, enum x11_button button, void *data) {
+	if (button != LEFT) {
+		return HOTSPOT_PROCESS;
+	}
 	ipc_send_workspace_command(output->bar, (const char *)data);
+	return HOTSPOT_IGNORE;
 }
 
 static uint32_t render_workspace_button(cairo_t *cairo,


### PR DESCRIPTION
As well as ignoring scroll events on status elements when click_events
is enabled.
Previously, using the scroll wheel on a workspace button would switch to
that workspace instead of scrolling through them. Clicks and scrolling
on status elements would always be processed by swaybar, too. So in case
you were using scrolling as volume control on a status item, swaybar
would additionally scroll through your workspaces.

Note: I'm unsure about the enum naming. It doesn't seem to express the intent well enough, open to suggestions.