### PR TITLE
Fix infinite loop when focusing sticky containers via workspace command

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -411,17 +411,20 @@ bool workspace_switch(struct sway_container *workspace,
 	struct sway_container *floating =
 		next_output_prev_ws->sway_workspace->floating;
 	bool has_sticky = false;
-	for (int i = 0; i < floating->children->length; ++i) {
-		struct sway_container *floater = floating->children->items[i];
-		if (floater->is_sticky) {
-			has_sticky = true;
-			container_remove_child(floater);
-			container_add_child(workspace->sway_workspace->floating, floater);
-			if (floater == focus) {
-				seat_set_focus(seat, NULL);
-				seat_set_focus(seat, floater);
+	if (workspace != next_output_prev_ws) {
+		for (int i = 0; i < floating->children->length; ++i) {
+			struct sway_container *floater = floating->children->items[i];
+			if (floater->is_sticky) {
+				has_sticky = true;
+				container_remove_child(floater);
+				container_add_child(workspace->sway_workspace->floating,
+						floater);
+				if (floater == focus) {
+					seat_set_focus(seat, NULL);
+					seat_set_focus(seat, floater);
+				}
+				--i;
 			}
-			--i;
 		}
 	}
 


### PR DESCRIPTION
In a multi-output setup, if a sticky container is on one output and focus is on the other output, and you run (eg) `workspace 1` to focus the workspace containing the sticky container, an infinite loop would occur. It would loop infinitely because it would remove the sticky container from the workspace, add it back to the same workspace, and then decrement the iterator variable.

The fix just wraps the loop in a workspace comparison.