### PR TITLE
Simplify runtime variable substitution

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -51,7 +51,7 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 /**
  * Parse and executes a command.
  */
-struct cmd_results *execute_command(char *command,  struct sway_seat *seat);
+struct cmd_results *execute_command(const char *command, struct sway_seat *seat);
 /**
  * Parse and handles a command during config file loading.
  *

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -206,14 +206,20 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 		binding->type = BINDING_MOUSE;
 	}
 
-	if (argc < 2) {
+	// the arguments to bindsym and bindcode are specially preprocessed,
+	// so that the command to be executed is provided as the final argument.
+	if (argc != 2) {
 		free_sway_binding(binding);
 		return cmd_results_new(CMD_FAILURE, bindtype,
-			"Invalid %s command "
-			"(expected at least 2 non-option arguments, got %d)", bindtype, argc);
+			"Invalid %s command (expected exactly one non-option "
+			"argument, followed by a command)", bindtype);
 	}
-
-	binding->command = join_args(argv + 1, argc - 1);
+	binding->command = strdup(argv[1]);
+	if (!binding->command) {
+		free_sway_binding(binding);
+		return cmd_results_new(CMD_FAILURE, bindtype,
+			"Unable to allocate a copy of the command");
+	}
 
 	list_t *split = split_string(argv[0], "+");
 	for (int i = 0; i < split->length; ++i) {

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -8,8 +8,16 @@
 
 struct cmd_results *cmd_for_window(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "for_window", EXPECTED_AT_LEAST, 2))) {
+	if ((error = checkarg(argc, "for_window", EXPECTED_EQUAL_TO, 2))) {
 		return error;
+	}
+
+	// the arguments to cmd_for_window are specially preprocessed,
+	// so that the command to be executed is provided as the final argument.
+	char *cmdlist = strdup(argv[1]);
+	if (!cmdlist) {
+		return cmd_results_new(CMD_FAILURE, "for_window",
+				"Unable to allocate a copy of the command");
 	}
 
 	char *err_str = NULL;
@@ -21,7 +29,7 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 	}
 
 	criteria->type = CT_COMMAND;
-	criteria->cmdlist = join_args(argv + 1, argc - 1);
+	criteria->cmdlist = cmdlist;
 
 	list_add(config->criteria, criteria);
 	wlr_log(WLR_DEBUG, "for_window: '%s' -> '%s' added", criteria->raw, criteria->cmdlist);

--- a/sway/config.c
+++ b/sway/config.c
@@ -748,7 +748,6 @@ bool read_config(FILE *file, struct sway_config *config,
 }
 
 char *do_var_replacement(char *str) {
-	int i;
 	char *find = str;
 	while ((find = strchr(find, '$'))) {
 		// Skip if escaped.
@@ -758,15 +757,8 @@ char *do_var_replacement(char *str) {
 				continue;
 			}
 		}
-		// Unescape double $ and move on
-		if (find[1] == '$') {
-			size_t length = strlen(find + 1);
-			memmove(find, find + 1, length);
-			find[length] = '\0';
-			++find;
-			continue;
-		}
 		// Find matching variable
+		int i;
 		for (i = 0; i < config->symbols->length; ++i) {
 			struct sway_variable *var = config->symbols->items[i];
 			int vnlen = strlen(var->name);


### PR DESCRIPTION
I've looked at #2084, and think that the difficulties in the current solution for runtime variable substitution (RVS) lie in that commands evaluated at runtime via `bindsym`, `bindcode`, and `for_window`, are preprocessed twice. By ensuring that the nested commands are kept unprocessed until runtime, RVS follows more intuitively.

Under this change, a config file might include this

    set $term program
    bindsym $mod+Return exec $term
    exec $term
    set $term other-program

When the config file is read, `exec $term`  is preprocessed to `exec program` and is run. When `$mod+Return`, the asssociated command  `exec $term` is preprocessed to be `exec other-program`, 
and run.

This change rolls back the new syntax ($$var) introduced by #2084, but as that PR is recent and not yet in any stable releases, it shouldn't break any config files for people who should not already have been expecting it :-). It also ensures that the same level of string escaping is required for top-level commands
invocations as for nested command invocations.

