### PR TITLE
Allow moving containers when workspace itself is focused

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -59,8 +59,7 @@ static struct cmd_results *cmd_move_container(struct sway_container *current,
 			&& strcasecmp(argv[2], "workspace") == 0) {
 		// move container to workspace x
 		if (current->type == C_WORKSPACE) {
-			// TODO: Wrap children in a container and move that
-			return cmd_results_new(CMD_FAILURE, "move", "Unimplemented");
+			current = container_wrap_children(current);
 		} else if (current->type != C_CONTAINER && current->type != C_VIEW) {
 			return cmd_results_new(CMD_FAILURE, "move",
 					"Can only move containers and views.");


### PR DESCRIPTION
To test, create two views in a workspace, then use `focus parent` to focus the workspace, then run something like `move to workspace 2`.