### PR TITLE
Fix bad-free in swaynag

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -58,7 +58,7 @@ struct swaynag_details {
 	int offset;
 	int visible_lines;
 	int total_lines;
-	struct swaynag_button button_details;
+	struct swaynag_button *button_details;
 	struct swaynag_button button_up;
 	struct swaynag_button button_down;
 };

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -180,8 +180,8 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			break;
 		case 'L': // Detailed Button Text
 			if (swaynag) {
-				free(swaynag->details.button_details.text);
-				swaynag->details.button_details.text = strdup(optarg);
+				free(swaynag->details.button_details->text);
+				swaynag->details.button_details->text = strdup(optarg);
 			}
 			break;
 		case 'm': // Message

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -34,9 +34,10 @@ int main(int argc, char **argv) {
 	button_close->type = SWAYNAG_ACTION_DISMISS;
 	list_add(swaynag.buttons, button_close);
 
-	swaynag.details.button_details.text = strdup("Toggle Details");
-	swaynag.details.button_details.type = SWAYNAG_ACTION_EXPAND;
-
+	swaynag.details.button_details =
+		calloc(sizeof(struct swaynag_button), 1);
+	swaynag.details.button_details->text = strdup("Toggle Details");
+	swaynag.details.button_details->type = SWAYNAG_ACTION_EXPAND;
 
 	char *config_path = NULL;
 	bool debug = false;
@@ -99,9 +100,10 @@ int main(int argc, char **argv) {
 	swaynag_types_free(types);
 
 	if (swaynag.details.message) {
-		list_add(swaynag.buttons, &swaynag.details.button_details);
+		list_add(swaynag.buttons, swaynag.details.button_details);
 	} else {
-		free(swaynag.details.button_details.text);
+		free(swaynag.details.button_details->text);
+		free(swaynag.details.button_details);
 	}
 
 	wlr_log(WLR_DEBUG, "Output: %s", swaynag.type->output);
@@ -123,7 +125,8 @@ int main(int argc, char **argv) {
 
 cleanup:
 	swaynag_types_free(types);
-	free(swaynag.details.button_details.text);
+	free(swaynag.details.button_details->text);
+	free(swaynag.details.button_details);
 	swaynag_destroy(&swaynag);
 	return exit_code;
 }


### PR DESCRIPTION
I messed up and added the details button (which was never malloc'd) to `swaynag->buttons`.

This changes it so `button_details` is `struct swaynag_button *` and malloc'd so that it can be free'd with the rest of the buttons.