### PR TITLE
Fix commands: criteria, layout, move, workspace

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -113,7 +113,7 @@ struct sway_container {
 
 	enum sway_container_type type;
 	enum sway_container_layout layout;
-	enum sway_container_layout prev_layout;
+	enum sway_container_layout prev_split_layout;
 
 	bool is_sticky;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -316,6 +316,11 @@ void view_update_title(struct sway_view *view, bool force);
 void view_execute_criteria(struct sway_view *view);
 
 /**
+ * Find any view that has the given mark and return it.
+ */
+struct sway_view *view_find_mark(char *mark);
+
+/**
  * Find any view that has the given mark and remove the mark from the view.
  * Returns true if it matched a view.
  */

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_WORKSPACE_H
 #define _SWAY_WORKSPACE_H
 
+#include <stdbool.h>
 #include "sway/tree/container.h"
 
 struct sway_view;
@@ -17,7 +18,8 @@ extern char *prev_workspace_name;
 
 char *workspace_next_name(const char *output_name);
 
-bool workspace_switch(struct sway_container *workspace);
+bool workspace_switch(struct sway_container *workspace,
+		bool no_auto_back_and_forth);
 
 struct sway_container *workspace_by_number(const char* name);
 

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -1,9 +1,30 @@
+#include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "log.h"
+
+static bool parse_layout_string(char *s, enum sway_container_layout *ptr) {
+	if (strcasecmp(s, "splith") == 0) {
+		*ptr = L_HORIZ;
+	} else if (strcasecmp(s, "splitv") == 0) {
+		*ptr = L_VERT;
+	} else if (strcasecmp(s, "tabbed") == 0) {
+		*ptr = L_TABBED;
+	} else if (strcasecmp(s, "stacking") == 0) {
+		*ptr = L_STACKED;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+static const char* expected_syntax =
+	"Expected 'layout default|tabbed|stacking|splitv|splith' or "
+	"'layout toggle [split|all]' or "
+	"'layout toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...'";
 
 struct cmd_results *cmd_layout(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -23,29 +44,54 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 
 	if (strcasecmp(argv[0], "default") == 0) {
 		parent->layout = parent->prev_layout;
-		if (parent->layout == L_NONE) {
-			parent->layout = container_get_default_layout(parent);
-		}
 	} else {
 		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
 			parent->prev_layout = parent->layout;
 		}
 
-		if (strcasecmp(argv[0], "splith") == 0) {
-			parent->layout = L_HORIZ;
-		} else if (strcasecmp(argv[0], "splitv") == 0) {
-			parent->layout = L_VERT;
-		} else if (strcasecmp(argv[0], "tabbed") == 0) {
-			parent->layout = L_TABBED;
-		} else if (strcasecmp(argv[0], "stacking") == 0) {
-			parent->layout = L_STACKED;
-		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
-			if (parent->layout == L_HORIZ) {
-				parent->layout = L_VERT;
+		bool assigned_directly = parse_layout_string(argv[0], &parent->layout);
+		if (!assigned_directly && strcasecmp(argv[0], "toggle") == 0) {
+			if (argc == 1) {
+				parent->layout =
+					parent->layout == L_STACKED ? L_TABBED :
+					parent->layout == L_TABBED ? parent->prev_layout : L_STACKED;
+			} else if (argc == 2) {
+				if (strcasecmp(argv[1], "all") == 0) {
+					parent->layout =
+						parent->layout == L_HORIZ ? L_VERT :
+						parent->layout == L_VERT ? L_STACKED :
+						parent->layout == L_STACKED ? L_TABBED : L_HORIZ;
+				} else if (strcasecmp(argv[1], "split") == 0) {
+					parent->layout = parent->layout == L_VERT ? L_HORIZ : L_VERT;
+				} else {
+					return cmd_results_new(CMD_INVALID, "layout", expected_syntax);
+				}
 			} else {
-				parent->layout = L_HORIZ;
+				bool valid;
+				enum sway_container_layout parsed_layout;
+				int curr = 1;
+				for (; curr < argc; curr++) {
+					valid = parse_layout_string(argv[curr], &parsed_layout);
+					if (valid && parsed_layout == parent->layout) {
+						break;
+					}
+				}
+				for (int i = curr + 1; i != curr; ++i) {
+					// cycle round to find next valid layout
+					if (i >= argc) {
+						i = 1;
+					}
+					if (parse_layout_string(argv[i], &parent->layout)) {
+						break;
+					} // invalid layout strings are silently ignored
+				}
 			}
+		} else {
+			return cmd_results_new(CMD_INVALID, "layout", expected_syntax);
 		}
+	}
+	if (parent->layout == L_NONE) {
+		parent->layout = container_get_default_layout(parent);
 	}
 
 	container_notify_subtree_changed(parent);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -107,8 +107,13 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 				strcasecmp(argv[2], "current") == 0) {
 			ws = workspace_by_name(argv[2]);
 		} else if (strcasecmp(argv[2], "back_and_forth") == 0) {
-			if (!(ws = workspace_by_name(argv[0])) && prev_workspace_name) {
-				ws = workspace_create(NULL, prev_workspace_name);
+			if (!(ws = workspace_by_name(argv[2]))) {
+				if (prev_workspace_name) {
+					ws = workspace_create(NULL, prev_workspace_name);
+				} else {
+					return cmd_results_new(CMD_FAILURE, "move",
+							"No workspace was previously active.");
+				}
 			}
 		} else {
 			char *ws_name = NULL;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 500
+#include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 #include <wlr/types/wlr_cursor.h>
@@ -16,12 +17,11 @@
 #include "stringop.h"
 #include "list.h"
 
-static const char* expected_syntax =
+static const char *expected_syntax =
 	"Expected 'move <left|right|up|down> <[px] px>' or "
-	"'move <container|window> to workspace <name>' or "
-	"'move <container|window|workspace> to output <name|direction>' or "
-	"'move <container|window> to mark <mark>' or "
-	"'move position mouse'";
+	"'move [--no-auto-back-and-forth] <container|window> [to] workspace <name>' or "
+	"'move [--no-auto-back-and-forth] <container|window|workspace> [to] output <name|direction>' or "
+	"'move <container|window> [to] mark <mark>'";
 
 static struct sway_container *output_in_direction(const char *direction,
 		struct wlr_output *reference, int ref_lx, int ref_ly) {
@@ -53,7 +53,7 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 		int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "move container/window",
-				EXPECTED_AT_LEAST, 4))) {
+				EXPECTED_AT_LEAST, 3))) {
 		return error;
 	}
 
@@ -68,26 +68,52 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 				"Can only move containers and views.");
 	}
 
+	bool no_auto_back_and_forth = false;
+	while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
+		no_auto_back_and_forth = true;
+		if (--argc < 3) {
+			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		}
+		++argv;
+	}
+	while (strcasecmp(argv[1], "--no-auto-back-and-forth") == 0) {
+		no_auto_back_and_forth = true;
+		if (--argc < 3) {
+			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		}
+		argv++;
+	}
+
+	while (strcasecmp(argv[1], "to") == 0) {
+		if (--argc < 3) {
+			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		}
+		argv++;
+	}
+
 	struct sway_container *old_parent = current->parent;
 	struct sway_container *old_ws = container_parent(current, C_WORKSPACE);
 	struct sway_container *destination = NULL;
 
 	// determine destination
-	if (strcasecmp(argv[1], "to") == 0
-			&& strcasecmp(argv[2], "workspace") == 0) {
+	if (strcasecmp(argv[1], "workspace") == 0) {
 		// move container to workspace x
 		struct sway_container *ws;
 		char *ws_name = NULL;
-		if (argc == 5 && strcasecmp(argv[3], "number") == 0) {
+		if (strcasecmp(argv[2], "number") == 0) {
 			// move "container to workspace number x"
-			ws_name = strdup(argv[4]);
+			if (argc < 4) {
+				return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+			}
+			ws_name = strdup(argv[3]);
 			ws = workspace_by_number(ws_name);
 		} else {
-			ws_name = join_args(argv + 3, argc - 3);
+			ws_name = join_args(argv + 2, argc - 2);
 			ws = workspace_by_name(ws_name);
 		}
 
-		if (config->auto_back_and_forth && prev_workspace_name) {
+		if (!no_auto_back_and_forth && config->auto_back_and_forth &&
+				prev_workspace_name) {
 			// auto back and forth move
 			if (old_ws->name && strcmp(old_ws->name, ws_name) == 0) {
 				// if target workspace is the current one
@@ -98,19 +124,23 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 		}
 
 		if (!ws) {
+			if (strcasecmp(argv[2], "back_and_forth") == 0) {
+				if (prev_workspace_name) {
+					ws = workspace_create(NULL, prev_workspace_name);
+				}
+			}
 			ws = workspace_create(NULL, ws_name);
 		}
 		free(ws_name);
 
 		destination = seat_get_focus_inactive(config->handler_context.seat, ws);
-	} else if (strcasecmp(argv[1], "to") == 0
-			&& strcasecmp(argv[2], "output") == 0) {
+	} else if (strcasecmp(argv[1], "output") == 0) {
 		struct sway_container *source = container_parent(current, C_OUTPUT);
-		struct sway_container *dest_output = output_in_direction(argv[3],
+		struct sway_container *dest_output = output_in_direction(argv[2],
 				source->sway_output->wlr_output, current->x, current->y);
 		if (!dest_output) {
 			return cmd_results_new(CMD_FAILURE, "move workspace",
-				"Can't find output with name/direction '%s'", argv[3]);
+				"Can't find output with name/direction '%s'", argv[2]);
 		}
 		destination = seat_get_focus_inactive(
 				config->handler_context.seat, dest_output);
@@ -118,12 +148,11 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 			// We've never been to this output before
 			destination = dest_output->children->items[0];
 		}
-	} else if (strcasecmp(argv[1], "to") == 0
-			&& strcasecmp(argv[2], "mark") == 0) {
-		struct sway_view *dest_view = view_find_mark(argv[3]);
+	} else if (strcasecmp(argv[1], "mark") == 0) {
+		struct sway_view *dest_view = view_find_mark(argv[2]);
 		if (dest_view == NULL) {
 			return cmd_results_new(CMD_FAILURE, "move",
-					"Mark '%s' not found", argv[3]);
+					"Mark '%s' not found", argv[2]);
 		}
 		destination = dest_view->swayc;
 	} else {
@@ -150,20 +179,29 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 static struct cmd_results *cmd_move_workspace(struct sway_container *current,
 		int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "move workspace", EXPECTED_EQUAL_TO, 4))) {
+	if ((error = checkarg(argc, "move workspace", EXPECTED_AT_LEAST, 2))) {
 		return error;
-	} else if (strcasecmp(argv[1], "to") != 0
-			|| strcasecmp(argv[2], "output") != 0) {
+	}
+
+	while (strcasecmp(argv[1], "to") == 0) {
+		if (--argc < 3) {
+			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		}
+		++argv;
+	}
+
+	if (strcasecmp(argv[1], "output") != 0) {
 		return cmd_results_new(CMD_INVALID, "move", expected_syntax);
 	}
+
 	struct sway_container *source = container_parent(current, C_OUTPUT);
 	int center_x = current->width / 2 + current->x,
 		center_y = current->height / 2 + current->y;
-	struct sway_container *destination = output_in_direction(argv[3],
+	struct sway_container *destination = output_in_direction(argv[2],
 			source->sway_output->wlr_output, center_x, center_y);
 	if (!destination) {
 		return cmd_results_new(CMD_FAILURE, "move workspace",
-			"Can't find output with name/direction '%s'", argv[3]);
+			"Can't find output with name/direction '%s'", argv[2]);
 	}
 	if (current->type != C_WORKSPACE) {
 		current = container_parent(current, C_WORKSPACE);
@@ -237,7 +275,7 @@ static struct cmd_results *move_in_direction(struct sway_container *container,
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
-static const char* expected_position_syntax =
+static const char *expected_position_syntax =
 	"Expected 'move [absolute] position <x> [px] <y> [px]' or "
 	"'move [absolute] position center|mouse'";
 
@@ -356,8 +394,11 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 		return move_in_direction(current, MOVE_UP, argc, argv);
 	} else if (strcasecmp(argv[0], "down") == 0) {
 		return move_in_direction(current, MOVE_DOWN, argc, argv);
-	} else if (strcasecmp(argv[0], "container") == 0
-			|| strcasecmp(argv[0], "window") == 0) {
+	} else if ((strcasecmp(argv[0], "container") == 0
+			|| strcasecmp(argv[0], "window") == 0) ||
+			(strcasecmp(argv[0], "--no-auto-back-and-forth") &&
+			(strcasecmp(argv[0], "container") == 0
+			|| strcasecmp(argv[0], "window") == 0))) {
 		return cmd_move_container(current, argc, argv);
 	} else if (strcasecmp(argv[0], "workspace") == 0) {
 		return cmd_move_workspace(current, argc, argv);

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -61,6 +61,16 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	}
 
 	char *new_name = join_args(argv + argn, argc - argn);
+	if (strcasecmp(new_name, "next") == 0 ||
+			strcasecmp(new_name, "prev") == 0 ||
+			strcasecmp(new_name, "next_on_output") == 0 ||
+			strcasecmp(new_name, "prev_on_output") == 0 ||
+			strcasecmp(new_name, "back_and_forth") == 0 ||
+			strcasecmp(new_name, "current") == 0) {
+		free(new_name);
+		return cmd_results_new(CMD_INVALID, "rename",
+				"Cannot use special workspace name '%s'", argv[argn]);
+	}
 	struct sway_container *tmp_workspace = workspace_by_name(new_name);
 	if (tmp_workspace) {
 		free(new_name);

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -68,16 +68,20 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				ws = workspace_create(NULL, name);
 				free(name);
 			}
+		} else if (strcasecmp(argv[0], "next") == 0 ||
+				strcasecmp(argv[0], "prev") == 0 ||
+				strcasecmp(argv[0], "next_on_output") == 0 ||
+				strcasecmp(argv[0], "prev_on_output") == 0 ||
+				strcasecmp(argv[0], "current") == 0) {
+			ws = workspace_by_name(argv[0]);
+		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
+			if (!(ws = workspace_by_name(argv[0])) && prev_workspace_name) {
+				ws = workspace_create(NULL, prev_workspace_name);
+			}
 		} else {
 			char *name = join_args(argv, argc);
 			if (!(ws = workspace_by_name(name))) {
-				if (strcasecmp(argv[0], "back_and_forth") == 0) {
-					if (prev_workspace_name) {
-						ws = workspace_create(NULL, prev_workspace_name);
-					}
-				} else {
-					ws = workspace_create(NULL, name);
-				}
+				ws = workspace_create(NULL, name);
 			}
 			free(name);
 		}

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -17,17 +17,6 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 
 	int output_location = -1;
 
-	struct sway_container *current_container = config->handler_context.current_container;
-	struct sway_container *old_workspace = NULL, *old_output = NULL;
-	if (current_container) {
-		if (current_container->type == C_WORKSPACE) {
-			old_workspace = current_container;
-		} else {
-			old_workspace = container_parent(current_container, C_WORKSPACE);
-		}
-		old_output = container_parent(current_container, C_OUTPUT);
-	}
-
 	for (int i = 0; i < argc; ++i) {
 		if (strcasecmp(argv[i], "output") == 0) {
 			output_location = i;
@@ -57,39 +46,42 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, "workspace", NULL);
 		}
+
+		bool no_auto_back_and_forth = false;
+		while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
+			no_auto_back_and_forth = true;
+			if ((error = checkarg(--argc, "workspace", EXPECTED_AT_LEAST, 1))) {
+				return error;
+			}
+			++argv;
+		}
+
+
 		struct sway_container *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
+			if (argc < 2) {
+				cmd_results_new(CMD_INVALID, "workspace",
+						"Expected workspace number");
+			}
 			if (!(ws = workspace_by_number(argv[1]))) {
 				char *name = join_args(argv + 1, argc - 1);
 				ws = workspace_create(NULL, name);
 				free(name);
 			}
-		} else if (strcasecmp(argv[0], "next") == 0) {
-			ws = workspace_next(old_workspace);
-		} else if (strcasecmp(argv[0], "prev") == 0) {
-			ws = workspace_prev(old_workspace);
-		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
-			ws = workspace_output_next(old_output);
-		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
-			ws = workspace_output_prev(old_output);
-		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
-			// if auto_back_and_forth is enabled, workspace_switch will swap
-			// the workspaces. If we created prev_workspace here, workspace_switch
-			// would put us back on original workspace.
-			if (config->auto_back_and_forth) {
-				ws = old_workspace;
-			} else if (prev_workspace_name
-					&& !(ws = workspace_by_name(prev_workspace_name))) {
-				ws = workspace_create(NULL, prev_workspace_name);
-			}
 		} else {
 			char *name = join_args(argv, argc);
 			if (!(ws = workspace_by_name(name))) {
-				ws = workspace_create(NULL, name);
+				if (strcasecmp(argv[0], "back_and_forth") == 0) {
+					if (prev_workspace_name) {
+						ws = workspace_create(NULL, prev_workspace_name);
+					}
+				} else {
+					ws = workspace_create(NULL, name);
+				}
 			}
 			free(name);
 		}
-		workspace_switch(ws);
+		workspace_switch(ws, no_auto_back_and_forth);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -361,8 +361,17 @@ static char *get_focused_prop(enum criteria_token token) {
 			}
 		}
 		break;
-	case T_CON_ID: // These do not support __focused__
-	case T_CON_MARK:
+	case T_CON_ID:
+		if (view->swayc == NULL) {
+			return NULL;
+		}
+		size_t id = view->swayc->id;
+		int len = snprintf(NULL, 0, "%zu", id) + 1;
+		char *id_str = malloc(len);
+		snprintf(id_str, len, "%zu", id);
+		value = id_str;
+		break;
+	case T_CON_MARK: // These do not support __focused__
 	case T_FLOATING:
 #ifdef HAVE_XWAYLAND
 	case T_ID:
@@ -425,7 +434,7 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 	case T_CON_ID:
 		criteria->con_id = strtoul(effective_value, &endptr, 10);
 		if (*endptr != 0) {
-			error = strdup("The value for 'con_id' should be numeric");
+			error = strdup("The value for 'con_id' should be '__focused__' or numeric");
 		}
 		break;
 	case T_CON_MARK:

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -452,13 +452,18 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		criteria->tiling = true;
 		break;
 	case T_URGENT:
-		if (strcmp(effective_value, "latest") == 0) {
+		if (strcmp(effective_value, "latest") == 0 ||
+				strcmp(effective_value, "newest") == 0 ||
+				strcmp(effective_value, "last") == 0 ||
+				strcmp(effective_value, "recent") == 0) {
 			criteria->urgent = 'l';
-		} else if (strcmp(effective_value, "oldest") == 0) {
+		} else if (strcmp(effective_value, "oldest") == 0 ||
+				strcmp(effective_value, "first") == 0) {
 			criteria->urgent = 'o';
 		} else {
 			error =
-				strdup("The value for 'urgent' must be 'latest' or 'oldest'");
+				strdup("The value for 'urgent' must be 'first', 'last', "
+						"'latest', 'newest', 'oldest' or 'recent'");
 		}
 		break;
 	case T_WORKSPACE:

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -366,9 +366,9 @@ static char *get_focused_prop(enum criteria_token token) {
 			return NULL;
 		}
 		size_t id = view->swayc->id;
-		int len = snprintf(NULL, 0, "%zu", id) + 1;
-		char *id_str = malloc(len);
-		snprintf(id_str, len, "%zu", id);
+		size_t id_size = snprintf(NULL, 0, "%zu", id) + 1;
+		char *id_str = malloc(id_size);
+		snprintf(id_str, id_size, "%zu", id);
 		value = id_str;
 		break;
 	case T_CON_MARK: // These do not support __focused__

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -582,7 +582,9 @@ The following attributes may be matched with:
 	the currently focused window.
 
 *con\_id*
-	Compare against the internal container ID, which you can find via IPC.
+	Compare against the internal container ID, which you can find via IPC. If
+	value is \_\_focused\_\_, then the id must be the same as that of the
+	currently focused window.
 
 *con\_mark*
 	Compare against the window marks. Can be a regular expression.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -123,18 +123,27 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *layout* toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...
 	Cycles the layout mode of the focused container through a list of layouts.
 
-*move* left|right|up|down [<px>]
+*move* left|right|up|down [<px> px]
 	Moves the focused container in the direction specified. If the container,
 	the optional _px_ argument specifies how many pixels to move the container.
 	If unspecified, the default is 10 pixels. Pixels are ignored when moving
 	tiled containers.
 
+*move* [absolute] position <pos_x> [px] <pos_y> [px]
+	Moves the focused container to the specified position.
+
+*move* [absolute] position center|mouse
+	Moves the focused container to be centered on the workspace or mouse.
+
+*move* container|window to mark <mark>
+	Moves the focused container to the specified mark.
+
 *move* container|window to workspace <name>
 	Moves the focused container to the specified workspace.
 
-*move* container|window to workspace prev|next
-	Moves the focused container to the previous or next workspace on this
-	output, or if no workspaces remain, the previous or next output.
+*move* container|window to workspace prev|next|current
+	Moves the focused container to the previous, next or current workspace on
+	this output, or if no workspaces remain, the previous or next output.
 
 *move* container|window to workspace prev\_on\_output|next\_on\_output
 	Moves the focused container to the previous or next workspace on this

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -84,6 +84,9 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *floating* enable|disable|toggle
 	Make focused view floating, non-floating, or the opposite of what it is now.
 
+<criteria> *focus*
+	Moves focus to the container that matches the specified criteria.
+
 *focus* up|right|down|left
 	Moves focus to the next container in the specified direction.
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -135,24 +135,29 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *move* [absolute] position center|mouse
 	Moves the focused container to be centered on the workspace or mouse.
 
-*move* container|window to mark <mark>
+*move* container|window [to] mark <mark>
 	Moves the focused container to the specified mark.
 
-*move* container|window to workspace <name>
-	Moves the focused container to the specified workspace.
+*move* [--no-auto-back-and-forth] container|window [to] workspace [number] <name>
+	Moves the focused container to the specified workspace. The string "number"
+	is optional and is used to match a workspace with the same number, even if
+	it has a different name.
 
-*move* container|window to workspace prev|next|current
+*move* container|window [to] workspace prev|next|current
 	Moves the focused container to the previous, next or current workspace on
 	this output, or if no workspaces remain, the previous or next output.
 
-*move* container|window to workspace prev\_on\_output|next\_on\_output
+*move* container|window [to] workspace prev\_on\_output|next\_on\_output
 	Moves the focused container to the previous or next workspace on this
 	output, wrapping around if already at the first or last workspace.
 
-*move* container|window|workspace to output <name>
+*move* container|window [to] workspace back_and_forth
+	Moves the focused container to previously focused workspace.
+
+*move* container|window|workspace [to] output <name>
 	Moves the focused container or workspace to the specified output.
 
-*move* container|window|workspace to output up|right|down|left
+*move* container|window|workspace [to] output up|right|down|left
 	Moves the focused container or workspace to next output in the specified
 	direction.
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -111,11 +111,17 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *fullscreen*
 	Toggles fullscreen for the focused view.
 
-*layout* splith|splitv|stacking|tabbed
+*layout* default|splith|splitv|stacking|tabbed
 	Sets the layout mode of the focused container.
 
-*layout* toggle split
-	Switches the focused container between the splitv and splith layouts.
+*layout* toggle [split|all]
+	Cycles the layout mode of the focused container though a preset list of
+	layouts. If no argument is given, then it cycles through stacking, tabbed
+	and the last split layout. If "split" is given, then it cycles through
+	splith and splitv. If "all" is given, then it cycles through every layout.
+
+*layout* toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...
+	Cycles the layout mode of the focused container through a list of layouts.
 
 *move* left|right|up|down [<px>]
 	Moves the focused container in the direction specified. If the container,

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -526,7 +526,7 @@ config after the others, or it will be matched instead of the others.
 	state. Using _allow_ or _deny_ controls the window's ability to set itself
 	as urgent. By default, windows are allowed to set their own urgency.
 
-*workspace* [number] <name>
+*workspace* [--no-auto-back-and-forth] [number] <name>
 	Switches to the specified workspace. The string "number" is optional and is
 	used to sort workspaces.
 
@@ -536,6 +536,9 @@ config after the others, or it will be matched instead of the others.
 
 *workspace* prev\_on\_output|next\_on\_output
 	Switches to the next workspace on the current output.
+
+*workspace* back_and_forth
+	Switches to the previously focused workspace.
 
 *workspace* <name> output <output>
 	Specifies that workspace _name_ should be shown on the specified _output_.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -612,7 +612,8 @@ The following attributes may be matched with:
 	currently focused window.
 
 *urgent*
-	Compares the urgent state of the window. Can be "latest" or "oldest".
+	Compares the urgent state of the window. Can be "first", "last", "latest",
+	"newest", "oldest" or "recent".
 
 *window\_role*
 	Compare against the window role (WM\_WINDOW\_ROLE). Can be a regular

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -859,7 +859,7 @@ struct sway_container *container_split(struct sway_container *child,
 	}
 	if (child->type == C_WORKSPACE && child->children->length == 0) {
 		// Special case: this just behaves like splitt
-		child->prev_layout = child->layout;
+		child->prev_split_layout = child->layout;
 		child->layout = layout;
 		return child;
 	}
@@ -870,7 +870,7 @@ struct sway_container *container_split(struct sway_container *child,
 
 	remove_gaps(child);
 
-	cont->prev_layout = L_NONE;
+	cont->prev_split_layout = L_NONE;
 	cont->width = child->width;
 	cont->height = child->height;
 	cont->x = child->x;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
+#include <strings.h>
 #include <wayland-server.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_buffer.h>
@@ -456,7 +457,13 @@ static struct sway_container *select_workspace(struct sway_view *view) {
 		if (criteria->type == CT_ASSIGN_WORKSPACE) {
 			ws = workspace_by_name(criteria->target);
 			if (!ws) {
-				ws = workspace_create(NULL, criteria->target);
+				if (strcasecmp(criteria->target, "back_and_forth") == 0) {
+					if (prev_workspace_name) {
+						ws = workspace_create(NULL, prev_workspace_name);
+					}
+				} else {
+					ws = workspace_create(NULL, criteria->target);
+				}
 			}
 			break;
 		} else {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -891,6 +891,15 @@ static bool find_by_mark_iterator(struct sway_container *con,
 	return con->type == C_VIEW && view_has_mark(con->sway_view, mark);
 }
 
+struct sway_view *view_find_mark(char *mark) {
+	struct sway_container *container = container_find(&root_container,
+		find_by_mark_iterator, mark);
+	if (!container) {
+		return NULL;
+	}
+	return container->sway_view;
+}
+
 bool view_find_and_unmark(char *mark) {
 	struct sway_container *container = container_find(&root_container,
 		find_by_mark_iterator, mark);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -251,34 +251,23 @@ struct sway_container *workspace_by_name(const char *name) {
 		current_output = container_parent(focus, C_OUTPUT);
 	}
 
-	char *name_cpy = strdup(name);
-	char *first_word = strtok(name_cpy, " ");
-	if (first_word == NULL) {
-		first_word = name_cpy;
-	}
-
-	struct sway_container *ws = NULL;
-	if (strcmp(first_word, "prev") == 0) {
-		ws = workspace_prev(current_workspace);
-	} else if (strcmp(first_word, "prev_on_output") == 0) {
-		ws = workspace_output_prev(current_output);
-	} else if (strcmp(first_word, "next") == 0) {
-		ws = workspace_next(current_workspace);
-	} else if (strcmp(first_word, "next_on_output") == 0) {
-		ws = workspace_output_next(current_output);
-	} else if (strcmp(first_word, "current") == 0) {
-		ws = current_workspace;
-	} else if (strcasecmp(first_word, "back_and_forth") == 0) {
-		if (prev_workspace_name) {
-			ws = container_find(&root_container, _workspace_by_name,
-				(void *)prev_workspace_name);
-		}
+	if (strcmp(name, "prev") == 0) {
+		return workspace_prev(current_workspace);
+	} else if (strcmp(name, "prev_on_output") == 0) {
+		return workspace_output_prev(current_output);
+	} else if (strcmp(name, "next") == 0) {
+		return workspace_next(current_workspace);
+	} else if (strcmp(name, "next_on_output") == 0) {
+		return workspace_output_next(current_output);
+	} else if (strcmp(name, "current") == 0) {
+		return current_workspace;
+	} else if (strcasecmp(name, "back_and_forth") == 0) {
+		return prev_workspace_name ? container_find(&root_container,
+				_workspace_by_name, (void *)prev_workspace_name) : NULL;
 	} else {
-		ws = container_find(&root_container, _workspace_by_name,
+		return container_find(&root_container, _workspace_by_name,
 				(void *)name);
 	}
-	free(name_cpy);
-	return ws;
 }
 
 /**

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -59,7 +59,7 @@ struct sway_container *workspace_create(struct sway_container *output,
 	workspace->width = output->width;
 	workspace->height = output->height;
 	workspace->name = !name ? NULL : strdup(name);
-	workspace->prev_layout = L_NONE;
+	workspace->prev_split_layout = L_NONE;
 	workspace->layout = container_get_default_layout(output);
 
 	struct sway_workspace *swayws = calloc(1, sizeof(struct sway_workspace));


### PR DESCRIPTION
Ref #2336 

Fixes #1518

Criteria:
- [x] urgent
- [x] con_id=\_\_focused__

Commands:
- [x] layout
- [x] document \<criteria> focus
- [x] move
    - [x] documentation
    - [x] move position center
    - [x] move to mark
    - [x] move to workspace back_and_forth
    - [x] --no-auto-back-and-forth
    - [x] make "to" optional
- [x] workspace
    - [x] --no-auto-back-and-forth
    - [x] back_and_forth

Also prevents renaming workspace to "back_and_forth", as well as making it clear that they cannot be named to "special" workspace names.