### PR TITLE
Reset signal mask after fork

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <signal.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/tree/container.h"
@@ -47,6 +48,9 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	if ((pid = fork()) == 0) {
 		// Fork child process again
 		setsid();
+		sigset_t set;
+		sigemptyset(&set);
+		sigprocmask(SIG_SETMASK, &set, NULL);
 		close(fd[0]);
 		if ((child = fork()) == 0) {
 			close(fd[1]);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <strings.h>
+#include <signal.h>
 #include "sway/config.h"
 #include "stringop.h"
 #include "list.h"
@@ -175,6 +176,9 @@ void invoke_swaybar(struct bar_config *bar) {
 	if (bar->pid == 0) {
 		setpgid(0, 0);
 		close(filedes[0]);
+		sigset_t set;
+		sigemptyset(&set);
+		sigprocmask(SIG_SETMASK, &set, NULL);
 
 		// run custom swaybar
 		size_t len = snprintf(NULL, 0, "%s -b %s",


### PR DESCRIPTION
To test: run i3status as swaybar status_command and/or from a terminal launched from sway, `killall -USR1 i3status`. i3status should refresh.