### PR TITLE
Improve new workspace name selection

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -205,6 +205,7 @@ char *workspace_next_name(const char *output_name) {
 				&& workspace_by_name(wso->workspace) == NULL) {
 			free(target);
 			target = strdup(wso->workspace);
+			break;
 		}
 	}
 	if (target != NULL) {


### PR DESCRIPTION
Improves upon 18e425ed by using the first assigned workspace instead of
the last one. The order isn't explicitly guaranteed to be the same as in
the config, but in general works.