### PR TITLE
use standard ARRAY_SIZE() macro

### DIFF
--- a/common/unicode.c
+++ b/common/unicode.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "unicode.h"
+#include "util.h"
 
 size_t utf8_chsize(uint32_t ch) {
 	if (ch < 0x80) {
@@ -92,7 +93,7 @@ static const struct {
 
 int utf8_size(const char *s) {
 	uint8_t c = (uint8_t)*s;
-	for (size_t i = 0; i < sizeof(sizes) / sizeof(*sizes); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(sizes); ++i) {
 		if ((c & sizes[i].mask) == sizes[i].result) {
 			return sizes[i].octets;
 		}

--- a/common/util.c
+++ b/common/util.c
@@ -43,7 +43,7 @@ static struct modifier_key {
 
 uint32_t get_modifier_mask_by_name(const char *name) {
 	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+	for (i = 0; i < (int)(ARRAY_SIZE(modifiers)); ++i) {
 		if (strcasecmp(modifiers[i].name, name) == 0) {
 			return modifiers[i].mod;
 		}
@@ -54,7 +54,7 @@ uint32_t get_modifier_mask_by_name(const char *name) {
 
 const char *get_modifier_name_by_mask(uint32_t modifier) {
 	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+	for (i = 0; i < (int)(ARRAY_SIZE(modifiers)); ++i) {
 		if (modifiers[i].mod == modifier) {
 			return modifiers[i].name;
 		}
@@ -66,7 +66,7 @@ const char *get_modifier_name_by_mask(uint32_t modifier) {
 int get_modifier_names(const char **names, uint32_t modifier_masks) {
 	int length = 0;
 	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+	for (i = 0; i < (int)(ARRAY_SIZE(modifiers)); ++i) {
 		if ((modifier_masks & modifiers[i].mod) != 0) {
 			names[length] = modifiers[i].name;
 			++length;

--- a/include/util.h
+++ b/include/util.h
@@ -6,6 +6,8 @@
 #include <sys/types.h> 
 #include <xkbcommon/xkbcommon.h>
 
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a)[0])
+
 /**
  * Wrap i into the range [0, max[
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -15,6 +15,7 @@
 #include "sway/tree/view.h"
 #include "stringop.h"
 #include "log.h"
+#include "util.h"
 
 // Returns error object, or NULL if check succeeds.
 struct cmd_results *checkarg(int argc, const char *name, enum expected_args type, int val) {
@@ -177,7 +178,7 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 
 	if (!config_loading) {
 		res = bsearch(&d, command_handlers,
-				sizeof(command_handlers) / sizeof(struct cmd_handler),
+				ARRAY_SIZE(command_handlers),
 				sizeof(struct cmd_handler), handler_compare);
 
 		if (res) {
@@ -187,7 +188,7 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 
 	if (config->reading) {
 		res = bsearch(&d, config_handlers,
-				sizeof(config_handlers) / sizeof(struct cmd_handler),
+				ARRAY_SIZE(config_handlers),
 				sizeof(struct cmd_handler), handler_compare);
 
 		if (res) {
@@ -455,12 +456,12 @@ struct cmd_results *config_commands_command(char *exec) {
 
 	for (int i = 1; i < argc; ++i) {
 		size_t j;
-		for (j = 0; j < sizeof(context_names) / sizeof(context_names[0]); ++j) {
+		for (j = 0; j < ARRAY_SIZE(context_names); ++j) {
 			if (strcmp(context_names[j].name, argv[i]) == 0) {
 				break;
 			}
 		}
-		if (j == sizeof(context_names) / sizeof(context_names[0])) {
+		if (j == ARRAY_SIZE(context_names)) {
 			results = cmd_results_new(CMD_INVALID, cmd,
 					"Invalid command context %s", argv[i]);
 			goto cleanup;

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -3,6 +3,7 @@
 #include <strings.h>
 #include "sway/commands.h"
 #include "log.h"
+#include "util.h"
 
 struct cmd_results *bar_cmd_position(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -13,7 +14,7 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "position", "No bar defined.");
 	}
 	char *valid[] = { "top", "bottom", "left", "right" };
-	for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(valid); ++i) {
 		if (strcasecmp(valid[i], argv[0]) == 0) {
 			wlr_log(WLR_DEBUG, "Setting bar position '%s' for bar: %s",
 					argv[0], config->current_bar->id);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -16,6 +16,7 @@
 #include "sway/tree/workspace.h"
 #include "stringop.h"
 #include "list.h"
+#include "util.h"
 
 static const char* expected_syntax =
 	"Expected 'move <left|right|up|down> <[px] px>' or "
@@ -34,7 +35,7 @@ static struct sway_container *output_in_direction(const char *direction,
 		{ "left", WLR_DIRECTION_LEFT },
 		{ "right", WLR_DIRECTION_RIGHT },
 	};
-	for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(names); ++i) {
 		if (strcasecmp(names[i].name, direction) == 0) {
 			struct wlr_output *adjacent = wlr_output_layout_adjacent_output(
 					root_container.sway_root->output_layout,

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -8,6 +8,7 @@
 #include "sway/config.h"
 #include "log.h"
 #include "stringop.h"
+#include "util.h"
 
 static const char *bg_options[] = {
 	"stretch",
@@ -43,7 +44,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		size_t j;
 		for (j = 0; j < (size_t)argc; ++j) {
 			mode = argv[j];
-			size_t n = sizeof(bg_options) / sizeof(char *);
+			size_t n = ARRAY_SIZE(bg_options);
 			for (size_t k = 0; k < n; ++k) {
 				if (strcasecmp(mode, bg_options[k]) == 0) {
 					valid = true;

--- a/sway/config.c
+++ b/sway/config.c
@@ -34,6 +34,7 @@
 #include "stringop.h"
 #include "list.h"
 #include "log.h"
+#include "util.h"
 
 struct sway_config *config = NULL;
 
@@ -305,7 +306,7 @@ static char *get_config_path(void) {
 	char *path;
 
 	int i;
-	for (i = 0; i < (int)(sizeof(config_paths) / sizeof(char *)); ++i) {
+	for (i = 0; i < (int)(ARRAY_SIZE(config_paths)); ++i) {
 		if (wordexp(config_paths[i], &p, 0) == 0) {
 			path = strdup(p.we_wordv[0]);
 			wordfree(&p);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -14,6 +14,7 @@
 #include "sway/server.h"
 #include "sway/tree/layout.h"
 #include "log.h"
+#include "util.h"
 
 static void apply_exclusive(struct wlr_box *usable_area,
 		uint32_t anchor, int32_t exclusive,
@@ -65,7 +66,7 @@ static void apply_exclusive(struct wlr_box *usable_area,
 			.margin = margin_right,
 		},
 	};
-	for (size_t i = 0; i < sizeof(edges) / sizeof(edges[0]); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(edges); ++i) {
 		if ((anchor & edges[i].anchors) == edges[i].anchors) {
 			if (edges[i].positive_axis) {
 				*edges[i].positive_axis += exclusive + edges[i].margin;
@@ -193,7 +194,7 @@ void arrange_layers(struct sway_output *output) {
 		ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY,
 		ZWLR_LAYER_SHELL_V1_LAYER_TOP,
 	};
-	size_t nlayers = sizeof(layers_above_shell) / sizeof(layers_above_shell[0]);
+	size_t nlayers = ARRAY_SIZE(layers_above_shell);
 	struct sway_layer_surface *layer, *topmost = NULL;
 	for (size_t i = 0; i < nlayers; ++i) {
 		wl_list_for_each_reverse(layer,

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -15,6 +15,7 @@
 #include <wlr/util/region.h>
 #include "log.h"
 #include "config.h"
+#include "util.h"
 #include "sway/config.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -559,7 +560,7 @@ void output_enable(struct sway_output *output) {
 		return;
 	}
 
-	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
+	size_t len = ARRAY_SIZE(output->layers);
 	for (size_t i = 0; i < len; ++i) {
 		wl_list_init(&output->layers[i]);
 	}

--- a/sway/main.c
+++ b/sway/main.c
@@ -129,7 +129,7 @@ static void log_env() {
 		"SWAY_CURSOR_SIZE",
 		"SWAYSOCK"
 	};
-	for (size_t i = 0; i < sizeof(log_vars) / sizeof(char *); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(log_vars); ++i) {
 		wlr_log(WLR_INFO, "%s=%s", log_vars[i], getenv(log_vars[i]));
 	}
 }
@@ -142,7 +142,7 @@ static void log_distro() {
 		"/etc/redhat-release",
 		"/etc/gentoo-release",
 	};
-	for (size_t i = 0; i < sizeof(paths) / sizeof(char *); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(paths); ++i) {
 		FILE *f = fopen(paths[i], "r");
 		if (f) {
 			wlr_log(WLR_INFO, "Contents of %s:", paths[i]);

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -7,6 +7,7 @@
 #include <wlr/util/log.h>
 #include "swaybar/config.h"
 #include "swaybar/status_line.h"
+#include "util.h"
 
 void i3bar_block_free(struct i3bar_block *block) {
 	if (!block) {
@@ -146,8 +147,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 			switch (*cur) {
 			case '[':
 				++state->depth;
-				if (state->depth >
-						sizeof(state->nodes) / sizeof(state->nodes[0])) {
+				if (state->depth > ARRAY_SIZE(state->nodes)) {
 					status_error(status, "[i3bar json too deep]");
 					return false;
 				}
@@ -177,8 +177,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 				break;
 			case '"':
 				++state->depth;
-				if (state->depth >
-						sizeof(state->nodes) / sizeof(state->nodes[0])) {
+				if (state->depth > ARRAY_SIZE(state->nodes)) {
 					status_error(status, "[i3bar json too deep]");
 					return false;
 				}

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -783,7 +783,7 @@ static char *get_config_path(void) {
 
 	wordexp_t p;
 	char *path;
-	for (size_t i = 0; i < sizeof(config_paths) / sizeof(char *); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(config_paths); ++i) {
 		if (wordexp(config_paths[i], &p, 0) == 0) {
 			path = strdup(p.we_wordv[0]);
 			wordfree(&p);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -14,6 +14,7 @@
 #include "ipc-client.h"
 #include "readline.h"
 #include "log.h"
+#include "util.h"
 
 void sway_terminate(int exit_code) {
 	exit(exit_code);
@@ -101,7 +102,7 @@ static const char *pretty_type_name(const char *name) {
 		{ "touch", "Touch" },
 	};
 
-	for (size_t i = 0; i < sizeof(type_names) / sizeof(type_names[0]); ++i) {
+	for (size_t i = 0; i < ARRAY_SIZE(type_names); ++i) {
 		if (strcmp(type_names[i].a, name) == 0) {
 			return type_names[i].b;
 		}


### PR DESCRIPTION
Replace all the custom `sizeof(array)/sizeof(element)` and `sizeof(array)/sizeof(type)` with the standard macro `ARRAY_SIZE()`.

This reduces the risk of passing the wrong type, especially when code gets refactored and things change type.