### PR TITLE
Don't enable numlock by default.

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -387,7 +387,7 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 	wlr_keyboard_set_keymap(wlr_device->keyboard, keyboard->keymap);
 
 	xkb_mod_mask_t locked_mods = 0;
-	if (!input_config || input_config->xkb_numlock != 0) {
+	if (input_config && input_config->xkb_numlock > 0) {
 		xkb_mod_index_t mod_index = xkb_map_mod_get_index(keymap, XKB_MOD_NAME_NUM);
 		if (mod_index != XKB_MOD_INVALID) {
 		       locked_mods |= (uint32_t)1 << mod_index;

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -39,7 +39,7 @@ The following commands may only be used in the configuration file.
 	Initially enables or disables CapsLock, the default is disabled.
 
 *input* <identifier> xkb\_numlock enabled|disabled
-	Initially enables or disables NumLock, the default is enabled.
+	Initially enables or disables NumLock, the default is disabled.
 
 ## MAPPING CONFIGURATION
 


### PR DESCRIPTION
This fixes a confusing issue where some laptop keyboards would have 'numlock mode' enabled, remapping parts of the alphabet to numbers.

It'd be great if we could detect keyboards with dedicated numpads and enable numlock by default, but that sounds really hard. :/