### PR TITLE
Fix title textures on scale change

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -270,6 +270,8 @@ int container_count_descendants_of_type(struct sway_container *con,
 
 void container_create_notify(struct sway_container *container);
 
+void container_update_textures_recursive(struct sway_container *con);
+
 void container_damage_whole(struct sway_container *container);
 
 bool container_reap_empty(struct sway_container *con);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -506,14 +506,10 @@ static void handle_transform(struct wl_listener *listener, void *data) {
 	transaction_commit_dirty();
 }
 
-static void handle_scale_iterator(struct sway_container *view, void *data) {
-	view_update_marks_textures(view->sway_view);
-}
-
 static void handle_scale(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, scale);
 	arrange_layers(output);
-	container_descendants(output->swayc, C_VIEW, handle_scale_iterator, NULL);
+	container_update_textures_recursive(output->swayc);
 	arrange_windows(output->swayc);
 	transaction_commit_dirty();
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -67,7 +67,7 @@ void container_create_notify(struct sway_container *container) {
 	}
 }
 
-static void container_update_textures_recursive(struct sway_container *con) {
+void container_update_textures_recursive(struct sway_container *con) {
 	if (con->type == C_CONTAINER || con->type == C_VIEW) {
 		container_update_title_textures(con);
 	}
@@ -78,6 +78,10 @@ static void container_update_textures_recursive(struct sway_container *con) {
 		for (int i = 0; i < con->children->length; ++i) {
 			struct sway_container *child = con->children->items[i];
 			container_update_textures_recursive(child);
+		}
+
+		if (con->type == C_WORKSPACE) {
+			container_update_textures_recursive(con->sway_workspace->floating);
 		}
 	}
 }


### PR DESCRIPTION
On an output scale change, only the title texture of the focused container and all marks textures were being updated.

This PR updates the title textures for all containers.

Test Plan:
- Open any number of views in various layouts (including floating)
- Add some marks
- Change the scale of the output
- Verify all title and marks textures are updated to use the correct scale