### PR TITLE
Handle out-of-fd situations gracefully for transaction and urgent timers

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -319,9 +319,9 @@ static void transaction_commit(struct sway_transaction *transaction) {
 		if (transaction->timer) {
 			wl_event_source_timer_update(transaction->timer, txn_timeout_ms);
 		} else {
-			wlr_log(WLR_ERROR, "Unable to create transaction timer. "
-					"There might not be any available file descriptors. "
-					"Some imperfect frames might be rendered.");
+			wlr_log(WLR_ERROR, "Unable to create transaction timer (%s). "
+					"Some imperfect frames might be rendered.",
+					strerror(errno));
 			handle_timeout(transaction);
 		}
 	}

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -316,7 +316,14 @@ static void transaction_commit(struct sway_transaction *transaction) {
 		// Set up a timer which the views must respond within
 		transaction->timer = wl_event_loop_add_timer(server.wl_event_loop,
 				handle_timeout, transaction);
-		wl_event_source_timer_update(transaction->timer, txn_timeout_ms);
+		if (transaction->timer) {
+			wl_event_source_timer_update(transaction->timer, txn_timeout_ms);
+		} else {
+			wlr_log(WLR_ERROR, "Unable to create transaction timer. "
+					"There might not be any available file descriptors. "
+					"Some imperfect frames might be rendered.");
+			handle_timeout(transaction);
+		}
 	}
 
 	// The debug tree shows the pending/live tree. Here is a good place to

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 199309L
 #include <assert.h>
+#include <errno.h>
 #ifdef __linux__
 #include <linux/input-event-codes.h>
 #elif __FreeBSD__

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -700,8 +700,8 @@ void seat_set_focus_warp(struct sway_seat *seat,
 				wl_event_source_timer_update(view->urgent_timer,
 						config->urgent_timeout);
 			} else {
-				wlr_log(WLR_ERROR, "Unable to create urgency timer. "
-						"There might not be any available file descriptors.");
+				wlr_log(WLR_ERROR, "Unable to create urgency timer (%s)",
+						strerror(errno));
 				handle_urgent_timeout(view);
 			}
 		} else {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -696,8 +696,14 @@ void seat_set_focus_warp(struct sway_seat *seat,
 				config->urgent_timeout > 0) {
 			view->urgent_timer = wl_event_loop_add_timer(server.wl_event_loop,
 					handle_urgent_timeout, view);
-			wl_event_source_timer_update(view->urgent_timer,
-					config->urgent_timeout);
+			if (view->urgent_timer) {
+				wl_event_source_timer_update(view->urgent_timer,
+						config->urgent_timeout);
+			} else {
+				wlr_log(WLR_ERROR, "Unable to create urgency timer. "
+						"There might not be any available file descriptors.");
+				handle_urgent_timeout(view);
+			}
 		} else {
 			view_set_urgent(view, false);
 		}


### PR DESCRIPTION
I tested it by changing the condition to `false`.