### PR TITLE
Improve rendering with a fullscreen opaque overlay surface

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -65,8 +65,7 @@ struct sway_container *output_by_name(const char *name);
 
 void output_enable(struct sway_output *output);
 
-bool output_has_opaque_lockscreen(struct sway_output *output,
-	struct sway_seat *seat);
+bool output_has_opaque_overlay_layer_surface(struct sway_output *output);
 
 struct sway_container *output_get_active_workspace(struct sway_output *output);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -181,21 +181,14 @@ struct sway_container *output_get_active_workspace(struct sway_output *output) {
 	return workspace;
 }
 
-bool output_has_opaque_lockscreen(struct sway_output *output,
-		struct sway_seat *seat) {
-	if (!seat->exclusive_client) {
-		return false;
-	}
-
+bool output_has_opaque_overlay_layer_surface(struct sway_output *output) {
 	struct wlr_layer_surface *wlr_layer_surface;
 	wl_list_for_each(wlr_layer_surface, &server.layer_shell->surfaces, link) {
-		if (wlr_layer_surface->output != output->wlr_output) {
+		if (wlr_layer_surface->output != output->wlr_output ||
+				wlr_layer_surface->layer != ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY) {
 			continue;
 		}
 		struct wlr_surface *wlr_surface = wlr_layer_surface->surface;
-		if (wlr_surface->resource->client != seat->exclusive_client) {
-			continue;
-		}
 		struct sway_layer_surface *sway_layer_surface =
 			layer_from_wlr_layer_surface(wlr_layer_surface);
 		pixman_box32_t output_box = {
@@ -221,16 +214,11 @@ struct send_frame_done_data {
 	struct root_geometry root_geo;
 	struct sway_output *output;
 	struct timespec *when;
-	struct wl_client *exclusive_client;
 };
 
 static void send_frame_done_iterator(struct wlr_surface *surface,
 		int sx, int sy, void *_data) {
 	struct send_frame_done_data *data = _data;
-	if (data->exclusive_client &&
-			data->exclusive_client != surface->resource->client) {
-		return;
-	}
 
 	bool intersects = output_get_surface_box(&data->root_geo, data->output, surface,
 		sx, sy, NULL);
@@ -279,13 +267,14 @@ static void send_frame_done_container(struct send_frame_done_data *data,
 }
 
 static void send_frame_done(struct sway_output *output, struct timespec *when) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct send_frame_done_data data = {
 		.output = output,
 		.when = when,
-		.exclusive_client = output_has_opaque_lockscreen(output, seat) ?
-			seat->exclusive_client : NULL,
 	};
+
+	if (output_has_opaque_overlay_layer_surface(output)) {
+		goto send_frame_overlay;
+	}
 
 	struct sway_container *workspace = output_get_active_workspace(output);
 	if (workspace->current.ws_fullscreen) {
@@ -311,6 +300,7 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
 
+send_frame_overlay:
 	send_frame_done_layer(&data,
 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 	send_frame_done_drag_icons(&data, &root_container.sway_root->drag_icons);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -836,21 +836,12 @@ void output_render(struct sway_output *output, struct timespec *when,
 
 	struct sway_container *workspace = output_get_active_workspace(output);
 	struct sway_view *fullscreen_view = workspace->current.ws_fullscreen;
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
 
-	if (output_has_opaque_lockscreen(output, seat) && seat->focused_layer) {
-		struct wlr_layer_surface *wlr_layer_surface = seat->focused_layer;
-		struct sway_layer_surface *sway_layer_surface =
-			layer_from_wlr_layer_surface(seat->focused_layer);
-		struct render_data data = {
-			.output = output,
-			.damage = damage,
-			.alpha = 1.0f,
-		};
-		output_surface_for_each_surface(wlr_layer_surface->surface,
-			sway_layer_surface->geo.x, sway_layer_surface->geo.y,
-			&data.root_geo, render_surface_iterator, &data);
-	} else if (fullscreen_view) {
+	if (output_has_opaque_overlay_layer_surface(output)) {
+		goto render_overlay;
+	}
+
+	if (fullscreen_view) {
 		float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
 
 		int nrects;
@@ -894,6 +885,8 @@ void output_render(struct sway_output *output, struct timespec *when,
 		render_layer(output, damage,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
+
+render_overlay:
 	render_layer(output, damage,
 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]);
 	render_drag_icons(output, damage, &root_container.sway_root->drag_icons);


### PR DESCRIPTION
The rendering code doesn't use the exclusive input surface at all
anymore to decide to skip rendering of shell surfaces. This fixes
a weird situation in which a client requests exclusive input but
isn't an overlay layer surface.

The renderer also renders all overlay surfaces in this situation,
not just one. This simplifies the code and fixes rendering when
there are more than one overlay surfaces (e.g. for a virtual
keyboard to type the lockscreen password).