### PR TITLE
Create list for mouse bindings when creating new mode

### DIFF
--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -56,6 +56,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		mode->name = strdup(mode_name);
 		mode->keysym_bindings = create_list();
 		mode->keycode_bindings = create_list();
+		mode->mouse_bindings = create_list();
 		mode->pango = pango;
 		list_add(config->modes, mode);
 	}


### PR DESCRIPTION
When creating a new mode, a list for mouse bindings was not being created. This was causing a segfault while in any mode other than the default and clicking on a window.

This PR simply creates a list for mouse bindings when a mode is created.