### PR TITLE
Default to the previous workspace if the current one has no focused windows

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -258,7 +258,8 @@ struct sway_container *workspace_by_name(const char *name) {
 	struct sway_container *current_workspace = NULL, *current_output = NULL;
 	struct sway_container *focus = seat_get_focus(seat);
 	if (focus) {
-		current_workspace = container_parent(focus, C_WORKSPACE);
+		current_workspace = focus->type == C_WORKSPACE ?
+			focus : container_parent(focus, C_WORKSPACE);
 		current_output = container_parent(focus, C_OUTPUT);
 	}
 


### PR DESCRIPTION
This fixes a bug that I found that can be replicated as follows:

Go to a new workspace and open any app. Do this three times so you have 3 workspaces with one window each. Go to the middle workspace, close the window and attempt to use `workspace next` or `workspace prev` to navigate to either. You won't be able to

This seems to be because `workspace_by_name` only defines `current_workspace` and `current_output` if there's something focused on the current workspace as you can see here https://github.com/swaywm/sway/blob/master/sway/tree/workspace.c#L260 and in `workspace_prev_next_impl` it checks if the passed in workspace is null and stops if it is.

Since I'm not proficient in C, I just patched it in `workspace_prev_next_impl` by defaulting to the previous workspace if it exists.

This is probably not the solution you want so feel free to close this in favor of a better solution or I'm happy to work out something better with some guidance