### PR TITLE
Add missing checks to fix 2339

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -628,6 +628,7 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 	if (last_workspace && last_workspace == new_workspace
 			&& last_workspace->sway_workspace->fullscreen
+			&& container && container->type == C_VIEW
 			&& !container->sway_view->is_fullscreen) {
 		return;
 	}


### PR DESCRIPTION
Fixes #2339 

In `seat_set_focus_warp`, there was a missing null check and container type check that was causing the segfault.