### PR TITLE
Implement floating_modifier <mod> [inverse|normal]

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -320,6 +320,7 @@ struct sway_config {
 	struct bar_config *current_bar;
 	char *swaybg_command;
 	uint32_t floating_mod;
+	bool floating_mod_inverse;
 	uint32_t dragging_key;
 	uint32_t resizing_key;
 	char *floating_scroll_up_cmd;

--- a/sway/commands/floating_modifier.c
+++ b/sway/commands/floating_modifier.c
@@ -1,10 +1,11 @@
+#include "strings.h"
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "util.h"
 
 struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "floating_modifier", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "floating_modifier", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
@@ -12,6 +13,15 @@ struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 	if (!mod) {
 		return cmd_results_new(CMD_INVALID, "floating_modifier",
 				"Invalid modifier");
+	}
+
+	if (argc == 1 || strcasecmp(argv[1], "normal") == 0) {
+		config->floating_mod_inverse = false;
+	} else if (strcasecmp(argv[1], "inverse") == 0) {
+		config->floating_mod_inverse = true;
+	} else {
+		return cmd_results_new(CMD_INVALID, "floating_modifier",
+				"Usage: floating_modifier <mod> [inverse|normal]");
 	}
 
 	config->floating_mod = mod;

--- a/sway/config.c
+++ b/sway/config.c
@@ -180,6 +180,7 @@ static void config_defaults(struct sway_config *config) {
 	list_add(config->modes, config->current_mode);
 
 	config->floating_mod = 0;
+	config->floating_mod_inverse = false;
 	config->dragging_key = BTN_LEFT;
 	config->resizing_key = BTN_RIGHT;
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -452,7 +452,7 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 	uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
 	if (button == btn_move && state == WLR_BUTTON_PRESSED &&
 			(mod_pressed || over_title)) {
-		seat_begin_move(seat, cont, btn_move);
+		seat_begin_move(seat, cont, button);
 		return;
 	}
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -449,15 +449,17 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 	bool over_title = edge == WLR_EDGE_NONE && !surface;
 
 	// Check for beginning move
-	if (button == BTN_LEFT && state == WLR_BUTTON_PRESSED &&
+	uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
+	if (button == btn_move && state == WLR_BUTTON_PRESSED &&
 			(mod_pressed || over_title)) {
-		seat_begin_move(seat, cont, BTN_LEFT);
+		seat_begin_move(seat, cont, btn_move);
 		return;
 	}
 
 	// Check for beginning resize
 	bool resizing_via_border = button == BTN_LEFT && edge != WLR_EDGE_NONE;
-	bool resizing_via_mod = button == BTN_RIGHT && mod_pressed;
+	uint32_t btn_resize = config->floating_mod_inverse ? BTN_LEFT : BTN_RIGHT;
+	bool resizing_via_mod = button == btn_resize && mod_pressed;
 	if ((resizing_via_border || resizing_via_mod) &&
 			state == WLR_BUTTON_PRESSED) {
 		if (edge == WLR_EDGE_NONE) {


### PR DESCRIPTION
Closes #2335 

Implements the `[inverse|normal]` portion of `floating_modifier <mod> [inverse|normal]`.

In `normal` mode (default), `<mod> + left click` is move and `<mod> + right click` is resize.
In `inverse` mode, `<mod> + left click` is resize and `<mod> + right click` is move.