### PR TITLE
Correctly track saved surfaces during multiple transactions

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -42,17 +42,4 @@ void transaction_notify_view_ready(struct sway_view *view, uint32_t serial);
 void transaction_notify_view_ready_by_size(struct sway_view *view,
 		int width, int height);
 
-/**
- * Get the saved texture that should be rendered for a view.
- *
- * The addresses pointed at by the width and height pointers will be populated
- * with the surface's dimensions, which may be different to the texture's
- * dimensions if output scaling is used.
- *
- * This function should only be called if it is known that the view has
- * instructions.
- */
-struct wlr_texture *transaction_get_saved_texture(struct sway_view *view,
-		int *width, int *height);
-
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -82,6 +82,9 @@ struct sway_view {
 	bool allow_request_urgent;
 	struct wl_event_source *urgent_timer;
 
+	struct wlr_buffer *saved_buffer;
+	int saved_buffer_width, saved_buffer_height;
+
 	bool destroying;
 
 	list_t *executed_criteria; // struct criteria *
@@ -322,5 +325,9 @@ bool view_is_visible(struct sway_view *view);
 void view_set_urgent(struct sway_view *view, bool enable);
 
 bool view_is_urgent(struct sway_view *view);
+
+void view_remove_saved_buffer(struct sway_view *view);
+
+void view_save_buffer(struct sway_view *view);
 
 #endif

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -199,17 +199,14 @@ static void render_saved_view(struct sway_view *view,
 		struct sway_output *output, pixman_region32_t *damage, float alpha) {
 	struct wlr_output *wlr_output = output->wlr_output;
 
-	int width, height;
-	struct wlr_texture *texture =
-		transaction_get_saved_texture(view, &width, &height);
-	if (!texture) {
+	if (!view->saved_buffer || !view->saved_buffer->texture) {
 		return;
 	}
 	struct wlr_box box = {
 		.x = view->swayc->current.view_x - output->swayc->current.swayc_x,
 		.y = view->swayc->current.view_y - output->swayc->current.swayc_y,
-		.width = width,
-		.height = height,
+		.width = view->saved_buffer_width,
+		.height = view->saved_buffer_height,
 	};
 
 	struct wlr_box output_box = {
@@ -229,7 +226,8 @@ static void render_saved_view(struct sway_view *view,
 	wlr_matrix_project_box(matrix, &box, WL_OUTPUT_TRANSFORM_NORMAL, 0,
 		wlr_output->transform_matrix);
 
-	render_texture(wlr_output, damage, texture, &box, matrix, alpha);
+	render_texture(wlr_output, damage, view->saved_buffer->texture,
+			&box, matrix, alpha);
 }
 
 /**
@@ -238,7 +236,7 @@ static void render_saved_view(struct sway_view *view,
 static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		struct sway_container *con, struct border_colors *colors) {
 	struct sway_view *view = con->sway_view;
-	if (view->swayc->instructions->length) {
+	if (view->saved_buffer) {
 		render_saved_view(view, output, damage, view->swayc->alpha);
 	} else {
 		render_view_surfaces(view, output, damage, view->swayc->alpha);
@@ -841,7 +839,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 
 		// TODO: handle views smaller than the output
 		if (fullscreen_con->type == C_VIEW) {
-			if (fullscreen_con->instructions->length) {
+			if (fullscreen_con->sway_view->saved_buffer) {
 				render_saved_view(fullscreen_con->sway_view,
 						output, damage, 1.0f);
 			} else {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_output_layout.h>
 #include "config.h"
 #ifdef HAVE_XWAYLAND
@@ -1069,4 +1070,23 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 
 bool view_is_urgent(struct sway_view *view) {
 	return view->urgent.tv_sec || view->urgent.tv_nsec;
+}
+
+void view_remove_saved_buffer(struct sway_view *view) {
+	if (!sway_assert(view->saved_buffer, "Expected a saved buffer")) {
+		return;
+	}
+	wlr_buffer_unref(view->saved_buffer);
+	view->saved_buffer = NULL;
+}
+
+void view_save_buffer(struct sway_view *view) {
+	if (!sway_assert(!view->saved_buffer, "Didn't expect saved buffer")) {
+		view_remove_saved_buffer(view);
+	}
+	if (view->surface && wlr_surface_has_buffer(view->surface)) {
+		view->saved_buffer = wlr_buffer_ref(view->surface->buffer);
+		view->saved_buffer_width = view->surface->current.width;
+		view->saved_buffer_height = view->surface->current.height;
+	}
 }


### PR DESCRIPTION
Fixes #2364.

Suppose a view is 600px wide, and we tell it to resize to 601px during a resize operation. We create a transaction, save the 600px buffer and send the configure. This buffer is saved into the associated instruction, and is rendered while we wait for the view to commit a 601px buffer.

Before the view commits the 601px buffer, suppose we tell it to resize to 602px. The new transaction will also save the buffer, but it's still the 600px buffer because we haven't received a new one yet.

Then suppose the view commits its original 601px buffer. This completes the first transaction, so we apply the 601px width to the container. There's still the second (now only) transaction remaining, so we render the saved buffer from that. But this is still the 600px buffer, and we believe it's 601px. Whoops.

The problem here is we can't stack buffers like this. So this commit removes the saved buffer from the instructions, places it in the view instead, and re-saves the latest buffer every time the view completes a transaction and still has further pending transactions.

As saved buffers are now specific to views rather than instructions, the functions for saving and removing the saved buffer have been moved to `view.c`.

The calls to save and restore the buffer have been relocated to more appropriate functions too, favouring `transaction_commit` and `transaction_apply` rather than `transaction_add_container` and `transaction_destroy`.

To test:

* Open an xdg shell view
* Float it
* Resize it towards the top left using mod + right click

Do not test using FileZilla. That client appears to misbehave when there's multiple configures. It commits with a new size, but the texture contains old contents. I've spent so many hours trying to find a problem in sway or wlroots in relation to this, before realising that FileZilla was the only client that does this :-\