### PR TITLE
Fix some cases where the cursor doesn't update

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -726,6 +726,7 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 
 	wlr_cursor_set_surface(cursor->cursor, event->surface, event->hotspot_x,
 		event->hotspot_y);
+	cursor->image = NULL;
 	cursor->image_client = focused_client;
 }
 


### PR DESCRIPTION
`cursor_set_image` only uploads the named image if it doesn't match the previous named image. This means when setting the cursor image to a surface as given by a client (ie. not named), we have to clear the `cursor->image` property.

To test, open a window that sets a different cursor (eg. open a terminal and see the I-beam/text cursor) then switch to a new workspace. The cursor would not update, but now it changes to the regular pointer.