### PR TITLE
Use list_find in more places and refactor/fix workspace prev_next functions

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -77,7 +77,7 @@ int list_seq_find(list_t *list, int compare(const void *item, const void *data),
 	return -1;
 }
 
-int list_find(list_t *list, void *item) {
+int list_find(list_t *list, const void *item) {
 	for (int i = 0; i < list->length; i++) {
 		if (list->items[i] == item) {
 			return i;

--- a/include/list.h
+++ b/include/list.h
@@ -20,7 +20,7 @@ void list_qsort(list_t *list, int compare(const void *left, const void *right));
 // Return index for first item in list that returns 0 for given compare
 // function or -1 if none matches.
 int list_seq_find(list_t *list, int compare(const void *item, const void *cmp_to), const void *cmp_to);
-int list_find(list_t *list, void *item);
+int list_find(list_t *list, const void *item);
 // stable sort since qsort is not guaranteed to be stable
 void list_stable_sort(list_t *list, int compare(const void *a, const void *b));
 // swap two elements in a list

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -20,14 +20,7 @@
 #include "log.h"
 
 static int index_child(const struct sway_container *child) {
-	struct sway_container *parent = child->parent;
-	for (int i = 0; i < parent->children->length; ++i) {
-		if (parent->children->items[i] == child) {
-			return i;
-		}
-	}
-	// This happens if the child is a floating container
-	return -1;
+	return list_find(child->parent->children, child);
 }
 
 static void container_handle_fullscreen_reparent(struct sway_container *con,
@@ -125,11 +118,9 @@ struct sway_container *container_remove_child(struct sway_container *child) {
 	}
 
 	struct sway_container *parent = child->parent;
-	for (int i = 0; i < parent->children->length; ++i) {
-		if (parent->children->items[i] == child) {
-			list_del(parent->children, i);
-			break;
-		}
+	int index = index_child(child);
+	if (index != -1) {
+		list_del(parent->children, index);
 	}
 	child->parent = NULL;
 	container_notify_subtree_changed(parent);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -84,11 +84,9 @@ void root_scratchpad_remove_container(struct sway_container *con) {
 		return;
 	}
 	con->scratchpad = false;
-	for (int i = 0; i < root_container.sway_root->scratchpad->length; ++i) {
-		if (root_container.sway_root->scratchpad->items[i] == con) {
-			list_del(root_container.sway_root->scratchpad, i);
-			break;
-		}
+	int index = list_find(root_container.sway_root->scratchpad, con);
+	if (index != -1) {
+		list_del(root_container.sway_root->scratchpad, index);
 	}
 }
 


### PR DESCRIPTION
The original purpose of this commit is to replace some `for` loops with `list_find`. But while doing this I found the `workspace_prev_next_impl` functions to be difficult to read and also contained a bug, so I refactored them and fixed the bug.

To reproduce the bug:

* Have two outputs, where the left output has workspaces 1, 2, 3 and the right output has workspaces 4, 5, 6. Make workspace 2 focused_inactive and workspace 4 focused.
* Run `workspace prev`.
* Previously it would visit the left output, then apply `workspace prev` to workspace 2, which focuses workspace 1.
* Now it will focus the rightmost workspace on the left output (workspace 3).

The refactoring I made to the workspace functions are:

* Added the `static` keyword.
* They now accept an `int dir` rather than bool, to avoid an unnecessary conversion.
* Rather than preparing `start` and `end` variables for the purpose of iterating, just iterate everything.
* Replace `for` loops with `list_find`.
* Don't call `workspace_output_prev_next_impl` (this fixes the bug).