### PR TITLE
Fix popups (v2)

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -67,9 +67,17 @@ struct sway_container *output_get_active_workspace(struct sway_output *output);
 void output_render(struct sway_output *output, struct timespec *when,
 	pixman_region32_t *damage);
 
+void output_surface_for_each_surface(struct sway_output *output,
+		struct wlr_surface *surface, double ox, double oy,
+		sway_surface_iterator_func_t iterator, void *user_data);
+
 void output_view_for_each_surface(struct sway_output *output,
 	struct sway_view *view, sway_surface_iterator_func_t iterator,
 	void *user_data);
+
+void output_view_for_each_popup(struct sway_output *output,
+		struct sway_view *view, sway_surface_iterator_func_t iterator,
+		void *user_data);
 
 void output_layer_for_each_surface(struct sway_output *output,
 	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -230,16 +230,9 @@ struct sway_container *container_parent(struct sway_container *container,
  * surface-local coordinates of the given layout coordinates if the container
  * is a view and the view contains a surface at those coordinates.
  */
-struct sway_container *container_at(struct sway_container *container,
-		double ox, double oy, struct wlr_surface **surface,
+struct sway_container *container_at(struct sway_container *workspace,
+		double lx, double ly, struct wlr_surface **surface,
 		double *sx, double *sy);
-
-/**
- * Same as container_at, but only checks floating views and expects coordinates
- * to be layout coordinates, as that's what floating views use.
- */
-struct sway_container *floating_container_at(double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * Apply the function for each descendant of the container breadth first.

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -50,6 +50,7 @@ struct sway_view_impl {
 	void (*for_each_popup)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 	void (*close)(struct sway_view *view);
+	void (*close_popups)(struct sway_view *view);
 	void (*destroy)(struct sway_view *view);
 };
 
@@ -247,6 +248,8 @@ void view_set_activated(struct sway_view *view, bool activated);
 void view_set_tiled(struct sway_view *view, bool tiled);
 
 void view_close(struct sway_view *view);
+
+void view_close_popups(struct sway_view *view);
 
 void view_damage_from(struct sway_view *view);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -47,6 +47,8 @@ struct sway_view_impl {
 	bool (*has_client_side_decorations)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
+	void (*for_each_popup)(struct sway_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data);
 	void (*close)(struct sway_view *view);
 	void (*destroy)(struct sway_view *view);
 };
@@ -248,7 +250,16 @@ void view_close(struct sway_view *view);
 
 void view_damage_from(struct sway_view *view);
 
+/**
+ * Iterate all surfaces of a view (toplevels + popups).
+ */
 void view_for_each_surface(struct sway_view *view,
+	wlr_surface_iterator_func_t iterator, void *user_data);
+
+/**
+ * Iterate all popups recursively.
+ */
+void view_for_each_popup(struct sway_view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
 // view implementation

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -312,9 +312,8 @@ static void send_frame_done_container_iterator(struct sway_container *con,
 		return;
 	}
 
-	// Toplevels only
-	output_surface_for_each_surface(data->output, con->sway_view->surface,
-		con->x, con->y, send_frame_done_iterator, data->when);
+	output_view_for_each_surface(data->output, con->sway_view,
+		send_frame_done_iterator, data->when);
 }
 
 static void send_frame_done_container(struct sway_output *output,
@@ -325,27 +324,6 @@ static void send_frame_done_container(struct sway_output *output,
 	};
 	container_descendants(con, C_VIEW,
 		send_frame_done_container_iterator, &data);
-}
-
-static void send_frame_done_popup_iterator(struct sway_output *output,
-		struct wlr_surface *surface, struct wlr_box *box, float rotation,
-		void *data) {
-	// Send frame done to this popup's surface
-	send_frame_done_iterator(output, surface, box, rotation, data);
-
-	// Send frame done to this popup's child toplevels
-	output_surface_for_each_surface(output, surface, box->x, box->y,
-			send_frame_done_iterator, data);
-}
-
-static void send_frame_done_popups(struct sway_output *output,
-		struct sway_view *view, struct timespec *when) {
-	struct send_frame_done_data data = {
-		.output = output,
-		.when = when,
-	};
-	output_view_for_each_popup(output, view,
-			send_frame_done_popup_iterator, &data);
 }
 
 static void send_frame_done(struct sway_output *output, struct timespec *when) {
@@ -384,13 +362,6 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 		send_frame_done_layer(output,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], when);
 	}
-
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = seat_get_focus(seat);
-	if (focus && focus->type == C_VIEW) {
-		send_frame_done_popups(output, focus->sway_view, when);
-	}
-
 
 send_frame_overlay:
 	send_frame_done_layer(output,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -179,6 +179,14 @@ static void for_each_surface(struct sway_view *view,
 		user_data);
 }
 
+static void for_each_popup(struct sway_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	if (xdg_shell_view_from_view(view) == NULL) {
+		return;
+	}
+	wlr_xdg_surface_for_each_popup(view->wlr_xdg_surface, iterator, user_data);
+}
+
 static void _close(struct sway_view *view) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return;
@@ -207,6 +215,7 @@ static const struct sway_view_impl view_impl = {
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
+	.for_each_popup = for_each_popup,
 	.close = _close,
 	.destroy = destroy,
 };

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -197,6 +197,18 @@ static void _close(struct sway_view *view) {
 	}
 }
 
+static void close_popups_iterator(struct wlr_surface *surface,
+		int sx, int sy, void *data) {
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_from_wlr_surface(surface);
+	wlr_xdg_surface_send_close(xdg_surface);
+}
+
+static void close_popups(struct sway_view *view) {
+	wlr_xdg_surface_for_each_popup(view->wlr_xdg_surface,
+			close_popups_iterator, NULL);
+}
+
 static void destroy(struct sway_view *view) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		xdg_shell_view_from_view(view);
@@ -217,6 +229,7 @@ static const struct sway_view_impl view_impl = {
 	.for_each_surface = for_each_surface,
 	.for_each_popup = for_each_popup,
 	.close = _close,
+	.close_popups = close_popups,
 	.destroy = destroy,
 };
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -175,6 +175,15 @@ static void for_each_surface(struct sway_view *view,
 		user_data);
 }
 
+static void for_each_popup(struct sway_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	if (xdg_shell_v6_view_from_view(view) == NULL) {
+		return;
+	}
+	wlr_xdg_surface_v6_for_each_popup(view->wlr_xdg_surface_v6, iterator,
+		user_data);
+}
+
 static void _close(struct sway_view *view) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
 		return;
@@ -203,6 +212,7 @@ static const struct sway_view_impl view_impl = {
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
+	.for_each_popup = for_each_popup,
 	.close = _close,
 	.destroy = destroy,
 };

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -194,6 +194,18 @@ static void _close(struct sway_view *view) {
 	}
 }
 
+static void close_popups_iterator(struct wlr_surface *surface,
+		int sx, int sy, void *data) {
+	struct wlr_xdg_surface_v6 *xdg_surface_v6 =
+		wlr_xdg_surface_v6_from_wlr_surface(surface);
+	wlr_xdg_surface_v6_send_close(xdg_surface_v6);
+}
+
+static void close_popups(struct sway_view *view) {
+	wlr_xdg_surface_v6_for_each_popup(view->wlr_xdg_surface_v6,
+			close_popups_iterator, NULL);
+}
+
 static void destroy(struct sway_view *view) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		xdg_shell_v6_view_from_view(view);
@@ -214,6 +226,7 @@ static const struct sway_view_impl view_impl = {
 	.for_each_surface = for_each_surface,
 	.for_each_popup = for_each_popup,
 	.close = _close,
+	.close_popups = close_popups,
 	.destroy = destroy,
 };
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -109,9 +109,6 @@ static struct sway_container *container_at_coords(
 	}
 
 	struct sway_container *c;
-	if ((c = floating_container_at(lx, ly, surface, sx, sy))) {
-		return c;
-	}
 	if ((c = container_at(ws, lx, ly, surface, sx, sy))) {
 		return c;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -737,6 +737,13 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		}
 	}
 
+	// Close any popups on the old focus
+	if (last_focus && last_focus != container) {
+		if (last_focus->type == C_VIEW) {
+			view_close_popups(last_focus->sway_view);
+		}
+	}
+
 	if (last_focus) {
 		if (last_workspace) {
 			ipc_event_workspace(last_workspace, container, "focus");

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -302,6 +302,12 @@ void view_close(struct sway_view *view) {
 	}
 }
 
+void view_close_popups(struct sway_view *view) {
+	if (view->impl->close_popups) {
+		view->impl->close_popups(view);
+	}
+}
+
 void view_damage_from(struct sway_view *view) {
 	for (int i = 0; i < root_container.children->length; ++i) {
 		struct sway_container *cont = root_container.children->items[i];

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -332,6 +332,16 @@ void view_for_each_surface(struct sway_view *view,
 	}
 }
 
+void view_for_each_popup(struct sway_view *view,
+		wlr_surface_iterator_func_t iterator, void *user_data) {
+	if (!view->surface) {
+		return;
+	}
+	if (view->impl->for_each_popup) {
+		view->impl->for_each_popup(view, iterator, user_data);
+	}
+}
+
 static void view_subsurface_create(struct sway_view *view,
 	struct wlr_subsurface *subsurface);
 


### PR DESCRIPTION
Fixes the render and `container_at` order for popups.

Fixes #2210

For rendering:

* `render_view_surfaces` has been renamed to `render_view_toplevels`
* `render_view_toplevels` now uses `output_surface_for_each_surface` (which is now public), as that function uses `wlr_surface_for_each_surface` which doesn't descend into popups
* Views now have a `for_each_popup` iterator, which is used by the renderer to render the focused view's popups
* When rendering a popup, toplevels (xdg subsurfaces) of that popup are also rendered
* Popups are now rendered on top of all containers

For sending frame done, the logic has been updated to match the rendering logic:

* `send_frame_done_container` no longer descends into popups
* `for_each_popup` is used to send frame done to the focused view's popups and their child toplevels

For `container_at`:

* `floating_container_at` is now static, which means it had to be moved higher in the file.
* `container_at` now considers popups for the focused view before checking containers.
* `tiling_container_at` has been introduced, so that it doesn't call `container_at` recursively (it would check popups recursively if it did)