### PR TITLE
Refactor view_map

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -486,7 +486,7 @@ static struct sway_container *select_workspace(struct sway_view *view) {
 	for (int i = 0; i < criterias->length; ++i) {
 		struct criteria *criteria = criterias->items[i];
 		if (criteria->type == CT_ASSIGN_WORKSPACE) {
-			struct sway_container *ws = workspace_by_name(criteria->target);
+			ws = workspace_by_name(criteria->target);
 			if (!ws) {
 				ws = workspace_create(NULL, criteria->target);
 			}


### PR DESCRIPTION
* Move workspace selection into separate function
* Instead of keeping a `prev_focus` variable, do the check in `should_focus` (ie. views can only take focus if they're mapped into the active workspace)
* Fix assign-to-output - it previously set `prev_focus` but should be `target_sibling`
* Remove call to `workspace_switch` as we'll only ever focus the view if it's in the active workspace