### PR TITLE
commands: fix exec quoting

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -21,20 +21,15 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	}
 
 	char *tmp = NULL;
-	if (strcmp((char*)*argv, "--no-startup-id") == 0) {
+	if (strcmp(argv[0], "--no-startup-id") == 0) {
 		wlr_log(WLR_INFO, "exec switch '--no-startup-id' not supported, ignored.");
-		if ((error = checkarg(argc - 1, "exec_always", EXPECTED_MORE_THAN, 0))) {
+		--argc; ++argv;
+		if ((error = checkarg(argc, "exec_always", EXPECTED_MORE_THAN, 0))) {
 			return error;
 		}
-
-		--argc; ++argv;
 	}
 
-	if (argv[0][0] == '\'' || argv[0][0] == '"') {
-		if (argc > 0) {
-			return cmd_results_new(CMD_INVALID, "exec_always",
-					"command cannot be partially quoted");
-		}
+	if (argc == 1 && (argv[0][0] == '\'' || argv[0][0] == '"')) {
 		tmp = strdup(argv[0]);
 		strip_quotes(tmp);
 	} else {


### PR DESCRIPTION
The way I implemented it before was really a stop-gap measure, furthermore, there was a bug since it was comparing `argc > 0` rather than `argc > 1` so even fully-quoted commands were rejected.

Now, it allows partially-quoted commands, but does not strip quotes and split the command, only if it is fully quoted.