### PR TITLE
Switch to using a function to parse booleans

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -124,17 +124,18 @@ uint32_t parse_color(const char *color) {
 }
 
 bool parse_boolean(const char *boolean, bool current) {
-	if (strcmp(boolean, "1") == 0
-			|| strcmp(boolean, "yes") == 0
-			|| strcmp(boolean, "on") == 0
-			|| strcmp(boolean, "true") == 0
-			|| strcmp(boolean, "enable") == 0
-			|| strcmp(boolean, "enabled") == 0
-			|| strcmp(boolean, "active") == 0) {
+	if (strcasecmp(boolean, "1") == 0
+			|| strcasecmp(boolean, "yes") == 0
+			|| strcasecmp(boolean, "on") == 0
+			|| strcasecmp(boolean, "true") == 0
+			|| strcasecmp(boolean, "enable") == 0
+			|| strcasecmp(boolean, "enabled") == 0
+			|| strcasecmp(boolean, "active") == 0) {
 		return true;
-	} else if (strcmp(boolean, "toggle") == 0) {
+	} else if (strcasecmp(boolean, "toggle") == 0) {
 		return !current;
 	}
+	// All other values are false to match i3
 	return false;
 }
 

--- a/common/util.c
+++ b/common/util.c
@@ -123,7 +123,7 @@ uint32_t parse_color(const char *color) {
 	return res;
 }
 
-bool parse_boolean(const char *boolean, const bool current) {
+bool parse_boolean(const char *boolean, bool current) {
 	if (strcmp(boolean, "1") == 0
 			|| strcmp(boolean, "yes") == 0
 			|| strcmp(boolean, "on") == 0

--- a/common/util.c
+++ b/common/util.c
@@ -123,6 +123,21 @@ uint32_t parse_color(const char *color) {
 	return res;
 }
 
+bool parse_boolean(const char *boolean, const bool current) {
+	if (strcmp(boolean, "1") == 0
+			|| strcmp(boolean, "yes") == 0
+			|| strcmp(boolean, "on") == 0
+			|| strcmp(boolean, "true") == 0
+			|| strcmp(boolean, "enable") == 0
+			|| strcmp(boolean, "enabled") == 0
+			|| strcmp(boolean, "active") == 0) {
+		return true;
+	} else if (strcmp(boolean, "toggle") == 0) {
+		return !current;
+	}
+	return false;
+}
+
 char* resolve_path(const char* path) {
 	struct stat sb;
 	ssize_t r;

--- a/include/util.h
+++ b/include/util.h
@@ -56,7 +56,7 @@ uint32_t parse_color(const char *color);
  * toggling is not desired, pass in true for current so that toggling values
  * get parsed as not true.
  */
-bool parse_boolean(const char *boolean, const bool current);
+bool parse_boolean(const char *boolean, bool current);
 
 /**
  * Given a path string, recurseively resolves any symlinks to their targets

--- a/include/util.h
+++ b/include/util.h
@@ -51,6 +51,14 @@ pid_t get_parent_pid(pid_t pid);
 uint32_t parse_color(const char *color);
 
 /**
+ * Given a string that represents a boolean, return the boolean value. This
+ * function also takes in the current boolean value to support toggling. If
+ * toggling is not desired, pass in true for current so that toggling values
+ * get parsed as not true.
+ */
+bool parse_boolean(const char *boolean, const bool current);
+
+/**
  * Given a path string, recurseively resolves any symlinks to their targets
  * (which may be a file, directory) and returns the result.
  * argument is returned. Caller must free the returned buffer.

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -1,12 +1,14 @@
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
+#include "util.h"
 
 struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	config->focus_follows_mouse = !strcasecmp(argv[0], "yes");
+	config->focus_follows_mouse =
+		parse_boolean(argv[0], config->focus_follows_mouse);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/focus_wrapping.c
+++ b/sway/commands/focus_wrapping.c
@@ -9,7 +9,7 @@ struct cmd_results *cmd_focus_wrapping(int argc, char **argv) {
 		return error;
 	}
 
-	if (strcmp(argv[0], "force") == 0) {
+	if (strcasecmp(argv[0], "force") == 0) {
 		config->focus_wrapping = WRAP_FORCE;
 	} else if (parse_boolean(argv[0], config->focus_wrapping == WRAP_YES)) {
 		config->focus_wrapping = WRAP_YES;

--- a/sway/commands/focus_wrapping.c
+++ b/sway/commands/focus_wrapping.c
@@ -1,6 +1,7 @@
 #include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "util.h"
 
 struct cmd_results *cmd_focus_wrapping(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -8,15 +9,12 @@ struct cmd_results *cmd_focus_wrapping(int argc, char **argv) {
 		return error;
 	}
 
-	if (strcasecmp(argv[0], "no") == 0) {
-		config->focus_wrapping = WRAP_NO;
-	} else if (strcasecmp(argv[0], "yes") == 0) {
-		config->focus_wrapping = WRAP_YES;
-	} else if (strcasecmp(argv[0], "force") == 0) {
+	if (strcmp(argv[0], "force") == 0) {
 		config->focus_wrapping = WRAP_FORCE;
+	} else if (parse_boolean(argv[0], config->focus_wrapping == WRAP_YES)) {
+		config->focus_wrapping = WRAP_YES;
 	} else {
-		return cmd_results_new(CMD_INVALID, "focus_wrapping",
-				"Expected 'focus_wrapping yes|no|force'");
+		config->focus_wrapping = WRAP_NO;
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/force_focus_wrapping.c
+++ b/sway/commands/force_focus_wrapping.c
@@ -1,6 +1,7 @@
 #include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "util.h"
 
 struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
 	struct cmd_results *error =
@@ -9,13 +10,10 @@ struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
 		return error;
 	}
 
-	if (strcasecmp(argv[0], "no") == 0) {
-		config->focus_wrapping = WRAP_YES;
-	} else if (strcasecmp(argv[0], "yes") == 0) {
+	if (parse_boolean(argv[0], config->focus_wrapping == WRAP_FORCE)) {
 		config->focus_wrapping = WRAP_FORCE;
 	} else {
-		return cmd_results_new(CMD_INVALID, "force_focus_wrapping",
-				"Expected 'force_focus_wrapping yes|no'");
+		config->focus_wrapping = WRAP_YES;
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -5,6 +5,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 #include "sway/tree/layout.h"
+#include "util.h"
 
 struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,17 +19,10 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 				"Only views can fullscreen");
 	}
 	struct sway_view *view = container->sway_view;
-	bool wants_fullscreen;
+	bool wants_fullscreen = !view->is_fullscreen;
 
-	if (argc == 0 || strcmp(argv[0], "toggle") == 0) {
-		wants_fullscreen = !view->is_fullscreen;
-	} else if (strcmp(argv[0], "enable") == 0) {
-		wants_fullscreen = true;
-	} else if (strcmp(argv[0], "disable") == 0) {
-		wants_fullscreen = false;
-	} else {
-		return cmd_results_new(CMD_INVALID, "fullscreen",
-				"Expected 'fullscreen' or 'fullscreen <enable|disable|toggle>'");
+	if (argc) {
+		wants_fullscreen = parse_boolean(argv[0], view->is_fullscreen);
 	}
 
 	view_set_fullscreen(view, wants_fullscreen);

--- a/sway/commands/input/drag_lock.c
+++ b/sway/commands/input/drag_lock.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,14 +19,10 @@ struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
+	if (parse_boolean(argv[0], true)) {
 		new_config->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_ENABLED;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
 	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "drag_lock",
-			"Expected 'drag_lock <enabled|disabled>'");
+		new_config->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
 	}
 
 	apply_input_config(new_config);

--- a/sway/commands/input/dwt.c
+++ b/sway/commands/input/dwt.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -17,14 +18,10 @@ struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
+	if (parse_boolean(argv[0], true)) {
 		new_config->dwt = LIBINPUT_CONFIG_DWT_ENABLED;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->dwt = LIBINPUT_CONFIG_DWT_DISABLED;
 	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "dwt",
-			"Expected 'dwt <enabled|disabled>'");
+		new_config->dwt = LIBINPUT_CONFIG_DWT_DISABLED;
 	}
 
 	apply_input_config(new_config);

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,15 +19,7 @@ struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
-		new_config->left_handed = 1;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->left_handed = 0;
-	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "left_handed",
-			"Expected 'left_handed <enabled|disabled>'");
-	}
+	new_config->left_handed = parse_boolean(argv[0], true);
 
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/middle_emulation.c
+++ b/sway/commands/input/middle_emulation.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,15 +19,11 @@ struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
+	if (parse_boolean(argv[0], true)) {
 		new_config->middle_emulation = LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
+	} else {
 		new_config->middle_emulation =
 			LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
-	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "middle_emulation",
-			"Expected 'middle_emulation <enabled|disabled>'");
 	}
 
 	apply_input_config(new_config);

--- a/sway/commands/input/natural_scroll.c
+++ b/sway/commands/input/natural_scroll.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,15 +19,7 @@ struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
-		new_config->natural_scroll = 1;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->natural_scroll = 0;
-	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "natural_scroll",
-			"Expected 'natural_scroll <enabled|disabled>'");
-	}
+	new_config->natural_scroll = parse_boolean(argv[0], true);
 
 	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -4,6 +4,7 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 #include "log.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_tap(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -18,14 +19,10 @@ struct cmd_results *input_cmd_tap(int argc, char **argv) {
 	struct input_config *new_config =
 		new_input_config(current_input_config->identifier);
 
-	if (strcasecmp(argv[0], "enabled") == 0) {
+	if (parse_boolean(argv[0], true)) {
 		new_config->tap = LIBINPUT_CONFIG_TAP_ENABLED;
-	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->tap = LIBINPUT_CONFIG_TAP_DISABLED;
 	} else {
-		free_input_config(new_config);
-		return cmd_results_new(CMD_INVALID, "tap",
-			"Expected 'tap <enabled|disabled>'");
+		new_config->tap = LIBINPUT_CONFIG_TAP_DISABLED;
 	}
 
 	wlr_log(WLR_DEBUG, "apply-tap for device: %s",

--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -1,5 +1,6 @@
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "util.h"
 
 struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
@@ -9,13 +10,10 @@ struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "output", "Missing dpms argument.");
 	}
 
-	if (strcmp(*argv, "on") == 0) {
+	if (parse_boolean(argv[0], true)) {
 		config->handler_context.output_config->dpms_state = DPMS_ON;
-	} else if (strcmp(*argv, "off") == 0) {
-		config->handler_context.output_config->dpms_state = DPMS_OFF;
 	} else {
-		return cmd_results_new(CMD_INVALID, "output",
-				"Invalid dpms state, valid states are on/off.");
+		config->handler_context.output_config->dpms_state = DPMS_OFF;
 	}
 
 	config->handler_context.leftovers.argc = argc - 1;

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -7,6 +7,7 @@
 #include "list.h"
 #include "log.h"
 #include "stringop.h"
+#include "util.h"
 
 static void rebuild_marks_iterator(struct sway_container *con, void *data) {
 	if (con->type == C_VIEW) {
@@ -20,14 +21,7 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 		return error;
 	}
 
-	if (strcmp(*argv, "yes") == 0) {
-		config->show_marks = true;
-	} else if (strcmp(*argv, "no") == 0) {
-		config->show_marks = false;
-	} else {
-		return cmd_results_new(CMD_INVALID, "show_marks",
-				"Expected 'show_marks <yes|no>'");
-	}
+	config->show_marks = parse_boolean(argv[0], config->show_marks);
 
 	if (config->show_marks) {
 		container_for_each_descendant_dfs(&root_container,

--- a/sway/commands/urgent.c
+++ b/sway/commands/urgent.c
@@ -5,6 +5,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 #include "sway/tree/layout.h"
+#include "util.h"
 
 struct cmd_results *cmd_urgent(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -19,17 +20,12 @@ struct cmd_results *cmd_urgent(int argc, char **argv) {
 	}
 	struct sway_view *view = container->sway_view;
 
-	if (strcmp(argv[0], "enable") == 0) {
-		view_set_urgent(view, true);
-	} else if (strcmp(argv[0], "disable") == 0) {
-		view_set_urgent(view, false);
-	} else if (strcmp(argv[0], "allow") == 0) {
+	if (strcmp(argv[0], "allow") == 0) {
 		view->allow_request_urgent = true;
 	} else if (strcmp(argv[0], "deny") == 0) {
 		view->allow_request_urgent = false;
 	} else {
-		return cmd_results_new(CMD_INVALID, "urgent",
-				"Expected 'urgent <enable|disable|allow|deny>'");
+		view_set_urgent(view, parse_boolean(argv[0], view_is_urgent(view)));
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);


### PR DESCRIPTION
Related to #2336.

This PR adds a function (`parse_boolean`) similar to i3's `eval_boolstr`. The only `true` value that I added was `enabled` since that was in use for various commands. The rest are identical to i3's.

I also added support for toggling values. Currently, toggling is not supported for `input` or `output` commands (since it would require a change to the way their configs work, which is out of scope for this PR), but should work for anything else that takes a boolean value. For `input` and `output` commands, `toggle` is interpreted as a non-true value.