### PR TITLE
fix #2355: "move workspace to output up" crashes

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -68,7 +68,9 @@ void container_create_notify(struct sway_container *container) {
 }
 
 static void container_update_textures_recursive(struct sway_container *con) {
-	container_update_title_textures(con);
+	if (con->type == C_CONTAINER || con->type == C_VIEW) {
+		container_update_title_textures(con);
+	}
 
 	if (con->type == C_VIEW) {
 		view_update_marks_textures(con->sway_view);


### PR DESCRIPTION
when using 2 display, if scaling is different
`container_update_textures_recursive` is called when moving workspace on
different display.
We need to call `container_update_title_textures` only for container of type
"CONTAINER" or "VIEW" in order to be consistent with the assert in
`update_title_texture`.