### PR TITLE
Fix focus related crashes

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -775,8 +775,12 @@ void seat_set_focus_warp(struct sway_seat *seat,
 		}
 	}
 
-	if (container->type == C_VIEW) {
-		ipc_event_window(container, "focus");
+	if (container) {
+		if (container->type == C_VIEW) {
+			ipc_event_window(container, "focus");
+		} else if (container->type == C_WORKSPACE) {
+			ipc_event_workspace(NULL, container, "focus");
+		}
 	}
 
 	seat->has_focus = (container != NULL);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -496,7 +496,7 @@ static struct sway_container *select_workspace(struct sway_view *view) {
 	}
 
 	// Use the focused workspace
-	ws = seat_get_focus(seat);
+	ws = seat_get_focus_inactive(seat, &root_container);
 	if (ws->type != C_WORKSPACE) {
 		ws = container_parent(ws, C_WORKSPACE);
 	}
@@ -505,7 +505,8 @@ static struct sway_container *select_workspace(struct sway_view *view) {
 
 static bool should_focus(struct sway_view *view) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *prev_focus = seat_get_focus(seat);
+	struct sway_container *prev_focus =
+		seat_get_focus_inactive(seat, &root_container);
 	struct sway_container *prev_ws = prev_focus->type == C_WORKSPACE ?
 		prev_focus : container_parent(prev_focus, C_WORKSPACE);
 	struct sway_container *map_ws = container_parent(view->swayc, C_WORKSPACE);


### PR DESCRIPTION
Fixes #2402.

* `seat_set_focus_warp` lacked a container `NULL` check
* view mapping code needs to use `seat_get_focus_inactive`

Also, `seat_set_focus_warp` triggered the wrong IPC event if focus was a workspace, which resulted in swaybar not showing the workspace as active.

To test, I opened a terminal, ran `sleep 2 && firefox`, then locked the screen before the sleep finished.