### PR TITLE
Attempt to reap old tiling parent when floating a container

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1030,12 +1030,13 @@ void container_set_floating(struct sway_container *container, bool enable) {
 	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
 
 	if (enable) {
-		container_remove_child(container);
+		struct sway_container *old_parent = container_remove_child(container);
 		container_add_child(workspace->sway_workspace->floating, container);
 		container_init_floating(container);
 		if (container->type == C_VIEW) {
 			view_set_tiled(container->sway_view, false);
 		}
+		container_reap_empty(old_parent);
 	} else {
 		// Returning to tiled
 		if (container->scratchpad) {


### PR DESCRIPTION
To test:

* Create layout `H[view V[view]]`
* Focus the view inside the vertical split container and float it

The vertical split container was not reaped, so the tiling view would take up half the space.