### PR TITLE
[RFC] Fix segv when sway is terminating

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -596,7 +596,7 @@ void view_unmap(struct sway_view *view) {
 	struct sway_container *surviving_ancestor = container_destroy(view->swayc);
 
 	// If the workspace wasn't reaped
-	if (surviving_ancestor->type >= C_WORKSPACE) {
+	if (surviving_ancestor && surviving_ancestor->type >= C_WORKSPACE) {
 		struct sway_container *ws = surviving_ancestor->type == C_WORKSPACE ?
 			surviving_ancestor :
 			container_parent(surviving_ancestor, C_WORKSPACE);


### PR DESCRIPTION
I've got the following SIGSEGV when terminating sway:
Program terminated with signal SIGSEGV, Segmentation fault.
```
0x00005607dc603af5 in view_unmap (view=0x5607dcb3d350) at ../sway/tree/view.c:599
599		if (surviving_ancestor->type >= C_WORKSPACE) {
```
When I was printing the surviving_ancestor, it was NULL at that time
