### PR TITLE
Rename sway_root.outputs to sway_root.all_outputs

### DIFF
--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -21,7 +21,7 @@ struct sway_root {
 
 	struct wlr_texture *debug_tree;
 
-	struct wl_list outputs; // sway_output::link
+	struct wl_list all_outputs; // sway_output::link
 
 	list_t *scratchpad; // struct sway_container
 	list_t *saved_workspaces; // For when there's no connected outputs

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -21,6 +21,7 @@ struct sway_root {
 
 	struct wlr_texture *debug_tree;
 
+	// Includes disabled outputs
 	struct wl_list all_outputs; // sway_output::link
 
 	list_t *scratchpad; // struct sway_container

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -288,7 +288,8 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 	bool wildcard = strcmp(oc->name, "*") == 0;
 	char id[128];
 	struct sway_output *sway_output;
-	wl_list_for_each(sway_output, &root_container.sway_root->outputs, link) {
+	wl_list_for_each(sway_output,
+			&root_container.sway_root->all_outputs, link) {
 		char *name = sway_output->wlr_output->name;
 		output_get_identifier(id, sizeof(id), sway_output);
 		if (wildcard || !strcmp(name, oc->name) || !strcmp(id, oc->name)) {
@@ -348,7 +349,8 @@ static void default_output_config(struct output_config *oc,
 
 void create_default_output_configs(void) {
 	struct sway_output *sway_output;
-	wl_list_for_each(sway_output, &root_container.sway_root->outputs, link) {
+	wl_list_for_each(sway_output,
+			&root_container.sway_root->all_outputs, link) {
 		char *name = sway_output->wlr_output->name;
 		struct output_config *oc = new_output_config(name);
 		default_output_config(oc, sway_output->wlr_output);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -556,7 +556,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->destroy.notify = handle_destroy;
 
-	wl_list_insert(&root_container.sway_root->outputs, &output->link);
+	wl_list_insert(&root_container.sway_root->all_outputs, &output->link);
 
 	if (!wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *mode =

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -615,7 +615,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 			}
 		}
 		struct sway_output *output;
-		wl_list_for_each(output, &root_container.sway_root->outputs, link) {
+		wl_list_for_each(output, &root_container.sway_root->all_outputs, link) {
 			if (!output->swayc) {
 				json_object_array_add(outputs,
 						ipc_json_describe_disabled_output(output));

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -32,7 +32,7 @@ void root_create(void) {
 
 	root_container.sway_root = calloc(1, sizeof(*root_container.sway_root));
 	root_container.sway_root->output_layout = wlr_output_layout_create();
-	wl_list_init(&root_container.sway_root->outputs);
+	wl_list_init(&root_container.sway_root->all_outputs);
 #ifdef HAVE_XWAYLAND
 	wl_list_init(&root_container.sway_root->xwayland_unmanaged);
 #endif


### PR DESCRIPTION
This list includes disabled outputs.

When `sway_container` is demoted, we'll need to store the root's children (ie. enabled outputs) in the `sway_root`. It makes sense to put these in a list called `outputs`, so I'm renaming the existing list in advance.