### PR TITLE
Fix crash when a deferred command destroys a workspace

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -142,8 +142,6 @@ struct sway_container *container_create(enum sway_container_type type) {
 static void container_workspace_free(struct sway_workspace *ws) {
 	list_foreach(ws->output_priority, free);
 	list_free(ws->output_priority);
-	ws->floating->destroying = true;
-	container_free(ws->floating);
 	free(ws);
 }
 
@@ -196,6 +194,9 @@ void container_free(struct sway_container *cont) {
 	free(cont);
 }
 
+static struct sway_container *container_destroy_noreaping(
+		struct sway_container *con);
+
 static struct sway_container *container_workspace_destroy(
 		struct sway_container *workspace) {
 	if (!sway_assert(workspace, "cannot destroy null workspace")) {
@@ -239,6 +240,8 @@ static struct sway_container *container_workspace_destroy(
 					new_workspace->sway_workspace->floating);
 		}
 	}
+
+	container_destroy_noreaping(workspace->sway_workspace->floating);
 
 	return output;
 }


### PR DESCRIPTION
Example config that produces the crash (with a single output):

    workspace 1
    workspace 2

I'm not sure on the specifics as to why it fails, but this fixes it by committing a transaction after each deferred command.