### PR TITLE
Allow containers to float

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -124,6 +124,9 @@ struct sway_container *seat_get_focus(struct sway_seat *seat);
 struct sway_container *seat_get_focus_inactive(struct sway_seat *seat,
 		struct sway_container *container);
 
+struct sway_container *seat_get_focus_inactive_tiling(struct sway_seat *seat,
+		struct sway_container *container);
+
 /**
  * Descend into the focus stack to find the focus-inactive view. Useful for
  * container placement when they change position in the tree.

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -297,6 +297,11 @@ void container_notify_subtree_changed(struct sway_container *container);
  */
 size_t container_titlebar_height(void);
 
+/**
+ * Resize and center the container in its workspace.
+ */
+void container_init_floating(struct sway_container *container);
+
 void container_set_floating(struct sway_container *container, bool enable);
 
 void container_set_geometry_from_floating_view(struct sway_container *con);
@@ -339,6 +344,12 @@ bool container_has_urgent_child(struct sway_container *container);
 void container_end_mouse_operation(struct sway_container *container);
 
 void container_set_fullscreen(struct sway_container *container, bool enable);
+
+/**
+ * Return true if the container is floating, or a child of a floating split
+ * container.
+ */
+bool container_is_floating_or_child(struct sway_container *container);
 
 /**
  * Return true if the container is fullscreen, or a child of a fullscreen split

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -235,11 +235,6 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 	int height);
 
 /**
- * Center the view in its workspace and build the swayc decorations around it.
- */
-void view_init_floating(struct sway_view *view);
-
-/**
  * Configure the view's position and size based on the swayc's position and
  * size, taking borders into consideration.
  */

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -29,6 +29,14 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		seat_set_focus(config->handler_context.seat, container);
 	}
 
+	// If the container is in a floating split container,
+	// operate on the split container instead of the child.
+	if (container_is_floating_or_child(container)) {
+		while (container->parent->layout != L_FLOATING) {
+			container = container->parent;
+		}
+	}
+
 	bool wants_floating;
 	if (strcasecmp(argv[0], "enable") == 0) {
 		wants_floating = true;

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -17,9 +17,16 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 	}
 	struct sway_container *container =
 		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
-		// TODO: This doesn't strictly speaking have to be true
-		return cmd_results_new(CMD_INVALID, "float", "Only views can float");
+	if (container->type == C_WORKSPACE && container->children->length == 0) {
+		return cmd_results_new(CMD_INVALID, "floating",
+				"Can't float an empty workspace");
+	}
+	if (container->type == C_WORKSPACE) {
+		// Wrap the workspace's children in a container so we can float it
+		struct sway_container *workspace = container;
+		container = container_wrap_children(container);
+		workspace->layout = L_HORIZ;
+		seat_set_focus(config->handler_context.seat, container);
 	}
 
 	bool wants_floating;

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -35,14 +35,16 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 		struct sway_seat *seat, bool floating) {
 	struct sway_container *ws = con->type == C_WORKSPACE ?
 		con : container_parent(con, C_WORKSPACE);
-	struct sway_container *new_focus = ws;
+	struct sway_container *new_focus = NULL;
 	if (floating) {
-		new_focus = ws->sway_workspace->floating;
-		if (new_focus->children->length == 0) {
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
-		}
+		new_focus = seat_get_focus_inactive(seat, ws->sway_workspace->floating);
+	} else {
+		new_focus = seat_get_focus_inactive_tiling(seat, ws);
 	}
-	seat_set_focus(seat, seat_get_active_child(seat, new_focus));
+	if (!new_focus) {
+		new_focus = ws;
+	}
+	seat_set_focus(seat, new_focus);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -35,6 +35,15 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 		struct sway_seat *seat, bool floating) {
 	struct sway_container *ws = con->type == C_WORKSPACE ?
 		con : container_parent(con, C_WORKSPACE);
+
+	// If the container is in a floating split container,
+	// operate on the split container instead of the child.
+	if (container_is_floating_or_child(con)) {
+		while (con->parent->layout != L_FLOATING) {
+			con = con->parent;
+		}
+	}
+
 	struct sway_container *new_focus = NULL;
 	if (floating) {
 		new_focus = seat_get_focus_inactive(seat, ws->sway_workspace->floating);
@@ -99,7 +108,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	} else if (strcmp(argv[0], "tiling") == 0) {
 		return focus_mode(con, seat, false);
 	} else if (strcmp(argv[0], "mode_toggle") == 0) {
-		return focus_mode(con, seat, !container_is_floating(con));
+		return focus_mode(con, seat, !container_is_floating_or_child(con));
 	}
 
 	if (strcmp(argv[0], "output") == 0) {

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -308,6 +308,15 @@ static struct cmd_results *move_to_scratchpad(struct sway_container *con) {
 		con = container_wrap_children(con);
 		workspace->layout = L_HORIZ;
 	}
+
+	// If the container is in a floating split container,
+	// operate on the split container instead of the child.
+	if (container_is_floating_or_child(con)) {
+		while (con->parent->layout != L_FLOATING) {
+			con = con->parent;
+		}
+	}
+
 	if (con->scratchpad) {
 		return cmd_results_new(CMD_INVALID, "move",
 				"Container is already in the scratchpad");

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -298,9 +298,15 @@ static struct cmd_results *move_to_position(struct sway_container *container,
 }
 
 static struct cmd_results *move_to_scratchpad(struct sway_container *con) {
-	if (con->type != C_CONTAINER && con->type != C_VIEW) {
+	if (con->type == C_WORKSPACE && con->children->length == 0) {
 		return cmd_results_new(CMD_INVALID, "move",
-				"Only views and containers can be moved to the scratchpad");
+				"Can't move an empty workspace to the scratchpad");
+	}
+	if (con->type == C_WORKSPACE) {
+		// Wrap the workspace's children in a container
+		struct sway_container *workspace = con;
+		con = container_wrap_children(con);
+		workspace->layout = L_HORIZ;
 	}
 	if (con->scratchpad) {
 		return cmd_results_new(CMD_INVALID, "move",

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -19,11 +19,19 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 	}
 
 	if (config->handler_context.using_criteria) {
+		struct sway_container *con = config->handler_context.current_container;
+
+		// If the container is in a floating split container,
+		// operate on the split container instead of the child.
+		if (container_is_floating_or_child(con)) {
+			while (con->parent->layout != L_FLOATING) {
+				con = con->parent;
+			}
+		}
+
 		// If using criteria, this command is executed for every container which
 		// matches the criteria. If this container isn't in the scratchpad,
 		// we'll just silently return a success.
-		struct sway_container *con = config->handler_context.current_container;
-		wlr_log(WLR_INFO, "cmd_scratchpad(%s)", con->name);
 		if (!con->scratchpad) {
 			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 		}

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -10,10 +10,6 @@
 
 static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.current_container;
-	if (container_is_floating(con)) {
-		return cmd_results_new(CMD_FAILURE, "split",
-			"Can't split a floating view");
-	}
 	struct sway_container *parent = container_split(con, layout);
 	container_create_notify(parent);
 	arrange_windows(parent->parent);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -779,7 +779,7 @@ static void render_floating_container(struct sway_output *soutput,
 		}
 		render_view(soutput, damage, con, colors);
 	} else {
-		render_container(soutput, damage, con, false);
+		render_container(soutput, damage, con, con->current.focused);
 	}
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -598,7 +598,10 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			seat_set_focus_layer(cursor->seat, layer);
 		}
 		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
-	} else if (cont && container_is_floating(cont)) {
+	} else if (cont && container_is_floating_or_child(cont)) {
+		while (cont->parent->layout != L_FLOATING) {
+			cont = cont->parent;
+		}
 		dispatch_cursor_button_floating(cursor, time_msec, button, state,
 				surface, sx, sy, cont);
 	} else if (surface && cont && cont->type != C_VIEW) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -184,7 +184,6 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 	bool set_focus =
 		focus != NULL &&
 		(focus == con || container_has_child(con, focus)) &&
-		con->parent && con->parent->children->length > 1 &&
 		con->type != C_WORKSPACE;
 
 	seat_container_destroy(seat_con);
@@ -752,10 +751,6 @@ void seat_set_focus_warp(struct sway_seat *seat,
 				}
 			}
 		}
-	}
-
-	if (last_focus != NULL) {
-		cursor_send_pointer_motion(seat->cursor, 0, true);
 	}
 
 	seat->has_focus = (container != NULL);

--- a/sway/scratchpad.c
+++ b/sway/scratchpad.c
@@ -72,11 +72,7 @@ static void scratchpad_show(struct sway_container *con) {
 	if (!wlr_box_contains_point(&workspace_box, center_lx, center_ly)) {
 		// Maybe resize it
 		if (con->width > ws->width || con->height > ws->height) {
-			// TODO: Do this properly once we can float C_CONTAINERs
-			if (con->type == C_VIEW) {
-				view_init_floating(con->sway_view);
-				arrange_windows(con);
-			}
+			container_init_floating(con);
 		}
 
 		// Center it
@@ -85,6 +81,7 @@ static void scratchpad_show(struct sway_container *con) {
 		container_floating_move_to(con, new_lx, new_ly);
 	}
 
+	arrange_windows(ws);
 	seat_set_focus(seat, con);
 
 	container_set_dirty(con->parent);

--- a/sway/scratchpad.c
+++ b/sway/scratchpad.c
@@ -110,6 +110,15 @@ void scratchpad_toggle_auto(void) {
 	struct sway_container *ws = focus->type == C_WORKSPACE ?
 		focus : container_parent(focus, C_WORKSPACE);
 
+	// If the focus is in a floating split container,
+	// operate on the split container instead of the child.
+	if (container_is_floating_or_child(focus)) {
+		while (focus->parent->layout != L_FLOATING) {
+			focus = focus->parent;
+		}
+	}
+
+
     // Check if the currently focused window is a scratchpad window and should
     // be hidden again.
 	if (focus->scratchpad) {

--- a/sway/scratchpad.c
+++ b/sway/scratchpad.c
@@ -82,7 +82,7 @@ static void scratchpad_show(struct sway_container *con) {
 	}
 
 	arrange_windows(ws);
-	seat_set_focus(seat, con);
+	seat_set_focus(seat, seat_get_focus_inactive(seat, con));
 
 	container_set_dirty(con->parent);
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1015,6 +1015,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		return;
 	}
 
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
 
 	if (enable) {
@@ -1029,8 +1030,10 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		if (container->scratchpad) {
 			scratchpad_remove_container(container);
 		}
+		struct sway_container *sibling =
+			seat_get_focus_inactive_tiling(seat, workspace);
 		container_remove_child(container);
-		container_add_child(workspace, container);
+		container_add_child(sibling, container);
 		container->width = container->parent->width;
 		container->height = container->parent->height;
 		if (container->type == C_VIEW) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1033,7 +1033,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		struct sway_container *sibling =
 			seat_get_focus_inactive_tiling(seat, workspace);
 		container_remove_child(container);
-		container_add_child(sibling, container);
+		container_add_sibling(sibling, container);
 		container->width = container->parent->width;
 		container->height = container->parent->height;
 		if (container->type == C_VIEW) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -407,6 +407,10 @@ struct sway_container *container_flatten(struct sway_container *container) {
  * This function just wraps container_destroy_noreaping(), then does reaping.
  */
 struct sway_container *container_destroy(struct sway_container *con) {
+	if (con->is_fullscreen) {
+		struct sway_container *ws = container_parent(con, C_WORKSPACE);
+		ws->sway_workspace->fullscreen = NULL;
+	}
 	struct sway_container *parent = container_destroy_noreaping(con);
 
 	if (!parent) {
@@ -945,23 +949,81 @@ size_t container_titlebar_height() {
 	return config->font_height + TITLEBAR_V_PADDING * 2;
 }
 
+void container_init_floating(struct sway_container *con) {
+	if (!sway_assert(con->type == C_VIEW || con->type == C_CONTAINER,
+			"Expected a view or container")) {
+		return;
+	}
+	struct sway_container *ws = container_parent(con, C_WORKSPACE);
+	int min_width, min_height;
+	int max_width, max_height;
+
+	if (config->floating_minimum_width == -1) { // no minimum
+		min_width = 0;
+	} else if (config->floating_minimum_width == 0) { // automatic
+		min_width = 75;
+	} else {
+		min_width = config->floating_minimum_width;
+	}
+
+	if (config->floating_minimum_height == -1) { // no minimum
+		min_height = 0;
+	} else if (config->floating_minimum_height == 0) { // automatic
+		min_height = 50;
+	} else {
+		min_height = config->floating_minimum_height;
+	}
+
+	if (config->floating_maximum_width == -1) { // no maximum
+		max_width = INT_MAX;
+	} else if (config->floating_maximum_width == 0) { // automatic
+		max_width = ws->width * 0.6666;
+	} else {
+		max_width = config->floating_maximum_width;
+	}
+
+	if (config->floating_maximum_height == -1) { // no maximum
+		max_height = INT_MAX;
+	} else if (config->floating_maximum_height == 0) { // automatic
+		max_height = ws->height * 0.6666;
+	} else {
+		max_height = config->floating_maximum_height;
+	}
+
+	if (con->type == C_CONTAINER) {
+		con->width = max_width;
+		con->height = max_height;
+		con->x = ws->x + (ws->width - con->width) / 2;
+		con->y = ws->y + (ws->height - con->height) / 2;
+	} else {
+		struct sway_view *view = con->sway_view;
+		view->width = fmax(min_width, fmin(view->natural_width, max_width));
+		view->height = fmax(min_height, fmin(view->natural_height, max_height));
+		view->x = ws->x + (ws->width - view->width) / 2;
+		view->y = ws->y + (ws->height - view->height) / 2;
+
+		// If the view's border is B_NONE then these properties are ignored.
+		view->border_top = view->border_bottom = true;
+		view->border_left = view->border_right = true;
+
+		container_set_geometry_from_floating_view(view->swayc);
+	}
+}
+
 void container_set_floating(struct sway_container *container, bool enable) {
 	if (container_is_floating(container) == enable) {
 		return;
 	}
 
 	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
 
 	if (enable) {
 		container_remove_child(container);
 		container_add_child(workspace->sway_workspace->floating, container);
+		container_init_floating(container);
 		if (container->type == C_VIEW) {
-			view_init_floating(container->sway_view);
 			view_set_tiled(container->sway_view, false);
 		}
-		seat_set_focus(seat, seat_get_focus_inactive(seat, container));
-		container_reap_empty_recursive(workspace);
 	} else {
 		// Returning to tiled
 		if (container->scratchpad) {
@@ -975,7 +1037,6 @@ void container_set_floating(struct sway_container *container, bool enable) {
 			view_set_tiled(container->sway_view, true);
 		}
 		container->is_sticky = false;
-		container_reap_empty_recursive(workspace->sway_workspace->floating);
 	}
 
 	container_end_mouse_operation(container);
@@ -1193,6 +1254,17 @@ void container_set_fullscreen(struct sway_container *container, bool enable) {
 	container_end_mouse_operation(container);
 
 	ipc_event_window(container, "fullscreen_mode");
+}
+
+bool container_is_floating_or_child(struct sway_container *container) {
+	do {
+		if (container->parent && container->parent->layout == L_FLOATING) {
+			return true;
+		}
+		container = container->parent;
+	} while (container && container->type != C_WORKSPACE);
+
+	return false;
 }
 
 bool container_is_fullscreen_or_child(struct sway_container *container) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1030,10 +1030,13 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		if (container->scratchpad) {
 			scratchpad_remove_container(container);
 		}
-		struct sway_container *sibling =
-			seat_get_focus_inactive_tiling(seat, workspace);
 		container_remove_child(container);
-		container_add_sibling(sibling, container);
+		struct sway_container *reference =
+			seat_get_focus_inactive_tiling(seat, workspace);
+		if (reference->type == C_VIEW) {
+			reference = reference->parent;
+		}
+		container_add_child(reference, container);
 		container->width = container->parent->width;
 		container->height = container->parent->height;
 		if (container->type == C_VIEW) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -168,55 +168,6 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 	return 0;
 }
 
-void view_init_floating(struct sway_view *view) {
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	int min_width, min_height;
-	int max_width, max_height;
-
-	if (config->floating_minimum_width == -1) { // no minimum
-		min_width = 0;
-	} else if (config->floating_minimum_width == 0) { // automatic
-		min_width = 75;
-	} else {
-		min_width = config->floating_minimum_width;
-	}
-
-	if (config->floating_minimum_height == -1) { // no minimum
-		min_height = 0;
-	} else if (config->floating_minimum_height == 0) { // automatic
-		min_height = 50;
-	} else {
-		min_height = config->floating_minimum_height;
-	}
-
-	if (config->floating_maximum_width == -1) { // no maximum
-		max_width = INT_MAX;
-	} else if (config->floating_maximum_width == 0) { // automatic
-		max_width = ws->width * 0.6666;
-	} else {
-		max_width = config->floating_maximum_width;
-	}
-
-	if (config->floating_maximum_height == -1) { // no maximum
-		max_height = INT_MAX;
-	} else if (config->floating_maximum_height == 0) { // automatic
-		max_height = ws->height * 0.6666;
-	} else {
-		max_height = config->floating_maximum_height;
-	}
-
-	view->width = fmax(min_width, fmin(view->natural_width, max_width));
-	view->height = fmax(min_height, fmin(view->natural_height, max_height));
-	view->x = ws->x + (ws->width - view->width) / 2;
-	view->y = ws->y + (ws->height - view->height) / 2;
-
-	// If the view's border is B_NONE then these properties are ignored.
-	view->border_top = view->border_bottom = true;
-	view->border_left = view->border_right = true;
-
-	container_set_geometry_from_floating_view(view->swayc);
-}
-
 void view_autoconfigure(struct sway_view *view) {
 	if (!sway_assert(view->swayc,
 				"Called view_autoconfigure() on a view without a swayc")) {
@@ -626,10 +577,8 @@ void view_unmap(struct sway_view *view) {
 	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
 
 	struct sway_container *parent;
-	if (view->swayc->is_fullscreen) {
-		ws->sway_workspace->fullscreen = NULL;
+	if (container_is_fullscreen_or_child(view->swayc)) {
 		parent = container_destroy(view->swayc);
-
 		arrange_windows(ws->parent);
 	} else {
 		parent = container_destroy(view->swayc);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -999,11 +999,14 @@ void view_update_marks_textures(struct sway_view *view) {
 }
 
 bool view_is_visible(struct sway_view *view) {
-	if (!view->swayc || view->swayc->destroying || !view->swayc->parent) {
+	if (!view->swayc || view->swayc->destroying) {
 		return false;
 	}
 	struct sway_container *workspace =
 		container_parent(view->swayc, C_WORKSPACE);
+	if (!workspace) {
+		return false;
+	}
 	// Determine if view is nested inside a floating container which is sticky.
 	// A simple floating view will have this ancestry:
 	// C_VIEW -> floating -> workspace


### PR DESCRIPTION
Things worth noting:

* When a fullscreen view unmaps, the check to unset fullscreen on the workspace has been moved out of `view_unmap` and into `container_destroy`, because containers can be fullscreen too
* The calls to `container_reap_empty_recursive(workspace)` have been removed from `container_set_floating`. That function reaps upwards so it wouldn't do anything. I'm probably the one who originally added it...
* My fix (b14bd1b0b1536039e4f46fe94515c7c44e7afc61) for the tabbed child crash has a side effect where when you close a floating container, focus is not given to the tiled container again. I've removed my fix and removed the call to `send_cursor_motion` from `seat_set_focus_warp`. We should consider calling it from somewhere earlier in the call stack.

Test plan:

* `focus parent` then `floating enable` with different layout types
* Try to move children of floating containers out of the container
* Fullscreen floating containers
* Send containers to the scratchpad
* Use `floating_modifier` to move and resize a floating container