### PR TITLE
Add app_id and class to get_tree output

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -5,6 +5,7 @@
 #include "sway/config.h"
 #include "sway/ipc-json.h"
 #include "sway/tree/container.h"
+#include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "sway/output.h"
 #include "sway/input/input-manager.h"
@@ -191,6 +192,16 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "name",
 			c->name ? json_object_new_string(c->name) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("con"));
+
+	if (c->type == C_VIEW) {
+		const char *app_id = view_get_app_id(c->sway_view);
+		json_object_object_add(object, "app_id",
+				app_id ? json_object_new_string(app_id) : NULL);
+
+		const char *class = view_get_class(c->sway_view);
+		json_object_object_add(object, "class",
+				class ? json_object_new_string(class) : NULL);
+	}
 
 	if (c->parent) {
 		json_object_object_add(object, "layout",


### PR DESCRIPTION
This makes it much easier (possible at all?) to get ahold of the values you need to create criteria for both Wayland and X clients. Wayland clients will have a null `class`, X clients will have a null `app_id`. Tested both to make sure nothing exploded when serializing the opposite.