### PR TITLE
Remove container_for_each_descendant_bfs

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -239,15 +239,9 @@ struct sway_container *tiling_container_at(
 		struct wlr_surface **surface, double *sx, double *sy);
 
 /**
- * Apply the function for each descendant of the container breadth first.
- */
-void container_for_each_descendant_bfs(struct sway_container *container,
-		void (*f)(struct sway_container *container, void *data), void *data);
-
-/**
  * Apply the function for each child of the container depth first.
  */
-void container_for_each_descendant_dfs(struct sway_container *container,
+void container_for_each_descendant(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data), void *data);
 
 /**

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -31,7 +31,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 				"<none|vertical|horizontal|both|smart>'");
 	}
 
-	container_for_each_descendant_dfs(&root_container, _configure_view, NULL);
+	container_for_each_descendant(&root_container, _configure_view, NULL);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -24,7 +24,7 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 	config->show_marks = parse_boolean(argv[0], config->show_marks);
 
 	if (config->show_marks) {
-		container_for_each_descendant_dfs(&root_container,
+		container_for_each_descendant(&root_container,
 				rebuild_marks_iterator, NULL);
 	}
 

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -52,7 +52,7 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 		view_find_and_unmark(mark);
 	} else {
 		// Remove all marks from all views
-		container_for_each_descendant_dfs(&root_container,
+		container_for_each_descendant(&root_container,
 				remove_all_marks_iterator, NULL);
 	}
 	free(mark);

--- a/sway/config.c
+++ b/sway/config.c
@@ -822,7 +822,7 @@ void config_update_font_height(bool recalculate) {
 	size_t prev_max_height = config->font_height;
 	config->font_height = 0;
 
-	container_for_each_descendant_dfs(&root_container,
+	container_for_each_descendant(&root_container,
 			find_font_height_iterator, &recalculate);
 
 	// Also consider floating views
@@ -830,7 +830,7 @@ void config_update_font_height(bool recalculate) {
 		struct sway_container *output = root_container.children->items[i];
 		for (int j = 0; j < output->children->length; ++j) {
 			struct sway_container *ws = output->children->items[j];
-			container_for_each_descendant_dfs(ws->sway_workspace->floating,
+			container_for_each_descendant(ws->sway_workspace->floating,
 					find_font_height_iterator, &recalculate);
 		}
 	}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -167,7 +167,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 			return false;
 		}
 		list_t *urgent_views = create_list();
-		container_for_each_descendant_dfs(&root_container,
+		container_for_each_descendant(&root_container,
 				find_urgent_iterator, urgent_views);
 		list_stable_sort(urgent_views, cmp_urgent);
 		struct sway_view *target;
@@ -228,7 +228,7 @@ list_t *criteria_get_views(struct criteria *criteria) {
 		.criteria = criteria,
 		.matches = matches,
 	};
-	container_for_each_descendant_dfs(&root_container,
+	container_for_each_descendant(&root_container,
 		criteria_get_views_iterator, &data);
 
 	// Scratchpad items which are hidden are not in the tree.

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -375,8 +375,7 @@ struct sway_seat *seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	container_for_each_descendant_dfs(&root_container,
-		collect_focus_iter, seat);
+	container_for_each_descendant(&root_container, collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -631,7 +631,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_GET_WORKSPACES:
 	{
 		json_object *workspaces = json_object_new_array();
-		container_for_each_descendant_dfs(&root_container,
+		container_for_each_descendant(&root_container,
 				ipc_get_workspaces_callback, workspaces);
 		const char *json_string = json_object_to_json_string(workspaces);
 		client_valid =

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -25,21 +25,6 @@
 #include "log.h"
 #include "stringop.h"
 
-static list_t *bfs_queue;
-
-static list_t *get_bfs_queue() {
-	if (!bfs_queue) {
-		bfs_queue = create_list();
-		if (!bfs_queue) {
-			wlr_log(WLR_ERROR, "could not allocate list for bfs queue");
-			return NULL;
-		}
-	}
-	bfs_queue->length = 0;
-
-	return bfs_queue;
-}
-
 const char *container_type_to_str(enum sway_container_type type) {
 	switch (type) {
 	case C_ROOT:
@@ -450,7 +435,7 @@ struct sway_container *container_close(struct sway_container *con) {
 	if (con->type == C_VIEW) {
 		view_close(con->sway_view);
 	} else {
-		container_for_each_descendant_dfs(con, container_close_func, NULL);
+		container_for_each_descendant(con, container_close_func, NULL);
 	}
 
 	return parent;
@@ -760,7 +745,7 @@ struct sway_container *container_at(struct sway_container *workspace,
 	return NULL;
 }
 
-void container_for_each_descendant_dfs(struct sway_container *container,
+void container_for_each_descendant(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data),
 		void *data) {
 	if (!container) {
@@ -769,41 +754,17 @@ void container_for_each_descendant_dfs(struct sway_container *container,
 	if (container->children)  {
 		for (int i = 0; i < container->children->length; ++i) {
 			struct sway_container *child = container->children->items[i];
-			container_for_each_descendant_dfs(child, f, data);
+			container_for_each_descendant(child, f, data);
 		}
 	}
 	if (container->type == C_WORKSPACE)  {
 		struct sway_container *floating = container->sway_workspace->floating;
 		for (int i = 0; i < floating->children->length; ++i) {
 			struct sway_container *child = floating->children->items[i];
-			container_for_each_descendant_dfs(child, f, data);
+			container_for_each_descendant(child, f, data);
 		}
 	}
 	f(container, data);
-}
-
-void container_for_each_descendant_bfs(struct sway_container *con,
-		void (*f)(struct sway_container *con, void *data), void *data) {
-	list_t *queue = get_bfs_queue();
-	if (!queue) {
-		return;
-	}
-
-	if (queue == NULL) {
-		wlr_log(WLR_ERROR, "could not allocate list");
-		return;
-	}
-
-	list_add(queue, con);
-
-	struct sway_container *current = NULL;
-	while (queue->length) {
-		current = queue->items[0];
-		list_del(queue, 0);
-		f(current, data);
-		// TODO floating containers
-		list_cat(queue, current->children);
-	}
 }
 
 bool container_has_ancestor(struct sway_container *descendant,
@@ -1289,8 +1250,7 @@ void container_set_fullscreen(struct sway_container *container, bool enable) {
 		container_set_fullscreen(workspace->sway_workspace->fullscreen, false);
 	}
 
-	container_for_each_descendant_dfs(container,
-			set_fullscreen_iterator, &enable);
+	container_for_each_descendant(container, set_fullscreen_iterator, &enable);
 
 	container->is_fullscreen = enable;
 


### PR DESCRIPTION
The function was not used.

Also renames `container_for_each_descendant_dfs` to just `container_for_each_descendant`.