### PR TITLE
Added meson option to allow building sway without xwayland support

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -25,7 +25,9 @@ struct criteria {
 	pcre *instance;
 	pcre *con_mark;
 	uint32_t con_id; // internal ID
+  #ifdef HAVE_XWAYLAND
 	uint32_t id; // X11 window ID
+  #endif
 	pcre *window_role;
 	uint32_t window_type;
 	bool floating;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -12,7 +12,9 @@
 #include <wlr/render/wlr_renderer.h>
 // TODO WLR: make Xwayland optional
 #include "list.h"
+#ifdef HAVE_XWAYLAND
 #include "sway/xwayland.h"
+#endif
 
 struct sway_server {
 	struct wl_display *wl_display;
@@ -39,11 +41,11 @@ struct sway_server {
 
 	struct wlr_xdg_shell *xdg_shell;
 	struct wl_listener xdg_shell_surface;
-
+  #ifdef HAVE_XWAYLAND
 	struct sway_xwayland xwayland;
 	struct wl_listener xwayland_surface;
 	struct wl_listener xwayland_ready;
-
+  #endif
 	bool debug_txn_timings;
 
 	list_t *transactions;
@@ -65,6 +67,7 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);
 void handle_layer_shell_surface(struct wl_listener *listener, void *data);
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data);
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data);
+#ifdef HAVE_XWAYLAND
 void handle_xwayland_surface(struct wl_listener *listener, void *data);
-
+#endif
 #endif

--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -27,8 +27,9 @@ struct sway_root {
 	struct wlr_output_layout *output_layout;
 
 	struct wl_listener output_layout_change;
-
+  #ifdef HAVE_XWAYLAND
 	struct wl_list xwayland_unmanaged; // sway_xwayland_unmanaged::link
+  #endif
 	struct wl_list drag_icons; // sway_drag_icon::link
 
 	struct wlr_texture *debug_tree;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
+#ifdef HAVE_XWAYLAND
 #include <wlr/xwayland.h>
+#endif
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 
@@ -12,7 +14,9 @@ struct sway_container;
 enum sway_view_type {
 	SWAY_VIEW_XDG_SHELL_V6,
 	SWAY_VIEW_XDG_SHELL,
+  #ifdef HAVE_XWAYLAND
 	SWAY_VIEW_XWAYLAND,
+  #endif
 };
 
 enum sway_view_prop {
@@ -22,7 +26,9 @@ enum sway_view_prop {
 	VIEW_PROP_INSTANCE,
 	VIEW_PROP_WINDOW_TYPE,
 	VIEW_PROP_WINDOW_ROLE,
+  #ifdef HAVE_XWAYLAND
 	VIEW_PROP_X11_WINDOW_ID,
+  #endif
 };
 
 struct sway_view_impl {
@@ -90,7 +96,9 @@ struct sway_view {
 	union {
 		struct wlr_xdg_surface_v6 *wlr_xdg_surface_v6;
 		struct wlr_xdg_surface *wlr_xdg_surface;
+    #ifdef HAVE_XWAYLAND
 		struct wlr_xwayland_surface *wlr_xwayland_surface;
+    #endif
 		struct wlr_wl_shell_surface *wlr_wl_shell_surface;
 	};
 
@@ -133,7 +141,7 @@ struct sway_xdg_shell_view {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
-
+#ifdef HAVE_XWAYLAND
 struct sway_xwayland_view {
 	struct sway_view view;
 
@@ -165,7 +173,7 @@ struct sway_xwayland_unmanaged {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
-
+#endif
 struct sway_view_child;
 
 struct sway_view_child_impl {
@@ -281,9 +289,10 @@ struct sway_view *view_from_wlr_xdg_surface(
 	struct wlr_xdg_surface *xdg_surface);
 struct sway_view *view_from_wlr_xdg_surface_v6(
 	struct wlr_xdg_surface_v6 *xdg_surface_v6);
+#ifdef HAVE_XWAYLAND
 struct sway_view *view_from_wlr_xwayland_surface(
 	struct wlr_xwayland_surface *xsurface);
-
+#endif
 struct sway_view *view_from_wlr_surface(struct wlr_surface *surface);
 
 /**

--- a/include/sway/xwayland.h
+++ b/include/sway/xwayland.h
@@ -1,3 +1,4 @@
+#ifdef HAVE_XWAYLAND
 #ifndef SWAY_XWAYLAND_H
 #define SWAY_XWAYLAND_H
 
@@ -22,4 +23,5 @@ struct sway_xwayland {
 
 void handle_xwayland_ready(struct wl_listener *listener, void *data);
 
+#endif
 #endif

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,12 @@ git            = find_program('git', required: false)
 
 conf_data = configuration_data()
 
+if get_option('enable-xwayland')
+  conf_data.set('HAVE_XWAYLAND', true)
+else
+  conf_data.set('HAVE_XWAYLAND', false)
+endif
+
 if gdk_pixbuf.found()
 	conf_data.set('HAVE_GDK_PIXBUF', true)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('sway_version', type : 'string', description: 'The version string reported in `sway --version`.')
 option('default_wallpaper', type: 'boolean', value: true, description: 'Install the default wallpaper.')
 option('zsh_completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
+option('enable-xwayland', type: 'boolean', value: false, description: 'Enable support X11 applications')

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -14,10 +14,14 @@ static bool test_con_id(struct sway_container *container, void *con_id) {
 }
 
 static bool test_id(struct sway_container *container, void *id) {
+  #ifdef HAVE_XWAYLAND
 	xcb_window_t *wid = id;
 	return (container->type == C_VIEW
 			&& container->sway_view->type == SWAY_VIEW_XWAYLAND
 			&& container->sway_view->wlr_xwayland_surface->window_id == *wid);
+  #else
+  return false;
+  #endif
 }
 
 static bool test_mark(struct sway_container *container, void *mark) {
@@ -43,8 +47,10 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 
 	char *value = join_args(argv + 3, argc - 3);
 	if (strcasecmp(argv[2], "id") == 0) {
+    #ifdef HAVE_XWAYLAND
 		xcb_window_t id = strtol(value, NULL, 0);
 		other = container_find(&root_container, test_id, (void *)&id);
+    #endif
 	} else if (strcasecmp(argv[2], "con_id") == 0) {
 		size_t con_id = atoi(value);
 		other = container_find(&root_container, test_con_id, (void *)con_id);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -19,7 +19,9 @@ bool criteria_is_empty(struct criteria *criteria) {
 		&& !criteria->instance
 		&& !criteria->con_mark
 		&& !criteria->con_id
+    #ifdef HAVE_XWAYLAND
 		&& !criteria->id
+    #endif
 		&& !criteria->window_role
 		&& !criteria->window_type
 		&& !criteria->floating
@@ -127,12 +129,14 @@ static bool criteria_matches_view(struct criteria *criteria,
 		}
 	}
 
+  #ifdef HAVE_XWAYLAND
 	if (criteria->id) { // X11 window ID
 		uint32_t x11_window_id = view_get_x11_window_id(view);
 		if (!x11_window_id || x11_window_id != criteria->id) {
 			return false;
 		}
 	}
+  #endif
 
 	if (criteria->window_role) {
 		// TODO
@@ -265,7 +269,9 @@ enum criteria_token {
 	T_CON_ID,
 	T_CON_MARK,
 	T_FLOATING,
+  #ifdef HAVE_XWAYLAND
 	T_ID,
+  #endif
 	T_INSTANCE,
 	T_SHELL,
 	T_TILING,
@@ -287,8 +293,10 @@ static enum criteria_token token_from_name(char *name) {
 		return T_CON_ID;
 	} else if (strcmp(name, "con_mark") == 0) {
 		return T_CON_MARK;
+  #ifdef HAVE_XWAYLAND
 	} else if (strcmp(name, "id") == 0) {
 		return T_ID;
+  #endif
 	} else if (strcmp(name, "instance") == 0) {
 		return T_INSTANCE;
 	} else if (strcmp(name, "shell") == 0) {
@@ -355,7 +363,9 @@ static char *get_focused_prop(enum criteria_token token) {
 	case T_CON_ID: // These do not support __focused__
 	case T_CON_MARK:
 	case T_FLOATING:
+  #ifdef HAVE_XWAYLAND
 	case T_ID:
+  #endif
 	case T_TILING:
 	case T_URGENT:
 	case T_WINDOW_TYPE:
@@ -426,12 +436,14 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 	case T_WINDOW_TYPE:
 		// TODO: This is a string but will be stored as an enum or integer
 		break;
+  #ifdef HAVE_XWAYLAND
 	case T_ID:
 		criteria->id = strtoul(effective_value, &endptr, 10);
 		if (*endptr != 0) {
 			error = strdup("The value for 'id' should be numeric");
 		}
 		break;
+  #endif
 	case T_FLOATING:
 		criteria->floating = true;
 		break;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -128,7 +128,7 @@ void output_layer_for_each_surface(struct wl_list *layer_surfaces,
 			user_data);
 	}
 }
-
+#ifdef HAVE_XWAYLAND
 void output_unmanaged_for_each_surface(struct wl_list *unmanaged,
 		struct sway_output *output, struct root_geometry *geo,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
@@ -143,7 +143,7 @@ void output_unmanaged_for_each_surface(struct wl_list *unmanaged,
 			iterator, user_data);
 	}
 }
-
+#endif
 void output_drag_icons_for_each_surface(struct wl_list *drag_icons,
 		struct sway_output *output, struct root_geometry *geo,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
@@ -244,13 +244,13 @@ static void send_frame_done_layer(struct send_frame_done_data *data,
 	output_layer_for_each_surface(layer_surfaces, &data->root_geo,
 		send_frame_done_iterator, data);
 }
-
+#ifdef HAVE_XWAYLAND
 static void send_frame_done_unmanaged(struct send_frame_done_data *data,
 		struct wl_list *unmanaged) {
 	output_unmanaged_for_each_surface(unmanaged, data->output, &data->root_geo,
 		send_frame_done_iterator, data);
 }
-
+#endif
 static void send_frame_done_drag_icons(struct send_frame_done_data *data,
 		struct wl_list *drag_icons) {
 	output_drag_icons_for_each_surface(drag_icons, data->output, &data->root_geo,
@@ -291,11 +291,12 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 	if (workspace->current.ws_fullscreen) {
 		send_frame_done_container_iterator(
 			workspace->current.ws_fullscreen->swayc, &data);
-
+    #ifdef HAVE_XWAYLAND
 		if (workspace->current.ws_fullscreen->type == SWAY_VIEW_XWAYLAND) {
 			send_frame_done_unmanaged(&data,
 				&root_container.sway_root->xwayland_unmanaged);
 		}
+    #endif
 	} else {
 		send_frame_done_layer(&data,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]);
@@ -304,9 +305,11 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 
 		send_frame_done_container(&data, workspace);
 		send_frame_done_container(&data, workspace->sway_workspace->floating);
-
+    
+    #ifdef HAVE_XWAYLAND
 		send_frame_done_unmanaged(&data,
 			&root_container.sway_root->xwayland_unmanaged);
+    #endif
 		send_frame_done_layer(&data,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -132,7 +132,7 @@ static void render_layer(struct sway_output *output,
 	output_layer_for_each_surface(layer_surfaces, &data.root_geo,
 		render_surface_iterator, &data);
 }
-
+#ifdef HAVE_XWAYLAND
 static void render_unmanaged(struct sway_output *output,
 		pixman_region32_t *damage, struct wl_list *unmanaged) {
 	struct render_data data = {
@@ -143,7 +143,7 @@ static void render_unmanaged(struct sway_output *output,
 	output_unmanaged_for_each_surface(unmanaged, output, &data.root_geo,
 		render_surface_iterator, &data);
 }
-
+#endif
 static void render_drag_icons(struct sway_output *output,
 		pixman_region32_t *damage, struct wl_list *drag_icons) {
 	struct render_data data = {
@@ -866,11 +866,12 @@ void output_render(struct sway_output *output, struct timespec *when,
 		} else {
 			render_view_surfaces(fullscreen_view, output, damage, 1.0f);
 		}
-
+    #ifdef HAVE_XWAYLAND
 		if (fullscreen_view->type == SWAY_VIEW_XWAYLAND) {
 			render_unmanaged(output, damage,
 				&root_container.sway_root->xwayland_unmanaged);
 		}
+    #endif
 	} else {
 		float clear_color[] = {0.25f, 0.25f, 0.25f, 1.0f};
 
@@ -888,9 +889,10 @@ void output_render(struct sway_output *output, struct timespec *when,
 
 		render_container(output, damage, workspace, workspace->current.focused);
 		render_floating(output, damage);
-
+    #ifdef HAVE_XWAYLAND
 		render_unmanaged(output, damage,
 			&root_container.sway_root->xwayland_unmanaged);
+    #endif  
 		render_layer(output, damage,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 199309L
+#ifdef HAVE_XWAYLAND
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wayland-server.h>
@@ -591,3 +592,4 @@ void handle_xwayland_ready(struct wl_listener *listener, void *data) {
 
 	xcb_disconnect(xcb_conn);
 }
+#endif

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -54,6 +54,7 @@ static struct sway_container *container_at_coords(
 		struct sway_seat *seat, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	// check for unmanaged views first
+  #ifdef HAVE_XWAYLAND
 	struct wl_list *unmanaged = &root_container.sway_root->xwayland_unmanaged;
 	struct sway_xwayland_unmanaged *unmanaged_surface;
 	wl_list_for_each_reverse(unmanaged_surface, unmanaged, link) {
@@ -69,7 +70,7 @@ static struct sway_container *container_at_coords(
 			return NULL;
 		}
 	}
-
+  #endif
 	// find the output the cursor is on
 	struct wlr_output_layout *output_layout =
 		root_container.sway_root->output_layout;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -103,11 +103,13 @@ static void seat_send_focus(struct sway_container *con,
 
 	if (con->type == C_VIEW
 			&& seat_is_input_allowed(seat, con->sway_view->surface)) {
+    #ifdef HAVE_XWAYLAND
 		if (con->sway_view->type == SWAY_VIEW_XWAYLAND) {
 			struct wlr_xwayland *xwayland =
 				seat->input->server->xwayland.wlr_xwayland;
 			wlr_xwayland_set_seat(xwayland, seat->wlr_seat);
 		}
+    #endif
 		struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
 		if (keyboard) {
 			wlr_seat_keyboard_notify_enter(seat->wlr_seat,

--- a/sway/server.c
+++ b/sway/server.c
@@ -25,7 +25,9 @@
 #include "sway/input/input-manager.h"
 #include "sway/server.h"
 #include "sway/tree/layout.h"
+#ifdef HAVE_XWAYLAND
 #include "sway/xwayland.h"
+#endif
 
 bool server_privileged_prepare(struct sway_server *server) {
 	wlr_log(WLR_DEBUG, "Preparing Wayland server initialization");
@@ -81,6 +83,7 @@ bool server_init(struct sway_server *server) {
 	server->xdg_shell_surface.notify = handle_xdg_shell_surface;
 
 	// TODO make xwayland optional
+  #ifdef HAVE_XWAYLAND
 	server->xwayland.wlr_xwayland =
 		wlr_xwayland_create(server->wl_display, server->compositor, true);
 	wl_signal_add(&server->xwayland.wlr_xwayland->events.new_surface,
@@ -101,6 +104,7 @@ bool server_init(struct sway_server *server) {
 			image->width * 4, image->width, image->height, image->hotspot_x,
 			image->hotspot_y);
 	}
+  #endif
 
 	// TODO: Integration with sway borders
 	struct wlr_server_decoration_manager *deco_manager =

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -527,10 +527,12 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 	double _sx, _sy;
 	struct wlr_surface *_surface = NULL;
 	switch (sview->type) {
+  #ifdef HAVE_XWAYLAND
 	case SWAY_VIEW_XWAYLAND:
 		_surface = wlr_surface_surface_at(sview->surface,
 				view_sx, view_sy, &_sx, &_sy);
 		break;
+  #endif
 	case SWAY_VIEW_XDG_SHELL_V6:
 		_surface = wlr_xdg_surface_v6_surface_at(
 				sview->wlr_xdg_surface_v6,

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -39,7 +39,9 @@ void layout_init(void) {
 	root_container.sway_root = calloc(1, sizeof(*root_container.sway_root));
 	root_container.sway_root->output_layout = wlr_output_layout_create();
 	wl_list_init(&root_container.sway_root->outputs);
+  #ifdef HAVE_XWAYLAND
 	wl_list_init(&root_container.sway_root->xwayland_unmanaged);
+  #endif
 	wl_list_init(&root_container.sway_root->drag_icons);
 	wl_signal_init(&root_container.sway_root->events.new_container);
 	root_container.sway_root->scratchpad = create_list();

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -3,7 +3,9 @@
 #include <wayland-server.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_output_layout.h>
+#ifdef HAVE_XWAYLAND
 #include <wlr/xwayland.h>
+#endif
 #include "list.h"
 #include "log.h"
 #include "sway/criteria.h"
@@ -108,14 +110,14 @@ const char *view_get_instance(struct sway_view *view) {
 	}
 	return NULL;
 }
-
+#ifdef HAVE_XWAYLAND
 uint32_t view_get_x11_window_id(struct sway_view *view) {
 	if (view->impl->get_int_prop) {
 		return view->impl->get_int_prop(view, VIEW_PROP_X11_WINDOW_ID);
 	}
 	return 0;
 }
-
+#endif
 const char *view_get_window_role(struct sway_view *view) {
 	if (view->impl->get_string_prop) {
 		return view->impl->get_string_prop(view, VIEW_PROP_WINDOW_ROLE);
@@ -136,8 +138,10 @@ const char *view_get_shell(struct sway_view *view) {
 		return "xdg_shell_v6";
 	case SWAY_VIEW_XDG_SHELL:
 		return "xdg_shell";
+  #ifdef HAVE_XWAYLAND
 	case SWAY_VIEW_XWAYLAND:
 		return "xwayland";
+  #endif
 	}
 	return "unknown";
 }
@@ -563,6 +567,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	}
 
 	pid_t pid;
+  #ifdef HAVE_XWAYLAND
 	if (view->type == SWAY_VIEW_XWAYLAND) {
 		struct wlr_xwayland_surface *surf =
 			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
@@ -572,6 +577,11 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 			wl_resource_get_client(wlr_surface->resource);
 		wl_client_get_credentials(client, &pid, NULL, NULL);
 	}
+  #else
+	struct wl_client *client =
+		wl_resource_get_client(wlr_surface->resource);
+	wl_client_get_credentials(client, &pid, NULL, NULL);
+  #endif
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *target_sibling =
@@ -825,11 +835,13 @@ struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
 			wlr_xdg_surface_v6_from_wlr_surface(wlr_surface);
 		return view_from_wlr_xdg_surface_v6(xdg_surface_v6);
 	}
+  #ifdef HAVE_XWAYLAND
 	if (wlr_surface_is_xwayland_surface(wlr_surface)) {
 		struct wlr_xwayland_surface *xsurface =
 			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
 		return view_from_wlr_xwayland_surface(xsurface);
 	}
+  #endif
 	if (wlr_surface_is_subsurface(wlr_surface)) {
 		struct wlr_subsurface *subsurface =
 			wlr_subsurface_from_wlr_surface(wlr_surface);


### PR DESCRIPTION
This PR is based on another PR by @armtux
https://github.com/swaywm/sway/pull/2114/commits

Added meson option "enable_xwayland" (default: true) to enable/disable xwayland support in sway.
I tested this with a build of wlroots using "-Denable-xcb_errors=false -Denable-xwayland=false -Denable-x11_backend=false".
