### PR TITLE
Fix focus when clicking floating decorations

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -429,6 +429,9 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 		struct sway_container *cont) {
 	struct sway_seat *seat = cursor->seat;
 
+	seat_set_focus(seat, cont);
+	seat_pointer_notify_button(seat, time_msec, button, state);
+
 	// Deny moving or resizing a fullscreen container
 	if (container_is_fullscreen_or_child(cont)) {
 		seat_pointer_notify_button(seat, time_msec, button, state);
@@ -468,10 +471,6 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 		seat_begin_resize(seat, floater, button, edge);
 		return;
 	}
-
-	// Send event to surface
-	seat_set_focus(seat, cont);
-	seat_pointer_notify_button(seat, time_msec, button, state);
 }
 
 /**

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -430,7 +430,6 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 	struct sway_seat *seat = cursor->seat;
 
 	seat_set_focus(seat, cont);
-	seat_pointer_notify_button(seat, time_msec, button, state);
 
 	// Deny moving or resizing a fullscreen container
 	if (container_is_fullscreen_or_child(cont)) {
@@ -471,6 +470,8 @@ static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
 		seat_begin_resize(seat, floater, button, edge);
 		return;
 	}
+
+	seat_pointer_notify_button(seat, time_msec, button, state);
 }
 
 /**

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -567,9 +567,8 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 		*sx = _sx;
 		*sy = _sy;
 		*surface = _surface;
-		return swayc;
 	}
-	return NULL;
+	return swayc;
 }
 
 /**

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -533,11 +533,10 @@ struct sway_container *container_parent(struct sway_container *container,
 	return container;
 }
 
-static struct sway_container *container_at_view(struct sway_container *swayc,
-		double lx, double ly,
+static void surface_at_view(struct sway_container *swayc, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	if (!sway_assert(swayc->type == C_VIEW, "Expected a view")) {
-		return NULL;
+		return;
 	}
 	struct sway_view *sview = swayc->sway_view;
 	double view_sx = lx - sview->x;
@@ -568,7 +567,6 @@ static struct sway_container *container_at_view(struct sway_container *swayc,
 		*sy = _sy;
 		*surface = _surface;
 	}
-	return swayc;
 }
 
 /**
@@ -681,7 +679,8 @@ struct sway_container *tiling_container_at(
 		struct sway_container *con, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	if (con->type == C_VIEW) {
-		return container_at_view(con, lx, ly, surface, sx, sy);
+		surface_at_view(con, lx, ly, surface, sx, sy);
+		return con;
 	}
 	if (!con->children->length) {
 		return NULL;
@@ -744,7 +743,7 @@ struct sway_container *container_at(struct sway_container *workspace,
 	struct sway_container *focus =
 		seat_get_focus_inactive(seat, &root_container);
 	if (focus && focus->type == C_VIEW) {
-		container_at_view(focus, lx, ly, surface, sx, sy);
+		surface_at_view(focus, lx, ly, surface, sx, sy);
 		if (*surface && surface_is_popup(*surface)) {
 			return focus;
 		}


### PR DESCRIPTION
Fixes #2431.

It's not right for `container_at_view` to only return the swayc if a surface was clicked. It needs to also return the swayc if the decorations are clicked.

Note that `container_at_view` will now always return the swayc, so it assumes you've done a box check already. This seems like a safe assumption as I can't fault it.

To test, float a view which has title decorations then click the title. The floating view should be become focused.