### PR TITLE
XCursor is not configured if no pointer device is available

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -393,7 +393,6 @@ struct sway_seat *seat_create(struct sway_input_manager *input,
 		WL_SEAT_CAPABILITY_POINTER |
 		WL_SEAT_CAPABILITY_TOUCH);
 
-	seat_configure_xcursor(seat);
 
 	wl_list_insert(&input->seats, &seat->link);
 
@@ -438,6 +437,7 @@ static void seat_apply_input_config(struct sway_seat *seat,
 
 static void seat_configure_pointer(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
+	seat_configure_xcursor(seat);
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 	seat_apply_input_config(seat, sway_device);


### PR DESCRIPTION
Small change that stops the cursor from being displayed if there is no pointer input device. Created this to address the floating cursor in the middle of my screen, even though I am a keyboard-only user.