### PR TITLE
Don't call swaynag_log for bg when not reading

### DIFF
--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -110,7 +110,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		if (!can_access) {
 			wlr_log(WLR_ERROR, "Unable to access background file '%s': %s",
 					src, strerror(errno));
-			if (!config->validating) {
+			if (config->reading && !config->validating) {
 				swaynag_log(config->swaynag_command,
 						&config->swaynag_config_errors,
 						"Unable to access background file '%s'", src);


### PR DESCRIPTION
In #2439, I forgot to make sure the config was being read when calling `swaynag_log` for an inaccessible path. This PR just adds that check.