### PR TITLE
Add missing stdlib.h includes to swaynag

### DIFF
--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 500
+#include <stdlib.h>
 #include <signal.h>
 #include "log.h"
 #include "list.h"

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 500
+#include <stdlib.h>
 #include <assert.h>
 #include <sys/stat.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Without this swaynag does not build on my system (implicit declaration of
functions like "free"). With these includes added it builds and works.