### PR TITLE
Refactor surface iterators

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -39,16 +39,6 @@ struct sway_output {
 	} events;
 };
 
-/**
- * Contains a surface's root geometry information. For instance, when rendering
- * a popup, this will contain the parent view's position and size.
- */
-struct root_geometry {
-	double x, y;
-	int width, height;
-	float rotation;
-};
-
 typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
 	struct wlr_surface *surface, struct wlr_box *box, float rotation,
 	void *user_data);
@@ -76,14 +66,6 @@ struct sway_container *output_get_active_workspace(struct sway_output *output);
 
 void output_render(struct sway_output *output, struct timespec *when,
 	pixman_region32_t *damage);
-
-bool output_get_surface_box(struct root_geometry *geo,
-	struct sway_output *output, struct wlr_surface *surface, int sx, int sy,
-	struct wlr_box *surface_box);
-
-void output_surface_for_each_surface(struct wlr_surface *surface,
-	double ox, double oy, struct root_geometry *geo,
-	wlr_surface_iterator_func_t iterator, void *user_data);
 
 void output_surface_for_each_surface2(struct sway_output *output,
 	struct wlr_surface *surface, double ox, double oy, float rotation,

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -5,6 +5,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
+#include "config.h"
 #include "sway/tree/view.h"
 
 struct sway_server;
@@ -48,6 +49,10 @@ struct root_geometry {
 	float rotation;
 };
 
+typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
+	struct wlr_surface *surface, struct wlr_box *box, float rotation,
+	void *user_data);
+
 void output_damage_whole(struct sway_output *output);
 
 void output_damage_surface(struct sway_output *output, double ox, double oy,
@@ -80,6 +85,10 @@ void output_surface_for_each_surface(struct wlr_surface *surface,
 	double ox, double oy, struct root_geometry *geo,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
+void output_surface_for_each_surface2(struct sway_output *output,
+	struct wlr_surface *surface, double ox, double oy, float rotation,
+	sway_surface_iterator_func_t iterator, void *user_data);
+
 void output_view_for_each_surface(struct sway_view *view,
 	struct sway_output *output, struct root_geometry *geo,
 	wlr_surface_iterator_func_t iterator, void *user_data);
@@ -88,9 +97,11 @@ void output_layer_for_each_surface(struct wl_list *layer_surfaces,
 	struct root_geometry *geo, wlr_surface_iterator_func_t iterator,
 	void *user_data);
 
-void output_unmanaged_for_each_surface(struct wl_list *unmanaged,
-	struct sway_output *output, struct root_geometry *geo,
-	wlr_surface_iterator_func_t iterator, void *user_data);
+#ifdef HAVE_XWAYLAND
+void output_unmanaged_for_each_surface(struct sway_output *output,
+	struct wl_list *unmanaged, sway_surface_iterator_func_t iterator,
+	void *user_data);
+#endif
 
 void output_drag_icons_for_each_surface(struct wl_list *drag_icons,
 	struct sway_output *output, struct root_geometry *geo,

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -93,8 +93,8 @@ void output_view_for_each_surface(struct sway_view *view,
 	struct sway_output *output, struct root_geometry *geo,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
-void output_layer_for_each_surface(struct wl_list *layer_surfaces,
-	struct root_geometry *geo, wlr_surface_iterator_func_t iterator,
+void output_layer_for_each_surface(struct sway_output *output,
+	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
 #ifdef HAVE_XWAYLAND

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -89,9 +89,9 @@ void output_surface_for_each_surface2(struct sway_output *output,
 	struct wlr_surface *surface, double ox, double oy, float rotation,
 	sway_surface_iterator_func_t iterator, void *user_data);
 
-void output_view_for_each_surface(struct sway_view *view,
-	struct sway_output *output, struct root_geometry *geo,
-	wlr_surface_iterator_func_t iterator, void *user_data);
+void output_view_for_each_surface(struct sway_output *output,
+	struct sway_view *view, sway_surface_iterator_func_t iterator,
+	void *user_data);
 
 void output_layer_for_each_surface(struct sway_output *output,
 	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -103,8 +103,8 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 	void *user_data);
 #endif
 
-void output_drag_icons_for_each_surface(struct wl_list *drag_icons,
-	struct sway_output *output, struct root_geometry *geo,
-	wlr_surface_iterator_func_t iterator, void *user_data);
+void output_drag_icons_for_each_surface(struct sway_output *output,
+	struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
+	void *user_data);
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -67,10 +67,6 @@ struct sway_container *output_get_active_workspace(struct sway_output *output);
 void output_render(struct sway_output *output, struct timespec *when,
 	pixman_region32_t *damage);
 
-void output_surface_for_each_surface2(struct sway_output *output,
-	struct wlr_surface *surface, double ox, double oy, float rotation,
-	sway_surface_iterator_func_t iterator, void *user_data);
-
 void output_view_for_each_surface(struct sway_output *output,
 	struct sway_view *view, sway_surface_iterator_func_t iterator,
 	void *user_data);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -119,8 +119,8 @@ void output_surface_for_each_surface_iterator(struct wlr_surface *surface,
 		data->user_data);
 }
 
-void output_surface_for_each_surface(struct sway_output *output,
-		struct wlr_surface *surface, double ox, double oy, float rotation,
+static void output_surface_for_each_surface(struct sway_output *output,
+		struct wlr_surface *surface, double ox, double oy,
 		sway_surface_iterator_func_t iterator, void *user_data) {
 	struct surface_iterator_data data = {
 		.user_iterator = iterator,
@@ -130,7 +130,7 @@ void output_surface_for_each_surface(struct sway_output *output,
 		.oy = oy,
 		.width = surface->current.width,
 		.height = surface->current.height,
-		.rotation = rotation,
+		.rotation = 0,
 	};
 
 	wlr_surface_for_each_surface(surface,
@@ -163,7 +163,7 @@ void output_layer_for_each_surface(struct sway_output *output,
 		struct wlr_layer_surface *wlr_layer_surface =
 			layer_surface->layer_surface;
 		output_surface_for_each_surface(output, wlr_layer_surface->surface,
-			layer_surface->geo.x, layer_surface->geo.y, 0, iterator,
+			layer_surface->geo.x, layer_surface->geo.y, iterator,
 			user_data);
 	}
 }
@@ -179,7 +179,7 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 		double ox = unmanaged_surface->lx - output->swayc->current.swayc_x;
 		double oy = unmanaged_surface->ly - output->swayc->current.swayc_y;
 
-		output_surface_for_each_surface(output, xsurface->surface, ox, oy, 0,
+		output_surface_for_each_surface(output, xsurface->surface, ox, oy,
 			iterator, user_data);
 	}
 }
@@ -195,7 +195,7 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 
 		if (drag_icon->wlr_drag_icon->mapped) {
 			output_surface_for_each_surface(output,
-				drag_icon->wlr_drag_icon->surface, ox, oy, 0,
+				drag_icon->wlr_drag_icon->surface, ox, oy,
 				iterator, user_data);
 		}
 	}
@@ -430,7 +430,7 @@ static void damage_surface_iterator(struct sway_output *output,
 
 void output_damage_surface(struct sway_output *output, double ox, double oy,
 		struct wlr_surface *surface, bool whole) {
-	output_surface_for_each_surface(output, surface, ox, oy, 0,
+	output_surface_for_each_surface(output, surface, ox, oy,
 		damage_surface_iterator, &whole);
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -197,17 +197,18 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 }
 #endif
 
-void output_drag_icons_for_each_surface(struct wl_list *drag_icons,
-		struct sway_output *output, struct root_geometry *geo,
-		wlr_surface_iterator_func_t iterator, void *user_data) {
+void output_drag_icons_for_each_surface(struct sway_output *output,
+		struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
+		void *user_data) {
 	struct sway_drag_icon *drag_icon;
 	wl_list_for_each(drag_icon, drag_icons, link) {
 		double ox = drag_icon->x - output->swayc->x;
 		double oy = drag_icon->y - output->swayc->y;
 
 		if (drag_icon->wlr_drag_icon->mapped) {
-			output_surface_for_each_surface(drag_icon->wlr_drag_icon->surface,
-				ox, oy, geo, iterator, user_data);
+			output_surface_for_each_surface2(output,
+				drag_icon->wlr_drag_icon->surface, ox, oy, 0,
+				iterator, user_data);
 		}
 	}
 }
@@ -303,8 +304,8 @@ static void send_frame_done_unmanaged(struct send_frame_done_data *data,
 
 static void send_frame_done_drag_icons(struct send_frame_done_data *data,
 		struct wl_list *drag_icons) {
-	output_drag_icons_for_each_surface(drag_icons, data->output, &data->root_geo,
-		send_frame_done_iterator, data);
+	output_drag_icons_for_each_surface(data->output, drag_icons,
+		send_frame_done_iterator2, data);
 }
 
 static void send_frame_done_container_iterator(struct sway_container *con,

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -534,10 +534,6 @@ static void handle_scale(struct wl_listener *listener, void *data) {
 	transaction_commit_dirty();
 }
 
-struct sway_output *output_from_wlr_output(struct wlr_output *wlr_output) {
-	return wlr_output->data;
-}
-
 void handle_new_output(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -105,7 +105,7 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	return wlr_box_intersection(&output_box, &rotated_box, &intersection);
 }
 
-void output_surface_for_each_surface_iterator(struct wlr_surface *surface,
+static void output_for_each_surface_iterator(struct wlr_surface *surface,
 		int sx, int sy, void *_data) {
 	struct surface_iterator_data *data = _data;
 
@@ -134,7 +134,7 @@ static void output_surface_for_each_surface(struct sway_output *output,
 	};
 
 	wlr_surface_for_each_surface(surface,
-		output_surface_for_each_surface_iterator, &data);
+		output_for_each_surface_iterator, &data);
 }
 
 void output_view_for_each_surface(struct sway_output *output,
@@ -152,7 +152,7 @@ void output_view_for_each_surface(struct sway_output *output,
 	};
 
 	view_for_each_surface(view,
-		output_surface_for_each_surface_iterator, &data);
+		output_for_each_surface_iterator, &data);
 }
 
 void output_layer_for_each_surface(struct sway_output *output,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -155,8 +155,8 @@ static void render_layer(struct sway_output *output,
 		.damage = damage,
 		.alpha = 1.0f,
 	};
-	output_layer_for_each_surface(layer_surfaces, &data.root_geo,
-		render_surface_iterator, &data);
+	output_layer_for_each_surface(output, layer_surfaces,
+		render_surface_iterator2, &data);
 }
 
 #ifdef HAVE_XWAYLAND

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -231,8 +231,7 @@ static void render_view_surfaces(struct sway_view *view,
 		.view = view,
 		.alpha = alpha,
 	};
-	output_view_for_each_surface(view, output, &data.root_geo,
-		render_surface_iterator, &data);
+	output_view_for_each_surface(output, view, render_surface_iterator2, &data);
 }
 
 static void render_saved_view(struct sway_view *view,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -179,8 +179,8 @@ static void render_drag_icons(struct sway_output *output,
 		.damage = damage,
 		.alpha = 1.0f,
 	};
-	output_drag_icons_for_each_surface(drag_icons, output, &data.root_geo,
-		render_surface_iterator, &data);
+	output_drag_icons_for_each_surface(output, drag_icons,
+		render_surface_iterator2, &data);
 }
 
 static void render_rect(struct wlr_output *wlr_output,


### PR DESCRIPTION
The current iterators design is very confusing. This PR will:
- Remove `struct root_geometry`
- Remove `output_get_surface_box`

Updates #2291