### PR TITLE
Fix crash when a view destroys with pending transactions

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -175,7 +175,9 @@ static void transaction_apply(struct sway_transaction *transaction) {
 				sizeof(struct sway_container_state));
 
 		if (container->type == C_VIEW && container->sway_view->saved_buffer) {
-			view_remove_saved_buffer(container->sway_view);
+			if (!container->destroying || container->ntxnrefs == 1) {
+				view_remove_saved_buffer(container->sway_view);
+			}
 		}
 
 		// Damage the new location
@@ -283,7 +285,7 @@ static void transaction_commit(struct sway_transaction *transaction) {
 			struct timespec when;
 			wlr_surface_send_frame_done(con->sway_view->surface, &when);
 		}
-		if (con->type == C_VIEW) {
+		if (con->type == C_VIEW && !con->sway_view->saved_buffer) {
 			view_save_buffer(con->sway_view);
 			memcpy(&con->sway_view->saved_geometry, &con->sway_view->geometry,
 					sizeof(struct wlr_box));


### PR DESCRIPTION
We were removing the saved buffer when one transaction applies, then didn't have a new buffer to save when the next transaction ran. This made the rendering code crash as it had no surface to use.

This commit makes it continue to hold the buffer if the view is destroying and has more transactions. Additionally, a check is added when saving the buffer to make sure there's no one already there.

To test, kill a view while doing an aggressive resize motion.