### PR TITLE
Link xcb dependency to meson options "enable_xwayland"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ conf_data = configuration_data()
 
 if get_option('enable-xwayland')
 	conf_data.set('HAVE_XWAYLAND', true)
-	xcb    = dependency('xcb')
+	xcb = dependency('xcb')
 else
 	conf_data.set('HAVE_XWAYLAND', false)
 endif

--- a/meson.build
+++ b/meson.build
@@ -44,13 +44,13 @@ systemd        = dependency('libsystemd', required: false)
 elogind        = dependency('libelogind', required: false)
 math           = cc.find_library('m')
 rt             = cc.find_library('rt')
-xcb            = dependency('xcb')
 git            = find_program('git', required: false)
 
 conf_data = configuration_data()
 
 if get_option('enable-xwayland')
 	conf_data.set('HAVE_XWAYLAND', true)
+	xcb    = dependency('xcb')
 else
 	conf_data.set('HAVE_XWAYLAND', false)
 endif

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -153,10 +153,6 @@ sway_sources = files(
 	'tree/output.c',
 )
 
-if get_option('enable-xwayland')
-	sway_sources += 'desktop/xwayland.c'
-endif
-
 sway_deps = [
 	cairo,
 	gdk_pixbuf,
@@ -170,9 +166,13 @@ sway_deps = [
 	server_protos,
 	wayland_server,
 	wlroots,
-	xcb,
 	xkbcommon,
 ]
+
+if get_option('enable-xwayland')
+	sway_sources += 'desktop/xwayland.c'
+	sway_deps += xcb
+endif
 
 executable(
 	'sway',


### PR DESCRIPTION
xcb is only required with xwayland, so remove xcb dependency if xwayland is disabled.

I'm new to meson, so I'm not sure it's done the right way. But I successfully tested the build with both -Denable-xwayland=true and -Denable-xwayland=false.