### PR TITLE
Fix pointer events for fullscreen views

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -234,6 +234,10 @@ struct sway_container *container_at(struct sway_container *workspace,
 		double lx, double ly, struct wlr_surface **surface,
 		double *sx, double *sy);
 
+struct sway_container *container_at_view(struct sway_container *view,
+		double lx, double ly, struct wlr_surface **surface,
+		double *sx, double *sy);
+
 /**
  * Apply the function for each descendant of the container breadth first.
  */

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -99,7 +99,8 @@ static struct sway_container *container_at_coords(
 		return ws;
 	}
 	if (ws->sway_workspace->fullscreen) {
-		return container_at(ws, lx, ly, surface, sx, sy);
+		return container_at_view(ws->sway_workspace->fullscreen, lx, ly,
+				surface, sx, sy);
 	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -535,7 +535,7 @@ struct sway_container *container_parent(struct sway_container *container,
 	return container;
 }
 
-static struct sway_container *container_at_view(struct sway_container *swayc,
+struct sway_container *container_at_view(struct sway_container *swayc,
 		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	if (!sway_assert(swayc->type == C_VIEW, "Expected a view")) {


### PR DESCRIPTION
Leftover from https://github.com/swaywm/sway/pull/2410

To test, open mpv in fullscreen mode and try to use the UI with the mouse.