### PR TITLE
Pre-parse binding commands

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -18,6 +18,7 @@ list_t *create_list(void) {
 static void list_resize(list_t *list) {
 	if (list->length == list->capacity) {
 		list->capacity += 10;
+		// TODO: safely handle realloc failure
 		list->items = realloc(list->items, sizeof(void*) * list->capacity);
 	}
 }

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -47,7 +47,7 @@ struct cmd_results *checkarg(int argc, const char *name,
 		enum expected_args type, int val);
 
 struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
-		int handlers_size);
+		int handlers_size, bool reading, bool active);
 /**
  * Parse and executes a command.
  */
@@ -56,10 +56,17 @@ struct cmd_results *execute_command(const char *command,  struct sway_seat *seat
 struct stored_command {
 	sway_cmd *handle;
 	int argc;
-	char** argv;
-	struct criteria* criteria;
+	char **argv;
+	struct criteria *criteria;
 };
+void free_stored_command(struct stored_command *command);
 
+/**
+ * Parses a command, and returns a list of stored_commands. If `for_runtime`
+ * is true, then command handler lookup is performed as though it were runtime;
+ * otherwise, as appropriate for the current `config` state.
+ */
+list_t *parse_command(const char *command, bool for_runtime);
 /**
  * Executes a pre-parsed command. (Returns NULL if command was not unsuccessful: TODO, fix)
  */

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -51,7 +51,20 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 /**
  * Parse and executes a command.
  */
-struct cmd_results *execute_command(char *command,  struct sway_seat *seat);
+struct cmd_results *execute_command(const char *command,  struct sway_seat *seat);
+
+struct stored_command {
+	sway_cmd *handle;
+	int argc;
+	char** argv;
+	struct criteria* criteria;
+};
+
+/**
+ * Executes a pre-parsed command. (Returns NULL if command was not unsuccessful: TODO, fix)
+ */
+struct cmd_results *execute_stored_command(const struct stored_command *command,
+		struct sway_seat *seat);
 /**
  * Parse and handles a command during config file loading.
  *

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -38,7 +38,9 @@ enum binding_flags {
 };
 
 /**
- * A key binding and an associated command.
+ * A key binding and an associated command. In order to extend the lifetime
+ * of a binding slightly while executing the reload command, bindings are
+ * reference counted, and should only be freed if the reference count is <= 0.
  */
 struct sway_binding {
 	enum binding_input_type type;
@@ -46,15 +48,9 @@ struct sway_binding {
 	uint32_t flags;
 	list_t *keys; // sorted in ascending order
 	uint32_t modifiers;
-	char *command;
-};
-
-/**
- * A mouse binding and an associated command.
- */
-struct sway_mouse_binding {
-	uint32_t button;
-	char *command;
+	char *command_str; // original command string for IPC compatibility
+	list_t *command; // a preparsed list of struct stored_command
+	int refcount;
 };
 
 /**

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -36,6 +36,9 @@ struct criteria {
 	bool tiling;
 	char urgent; // 'l' for latest or 'o' for oldest
 	char *workspace;
+	// optional refcount for users (like struct stored_command) for which
+	// a criterion may be referenced multiple times.
+	int refcount;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -170,12 +170,12 @@ static int handler_compare(const void *_a, const void *_b) {
 }
 
 struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
-		int handlers_size) {
+		int handlers_size, bool reading, bool active) {
 	struct cmd_handler d = { .command=line };
 	struct cmd_handler *res = NULL;
 	wlr_log(WLR_DEBUG, "find_handler(%s)", line);
 
-	bool config_loading = config->reading || !config->active;
+	bool config_loading = reading || !active;
 
 	if (!config_loading) {
 		res = bsearch(&d, command_handlers,
@@ -210,14 +210,11 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 }
 
 struct cmd_results *execute_command(const char *_exec, struct sway_seat *seat) {
-	// Even though this function will process multiple commands we will only
-	// return the last error, if any (for now). (Since we have access to an
-	// error string we could e.g. concatenate all errors there.)
-	struct cmd_results *results = NULL;
-	char *exec = strdup(_exec);
-	char *head = exec;
-	char *cmdlist;
-	char *cmd;
+	list_t *subcommands = parse_command(_exec, false);
+	if (!subcommands) {
+		return cmd_results_new(CMD_INVALID, _exec,
+				"Failed to allocate list of commands");
+	}
 
 	if (seat == NULL) {
 		// passing a NULL seat means we just pick the default seat
@@ -227,7 +224,53 @@ struct cmd_results *execute_command(const char *_exec, struct sway_seat *seat) {
 		}
 	}
 
-	head = exec;
+	// Even though this function will process multiple commands we will only
+	// return the last error, if any (for now). (Since we have access to an
+	// error string we could e.g. concatenate all errors there.)
+	struct cmd_results *results = NULL;
+	for (int i = 0; i < subcommands->length; i++) {
+		struct stored_command *command = subcommands->items[i];
+		struct cmd_results *res = execute_stored_command(command, seat);
+		if (res->status != CMD_SUCCESS) {
+			if (results) {
+				free_cmd_results(results);
+			}
+			results = res;
+			goto cleanup;
+		}
+	}
+cleanup:
+	for (int i = 0; i < subcommands->length; i++) {
+		free_stored_command(subcommands->items[i]);
+	}
+	list_free(subcommands);
+	if (!results) {
+		results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+	return results;
+}
+
+void free_stored_command(struct stored_command *command) {
+	free_argv(command->argc, command->argv);
+	if (command->criteria) {
+		command->criteria->refcount--;
+		if (command->criteria->refcount <= 0) {
+			criteria_destroy(command->criteria);
+		}
+	}
+	free(command);
+}
+
+list_t *parse_command(const char *_exec, bool for_runtime) {
+	char *exec = strdup(_exec);
+	if (!exec) {
+		return NULL;
+	}
+	list_t *stored_list = create_list();
+
+	bool abort = false;
+
+	char *head = exec;
 	do {
 		// Extract criteria (valid for this command list only).
 		struct criteria *criteria = NULL;
@@ -235,28 +278,28 @@ struct cmd_results *execute_command(const char *_exec, struct sway_seat *seat) {
 			char *error = NULL;
 			criteria = criteria_parse(head, &error);
 			if (!criteria) {
-				results = cmd_results_new(CMD_INVALID, head,
-					"%s", error);
+				wlr_log(WLR_ERROR, "%s", error);
 				free(error);
 				goto cleanup;
 			}
+			criteria->refcount++;
 			head += strlen(criteria->raw);
 			// Skip leading whitespace
 			head += strspn(head, whitespace);
 		}
 		// Split command list
-		cmdlist = argsep(&head, ";");
+		char *cmdlist = argsep(&head, ";");
 		cmdlist += strspn(cmdlist, whitespace);
 		do {
 			// Split commands
-			cmd = argsep(&cmdlist, ",");
+			char *cmd = argsep(&cmdlist, ",");
 			cmd += strspn(cmd, whitespace);
 			if (strcmp(cmd, "") == 0) {
 				wlr_log(WLR_INFO, "Ignoring empty command.");
 				continue;
 			}
 			wlr_log(WLR_INFO, "Handling command '%s'", cmd);
-			//TODO better handling of argv
+			// TODO better handling of argv
 			int argc;
 			char **argv = split_args(cmd, &argc);
 			if (strcmp(argv[0], "exec") != 0) {
@@ -267,17 +310,20 @@ struct cmd_results *execute_command(const char *_exec, struct sway_seat *seat) {
 					}
 				}
 			}
-			struct cmd_handler *handler = find_handler(argv[0], NULL, 0);
+			// Identify the command
+			struct cmd_handler *handler;
+			if (for_runtime) {
+				handler = find_handler(argv[0], NULL, 0, false, true);
+			} else {
+				handler = find_handler(argv[0], NULL, 0,
+						config->reading, config->active);
+			}
+
 			if (!handler) {
-				if (results) {
-					free_cmd_results(results);
-				}
-				results = cmd_results_new(CMD_INVALID, cmd, "Unknown/invalid command");
+				wlr_log(WLR_ERROR, "Unknown/invalid command");
 				free_argv(argc, argv);
-				if (criteria) {
-					criteria_destroy(criteria);
-				}
-				goto cleanup;
+				abort = true;
+				break;
 			}
 
 			// Var replacement, for all but first argument of set
@@ -286,38 +332,51 @@ struct cmd_results *execute_command(const char *_exec, struct sway_seat *seat) {
 				unescape_string(argv[i]);
 			}
 
-			struct stored_command command;
-			command.handle = handler->handle;
-			command.argv = argv;
-			command.argc = argc;
-			command.criteria = criteria;
-			struct cmd_results *res = execute_stored_command(&command, seat);
-			free_argv(argc, argv);
-
-			if (res->status != CMD_SUCCESS) {
-				if (results) {
-					free_cmd_results(results);
-				}
-				results = res;
-				if (criteria) {
-					criteria_destroy(criteria);
-				}
-				goto cleanup;
+			struct stored_command *command = (struct stored_command *)
+					calloc(1, sizeof(struct stored_command));
+			if (!command) {
+				wlr_log(WLR_ERROR, "Unknown/invalid command");
+				abort = true;
+				break;
 			}
-			free_cmd_results(res);
 
+			// TODO: handle realloc failure case for list_add
+			list_add(stored_list, command);
+
+			command->handle = handler->handle;
+			command->argv = argv;
+			command->argc = argc;
+			command->criteria = criteria;
+			if (criteria) {
+				command->criteria->refcount++;
+			}
 		} while(cmdlist);
+
+		if (criteria) {
+			criteria->refcount--;
+			if (criteria->refcount <= 0) {
+				criteria_destroy(criteria);
+			}
+		}
+		if (abort) {
+			break;
+		}
 	} while(head);
+
 cleanup:
 	free(exec);
-	if (!results) {
-		results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
-	}
-	return results;
+	return stored_list;
 }
 
-struct cmd_results *execute_stored_command(const struct stored_command* command,
-		struct sway_seat* seat) {
+struct cmd_results *execute_stored_command(const struct stored_command *command,
+		struct sway_seat *seat) {
+	if (seat == NULL) {
+		// passing a NULL seat means we just pick the default seat
+		seat = input_manager_get_default_seat(input_manager);
+		if (!sway_assert(seat, "could not find a seat to run the command on")) {
+			return NULL;
+		}
+	}
 	config->handler_context.seat = seat;
 
 	if (!command->criteria) {
@@ -378,7 +437,8 @@ struct cmd_results *config_command(char *exec) {
 		goto cleanup;
 	}
 	wlr_log(WLR_INFO, "handling config command '%s'", exec);
-	struct cmd_handler *handler = find_handler(argv[0], NULL, 0);
+	struct cmd_handler *handler = find_handler(argv[0], NULL, 0,
+			config->reading, config->active);
 	if (!handler) {
 		char *input = argv[0] ? argv[0] : "(empty)";
 		results = cmd_results_new(CMD_INVALID, input, "Unknown/invalid command");
@@ -414,7 +474,7 @@ struct cmd_results *config_subcommand(char **argv, int argc,
 	free(command);
 
 	struct cmd_handler *handler = find_handler(argv[0], handlers,
-			handlers_size);
+			handlers_size, config->reading, config->active);
 	if (!handler) {
 		char *input = argv[0] ? argv[0] : "(empty)";
 		return cmd_results_new(CMD_INVALID, input, "Unknown/invalid command");
@@ -448,7 +508,8 @@ struct cmd_results *config_commands_command(char *exec) {
 		goto cleanup;
 	}
 
-	struct cmd_handler *handler = find_handler(cmd, NULL, 0);
+	struct cmd_handler *handler = find_handler(cmd, NULL, 0,
+			config->reading, config->active);
 	if (!handler && strcmp(cmd, "*") != 0) {
 		results = cmd_results_new(CMD_INVALID, cmd, "Unknown/invalid command");
 		goto cleanup;

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -48,7 +48,8 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 
 	if (!config->reading) {
 		if (!find_handler(argv[0], bar_config_handlers,
-					sizeof(bar_config_handlers))) {
+				sizeof(bar_config_handlers), config->reading,
+				config->active)) {
 			return cmd_results_new(CMD_FAILURE, "bar",
 					"Can only be used in config file.");
 		}
@@ -58,8 +59,10 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 
 	if (argc > 1) {
 		struct bar_config *bar = NULL;
-		if (!find_handler(argv[0], bar_handlers, sizeof(bar_handlers))
-				&& find_handler(argv[1], bar_handlers, sizeof(bar_handlers))) {
+		if (!find_handler(argv[0], bar_handlers, sizeof(bar_handlers),
+				  config->reading, config->active)
+				&& find_handler(argv[1], bar_handlers, sizeof(bar_handlers),
+						config->reading, config->active)) {
 			for (int i = 0; i < config->bars->length; ++i) {
 				struct bar_config *item = config->bars->items[i];
 				if (strcmp(item->id, argv[0]) == 0) {

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -53,7 +53,8 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 	struct cmd_results *res;
 
 	if (find_handler(argv[1], input_config_handlers,
-			sizeof(input_config_handlers))) {
+			sizeof(input_config_handlers), config->reading,
+			config->active)) {
 		if (config->reading) {
 			res = config_subcommand(argv + 1, argc - 1,
 				input_config_handlers, sizeof(input_config_handlers));

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -40,7 +40,8 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 		config->handler_context.leftovers.argc = 0;
 		config->handler_context.leftovers.argv = NULL;
 
-		if (find_handler(*argv, output_handlers, sizeof(output_handlers))) {
+		if (find_handler(*argv, output_handlers, sizeof(output_handlers),
+				config->reading, config->active)) {
 			error = config_subcommand(argv, argc, output_handlers,
 					sizeof(output_handlers));
 		} else {

--- a/sway/config.c
+++ b/sway/config.c
@@ -47,19 +47,31 @@ static void free_mode(struct sway_mode *mode) {
 	free(mode->name);
 	if (mode->keysym_bindings) {
 		for (i = 0; i < mode->keysym_bindings->length; i++) {
-			free_sway_binding(mode->keysym_bindings->items[i]);
+			struct sway_binding* binding = mode->keysym_bindings->items[i];
+			binding->refcount--;
+			if (binding->refcount <= 0) {
+				free_sway_binding(binding);
+			}
 		}
 		list_free(mode->keysym_bindings);
 	}
 	if (mode->keycode_bindings) {
 		for (i = 0; i < mode->keycode_bindings->length; i++) {
-			free_sway_binding(mode->keycode_bindings->items[i]);
+			struct sway_binding* binding = mode->keycode_bindings->items[i];
+			binding->refcount--;
+			if (binding->refcount <= 0) {
+				free_sway_binding(binding);
+			}
 		}
 		list_free(mode->keycode_bindings);
 	}
 	if (mode->mouse_bindings) {
 		for (i = 0; i < mode->mouse_bindings->length; i++) {
-			free_sway_binding(mode->mouse_bindings->items[i]);
+			struct sway_binding* binding = mode->mouse_bindings->items[i];
+			binding->refcount--;
+			if (binding->refcount <= 0) {
+				free_sway_binding(binding);
+			}
 		}
 		list_free(mode->mouse_bindings);
 	}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -525,6 +525,7 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 	}
 	++head;
 
+	// zero allocation also ensures the optional refcount defaults to zero
 	struct criteria *criteria = calloc(sizeof(struct criteria), 1);
 	char *name = NULL, *value = NULL;
 	bool in_quotes = false;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -379,7 +379,7 @@ void ipc_event_binding(struct sway_binding *binding) {
 	wlr_log(WLR_DEBUG, "Sending binding event");
 
 	json_object *json_binding = json_object_new_object();
-	json_object_object_add(json_binding, "command", json_object_new_string(binding->command));
+	json_object_object_add(json_binding, "command", json_object_new_string(binding->command_str));
 
 	const char *names[10];
 	int len = get_modifier_names(names, binding->modifiers);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -162,7 +162,7 @@ static bool workspace_valid_on_output(const char *output_name,
 
 static void workspace_name_from_binding(const struct sway_binding * binding,
 		const char* output_name, int *min_order, char **earliest_name) {
-	char *cmdlist = strdup(binding->command);
+	char *cmdlist = strdup(binding->command_str);
 	char *dup = cmdlist;
 	char *name = NULL;
 


### PR DESCRIPTION
Hi there!

This PR shifts complexity from runtime to setup, so that keyboard and mouse bindings always execute their associated command, even when allocation fails. This change has the additional benefit of validating all commands on startup.

(I would have preferred a zero-allocation command parsing method, but variable substitution and string escaping make the latter task almost impossible unless you maintain a 'large-enough' temporary buffer for string rewriting and then provide either a custom allocator or move away from null-terminated strings. I really would like to find a cleaner solution.)

As criteria are rarely used (I've yet to see an i3 config with more than a few, and don't require any myself), the corresponding code has gone mostly untested. Is there a test config file that includes everything?

FYI, `list_t` managed to be ambiguous once or twice, as I forgot if it was a pointer or plain struct.

Please review.

