### PR TITLE
Add using_csd variable to transaction state

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -83,6 +83,7 @@ struct sway_container_state {
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
+	bool using_csd;
 
 	// Workspace properties
 	struct sway_container *ws_fullscreen;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -266,7 +266,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		render_view_toplevels(view, output, damage, view->swayc->alpha);
 	}
 
-	if (view->using_csd) {
+	if (view->swayc->current.using_csd) {
 		return;
 	}
 
@@ -585,7 +585,7 @@ static void render_container_simple(struct sway_output *output,
 				marks_texture = view->marks_unfocused;
 			}
 
-			if (!view->using_csd) {
+			if (!view->swayc->current.using_csd) {
 				if (state->border == B_NORMAL) {
 					render_titlebar(output, damage, child, state->swayc_x,
 							state->swayc_y, state->swayc_width, colors,
@@ -777,7 +777,7 @@ static void render_floating_container(struct sway_output *soutput,
 			marks_texture = view->marks_unfocused;
 		}
 
-		if (!view->using_csd) {
+		if (!view->swayc->current.using_csd) {
 			if (con->current.border == B_NORMAL) {
 				render_titlebar(soutput, damage, con, con->current.swayc_x,
 						con->current.swayc_y, con->current.swayc_width, colors,

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -107,6 +107,7 @@ static void copy_pending_state(struct sway_container *container,
 		state->border_left = view->border_left;
 		state->border_right = view->border_right;
 		state->border_bottom = view->border_bottom;
+		state->using_csd = view->using_csd;
 	} else if (container->type == C_WORKSPACE) {
 		state->ws_fullscreen = container->sway_workspace->fullscreen;
 		state->ws_floating = container->sway_workspace->floating;


### PR DESCRIPTION
This fixes a race condition flicker when unfloating a view which uses client side decorations.

When the view is floated it has `using_csd = true`, so the decorations are not drawn. When unfloating it it changes to false, but this change wasn't part of transactions so it could potentially render the decorations around the view while it's waiting for the transaction to apply.