### PR TITLE
Replace enum resize_edge with wlr_edges

### DIFF
--- a/include/sway/tree/layout.h
+++ b/include/sway/tree/layout.h
@@ -15,13 +15,7 @@ enum movement_direction {
 	MOVE_CHILD,
 };
 
-enum resize_edge {
-	RESIZE_EDGE_NONE   = 0,
-	RESIZE_EDGE_LEFT   = 1,
-	RESIZE_EDGE_RIGHT  = 2,
-	RESIZE_EDGE_TOP    = 4,
-	RESIZE_EDGE_BOTTOM = 8,
-};
+enum wlr_edges;
 
 struct sway_container;
 
@@ -52,7 +46,7 @@ struct sway_container *container_split(struct sway_container *child,
 		enum sway_container_layout layout);
 
 void container_recursive_resize(struct sway_container *container,
-		double amount, enum resize_edge edge);
+		double amount, enum wlr_edges edge);
 
 void container_swap(struct sway_container *con1, struct sway_container *con2);
 

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <wlr/util/edges.h>
 #include <wlr/util/log.h>
 #include "sway/commands.h"
 #include "sway/tree/arrange.h"
@@ -250,10 +251,10 @@ static void resize_tiled(struct sway_container *parent, int amount,
 		}
 	}
 
-	enum resize_edge minor_edge = axis == RESIZE_AXIS_HORIZONTAL ?
-		RESIZE_EDGE_LEFT : RESIZE_EDGE_TOP;
-	enum resize_edge major_edge = axis == RESIZE_AXIS_HORIZONTAL ?
-		RESIZE_EDGE_RIGHT : RESIZE_EDGE_BOTTOM;
+	enum wlr_edges minor_edge = axis == RESIZE_AXIS_HORIZONTAL ?
+		WLR_EDGE_LEFT : WLR_EDGE_TOP;
+	enum wlr_edges major_edge = axis == RESIZE_AXIS_HORIZONTAL ?
+		WLR_EDGE_RIGHT : WLR_EDGE_BOTTOM;
 
 	for (int i = 0; i < parent->parent->children->length; i++) {
 		struct sway_container *sibling = parent->parent->children->items[i];

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -984,7 +984,7 @@ void seat_begin_resize_floating(struct sway_seat *seat,
 	seat->op_resize_preserve_ratio = keyboard &&
 		(wlr_keyboard_get_modifiers(keyboard) & WLR_MODIFIER_SHIFT);
 	seat->op_resize_edge = edge == WLR_EDGE_NONE ?
-		RESIZE_EDGE_BOTTOM | RESIZE_EDGE_RIGHT : edge;
+		WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT : edge;
 	seat->op_button = button;
 	seat->op_ref_lx = seat->cursor->cursor->x;
 	seat->op_ref_ly = seat->cursor->cursor->y;

--- a/sway/tree/layout.c
+++ b/sway/tree/layout.c
@@ -876,13 +876,13 @@ struct sway_container *container_split(struct sway_container *child,
 }
 
 void container_recursive_resize(struct sway_container *container,
-		double amount, enum resize_edge edge) {
+		double amount, enum wlr_edges edge) {
 	bool layout_match = true;
 	wlr_log(WLR_DEBUG, "Resizing %p with amount: %f", container, amount);
-	if (edge == RESIZE_EDGE_LEFT || edge == RESIZE_EDGE_RIGHT) {
+	if (edge == WLR_EDGE_LEFT || edge == WLR_EDGE_RIGHT) {
 		container->width += amount;
 		layout_match = container->layout == L_HORIZ;
-	} else if (edge == RESIZE_EDGE_TOP || edge == RESIZE_EDGE_BOTTOM) {
+	} else if (edge == WLR_EDGE_TOP || edge == WLR_EDGE_BOTTOM) {
 		container->height += amount;
 		layout_match = container->layout == L_VERT;
 	}


### PR DESCRIPTION
No need to have two resize edge enums.