### PR TITLE
Fix crash when moving cursor over a fullscreen split container

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -234,9 +234,9 @@ struct sway_container *container_at(struct sway_container *workspace,
 		double lx, double ly, struct wlr_surface **surface,
 		double *sx, double *sy);
 
-struct sway_container *container_at_view(struct sway_container *view,
-		double lx, double ly, struct wlr_surface **surface,
-		double *sx, double *sy);
+struct sway_container *tiling_container_at(
+		struct sway_container *con, double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * Apply the function for each descendant of the container breadth first.

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -99,7 +99,7 @@ static struct sway_container *container_at_coords(
 		return ws;
 	}
 	if (ws->sway_workspace->fullscreen) {
-		return container_at_view(ws->sway_workspace->fullscreen, lx, ly,
+		return tiling_container_at(ws->sway_workspace->fullscreen, lx, ly,
 				surface, sx, sy);
 	}
 	if ((*surface = layer_surface_at(output,

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -535,7 +535,7 @@ struct sway_container *container_parent(struct sway_container *container,
 	return container;
 }
 
-struct sway_container *container_at_view(struct sway_container *swayc,
+static struct sway_container *container_at_view(struct sway_container *swayc,
 		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	if (!sway_assert(swayc->type == C_VIEW, "Expected a view")) {
@@ -573,10 +573,6 @@ struct sway_container *container_at_view(struct sway_container *swayc,
 	}
 	return NULL;
 }
-
-static struct sway_container *tiling_container_at(
-		struct sway_container *con, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * container_at for a container with layout L_TABBED.
@@ -684,7 +680,7 @@ static struct sway_container *floating_container_at(double lx, double ly,
 	return NULL;
 }
 
-static struct sway_container *tiling_container_at(
+struct sway_container *tiling_container_at(
 		struct sway_container *con, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	if (con->type == C_VIEW) {


### PR DESCRIPTION
Calling `container_at_view` fails an assertion if the container isn't a view. Calling `tiling_container_at` works correctly, as that function checks if the container is a view and calls `container_at_view` if so.

To test:

* Fullscreen mpv and interact with the UI
* Fullscreen a split container where one of them is mpv and interact with the UI