### PR TITLE
Reset outputs on reload

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -464,7 +464,11 @@ void apply_output_config(struct output_config *oc,
 
 struct output_config *store_output_config(struct output_config *oc);
 
+void apply_output_config_to_outputs(struct output_config *oc);
+
 void free_output_config(struct output_config *oc);
+
+void create_default_output_configs(void);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);
 

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -21,60 +21,6 @@ static struct cmd_handler output_handlers[] = {
 	{ "transform", output_cmd_transform },
 };
 
-static struct output_config *get_output_config(char *name, char *identifier) {
-	int i = list_seq_find(config->output_configs, output_name_cmp, name);
-	if (i >= 0) {
-		return config->output_configs->items[i];
-	}
-
-	i = list_seq_find(config->output_configs, output_name_cmp, identifier);
-	if (i >= 0) {
-		return config->output_configs->items[i];
-	}
-
-	return NULL;
-}
-
-static void apply_output_config_to_outputs(struct output_config *oc) {
-	// Try to find the output container and apply configuration now. If
-	// this is during startup then there will be no container and config
-	// will be applied during normal "new output" event from wlroots.
-	bool wildcard = strcmp(oc->name, "*") == 0;
-	char id[128];
-	struct sway_output *sway_output;
-	wl_list_for_each(sway_output, &root_container.sway_root->outputs, link) {
-		char *name = sway_output->wlr_output->name;
-		output_get_identifier(id, sizeof(id), sway_output);
-		if (wildcard || !strcmp(name, oc->name) || !strcmp(id, oc->name)) {
-			if (!sway_output->swayc) {
-				if (!oc->enabled) {
-					if (!wildcard) {
-						break;
-					}
-					continue;
-				}
-
-				output_enable(sway_output);
-			}
-
-			struct output_config *current = oc;
-			if (wildcard) {
-				struct output_config *tmp = get_output_config(name, id);
-				if (tmp) {
-					current = tmp;
-				}
-			}
-			apply_output_config(current, sway_output->swayc);
-
-			if (!wildcard) {
-				// Stop looking if the output config isn't applicable to all
-				// outputs
-				break;
-			}
-		}
-	}
-}
-
 struct cmd_results *cmd_output(int argc, char **argv) {
 	struct cmd_results *error = checkarg(argc, "output", EXPECTED_AT_LEAST, 1);
 	if (error != NULL) {
@@ -115,7 +61,13 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	config->handler_context.leftovers.argv = NULL;
 
 	output = store_output_config(output);
-	apply_output_config_to_outputs(output);
+
+	// If reloading, the output configs will be applied after reading the
+	// entire config and before the deferred commands so that an auto generated
+	// workspace name is not given to re-enabled outputs.
+	if (!config->reloading) {
+		apply_output_config_to_outputs(output);
+	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -361,6 +361,7 @@ bool load_main_config(const char *file, bool is_active) {
 		wlr_log(WLR_DEBUG, "Performing configuration file reload");
 		config->reloading = true;
 		config->active = true;
+		create_default_output_configs();
 	}
 
 	config->current_config_path = path;
@@ -419,6 +420,9 @@ bool load_main_config(const char *file, bool is_active) {
 	success = success && load_config(path, config);
 
 	if (is_active) {
+		for (int i = 0; i < config->output_configs->length; i++) {
+			apply_output_config_to_outputs(config->output_configs->items[i]);
+		}
 		config->reloading = false;
 	}
 


### PR DESCRIPTION
Fixes #1752 
Fixes #2293

This PR creates default output configs for connected outputs when reloading. This ensures that when the output configs are applied, if an option is missing it is reset to the default instead of left unchanged.

Additionally, when reloading output configs are now applied after the entire config is read and before the deferred commands. This ensures that all workspace command bindings are read and the output does not incorrectly get assigned an automatic workspace name. This simulates the behavior that sway would have on a fresh start. 