### PR TITLE
Fix crash when reaping a workspace

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -173,6 +173,9 @@ struct sway_container *container_reap_empty(struct sway_container *con) {
 	}
 	if (con && con->type == C_WORKSPACE) {
 		workspace_consider_destroy(con);
+		if (con->destroying) {
+			con = con->parent;
+		}
 	}
 	return con;
 }


### PR DESCRIPTION
It wasn't returning the surviving container.

To reproduce, open a terminal in a workspace with no siblings, run `sleep 2 && exit` then switch to another workspace during the sleep.