### PR TITLE
Remove container_has_child

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -256,12 +256,6 @@ void container_for_each_descendant_dfs(struct sway_container *container,
 bool container_has_ancestor(struct sway_container *container,
 		struct sway_container *ancestor);
 
-/**
- * Returns true if the given container is a child descendant of this container.
- */
-bool container_has_child(struct sway_container *con,
-		struct sway_container *child);
-
 int container_count_descendants_of_type(struct sway_container *con,
 		enum sway_container_type type);
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -145,14 +145,14 @@ static struct sway_container *seat_get_focus_by_type(struct sway_seat *seat,
 			continue;
 		}
 
-		if (container_has_child(container, current->container)) {
+		if (container_has_ancestor(current->container, container)) {
 			if (only_tiling &&
 					container_is_floating_or_child(current->container)) {
 				continue;
 			}
 			return current->container;
 		}
-		if (floating && container_has_child(floating, current->container)) {
+		if (floating && container_has_ancestor(current->container, floating)) {
 			return current->container;
 		}
 	}
@@ -190,7 +190,7 @@ static void handle_seat_container_destroy(struct wl_listener *listener,
 
 	bool set_focus =
 		focus != NULL &&
-		(focus == con || container_has_child(con, focus)) &&
+		(focus == con || container_has_ancestor(focus, con)) &&
 		con->type != C_WORKSPACE;
 
 	seat_container_destroy(seat_con);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -817,19 +817,6 @@ bool container_has_ancestor(struct sway_container *descendant,
 	return false;
 }
 
-static bool find_child_func(struct sway_container *con, void *data) {
-	struct sway_container *child = data;
-	return con == child;
-}
-
-bool container_has_child(struct sway_container *con,
-		struct sway_container *child) {
-	if (con == NULL || con->type == C_VIEW) {
-		return false;
-	}
-	return container_find(con, find_child_func, child);
-}
-
 int container_count_descendants_of_type(struct sway_container *con,
 		enum sway_container_type type) {
 	int children = 0;


### PR DESCRIPTION
In all cases you can use `container_has_ancestor` with the arguments swapped, which is faster than `container_has_child`.