### PR TITLE
Fix jumping views

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -236,7 +236,12 @@ void view_autoconfigure(struct sway_view *view) {
 		view->border_top = false;
 	}
 
-	switch (view->border) {
+	enum sway_container_border border = view->border;
+	if (view->using_csd) {
+		border = B_NONE;
+	}
+
+	switch (border) {
 	case B_NONE:
 		x = con->x;
 		y = con->y + y_offset;


### PR DESCRIPTION
Fixes #2490.

To be honest I'm not sure why this fixes the issue.

I observed that I could only make the view jump if I resized it to the smallest possible size first. Then I had a suspicion that we were accidentally factoring in the title and border sizes into the view size when it uses CSD. So I changed that and it appears to have fixed the jumping issue.

I guess when we factor the title and borders in, we send a configure to the surface with a size smaller than the minimum, and it comes back with a surface at the minimum size. We interpret this as an unexpected resize, and this somehow makes it jump.