### PR TITLE
Refactor destroy functions and save workspaces when there's no outputs

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -39,6 +39,12 @@ struct sway_output {
 	} events;
 };
 
+struct sway_container *output_create(struct sway_output *sway_output);
+
+void output_destroy(struct sway_container *output);
+
+void output_begin_destroy(struct sway_container *output);
+
 typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
 	struct wlr_surface *surface, struct wlr_box *box, float rotation,
 	void *user_data);

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -176,27 +176,6 @@ struct sway_container *container_create(enum sway_container_type type);
 
 const char *container_type_to_str(enum sway_container_type type);
 
-struct sway_container *output_create(struct sway_output *sway_output);
-
-/**
- * Create a new container container. A container container can be a a child of
- * a workspace container or another container container.
- */
-struct sway_container *container_container_create();
-
-/**
- * Create a new output. Outputs are children of the root container and have no
- * order in the tree structure.
- */
-struct sway_container *output_create(struct sway_output *sway_output);
-
-/**
- * Create a new workspace container. Workspaces are children of an output
- * container and are ordered alphabetically by name.
- */
-struct sway_container *workspace_create(struct sway_container *output,
-		const char *name);
-
 /*
  * Create a new view container. A view can be a child of a workspace container
  * or a container container and are rendered in the order and structure of
@@ -205,9 +184,9 @@ struct sway_container *workspace_create(struct sway_container *output,
 struct sway_container *container_view_create(
 		struct sway_container *sibling, struct sway_view *sway_view);
 
-void container_free(struct sway_container *cont);
+void container_destroy(struct sway_container *con);
 
-struct sway_container *container_destroy(struct sway_container *container);
+void container_begin_destroy(struct sway_container *con);
 
 struct sway_container *container_close(struct sway_container *container);
 
@@ -255,10 +234,7 @@ void container_update_textures_recursive(struct sway_container *con);
 
 void container_damage_whole(struct sway_container *container);
 
-bool container_reap_empty(struct sway_container *con);
-
-struct sway_container *container_reap_empty_recursive(
-		struct sway_container *con);
+struct sway_container *container_reap_empty(struct sway_container *con);
 
 struct sway_container *container_flatten(struct sway_container *container);
 

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -24,6 +24,7 @@ struct sway_root {
 	struct wl_list outputs; // sway_output::link
 
 	list_t *scratchpad; // struct sway_container
+	list_t *saved_workspaces; // For when there's no connected outputs
 
 	struct {
 		struct wl_signal new_container;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -284,9 +284,9 @@ void view_for_each_popup(struct sway_view *view,
 void view_init(struct sway_view *view, enum sway_view_type type,
 	const struct sway_view_impl *impl);
 
-void view_free(struct sway_view *view);
-
 void view_destroy(struct sway_view *view);
+
+void view_begin_destroy(struct sway_view *view);
 
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface);
 

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -18,6 +18,15 @@ extern char *prev_workspace_name;
 
 struct sway_container *workspace_get_initial_output(const char *name);
 
+struct sway_container *workspace_create(struct sway_container *output,
+		const char *name);
+
+void workspace_destroy(struct sway_container *workspace);
+
+void workspace_begin_destroy(struct sway_container *workspace);
+
+void workspace_consider_destroy(struct sway_container *ws);
+
 char *workspace_next_name(const char *output_name);
 
 bool workspace_switch(struct sway_container *workspace,

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -247,7 +247,7 @@ static void workspace_move_to_output(struct sway_container *workspace,
 	}
 
 	// Try to remove an empty workspace from the destination output.
-	container_reap_empty_recursive(new_output_focus);
+	container_reap_empty(new_output_focus);
 
 	output_sort_workspaces(output);
 	seat_set_focus(seat, output);

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -181,13 +181,11 @@ void apply_output_config(struct output_config *oc, struct sway_container *output
 	struct wlr_output *wlr_output = output->sway_output->wlr_output;
 
 	if (oc && oc->enabled == 0) {
-		struct sway_output *sway_output = output->sway_output;
 		if (output->sway_output->bg_pid != 0) {
 			terminate_swaybg(output->sway_output->bg_pid);
 			output->sway_output->bg_pid = 0;
 		}
-		container_destroy(output);
-		sway_output->swayc = NULL;
+		output_begin_destroy(output);
 		wlr_output_layout_remove(root_container.sway_root->output_layout,
 			wlr_output);
 		return;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -498,7 +498,7 @@ void output_damage_whole_container(struct sway_output *output,
 static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output =
 		wl_container_of(listener, output, damage_destroy);
-	container_destroy(output->swayc);
+	output_begin_destroy(output->swayc);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -506,7 +506,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_signal_emit(&output->events.destroy, output);
 
 	if (output->swayc) {
-		container_destroy(output->swayc);
+		output_begin_destroy(output->swayc);
 	}
 
 	wl_list_remove(&output->link);

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -54,7 +54,22 @@ static void transaction_destroy(struct sway_transaction *transaction) {
 			con->instruction = NULL;
 		}
 		if (con->destroying && con->ntxnrefs == 0) {
-			container_free(con);
+			switch (con->type) {
+			case C_ROOT:
+				break;
+			case C_OUTPUT:
+				output_destroy(con);
+				break;
+			case C_WORKSPACE:
+				workspace_destroy(con);
+				break;
+			case C_CONTAINER:
+			case C_VIEW:
+				container_destroy(con);
+				break;
+			case C_TYPES:
+				break;
+			}
 		}
 		free(instruction);
 	}

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -448,7 +448,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_view->map.link);
 	wl_list_remove(&xdg_shell_view->unmap.link);
 	view->wlr_xdg_surface = NULL;
-	view_destroy(view);
+	view_begin_destroy(view);
 }
 
 struct sway_view *view_from_wlr_xdg_surface(

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -441,7 +441,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_v6_view->map.link);
 	wl_list_remove(&xdg_shell_v6_view->unmap.link);
 	view->wlr_xdg_surface_v6 = NULL;
-	view_destroy(view);
+	view_begin_destroy(view);
 }
 
 struct sway_view *view_from_wlr_xdg_surface_v6(

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -341,7 +341,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xwayland_view->set_hints.link);
 	wl_list_remove(&xwayland_view->map.link);
 	wl_list_remove(&xwayland_view->unmap.link);
-	view_destroy(&xwayland_view->view);
+	view_begin_destroy(&xwayland_view->view);
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -694,13 +694,11 @@ void seat_set_focus_warp(struct sway_seat *seat,
 
 	// clean up unfocused empty workspace on new output
 	if (new_output_last_ws) {
-		if (!workspace_is_visible(new_output_last_ws)
-				&& workspace_is_empty(new_output_last_ws)) {
-			if (last_workspace == new_output_last_ws) {
-				last_focus = NULL;
-				last_workspace = NULL;
-			}
-			container_destroy(new_output_last_ws);
+		workspace_consider_destroy(new_output_last_ws);
+		if (new_output_last_ws->destroying &&
+				last_workspace == new_output_last_ws) {
+			last_focus = NULL;
+			last_workspace = NULL;
 		}
 	}
 
@@ -716,12 +714,9 @@ void seat_set_focus_warp(struct sway_seat *seat,
 			if (notify && last_workspace != new_workspace) {
 				 ipc_event_workspace(last_workspace, new_workspace, "focus");
 			}
-			if (!workspace_is_visible(last_workspace)
-					&& workspace_is_empty(last_workspace)) {
-				if (last_workspace == last_focus) {
-					last_focus = NULL;
-				}
-				container_destroy(last_workspace);
+			workspace_consider_destroy(last_workspace);
+			if (last_workspace->destroying && last_workspace == last_focus) {
+				last_focus = NULL;
 			}
 		}
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -104,209 +104,52 @@ struct sway_container *container_create(enum sway_container_type type) {
 	return c;
 }
 
-static void container_workspace_free(struct sway_workspace *ws) {
-	list_foreach(ws->output_priority, free);
-	list_free(ws->output_priority);
-	list_free(ws->floating);
-	free(ws);
-}
-
-void container_free(struct sway_container *cont) {
-	if (!sway_assert(cont->destroying,
+void container_destroy(struct sway_container *con) {
+	if (!sway_assert(con->type == C_CONTAINER || con->type == C_VIEW,
+				"Expected a container or view")) {
+		return;
+	}
+	if (!sway_assert(con->destroying,
 				"Tried to free container which wasn't marked as destroying")) {
 		return;
 	}
-	if (!sway_assert(cont->ntxnrefs == 0, "Tried to free container "
+	if (!sway_assert(con->ntxnrefs == 0, "Tried to free container "
 				"which is still referenced by transactions")) {
 		return;
 	}
-	free(cont->name);
-	free(cont->formatted_title);
-	wlr_texture_destroy(cont->title_focused);
-	wlr_texture_destroy(cont->title_focused_inactive);
-	wlr_texture_destroy(cont->title_unfocused);
-	wlr_texture_destroy(cont->title_urgent);
-	list_free(cont->children);
-	list_free(cont->current.children);
-	list_free(cont->outputs);
+	free(con->name);
+	free(con->formatted_title);
+	wlr_texture_destroy(con->title_focused);
+	wlr_texture_destroy(con->title_focused_inactive);
+	wlr_texture_destroy(con->title_unfocused);
+	wlr_texture_destroy(con->title_urgent);
+	list_free(con->children);
+	list_free(con->current.children);
+	list_free(con->outputs);
 
-	switch (cont->type) {
-	case C_ROOT:
-		break;
-	case C_OUTPUT:
-		break;
-	case C_WORKSPACE:
-		container_workspace_free(cont->sway_workspace);
-		break;
-	case C_CONTAINER:
-		break;
-	case C_VIEW:
-		{
-			struct sway_view *view = cont->sway_view;
-			view->swayc = NULL;
-			free(view->title_format);
-			view->title_format = NULL;
+	if (con->type == C_VIEW) {
+		struct sway_view *view = con->sway_view;
+		view->swayc = NULL;
+		free(view->title_format);
+		view->title_format = NULL;
 
-			if (view->destroying) {
-				view_free(view);
-			}
+		if (view->destroying) {
+			view_destroy(view);
 		}
-		break;
-	case C_TYPES:
-		sway_assert(false, "Didn't expect to see C_TYPES here");
-		break;
 	}
 
-	free(cont);
+	free(con);
 }
 
-static struct sway_container *container_destroy_noreaping(
-		struct sway_container *con);
-
-static struct sway_container *container_workspace_destroy(
-		struct sway_container *workspace) {
-	if (!sway_assert(workspace, "cannot destroy null workspace")) {
-		return NULL;
-	}
-
-	struct sway_container *output = container_parent(workspace, C_OUTPUT);
-
-	// If we're destroying the output, it will be NULL here. Return the root so
-	// that it doesn't appear that the workspace has refused to be destoyed,
-	// which would leave it in a broken state with no parent.
-	if (output == NULL) {
-		return &root_container;
-	}
-
-	// Do not destroy this if it's the last workspace on this output
-	if (output->children->length == 1) {
-		return NULL;
-	}
-
-	wlr_log(WLR_DEBUG, "destroying workspace '%s'", workspace->name);
-
-	if (!workspace_is_empty(workspace)) {
-		// Move children to a different workspace on this output
-		struct sway_container *new_workspace = NULL;
-		for (int i = 0; i < output->children->length; i++) {
-			if (output->children->items[i] != workspace) {
-				new_workspace = output->children->items[i];
-				break;
-			}
-		}
-
-		wlr_log(WLR_DEBUG, "moving children to different workspace '%s' -> '%s'",
-			workspace->name, new_workspace->name);
-		for (int i = 0; i < workspace->children->length; i++) {
-			container_move_to(workspace->children->items[i], new_workspace);
-		}
-		list_t *floating = workspace->sway_workspace->floating;
-		for (int i = 0; i < floating->length; i++) {
-			struct sway_container *floater = floating->items[i];
-			container_remove_child(floater);
-			workspace_add_floating(new_workspace, floater);
-		}
-	}
-
-	return output;
-}
-
-static void untrack_output(struct sway_container *con, void *data) {
-	struct sway_output *output = data;
-	int index = list_find(con->outputs, output);
-	if (index != -1) {
-		list_del(con->outputs, index);
-	}
-}
-
-static struct sway_container *container_output_destroy(
-		struct sway_container *output) {
-	if (!sway_assert(output, "cannot destroy null output")) {
-		return NULL;
-	}
-
-	if (output->children->length > 0) {
-		// TODO save workspaces when there are no outputs.
-		// TODO also check if there will ever be no outputs except for exiting
-		// program
-		if (root_container.children->length > 1) {
-			// Move workspace from this output to another output
-			struct sway_container *fallback_output =
-				root_container.children->items[0];
-			if (fallback_output == output) {
-				fallback_output = root_container.children->items[1];
-			}
-
-			while (output->children->length) {
-				struct sway_container *workspace = output->children->items[0];
-
-				struct sway_container *new_output =
-					workspace_output_get_highest_available(workspace, output);
-				if (!new_output) {
-					new_output = fallback_output;
-					workspace_output_add_priority(workspace, new_output);
-				}
-
-				container_remove_child(workspace);
-				if (!workspace_is_empty(workspace)) {
-					container_add_child(new_output, workspace);
-					ipc_event_workspace(NULL, workspace, "move");
-				} else {
-					container_destroy(workspace);
-				}
-
-				output_sort_workspaces(new_output);
-			}
-		}
-	}
-
-	root_for_each_container(untrack_output, output->sway_output);
-
-	wl_list_remove(&output->sway_output->mode.link);
-	wl_list_remove(&output->sway_output->transform.link);
-	wl_list_remove(&output->sway_output->scale.link);
-
-	wl_list_remove(&output->sway_output->damage_destroy.link);
-	wl_list_remove(&output->sway_output->damage_frame.link);
-
-	output->sway_output->swayc = NULL;
-	output->sway_output = NULL;
-
-	wlr_log(WLR_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
-
-	return &root_container;
-}
-
-/**
- * Implement the actual destroy logic, without reaping.
- */
-static struct sway_container *container_destroy_noreaping(
-		struct sway_container *con) {
-	if (con == NULL) {
-		return NULL;
-	}
-	if (con->destroying) {
-		return NULL;
+void container_begin_destroy(struct sway_container *con) {
+	if (!sway_assert(con->type == C_CONTAINER || con->type == C_VIEW,
+				"Expected a container or view")) {
+		return;
 	}
 
 	wl_signal_emit(&con->events.destroy, con);
-
-	// emit IPC event
 	if (con->type == C_VIEW) {
 		ipc_event_window(con, "close");
-	} else if (con->type == C_WORKSPACE) {
-		ipc_event_workspace(NULL, con, "empty");
-	}
-
-	// The below functions move their children to somewhere else.
-	if (con->type == C_OUTPUT) {
-		container_output_destroy(con);
-	} else if (con->type == C_WORKSPACE) {
-		// Workspaces will refuse to be destroyed if they're the last workspace
-		// on their output.
-		if (!container_workspace_destroy(con)) {
-			return NULL;
-		}
 	}
 
 	container_end_mouse_operation(con);
@@ -318,50 +161,21 @@ static struct sway_container *container_destroy_noreaping(
 		root_scratchpad_remove_container(con);
 	}
 
-	if (!con->parent) {
-		return NULL;
+	if (con->parent) {
+		container_remove_child(con);
 	}
-
-	return container_remove_child(con);
 }
 
-bool container_reap_empty(struct sway_container *con) {
-	switch (con->type) {
-	case C_ROOT:
-	case C_OUTPUT:
-		// dont reap these
-		break;
-	case C_WORKSPACE:
-		if (!workspace_is_visible(con) && workspace_is_empty(con)) {
-			wlr_log(WLR_DEBUG, "Destroying workspace via reaper");
-			container_destroy_noreaping(con);
-			return true;
-		}
-		break;
-	case C_CONTAINER:
-		if (con->children->length == 0) {
-			container_destroy_noreaping(con);
-			return true;
-		}
-	case C_VIEW:
-		break;
-	case C_TYPES:
-		sway_assert(false, "container_reap_empty called on an invalid "
-			"container");
-		break;
-	}
-
-	return false;
-}
-
-struct sway_container *container_reap_empty_recursive(
-		struct sway_container *con) {
-	while (con) {
+struct sway_container *container_reap_empty(struct sway_container *con) {
+	while (con && con->type == C_CONTAINER) {
 		struct sway_container *next = con->parent;
-		if (!container_reap_empty(con)) {
-			break;
+		if (con->children->length == 0) {
+			container_begin_destroy(con);
 		}
 		con = next;
+	}
+	if (con && con->type == C_WORKSPACE) {
+		workspace_consider_destroy(con);
 	}
 	return con;
 }
@@ -371,32 +185,10 @@ struct sway_container *container_flatten(struct sway_container *container) {
 		struct sway_container *child = container->children->items[0];
 		struct sway_container *parent = container->parent;
 		container_replace_child(container, child);
-		container_destroy_noreaping(container);
+		container_begin_destroy(container);
 		container = parent;
 	}
 	return container;
-}
-
-/**
- * container_destroy() is the first step in destroying a container. We'll emit
- * events, detach it from the tree and mark it as destroying. The container will
- * remain in memory until it's no longer used by a transaction, then it will be
- * freed via container_free().
- *
- * This function just wraps container_destroy_noreaping(), then does reaping.
- */
-struct sway_container *container_destroy(struct sway_container *con) {
-	if (con->is_fullscreen) {
-		struct sway_container *ws = container_parent(con, C_WORKSPACE);
-		ws->sway_workspace->fullscreen = NULL;
-	}
-	struct sway_container *parent = container_destroy_noreaping(con);
-
-	if (!parent) {
-		return NULL;
-	}
-
-	return container_reap_empty_recursive(parent);
 }
 
 static void container_close_func(struct sway_container *container, void *data) {

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -302,7 +302,7 @@ static void workspace_rejigger(struct sway_container *ws,
 		move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT;
 
 	container_flatten(ws);
-	container_reap_empty_recursive(original_parent);
+	container_reap_empty(original_parent);
 	container_create_notify(new_parent);
 }
 
@@ -325,7 +325,7 @@ static void move_out_of_tabs_stacks(struct sway_container *container,
 		container_insert_child(new_parent->parent, container, offs < 0 ? 0 : 1);
 	} else {
 		container_insert_child(new_parent, container, offs < 0 ? 0 : 1);
-		container_reap_empty_recursive(new_parent->parent);
+		container_reap_empty(new_parent->parent);
 		container_flatten(new_parent->parent);
 	}
 	container_create_notify(new_parent);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -39,6 +39,7 @@ void root_create(void) {
 	wl_list_init(&root_container.sway_root->drag_icons);
 	wl_signal_init(&root_container.sway_root->events.new_container);
 	root_container.sway_root->scratchpad = create_list();
+	root_container.sway_root->saved_workspaces = create_list();
 
 	root_container.sway_root->output_layout_change.notify =
 		output_layout_handle_change;
@@ -50,6 +51,7 @@ void root_destroy(void) {
 	// sway_root
 	wl_list_remove(&root_container.sway_root->output_layout_change.link);
 	list_free(root_container.sway_root->scratchpad);
+	list_free(root_container.sway_root->saved_workspaces);
 	wlr_output_layout_destroy(root_container.sway_root->output_layout);
 	free(root_container.sway_root);
 


### PR DESCRIPTION
This changes the destroy functions to the following:

* `output_begin_destroy`
* `output_destroy`
* `workspace_begin_destroy`
* `workspace_destroy`
* `container_begin_destroy`
* `container_destroy`
* `view_begin_destroy`
* `view_destroy`

The terminology was `destroy` and `free`, and it has been changed to `begin_destroy` and `destroy` respectively.

When the last output is disconnected, its workspaces will now be stashed in the root. Upon connection of a new output they will be restored.

There is a new function `workspace_consider_destroy` which decides whether the given workspace should be destroyed or not (ie. empty and not visible).

Calling `container_begin_destroy` will no longer automatically reap the parents. In some places we want to reap the parents and in some we don't, so this is left to the caller.

`container_reap_empty_recursive` and `container_reap_empty` have been combined into one function and it will recurse up the tree.

This needs testing with output hotplugging, and unplugging the last output to see what happens.

Despite adding more functions, I've somehow managed to delete more code than I've added :)