### PR TITLE
Implement iterators per container type

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -95,4 +95,16 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 	struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
+void output_for_each_workspace(struct sway_container *output,
+		void (*f)(struct sway_container *con, void *data), void *data);
+
+void output_for_each_container(struct sway_container *output,
+		void (*f)(struct sway_container *con, void *data), void *data);
+
+struct sway_container *output_find_workspace(struct sway_container *output,
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
+struct sway_container *output_find_container(struct sway_container *output,
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -214,15 +214,11 @@ struct sway_container *container_destroy(struct sway_container *container);
 
 struct sway_container *container_close(struct sway_container *container);
 
-void container_descendants(struct sway_container *root,
-		enum sway_container_type type,
-		void (*func)(struct sway_container *item, void *data), void *data);
-
 /**
  * Search a container's descendants a container based on test criteria. Returns
  * the first container that passes the test.
  */
-struct sway_container *container_find(struct sway_container *container,
+struct sway_container *container_find_child(struct sway_container *container,
 		bool (*test)(struct sway_container *view, void *data), void *data);
 
 /**
@@ -244,10 +240,7 @@ struct sway_container *tiling_container_at(
 		struct sway_container *con, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy);
 
-/**
- * Apply the function for each child of the container depth first.
- */
-void container_for_each_descendant(struct sway_container *container,
+void container_for_each_child(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data), void *data);
 
 /**

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -58,4 +58,19 @@ struct sway_container *root_workspace_for_pid(pid_t pid);
 
 void root_record_workspace_pid(pid_t pid);
 
+void root_for_each_workspace(void (*f)(struct sway_container *con, void *data),
+		void *data);
+
+void root_for_each_container(void (*f)(struct sway_container *con, void *data),
+		void *data);
+
+struct sway_container *root_find_output(
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
+struct sway_container *root_find_workspace(
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
+struct sway_container *root_find_container(
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -50,6 +50,12 @@ struct sway_container *workspace_output_get_highest_available(
 
 void workspace_detect_urgent(struct sway_container *workspace);
 
+void workspace_for_each_container(struct sway_container *ws,
+		void (*f)(struct sway_container *con, void *data), void *data);
+
+struct sway_container *workspace_find_container(struct sway_container *ws,
+		bool (*test)(struct sway_container *con, void *data), void *data);
+
 /**
  * Wrap the workspace's tiling children in a new container.
  * The new container will be the only direct tiling child of the workspace.

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -31,7 +31,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 				"<none|vertical|horizontal|both|smart>'");
 	}
 
-	container_for_each_descendant(&root_container, _configure_view, NULL);
+	root_for_each_container(_configure_view, NULL);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -24,8 +24,7 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 	config->show_marks = parse_boolean(argv[0], config->show_marks);
 
 	if (config->show_marks) {
-		container_for_each_descendant(&root_container,
-				rebuild_marks_iterator, NULL);
+		root_for_each_container(rebuild_marks_iterator, NULL);
 	}
 
 	for (int i = 0; i < root_container.children->length; ++i) {

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -50,13 +50,13 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	if (strcasecmp(argv[2], "id") == 0) {
 #ifdef HAVE_XWAYLAND
 		xcb_window_t id = strtol(value, NULL, 0);
-		other = container_find(&root_container, test_id, (void *)&id);
+		other = root_find_container(test_id, (void *)&id);
 #endif
 	} else if (strcasecmp(argv[2], "con_id") == 0) {
 		size_t con_id = atoi(value);
-		other = container_find(&root_container, test_con_id, (void *)con_id);
+		other = root_find_container(test_con_id, (void *)con_id);
 	} else if (strcasecmp(argv[2], "mark") == 0) {
-		other = container_find(&root_container, test_mark, (void *)value);
+		other = root_find_container(test_mark, (void *)value);
 	} else {
 		free(value);
 		return cmd_results_new(CMD_INVALID, "swap", EXPECTED_SYNTAX);

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -52,8 +52,7 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 		view_find_and_unmark(mark);
 	} else {
 		// Remove all marks from all views
-		container_for_each_descendant(&root_container,
-				remove_all_marks_iterator, NULL);
+		root_for_each_container(remove_all_marks_iterator, NULL);
 	}
 	free(mark);
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -822,18 +822,7 @@ void config_update_font_height(bool recalculate) {
 	size_t prev_max_height = config->font_height;
 	config->font_height = 0;
 
-	container_for_each_descendant(&root_container,
-			find_font_height_iterator, &recalculate);
-
-	// Also consider floating views
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *output = root_container.children->items[i];
-		for (int j = 0; j < output->children->length; ++j) {
-			struct sway_container *ws = output->children->items[j];
-			container_for_each_descendant(ws->sway_workspace->floating,
-					find_font_height_iterator, &recalculate);
-		}
-	}
+	root_for_each_container(find_font_height_iterator, &recalculate);
 
 	if (config->font_height != prev_max_height) {
 		arrange_windows(&root_container);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -167,8 +167,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 			return false;
 		}
 		list_t *urgent_views = create_list();
-		container_for_each_descendant(&root_container,
-				find_urgent_iterator, urgent_views);
+		root_for_each_container(find_urgent_iterator, urgent_views);
 		list_stable_sort(urgent_views, cmp_urgent);
 		struct sway_view *target;
 		if (criteria->urgent == 'o') { // oldest
@@ -228,17 +227,7 @@ list_t *criteria_get_views(struct criteria *criteria) {
 		.criteria = criteria,
 		.matches = matches,
 	};
-	container_for_each_descendant(&root_container,
-		criteria_get_views_iterator, &data);
-
-	// Scratchpad items which are hidden are not in the tree.
-	for (int i = 0; i < root_container.sway_root->scratchpad->length; ++i) {
-		struct sway_container *con =
-			root_container.sway_root->scratchpad->items[i];
-		if (!con->parent) {
-			criteria_get_views_iterator(con, &data);
-		}
-	}
+	root_for_each_container(criteria_get_views_iterator, &data);
 	return matches;
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -303,15 +303,14 @@ struct send_frame_done_data {
 
 static void send_frame_done_container_iterator(struct sway_container *con,
 		void *_data) {
-	struct send_frame_done_data *data = _data;
-	if (!sway_assert(con->type == C_VIEW, "expected a view")) {
+	if (con->type != C_VIEW) {
 		return;
 	}
-
 	if (!view_is_visible(con->sway_view)) {
 		return;
 	}
 
+	struct send_frame_done_data *data = _data;
 	output_view_for_each_surface(data->output, con->sway_view,
 		send_frame_done_iterator, data->when);
 }
@@ -322,8 +321,8 @@ static void send_frame_done_container(struct sway_output *output,
 		.output = output,
 		.when = when,
 	};
-	container_descendants(con, C_VIEW,
-		send_frame_done_container_iterator, &data);
+	output_for_each_container(output->swayc,
+			send_frame_done_container_iterator, &data);
 }
 
 static void send_frame_done(struct sway_output *output, struct timespec *when) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -313,9 +313,6 @@ static void handle_new_drag_icon(struct wl_listener *listener, void *data) {
 
 static void collect_focus_iter(struct sway_container *con, void *data) {
 	struct sway_seat *seat = data;
-	if (con->type > C_WORKSPACE) {
-		return;
-	}
 	struct sway_seat_container *seat_con =
 		seat_container_from_container(seat, con);
 	if (!seat_con) {
@@ -349,7 +346,8 @@ struct sway_seat *seat_create(struct sway_input_manager *input,
 	// init the focus stack
 	wl_list_init(&seat->focus_stack);
 
-	container_for_each_descendant(&root_container, collect_focus_iter, seat);
+	root_for_each_workspace(collect_focus_iter, seat);
+	root_for_each_container(collect_focus_iter, seat);
 
 	wl_signal_add(&root_container.sway_root->events.new_container,
 		&seat->new_container);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -522,7 +522,7 @@ void ipc_client_disconnect(struct ipc_client *client) {
 
 static void ipc_get_workspaces_callback(struct sway_container *workspace,
 		void *data) {
-	if (workspace->type != C_WORKSPACE) {
+	if (!sway_assert(workspace->type == C_WORKSPACE, "Expected a workspace")) {
 		return;
 	}
 	json_object *workspace_json = ipc_json_describe_container(workspace);
@@ -631,8 +631,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_GET_WORKSPACES:
 	{
 		json_object *workspaces = json_object_new_array();
-		container_for_each_descendant(&root_container,
-				ipc_get_workspaces_callback, workspaces);
+		root_for_each_workspace(ipc_get_workspaces_callback, workspaces);
 		const char *json_string = json_object_to_json_string(workspaces);
 		client_valid =
 			ipc_send_reply(client, json_string, (uint32_t)strlen(json_string));
@@ -729,8 +728,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	case IPC_GET_MARKS:
 	{
 		json_object *marks = json_object_new_array();
-		container_descendants(&root_container, C_VIEW, ipc_get_marks_callback,
-				marks);
+		root_for_each_container(ipc_get_marks_callback, marks);
 		const char *json_string = json_object_to_json_string(marks);
 		client_valid =
 			ipc_send_reply(client, json_string, (uint32_t)strlen(json_string));

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -103,6 +103,57 @@ struct sway_container *output_create(
 	return output;
 }
 
+void output_for_each_workspace(struct sway_container *output,
+		void (*f)(struct sway_container *con, void *data), void *data) {
+	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
+		return;
+	}
+	for (int i = 0; i < output->children->length; ++i) {
+		struct sway_container *workspace = output->children->items[i];
+		f(workspace, data);
+	}
+}
+
+void output_for_each_container(struct sway_container *output,
+		void (*f)(struct sway_container *con, void *data), void *data) {
+	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
+		return;
+	}
+	for (int i = 0; i < output->children->length; ++i) {
+		struct sway_container *workspace = output->children->items[i];
+		workspace_for_each_container(workspace, f, data);
+	}
+}
+
+struct sway_container *output_find_workspace(struct sway_container *output,
+		bool (*test)(struct sway_container *con, void *data), void *data) {
+	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
+		return NULL;
+	}
+	for (int i = 0; i < output->children->length; ++i) {
+		struct sway_container *workspace = output->children->items[i];
+		if (test(workspace, data)) {
+			return workspace;
+		}
+	}
+	return NULL;
+}
+
+struct sway_container *output_find_container(struct sway_container *output,
+		bool (*test)(struct sway_container *con, void *data), void *data) {
+	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
+		return NULL;
+	}
+	struct sway_container *result = NULL;
+	for (int i = 0; i < output->children->length; ++i) {
+		struct sway_container *workspace = output->children->items[i];
+		if ((result = workspace_find_container(workspace, test, data))) {
+			return result;
+		}
+	}
+	return NULL;
+}
+
 static int sort_workspace_cmp_qsort(const void *_a, const void *_b) {
 	struct sway_container *a = *(void **)_a;
 	struct sway_container *b = *(void **)_b;
@@ -122,4 +173,3 @@ static int sort_workspace_cmp_qsort(const void *_a, const void *_b) {
 void output_sort_workspaces(struct sway_container *output) {
 	list_stable_sort(output->children, sort_workspace_cmp_qsort);
 }
-

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -899,8 +899,8 @@ static bool find_by_mark_iterator(struct sway_container *con,
 }
 
 struct sway_view *view_find_mark(char *mark) {
-	struct sway_container *container = container_find(&root_container,
-		find_by_mark_iterator, mark);
+	struct sway_container *container = root_find_container(
+			find_by_mark_iterator, mark);
 	if (!container) {
 		return NULL;
 	}
@@ -908,7 +908,7 @@ struct sway_view *view_find_mark(char *mark) {
 }
 
 bool view_find_and_unmark(char *mark) {
-	struct sway_container *container = container_find(&root_container,
+	struct sway_container *container = root_find_container(
 		find_by_mark_iterator, mark);
 	if (!container) {
 		return false;


### PR DESCRIPTION
This introduces the following `for_each` functions:

* `root_for_each_workspace`
* `root_for_each_container`
* `output_for_each_workspace`
* `output_for_each_container`
* `workspace_for_each_container`
* `container_for_each_child`

And introduces the following `find` functions:

* `root_find_output`
* `root_find_workspace`
* `root_find_container`
* `output_find_workspace`
* `output_find_container`
* `workspace_find_container`
* `container_find_child`

And removes the following functions:

* `container_descendants`
* `container_for_each_descendant`
* `container_find`

This change is preparing the way for demoting `sway_container`. Eventually these functions will accept and return `sway_output`s, `sway_workspace`s and `sway_container`s (meaning a `C_CONTAINER` or `C_VIEW`), and which point their assertions can be removed and we can use typehinting.

This change also makes it easy to handle abnormalities like the workspace floating list, root's scratchpad list and (once implemented) root's saved workspaces list for when there's no connected outputs.