### PR TITLE
Fix crash on mouse motion on fullscreen container

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -99,8 +99,7 @@ static struct sway_container *container_at_coords(
 		return ws;
 	}
 	if (ws->sway_workspace->fullscreen) {
-		return container_at(ws->sway_workspace->fullscreen, lx, ly,
-				surface, sx, sy);
+		return container_at(ws, lx, ly, surface, sx, sy);
 	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],


### PR DESCRIPTION
`container_at` expects a workspace, not the fullscreened container.
Fixes #2409