### PR TITLE
Prepare arrange code for type safe arguments

### DIFF
--- a/include/sway/tree/arrange.h
+++ b/include/sway/tree/arrange.h
@@ -1,12 +1,16 @@
 #ifndef _SWAY_ARRANGE_H
 #define _SWAY_ARRANGE_H
-#include "sway/desktop/transaction.h"
 
 struct sway_container;
 
-/**
- * Arrange layout for all the children of the given container.
- */
+void arrange_container(struct sway_container *container);
+
+void arrange_workspace(struct sway_container *workspace);
+
+void arrange_output(struct sway_container *output);
+
+void arrange_root(void);
+
 void arrange_windows(struct sway_container *container);
 
 #endif

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -103,7 +103,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 			parent->prev_split_layout = prev;
 		}
 		container_notify_subtree_changed(parent);
-		arrange_windows(parent);
+		arrange_windows(parent->parent);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -16,6 +16,7 @@
 #include "log.h"
 #include "config.h"
 #include "sway/config.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/layers.h"

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -619,9 +619,7 @@ static void render_container_tabbed(struct sway_output *output,
 	struct sway_container *current = pstate->focused_inactive_child;
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 
-	double width_gap_adjustment = 2 * pstate->current_gaps;
-	int tab_width =
-		(pstate->swayc_width - width_gap_adjustment) / pstate->children->length;
+	int tab_width = (pstate->swayc_width) / pstate->children->length;
 
 	// Render tabs
 	for (int i = 0; i < pstate->children->length; ++i) {
@@ -656,8 +654,7 @@ static void render_container_tabbed(struct sway_output *output,
 
 		// Make last tab use the remaining width of the parent
 		if (i == pstate->children->length - 1) {
-			tab_width =
-				pstate->swayc_width - width_gap_adjustment - tab_width * i;
+			tab_width = pstate->swayc_width - tab_width * i;
 		}
 
 		render_titlebar(output, damage, child, x, pstate->swayc_y, tab_width,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -660,7 +660,7 @@ static void render_container_tabbed(struct sway_output *output,
 				pstate->swayc_width - width_gap_adjustment - tab_width * i;
 		}
 
-		render_titlebar(output, damage, child, x, cstate->swayc_y, tab_width,
+		render_titlebar(output, damage, child, x, pstate->swayc_y, tab_width,
 				colors, title_texture, marks_texture);
 
 		if (child == current) {
@@ -721,9 +721,9 @@ static void render_container_stacked(struct sway_output *output,
 			marks_texture = view ? view->marks_unfocused : NULL;
 		}
 
-		int y = cstate->swayc_y + titlebar_height * i;
-		render_titlebar(output, damage, child, cstate->swayc_x, y,
-				cstate->swayc_width, colors, title_texture, marks_texture);
+		int y = pstate->swayc_y + titlebar_height * i;
+		render_titlebar(output, damage, child, pstate->swayc_x, y,
+				pstate->swayc_width, colors, title_texture, marks_texture);
 
 		if (child == current) {
 			current_colors = colors;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "sway/decoration.h"
 #include "sway/desktop.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/server.h"

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -7,6 +7,7 @@
 #include "log.h"
 #include "sway/decoration.h"
 #include "sway/desktop.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/server.h"

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1163,7 +1163,9 @@ void container_add_gaps(struct sway_container *c) {
 		return;
 	}
 
-	c->current_gaps = c->has_gaps ? c->gaps_inner : config->gaps_inner;
+	struct sway_container *ws = container_parent(c, C_WORKSPACE);
+
+	c->current_gaps = ws->has_gaps ? ws->gaps_inner : config->gaps_inner;
 	c->x += c->current_gaps;
 	c->y += c->current_gaps;
 	c->width -= 2 * c->current_gaps;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1159,7 +1159,17 @@ void container_add_gaps(struct sway_container *c) {
 				"Expected a container or view")) {
 		return;
 	}
-	if (c->current_gaps > 0 || c->type != C_VIEW) {
+	if (c->current_gaps > 0) {
+		return;
+	}
+	// Linear containers don't have gaps because it'd create double gaps
+	if (c->type == C_CONTAINER &&
+			c->layout != L_TABBED && c->layout != L_STACKED) {
+		return;
+	}
+	// Children of tabbed/stacked containers re-use the gaps of the container
+	enum sway_container_layout layout = c->parent->layout;
+	if (layout == L_TABBED || layout == L_STACKED) {
 		return;
 	}
 
@@ -1355,19 +1365,15 @@ struct sway_container *container_split(struct sway_container *child,
 
 	wlr_log(WLR_DEBUG, "creating container %p around %p", cont, child);
 
-	child->type == C_WORKSPACE ? workspace_remove_gaps(child)
-		: container_remove_gaps(child);
-
 	cont->prev_split_layout = L_NONE;
 	cont->width = child->width;
 	cont->height = child->height;
 	cont->x = child->x;
 	cont->y = child->y;
+	cont->current_gaps = child->current_gaps;
 
 	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
 	bool set_focus = (seat_get_focus(seat) == child);
-
-	container_add_gaps(cont);
 
 	if (child->type == C_WORKSPACE) {
 		struct sway_container *workspace = child;

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wlr/types/wlr_output_layout.h>
+#include "sway/desktop/transaction.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
 #include "sway/tree/arrange.h"

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -694,7 +694,15 @@ void workspace_add_gaps(struct sway_container *ws) {
 		return;
 	}
 
-	ws->current_gaps = ws->has_gaps ? ws->gaps_inner : config->gaps_inner;
+	ws->current_gaps = ws->has_gaps ? ws->gaps_outer : config->gaps_outer;
+
+	if (ws->layout == L_TABBED || ws->layout == L_STACKED) {
+		// We have to add inner gaps for this, because children of tabbed and
+		// stacked containers don't apply their own gaps - they assume the
+		// tabbed/stacked container is using gaps.
+		ws->current_gaps += ws->has_gaps ? ws->gaps_inner : config->gaps_inner;
+	}
+
 	ws->x += ws->current_gaps;
 	ws->y += ws->current_gaps;
 	ws->width -= 2 * ws->current_gaps;


### PR DESCRIPTION
This commit changes the arrange code in a way that will support type safe arguments.

The `arrange_output` et al functions are now public, however I opted not to use them directly yet. I've kept the generic `arrange_windows` there for convenience until type safety is fully implemented. This means this patch has much less risk of breaking things as it would otherwise.

To be type safe, `arrange_children_of` cannot exist in its previous form because the thing passed to it could be either a workspace or a container. So it's now renamed to `arrange_children` and accepts a `list_t`, as well as the parent layout and parent's box.

There was some code which checked the grandparent's layout to see if it was tabbed or stacked and adjusted the Y offset of the grandchild accordingly. Accessing the grandparent layout isn't easy when using type safe arguments, and it seemed odd to even need to do this. I determined that this was needed because a child of a tabbed container would have a swayc Y matching the top of the tab bar. I've changed this so a child of a tabbed container will have a swayc Y matching the bottom of the tab bar, which means we don't need to access the grandparent layout. Some tweaks to the rendering and autoconfigure code have been made to implement this, and the `container_at` code appears to work without needing any changes.

`arrange_children_of` (now `arrange_children`) would check if the parent had gaps and would copy them to the child, effectively making the workspace's gaps recurse into all children. We can't do this any more without passing `has_gaps`, `gaps_inner` and `gaps_outer` as arguments to `arrange_children`, so I've changed the `add_gaps` function to retrieve it from the workspace directly.

`apply_tabbed_or_stacked_layout` has been split into two functions, as it had different logic depending on the layout.

Lastly, `arrange.h` had an unnecessary include of `transaction.h`. I've removed it, which means I've had to add it to several other files.