### PR TITLE
Implement resizing tiled containers via cursor

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -77,6 +77,15 @@ int list_seq_find(list_t *list, int compare(const void *item, const void *data),
 	return -1;
 }
 
+int list_find(list_t *list, void *item) {
+	for (int i = 0; i < list->length; i++) {
+		if (list->items[i] == item) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 void list_swap(list_t *list, int src, int dest) {
 	void *tmp = list->items[src];
 	list->items[src] = list->items[dest];

--- a/include/list.h
+++ b/include/list.h
@@ -20,6 +20,7 @@ void list_qsort(list_t *list, int compare(const void *left, const void *right));
 // Return index for first item in list that returns 0 for given compare
 // function or -1 if none matches.
 int list_seq_find(list_t *list, int compare(const void *item, const void *cmp_to), const void *cmp_to);
+int list_find(list_t *list, void *item);
 // stable sort since qsort is not guaranteed to be stable
 void list_stable_sort(list_t *list, int compare(const void *a, const void *b));
 // swap two elements in a list

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_COMMANDS_H
 #define _SWAY_COMMANDS_H
 
+#include <wlr/util/edges.h>
 #include "config.h"
 
 typedef struct cmd_results *sway_cmd(int argc, char **argv);
@@ -83,6 +84,12 @@ char *cmd_results_to_json(struct cmd_results *results);
 
 struct cmd_results *add_color(const char *name,
 		char *buffer, const char *color);
+
+/**
+ * TODO: Move this function and its dependent functions to container.c.
+ */
+void container_resize_tiled(struct sway_container *parent, enum wlr_edges edge,
+		int amount);
 
 sway_cmd cmd_assign;
 sway_cmd cmd_bar;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -57,7 +57,8 @@ struct sway_seat {
 	enum {
 		OP_NONE,
 		OP_MOVE,
-		OP_RESIZE,
+		OP_RESIZE_FLOATING,
+		OP_RESIZE_TILING,
 	} operation;
 
 	struct sway_container *op_container;
@@ -159,8 +160,11 @@ void drag_icon_update_position(struct sway_drag_icon *icon);
 void seat_begin_move(struct sway_seat *seat, struct sway_container *con,
 		uint32_t button);
 
-void seat_begin_resize(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button, enum wlr_edges edge);
+void seat_begin_resize_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge);
+
+void seat_begin_resize_tiling(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge);
 
 void seat_end_mouse_operation(struct sway_seat *seat);
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -33,6 +33,7 @@ struct sway_transaction {
 	list_t *instructions;   // struct sway_transaction_instruction *
 	size_t num_waiting;
 	size_t num_configures;
+	uint32_t con_ids;       // Bitwise XOR of view container IDs
 	struct timespec create_time;
 	struct timespec commit_time;
 };
@@ -212,29 +213,43 @@ static void transaction_apply(struct sway_transaction *transaction) {
 	}
 }
 
+static void transaction_commit(struct sway_transaction *transaction);
+
 static void transaction_progress_queue() {
-	// Check if any transactions in the queue are in a partially ready state.
-	// If so, we shouldn't progress any transactions, even ones which are fully
-	// ready at the front of the queue, because the views in the ready
-	// transactions might have committed past it to a transaction which isn't
-	// yet ready.
-	for (int i = 0; i < server.transactions->length; ++i) {
-		struct sway_transaction *transaction = server.transactions->items[i];
-		if (transaction->num_waiting != 0 &&
-				transaction->num_waiting != transaction->num_configures) {
-			return;
+	if (!server.transactions->length) {
+		return;
+	}
+	// There's only ever one committed transaction,
+	// and it's the first one in the queue.
+	struct sway_transaction *transaction = server.transactions->items[0];
+	if (transaction->num_waiting) {
+		return;
+	}
+	transaction_apply(transaction);
+	transaction_destroy(transaction);
+	list_del(server.transactions, 0);
+
+	if (!server.transactions->length) {
+		idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
+		return;
+	}
+
+	// If there's a bunch of consecutive transactions which all apply to the
+	// same views, skip all except the last one.
+	while (server.transactions->length >= 2) {
+		struct sway_transaction *a = server.transactions->items[0];
+		struct sway_transaction *b = server.transactions->items[1];
+		if (a->con_ids == b->con_ids) {
+			list_del(server.transactions, 0);
+			transaction_destroy(a);
+		} else {
+			break;
 		}
 	}
-	while (server.transactions->length) {
-		struct sway_transaction *transaction = server.transactions->items[0];
-		if (transaction->num_waiting) {
-			return;
-		}
-		transaction_apply(transaction);
-		transaction_destroy(transaction);
-		list_del(server.transactions, 0);
-	}
-	idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
+
+	transaction = server.transactions->items[0];
+	transaction_commit(transaction);
+	transaction_progress_queue();
 }
 
 static int handle_timeout(void *data) {
@@ -288,6 +303,7 @@ static void transaction_commit(struct sway_transaction *transaction) {
 					instruction->state.view_width,
 					instruction->state.view_height);
 			++transaction->num_waiting;
+			transaction->con_ids ^= con->id;
 
 			// From here on we are rendering a saved buffer of the view, which
 			// means we can send a frame done event to make the client redraw it
@@ -305,17 +321,6 @@ static void transaction_commit(struct sway_transaction *transaction) {
 	if (server.debug_txn_timings) {
 		clock_gettime(CLOCK_MONOTONIC, &transaction->commit_time);
 	}
-	if (server.transactions->length || transaction->num_waiting) {
-		list_add(server.transactions, transaction);
-	} else {
-		// There are no other transactions in progress, and this one has nothing
-		// to wait for, so we can skip the queue.
-		wlr_log(WLR_DEBUG, "Transaction %p has nothing to wait for", transaction);
-		transaction_apply(transaction);
-		transaction_destroy(transaction);
-		idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
-		return;
-	}
 
 	if (transaction->num_waiting) {
 		// Set up a timer which the views must respond within
@@ -329,6 +334,9 @@ static void transaction_commit(struct sway_transaction *transaction) {
 					strerror(errno));
 			handle_timeout(transaction);
 		}
+	} else {
+		wlr_log(WLR_DEBUG,
+				"Transaction %p has nothing to wait for", transaction);
 	}
 
 	// The debug tree shows the pending/live tree. Here is a good place to
@@ -415,5 +423,15 @@ void transaction_commit_dirty(void) {
 		container->dirty = false;
 	}
 	server.dirty_containers->length = 0;
-	transaction_commit(transaction);
+
+	list_add(server.transactions, transaction);
+
+	// There's only ever one committed transaction,
+	// and it's the first one in the queue.
+	if (server.transactions->length == 1) {
+		transaction_commit(transaction);
+		// Attempting to progress the queue here is useful
+		// if the transaction has nothing to wait for.
+		transaction_progress_queue();
+	}
 }

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -331,7 +331,8 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize(seat, view->swayc, seat->last_button, e->edges);
+		seat_begin_resize_floating(seat, view->swayc,
+				seat->last_button, e->edges);
 	}
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -327,7 +327,8 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_v6_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize(seat, view->swayc, seat->last_button, e->edges);
+		seat_begin_resize_floating(seat, view->swayc,
+				seat->last_button, e->edges);
 	}
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -432,7 +432,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	}
 	struct wlr_xwayland_resize_event *e = data;
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	seat_begin_resize(seat, view->swayc, seat->last_button, e->edges);
+	seat_begin_resize_floating(seat, view->swayc, seat->last_button, e->edges);
 }
 
 static void handle_set_title(struct wl_listener *listener, void *data) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -657,7 +657,8 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	}
 
 	// Handle tiling resize via border
-	if (resize_edge && button == BTN_LEFT && !is_floating) {
+	if (resize_edge && button == BTN_LEFT && state == WLR_BUTTON_PRESSED &&
+			!is_floating) {
 		seat_set_focus(seat, cont);
 		seat_begin_resize_tiling(seat, cont, button, edge);
 		return;
@@ -666,7 +667,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle tiling resize via mod
 	bool mod_pressed = keyboard &&
 		(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod);
-	if (!is_floating) {
+	if (!is_floating && mod_pressed && state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_resize = config->floating_mod_inverse ?
 			BTN_LEFT : BTN_RIGHT;
 		if (button == btn_resize) {
@@ -682,7 +683,8 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	}
 
 	// Handle beginning floating move
-	if (is_floating_or_child && !is_fullscreen_or_child) {
+	if (is_floating_or_child && !is_fullscreen_or_child &&
+			state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
 		if (button == btn_move && state == WLR_BUTTON_PRESSED &&
 				(mod_pressed || on_titlebar)) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -675,7 +675,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle tiling resize via mod
 	bool mod_pressed = keyboard &&
 		(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod);
-	if (!is_floating && mod_pressed && state == WLR_BUTTON_PRESSED) {
+	if (!is_floating_or_child && mod_pressed && state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_resize = config->floating_mod_inverse ?
 			BTN_LEFT : BTN_RIGHT;
 		if (button == btn_resize) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -175,7 +175,7 @@ static bool edge_is_external(struct sway_container *cont, enum wlr_edges edge) {
 	return true;
 }
 
-static enum wlr_edges find_resize_edge(struct sway_container *cont,
+static enum wlr_edges find_edge(struct sway_container *cont,
 		struct sway_cursor *cursor) {
 	if (cont->type != C_VIEW) {
 		return WLR_EDGE_NONE;
@@ -199,10 +199,19 @@ static enum wlr_edges find_resize_edge(struct sway_container *cont,
 		edge |= WLR_EDGE_BOTTOM;
 	}
 
+	return edge;
+}
+
+/**
+ * If the cursor is over a _resizable_ edge, return the edge.
+ * Edges that can't be resized are edges of the workspace.
+ */
+static enum wlr_edges find_resize_edge(struct sway_container *cont,
+		struct sway_cursor *cursor) {
+	enum wlr_edges edge = find_edge(cont, cursor);
 	if (edge && !container_is_floating(cont) && edge_is_external(cont, edge)) {
 		return WLR_EDGE_NONE;
 	}
-
 	return edge;
 }
 
@@ -500,57 +509,6 @@ static void handle_cursor_motion_absolute(
 	transaction_commit_dirty();
 }
 
-static void dispatch_cursor_button_floating(struct sway_cursor *cursor,
-		uint32_t time_msec, uint32_t button, enum wlr_button_state state,
-		struct wlr_surface *surface, double sx, double sy,
-		struct sway_container *cont) {
-	struct sway_seat *seat = cursor->seat;
-
-	seat_set_focus(seat, cont);
-
-	// Deny moving or resizing a fullscreen container
-	if (container_is_fullscreen_or_child(cont)) {
-		seat_pointer_notify_button(seat, time_msec, button, state);
-		return;
-	}
-	struct sway_container *floater = cont;
-	while (floater->parent->layout != L_FLOATING) {
-		floater = floater->parent;
-	}
-
-	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
-	bool mod_pressed = keyboard &&
-		(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod);
-	enum wlr_edges edge = find_resize_edge(floater, cursor);
-	bool over_title = edge == WLR_EDGE_NONE && !surface;
-
-	// Check for beginning move
-	uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
-	if (button == btn_move && state == WLR_BUTTON_PRESSED &&
-			(mod_pressed || over_title)) {
-		seat_begin_move(seat, floater, button);
-		return;
-	}
-
-	// Check for beginning resize
-	bool resizing_via_border = button == BTN_LEFT && edge != WLR_EDGE_NONE;
-	uint32_t btn_resize = config->floating_mod_inverse ? BTN_LEFT : BTN_RIGHT;
-	bool resizing_via_mod = button == btn_resize && mod_pressed;
-	if ((resizing_via_border || resizing_via_mod) &&
-			state == WLR_BUTTON_PRESSED) {
-		if (edge == WLR_EDGE_NONE) {
-			edge |= cursor->cursor->x > floater->x + floater->width / 2 ?
-				WLR_EDGE_RIGHT : WLR_EDGE_LEFT;
-			edge |= cursor->cursor->y > floater->y + floater->height / 2 ?
-				WLR_EDGE_BOTTOM : WLR_EDGE_TOP;
-		}
-		seat_begin_resize_floating(seat, floater, button, edge);
-		return;
-	}
-
-	seat_pointer_notify_button(seat, time_msec, button, state);
-}
-
 /**
  * Remove a button (and duplicates) to the sorted list of currently pressed buttons
  */
@@ -630,26 +588,36 @@ static struct sway_binding* get_active_mouse_binding(const struct sway_cursor *c
 
 void dispatch_cursor_button(struct sway_cursor *cursor,
 		uint32_t time_msec, uint32_t button, enum wlr_button_state state) {
-	if (cursor->seat->operation != OP_NONE &&
-			button == cursor->seat->op_button && state == WLR_BUTTON_RELEASED) {
-		seat_end_mouse_operation(cursor->seat);
-		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
-		return;
-	}
 	if (time_msec == 0) {
 		time_msec = get_current_time_msec();
 	}
+	struct sway_seat *seat = cursor->seat;
 
+	// Handle ending seat operation
+	if (cursor->seat->operation != OP_NONE &&
+			button == cursor->seat->op_button && state == WLR_BUTTON_RELEASED) {
+		seat_end_mouse_operation(seat);
+		seat_pointer_notify_button(seat, time_msec, button, state);
+		return;
+	}
+
+	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_container *cont = container_at_coords(cursor->seat,
+	struct sway_container *cont = container_at_coords(seat,
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	bool is_floating = cont && container_is_floating(cont);
+	bool is_floating_or_child = cont && container_is_floating_or_child(cont);
+	bool is_fullscreen_or_child = cont && container_is_fullscreen_or_child(cont);
+	enum wlr_edges edge = cont ? find_edge(cont, cursor) : WLR_EDGE_NONE;
+	enum wlr_edges resize_edge = edge ?
+		find_resize_edge(cont, cursor) : WLR_EDGE_NONE;
+	bool on_border = edge != WLR_EDGE_NONE;
+	bool on_contents = cont && !on_border && surface;
+	bool on_titlebar = cont && !on_border && !surface;
 
 	// Handle mouse bindings
-	bool on_border = cont && (find_resize_edge(cont, cursor) != WLR_EDGE_NONE);
-	bool on_contents = !on_border && surface;
-	bool on_titlebar = !on_border && !surface;
-	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(cursor->seat->wlr_seat);
+	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
 	uint32_t modifiers = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
 
 	struct sway_binding *binding = NULL;
@@ -665,51 +633,78 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		state_erase_button(cursor, button);
 	}
 	if (binding) {
-		seat_execute_command(cursor->seat, binding);
-		// TODO: do we want to pass on the event?
+		seat_execute_command(seat, binding);
+		return;
 	}
 
-	enum wlr_edges edge = cont ? find_resize_edge(cont, cursor) : WLR_EDGE_NONE;
-
+	// Handle clicking a layer surface
 	if (surface && wlr_surface_is_layer_surface(surface)) {
 		struct wlr_layer_surface *layer =
 			wlr_layer_surface_from_wlr_surface(surface);
 		if (layer->current.keyboard_interactive) {
-			seat_set_focus_layer(cursor->seat, layer);
+			seat_set_focus_layer(seat, layer);
 		}
-		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
-	} else if (edge && button == BTN_LEFT &&
-			!container_is_floating(cont)) {
-		seat_set_focus(cursor->seat, cont);
-		seat_begin_resize_tiling(cursor->seat, cont, BTN_LEFT, edge);
-	} else if (cont && container_is_floating_or_child(cont)) {
-		dispatch_cursor_button_floating(cursor, time_msec, button, state,
-				surface, sx, sy, cont);
-	} else if (surface && cont && cont->type != C_VIEW) {
-		// Avoid moving keyboard focus from a surface that accepts it to one
-		// that does not unless the change would move us to a new workspace.
-		//
-		// This prevents, for example, losing focus when clicking on swaybar.
-		struct sway_container *new_ws = cont;
-		if (new_ws && new_ws->type != C_WORKSPACE) {
-			new_ws = container_parent(new_ws, C_WORKSPACE);
-		}
-		struct sway_container *old_ws = seat_get_focus(cursor->seat);
-		if (old_ws && old_ws->type != C_WORKSPACE) {
-			old_ws = container_parent(old_ws, C_WORKSPACE);
-		}
-		if (new_ws != old_ws) {
-			seat_set_focus(cursor->seat, cont);
-		}
-		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
-	} else if (cont) {
-		seat_set_focus(cursor->seat, cont);
-		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
-	} else {
-		seat_pointer_notify_button(cursor->seat, time_msec, button, state);
+		seat_pointer_notify_button(seat, time_msec, button, state);
+		return;
 	}
 
-	transaction_commit_dirty();
+	// Handle tiling resize via border
+	if (resize_edge && button == BTN_LEFT && !is_floating) {
+		seat_set_focus(seat, cont);
+		seat_begin_resize_tiling(seat, cont, button, edge);
+		return;
+	}
+
+	// Handle beginning floating move
+	bool mod_pressed = keyboard &&
+		(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod);
+
+	if (is_floating_or_child && !is_fullscreen_or_child) {
+		uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
+		if (button == btn_move && state == WLR_BUTTON_PRESSED &&
+				(mod_pressed || on_titlebar)) {
+			while (cont->parent->layout != L_FLOATING) {
+				cont = cont->parent;
+			}
+			seat_begin_move(seat, cont, button);
+			return;
+		}
+	}
+
+	// Handle beginning floating resize
+	if (is_floating_or_child && !is_fullscreen_or_child &&
+			state == WLR_BUTTON_PRESSED) {
+		// Via border
+		if (button == BTN_LEFT && resize_edge != WLR_EDGE_NONE) {
+			seat_begin_resize_floating(seat, cont, button, resize_edge);
+			return;
+		}
+
+		// Via mod+click
+		struct sway_container *floater = cont;
+		while (floater->parent->layout != L_FLOATING) {
+			floater = floater->parent;
+		}
+		uint32_t btn_resize = config->floating_mod_inverse ?
+			BTN_LEFT : BTN_RIGHT;
+		if (button == btn_resize) {
+			edge |= cursor->cursor->x > floater->x + floater->width / 2 ?
+				WLR_EDGE_RIGHT : WLR_EDGE_LEFT;
+			edge |= cursor->cursor->y > floater->y + floater->height / 2 ?
+				WLR_EDGE_BOTTOM : WLR_EDGE_TOP;
+			seat_begin_resize_floating(seat, floater, button, edge);
+			return;
+		}
+	}
+
+	// Handle clicking a container surface
+	if (cont) {
+		seat_set_focus(seat, cont);
+		seat_pointer_notify_button(seat, time_msec, button, state);
+		return;
+	}
+
+	seat_pointer_notify_button(seat, time_msec, button, state);
 }
 
 static void handle_cursor_button(struct wl_listener *listener, void *data) {
@@ -718,6 +713,7 @@ static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_button *event = data;
 	dispatch_cursor_button(cursor,
 			event->time_msec, event->button, event->state);
+	transaction_commit_dirty();
 }
 
 static void handle_cursor_axis(struct wl_listener *listener, void *data) {
@@ -865,6 +861,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	dispatch_cursor_button(cursor, event->time_msec,
 			BTN_LEFT, event->state == WLR_TABLET_TOOL_TIP_DOWN ?
 				WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED);
+	transaction_commit_dirty();
 }
 
 static void handle_tool_button(struct wl_listener *listener, void *data) {
@@ -889,6 +886,7 @@ static void handle_tool_button(struct wl_listener *listener, void *data) {
 		cursor->tool_buttons--;
 		break;
 	}
+	transaction_commit_dirty();
 }
 
 static void handle_request_set_cursor(struct wl_listener *listener,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -980,9 +980,6 @@ void seat_begin_resize_tiling(struct sway_seat *seat,
 	seat->op_ref_con_ly = con->y;
 	seat->op_ref_width = con->width;
 	seat->op_ref_height = con->height;
-
-	const char *image = wlr_xcursor_get_resize_name(edge);
-	cursor_set_image(seat->cursor, image, NULL);
 }
 
 void seat_end_mouse_operation(struct sway_seat *seat) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -942,14 +942,14 @@ void seat_begin_move(struct sway_seat *seat, struct sway_container *con,
 	cursor_set_image(seat->cursor, "grab", NULL);
 }
 
-void seat_begin_resize(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button, enum wlr_edges edge) {
+void seat_begin_resize_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
 	if (!seat->cursor) {
 		wlr_log(WLR_DEBUG, "Ignoring resize request due to no cursor device");
 		return;
 	}
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
-	seat->operation = OP_RESIZE;
+	seat->operation = OP_RESIZE_FLOATING;
 	seat->op_container = con;
 	seat->op_resize_preserve_ratio = keyboard &&
 		(wlr_keyboard_get_modifiers(keyboard) & WLR_MODIFIER_SHIFT);
@@ -968,20 +968,29 @@ void seat_begin_resize(struct sway_seat *seat, struct sway_container *con,
 	cursor_set_image(seat->cursor, image, NULL);
 }
 
+void seat_begin_resize_tiling(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
+	seat->operation = OP_RESIZE_TILING;
+	seat->op_container = con;
+	seat->op_resize_edge = edge;
+	seat->op_button = button;
+	seat->op_ref_lx = seat->cursor->cursor->x;
+	seat->op_ref_ly = seat->cursor->cursor->y;
+	seat->op_ref_con_lx = con->x;
+	seat->op_ref_con_ly = con->y;
+	seat->op_ref_width = con->width;
+	seat->op_ref_height = con->height;
+
+	const char *image = wlr_xcursor_get_resize_name(edge);
+	cursor_set_image(seat->cursor, image, NULL);
+}
+
 void seat_end_mouse_operation(struct sway_seat *seat) {
-	switch (seat->operation) {
-	case OP_MOVE:
-		{
-			// We "move" the container to its own location so it discovers its
-			// output again.
-			struct sway_container *con = seat->op_container;
-			container_floating_move_to(con, con->x, con->y);
-		}
-	case OP_RESIZE:
-		// Don't need to do anything here.
-		break;
-	case OP_NONE:
-		break;
+	if (seat->operation == OP_MOVE) {
+		// We "move" the container to its own location so it discovers its
+		// output again.
+		struct sway_container *con = seat->op_container;
+		container_floating_move_to(con, con->x, con->y);
 	}
 	seat->operation = OP_NONE;
 	seat->op_container = NULL;


### PR DESCRIPTION
* The `OP_RESIZE` seat operation has been renamed to `OP_RESIZE_FLOATING`, and `OP_RESIZE_TILING` has been introduced.
* Similar to the above, `seat_begin_resize` and `handle_resize_motion` have been renamed and tiling variants introduced.
* `resize.c`'s `resize_tiled` has to be used, so `container_resize_tiled` has been introduced in `resize.c` to allow external code to call it. Ideally all this would be in `container.c`, but I didn't want to make this PR unnecessarily big.

Things to test:

* Create two tiled views in horizontal/vertical layout and resize all internal edges
* Float a container with two or more views inside it and resize them
* Check for regressions in the resize/move stuff that's already implemented

BTW, it would be good if the cursor icon could be something like this: 
![image](https://user-images.githubusercontent.com/2436833/43938515-6549e5b0-9ca7-11e8-9533-661965fc7648.png)

...but this would have to be added to wlroots.