### PR TITLE
Finish resize commands

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -133,12 +133,29 @@ static enum resize_axis parse_resize_axis(const char *axis) {
 	return RESIZE_AXIS_INVALID;
 }
 
+static enum resize_axis normalize_axis(enum resize_axis axis) {
+	switch (axis) {
+	case RESIZE_AXIS_HORIZONTAL:
+	case RESIZE_AXIS_LEFT:
+	case RESIZE_AXIS_RIGHT:
+		return RESIZE_AXIS_HORIZONTAL;
+	case RESIZE_AXIS_VERTICAL:
+	case RESIZE_AXIS_UP:
+	case RESIZE_AXIS_DOWN:
+		return RESIZE_AXIS_VERTICAL;
+	case RESIZE_AXIS_INVALID:
+		sway_assert(false, "Never reached");
+	}
+	sway_assert(false, "Never reached");
+	return RESIZE_AXIS_INVALID;
+}
+
 static int parallel_coord(struct sway_container *c, enum resize_axis a) {
-	return a == RESIZE_AXIS_HORIZONTAL ? c->x : c->y;
+	return normalize_axis(a) == RESIZE_AXIS_HORIZONTAL ? c->x : c->y;
 }
 
 static int parallel_size(struct sway_container *c, enum resize_axis a) {
-	return a == RESIZE_AXIS_HORIZONTAL ? c->width : c->height;
+	return normalize_axis(a) == RESIZE_AXIS_HORIZONTAL ? c->width : c->height;
 }
 
 static void resize_tiled(int amount, enum resize_axis axis) {
@@ -149,7 +166,7 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 	}
 
 	enum sway_container_layout parallel_layout =
-		axis == RESIZE_AXIS_HORIZONTAL ? L_HORIZ : L_VERT;
+		normalize_axis(axis) == RESIZE_AXIS_HORIZONTAL ? L_HORIZ : L_VERT;
 	int minor_weight = 0;
 	int major_weight = 0;
 	while (parent->parent) {
@@ -185,6 +202,15 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 			"Found the proper parent: %p. It has %d l conts, and %d r conts",
 			parent->parent, minor_weight, major_weight);
 
+	// Implement up/down/left/right direction by zeroing one of the weights,
+	// then setting the axis to be horizontal or vertical
+	if (axis == RESIZE_AXIS_UP || axis == RESIZE_AXIS_LEFT) {
+		major_weight = 0;
+	} else if (axis == RESIZE_AXIS_RIGHT || axis == RESIZE_AXIS_DOWN) {
+		minor_weight = 0;
+	}
+	axis = normalize_axis(axis);
+
 	int min_sane = axis == RESIZE_AXIS_HORIZONTAL ? MIN_SANE_W : MIN_SANE_H;
 
 	//TODO: Ensure rounding is done in such a way that there are NO pixel leaks
@@ -201,14 +227,14 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 		int parent_size = parallel_size(parent, axis);
 
 		if (sibling_pos != focused_pos) {
-			if (sibling_pos < parent_pos) {
+			if (sibling_pos < parent_pos && minor_weight) {
 				double pixels = -amount / minor_weight;
 				if (major_weight && (sibling_size + pixels / 2) < min_sane) {
 					return; // Too small
 				} else if ((sibling_size + pixels) < min_sane) {
 					return; // Too small
 				}
-			} else if (sibling_pos > parent_pos) {
+			} else if (sibling_pos > parent_pos && major_weight) {
 				double pixels = -amount / major_weight;
 				if (minor_weight && (sibling_size + pixels / 2) < min_sane) {
 					return; // Too small
@@ -237,7 +263,7 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 		int parent_pos = parallel_coord(parent, axis);
 
 		if (sibling_pos != focused_pos) {
-			if (sibling_pos < parent_pos) {
+			if (sibling_pos < parent_pos && minor_weight) {
 				double pixels = -1 * amount;
 				pixels /= minor_weight;
 				if (major_weight) {
@@ -245,7 +271,7 @@ static void resize_tiled(int amount, enum resize_axis axis) {
 				} else {
 					container_recursive_resize(sibling, pixels, major_edge);
 				}
-			} else if (sibling_pos > parent_pos) {
+			} else if (sibling_pos > parent_pos && major_weight) {
 				double pixels = -1 * amount;
 				pixels /= major_weight;
 				if (minor_weight) {
@@ -355,7 +381,6 @@ static struct cmd_results *resize_adjust_tiled(enum resize_axis axis,
 	}
 	if (amount->unit == RESIZE_UNIT_PPT) {
 		float pct = amount->amount / 100.0f;
-		// TODO: Make left/right/up/down resize in that direction?
 		switch (axis) {
 		case RESIZE_AXIS_LEFT:
 		case RESIZE_AXIS_RIGHT:

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -170,16 +170,16 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *reload*
 	Reloads the sway config file and applies any changes.
 
-*resize* shrink|grow width|height [<amount>] [px|ppt]
+*resize* shrink|grow width|height [<amount> [px|ppt]]
 	Resizes the currently focused container by _amount_, specified in pixels or
-	percentage points. If omitted, floating containers are resized in px and
-	tiled containers by ppt. If omitted, the default _amount_ is 10.
+	percentage points. If the units are omitted, floating containers are resized
+	in px and tiled containers by ppt. _amount_ will default to 10 if omitted.
 
-*resize set* <width> [px] <height> [px]
-	Sets the width and height of the currently focused container to _width_
-	pixels and _height_ pixels. The [px] parameters are optional and have no
-	effect. This command only accepts a size in pixels. Width and height may be
-	specified in either order.
+*resize set* <width> [px|ppt] <height> [px|ppt]
+	Sets the width and height of the currently focused container to _width_ and
+	_height_, specified in pixels or percentage points. If the units are
+	omitted, floating containers are resized in px and tiled containers by ppt.
+	If _width_ or _height_ is 0, no resize is done on that axis.
 
 *scratchpad show*
 	Shows a window from the scratchpad. Repeatedly using this command will


### PR DESCRIPTION
Completes #1737.

* Implements `resize grow|shrink <direction> <amount>` for tiled containers
* Implements `resize set <width> <height>` for tiled containers

I made `resize set` allow px units, then realised afterwards that i3 doesn't support it. So I left it in. Use `px` to use pixels, and `ppt` or no unit to use percentage points.

Also fixes a sane size check which failed to check against the correct amount of pixels in some cases.