### PR TITLE
Check correct ws for sticky and fix floating iter

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -412,6 +412,11 @@ bool workspace_switch(struct sway_container *workspace) {
 			has_sticky = true;
 			container_remove_child(floater);
 			container_add_child(workspace->sway_workspace->floating, floater);
+			if (floater == focus) {
+				seat_set_focus(seat, NULL);
+				seat_set_focus(seat, floater);
+			}
+			--i;
 		}
 	}
 


### PR DESCRIPTION
Fixes #2416 

~When switching workspaces, the wrong workspace could be checked for sticky floating containers. This is fixed by using `seat_get_focus_inactive` (followed-by `container_parent`) instead of `seat_get_active_child`.~ See comments below

Additionally, I fixed the iterator for the floating children so the current index is decremented when moving a sticky container to the workspace being switched to.