### PR TITLE
[RFC] Refactor seat_get_focus

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -166,6 +166,9 @@ void seat_begin_resize_floating(struct sway_seat *seat,
 void seat_begin_resize_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge);
 
+struct sway_container *seat_get_focus_inactive_floating(struct sway_seat *seat,
+		struct sway_container *container);
+
 void seat_end_mouse_operation(struct sway_seat *seat);
 
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -46,14 +46,13 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 
 	struct sway_container *new_focus = NULL;
 	if (floating) {
-		new_focus = seat_get_focus_inactive(seat, ws->sway_workspace->floating);
+		new_focus = seat_get_focus_inactive_floating(seat, ws);
 	} else {
 		new_focus = seat_get_focus_inactive_tiling(seat, ws);
 	}
-	if (!new_focus) {
-		new_focus = ws;
+	if (new_focus) {
+		seat_set_focus(seat, new_focus);
 	}
-	seat_set_focus(seat, new_focus);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 


### PR DESCRIPTION
The story here is I want to add a `seat_get_focus_inactive_floating` function to supplement `seat_get_focus_inactive_tiling`, but I don't want to add yet another argument to `seat_get_focus_by_type` and add more logic to that function.

There's two ways this can be refactored, and I can't decide which is best. The first is a callback approach, where each of the `seat_get_focus_inactive*` functions pass a callback function to `seat_get_focus_inactive_callback`. The second ditches the callback approach and puts the loop and conditional logic directly in the `seat_get_focus_inactive*` functions. Both commits are exactly the same number of lines of code.

Please refer to both commits separately and provide feedback.