### PR TITLE
Refactor seat_get_focus functions

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -166,6 +166,9 @@ void seat_begin_resize_floating(struct sway_seat *seat,
 void seat_begin_resize_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge);
 
+struct sway_container *seat_get_focus_inactive_floating(struct sway_seat *seat,
+		struct sway_container *container);
+
 void seat_end_mouse_operation(struct sway_seat *seat);
 
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -46,14 +46,13 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 
 	struct sway_container *new_focus = NULL;
 	if (floating) {
-		new_focus = seat_get_focus_inactive(seat, ws->sway_workspace->floating);
+		new_focus = seat_get_focus_inactive_floating(seat, ws);
 	} else {
 		new_focus = seat_get_focus_inactive_tiling(seat, ws);
 	}
-	if (!new_focus) {
-		new_focus = ws;
+	if (new_focus) {
+		seat_set_focus(seat, new_focus);
 	}
-	seat_set_focus(seat, new_focus);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 


### PR DESCRIPTION
Fixes #2467.

This commit introduces `seat_get_focus_inactive_floating` to supplement `seat_get_focus_inactive_tiling`, and uses it during `focus mode_toggle` which fixes a focus bug.

This also refactors the `seat_get_focus_inactive` functions so that they do their selection logic themselves rather than offloading it to `seat_get_focus_by_type` which was getting bloated. `seat_get_focus_by_type` is now removed.

Lastly, this commit changes `seat_get_focus` to just return the first container in the focus stack rather than looping and calling `seat_get_focus_by_type`.