### PR TITLE
Allow a fallback color to be specified for swaybg

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -151,6 +151,7 @@ struct output_config {
 
 	char *background;
 	char *background_option;
+	char *background_fallback;
 	enum config_dpms dpms_state;
 };
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -77,6 +77,10 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 		free(dst->background_option);
 		dst->background_option = strdup(src->background_option);
 	}
+	if (src->background_fallback) {
+		free(dst->background_fallback);
+		dst->background_fallback = strdup(src->background_fallback);
+	}
 	if (src->dpms_state != 0) {
 		dst->dpms_state = src->dpms_state;
 	}
@@ -226,17 +230,19 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 		wlr_log(WLR_DEBUG, "Setting background for output %d to %s",
 				output_i, oc->background);
 
-		size_t len = snprintf(NULL, 0, "%s %d %s %s",
+		size_t len = snprintf(NULL, 0, "%s %d %s %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
-				output_i, oc->background, oc->background_option);
+				output_i, oc->background, oc->background_option,
+				oc->background_fallback ? oc->background_fallback : "");
 		char *command = malloc(len + 1);
 		if (!command) {
 			wlr_log(WLR_DEBUG, "Unable to allocate swaybg command");
 			return;
 		}
-		snprintf(command, len + 1, "%s %d %s %s",
+		snprintf(command, len + 1, "%s %d %s %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
-				output_i, oc->background, oc->background_option);
+				output_i, oc->background, oc->background_option,
+				oc->background_fallback ? oc->background_fallback : "");
 		wlr_log(WLR_DEBUG, "-> %s", command);
 
 		char *const cmd[] = { "sh", "-c", command, NULL };

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -489,9 +489,13 @@ The default colors are:
 	setting an integral scale factor and adjusting the font size of your
 	applications to taste.
 
-*output* <name> background|bg <file> <mode>
+*output* <name> background|bg <file> <mode> [<fallback\_color>]
 	Sets the wallpaper for the given output to the specified file, using the
-	given scaling mode (one of "stretch", "fill", "fit", "center", "tile").
+	given scaling mode (one of "stretch", "fill", "fit", "center", "tile"). If
+	the specified file cannot be accessed or if the image does fill the entire
+	output, a fallback color may be provided to cover the rest of the output.
+	__fallback\_color__ should be specified as _#RRGGBB_. Alpha is not
+	supported.
 
 **output** <name> background|bg <color> solid\_color
 	Sets the background of the given output to the specified color. _color_


### PR DESCRIPTION
Closes #2434 
Fixes #2270

This allows for a color to be optionally set when the wallpaper does not fill the entire output. If specified, the fallback color is also used when the image path is inaccessible.

I opted to use the following syntax
```
output <name> bg <path> <mode> [<fallback_color>]
```
instead of the following from #2434
```
output <name> bg <color> solid_color
output <name> bg <path> <mode>
```

This allows for both solid colors and images (with an optional fallback color) to be set without affecting the other when changed via commands further down the config or swaymsg.