### PR TITLE
Simplify transactions

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -20,6 +20,8 @@
  * create and commits a transaction from the dirty containers.
  */
 
+struct sway_transaction_instruction;
+
 /**
  * Find all dirty containers, create and commit a transaction containing them,
  * and unmark them as dirty.
@@ -31,7 +33,8 @@ void transaction_commit_dirty(void);
  *
  * When all views in the transaction are ready, the layout will be applied.
  */
-void transaction_notify_view_ready(struct sway_view *view, uint32_t serial);
+void transaction_notify_view_ready_by_serial(struct sway_view *view,
+		uint32_t serial);
 
 /**
  * Notify the transaction system that a view is ready for the new layout, but

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -151,7 +151,12 @@ struct sway_container {
 	struct wlr_texture *title_urgent;
 	size_t title_height;
 
-	list_t *instructions; // struct sway_transaction_instruction *
+	// The number of transactions which reference this container.
+	size_t ntxnrefs;
+
+	// If this container is a view and is waiting for the client to respond to a
+	// configure then this will be populated, otherwise NULL.
+	struct sway_transaction_instruction *instruction;
 
 	bool destroying;
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -254,8 +254,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	if (view->swayc->instructions->length) {
-		transaction_notify_view_ready(view, xdg_surface->configure_serial);
+	if (view->swayc->instruction) {
+		transaction_notify_view_ready_by_serial(view,
+				xdg_surface->configure_serial);
 	}
 
 	view_damage_from(view);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -250,8 +250,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	if (!view->swayc) {
 		return;
 	}
-	if (view->swayc->instructions->length) {
-		transaction_notify_view_ready(view, xdg_surface_v6->configure_serial);
+	if (view->swayc->instruction) {
+		transaction_notify_view_ready_by_serial(view,
+				xdg_surface_v6->configure_serial);
 	}
 
 	view_damage_from(view);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -284,7 +284,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 	struct wlr_surface_state *surface_state = &xsurface->surface->current;
 
-	if (view->swayc->instructions->length) {
+	if (view->swayc->instruction) {
 		transaction_notify_view_ready_by_size(view,
 				surface_state->width, surface_state->height);
 	} else if (container_is_floating(view->swayc)) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -108,7 +108,6 @@ struct sway_container *container_create(enum sway_container_type type) {
 	c->layout = L_NONE;
 	c->type = type;
 	c->alpha = 1.0f;
-	c->instructions = create_list();
 
 	if (type != C_VIEW) {
 		c->children = create_list();
@@ -140,8 +139,8 @@ void container_free(struct sway_container *cont) {
 				"Tried to free container which wasn't marked as destroying")) {
 		return;
 	}
-	if (!sway_assert(cont->instructions->length == 0,
-				"Tried to free container with pending instructions")) {
+	if (!sway_assert(cont->ntxnrefs == 0, "Tried to free container "
+				"which is still referenced by transactions")) {
 		return;
 	}
 	free(cont->name);
@@ -150,7 +149,6 @@ void container_free(struct sway_container *cont) {
 	wlr_texture_destroy(cont->title_focused_inactive);
 	wlr_texture_destroy(cont->title_unfocused);
 	wlr_texture_destroy(cont->title_urgent);
-	list_free(cont->instructions);
 	list_free(cont->children);
 	list_free(cont->current.children);
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -26,7 +26,6 @@ void root_create(void) {
 	root_container.type = C_ROOT;
 	root_container.layout = L_NONE;
 	root_container.name = strdup("root");
-	root_container.instructions = create_list();
 	root_container.children = create_list();
 	root_container.current.children = create_list();
 	wl_signal_init(&root_container.events.destroy);
@@ -55,7 +54,6 @@ void root_destroy(void) {
 	free(root_container.sway_root);
 
 	// root_container
-	list_free(root_container.instructions);
 	list_free(root_container.children);
 	list_free(root_container.current.children);
 	free(root_container.name);


### PR DESCRIPTION
Commit 4b8e3a885be74c588291c51f798de80bd81a92db makes it so only one transaction is committed (ie. configures sent) at a time. This commit removes the now-unnecessary code which was used to support concurrent committed transactions.

* Instead of containers storing a list of instructions which they've been sent, it now stores a single instruction.
* Containers now have an `ntxnrefs` property. Previously we knew how many references there were by the length of the instruction list.
* Instructions no longer need a `ready` property. It was used to avoid marking an instruction ready twice when they were in a list, but this is now avoided because there is only one instruction and we nullify the `container->instruction` pointer when it's ready.
* When a transaction applies, we no longer need to consider releasing and resaving the surface, as we know there are no other committed transactions.
* `transaction_notify_view_ready` has been renamed to `view_notify_view_ready_by_serial` to make it consistent with `transaction_notify_view_ready_by_size`.
* Out-of-memory checks have been added when creating transactions and instructions.

BTW, we should consider doing some testing while out of memory to see if/where sway crashes and make sure the user can recover from that situation.