### PR TITLE
Fix output wildcard handling

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -461,6 +461,8 @@ void merge_output_config(struct output_config *dst, struct output_config *src);
 void apply_output_config(struct output_config *oc,
 		struct sway_container *output);
 
+struct output_config *store_output_config(struct output_config *oc);
+
 void free_output_config(struct output_config *oc);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);


### PR DESCRIPTION
Fixes #1724 
Fixes #2127 
Fixes #2295 
(Any others that I'm missing?)

This PR fixes issues related to `output *`.

Instead of applying the wildcard config directly to the output, the wildcard config is merged on top of the config for the output and that is then applied (falling back to the wildcard config). Additionally, when creating a non-wildcard config, it is merged on top of a copy of the wildcard config (if existent).

Output layout is no longer lost. This was due to an `output *` command being after the `output <name>` commands. When applying the `output *` config, the following snippet was changing it to auto positioning:
```c
if (oc && (oc->x != -1 || oc->y != -1)) {
	wlr_log(WLR_DEBUG, "Set %s position to %d, %d", oc->name, oc->x, oc->y);
	wlr_output_layout_add(output_layout, wlr_output, oc->x, oc->y);
} else {
	wlr_output_layout_add_auto(output_layout, wlr_output);
}
```
Since the `output *` config is never applied directly to the output (unless there is not an output config for the output), the positions in the config should be respected.

Setting the dpms state on a specific output should also work now. Before it would only work if there was a background specified by the output due to the following block changing the config before applying dpms:
```c
if (!oc || !oc->background) {
	// Look for a * config for background
	int i = list_seq_find(config->output_configs, output_name_cmp, "*");
	if (i >= 0) {
		oc = config->output_configs->items[i];
	} else {
		oc = NULL;
	}
}
/// DPMS applied below this point
```