### PR TITLE
Fix compiler errors.

### DIFF
--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include <fcntl.h>
 #include <signal.h>
 #include <stdbool.h>

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 #include "log.h"


### PR DESCRIPTION
- Some platforms don't expose kill() unless _POSIX_C_SOURCE is defined.
- fork(), execl(), and setsid() need unistd.h on some platforms.

Basically, this fixes some platform-specific build errors.