### PR TITLE
Implement type safe arguments and demote sway_container

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -407,7 +407,9 @@ struct sway_config {
 		struct output_config *output_config;
 		struct seat_config *seat_config;
 		struct sway_seat *seat;
-		struct sway_container *current_container;
+		struct sway_node *node;
+		struct sway_container *container;
+		struct sway_workspace *workspace;
 		bool using_criteria;
 		struct {
 			int argc;
@@ -486,8 +488,7 @@ struct output_config *new_output_config(const char *name);
 
 void merge_output_config(struct output_config *dst, struct output_config *src);
 
-void apply_output_config(struct output_config *oc,
-		struct sway_container *output);
+void apply_output_config(struct output_config *oc, struct sway_output *output);
 
 struct output_config *store_output_config(struct output_config *oc);
 

--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -1,7 +1,6 @@
 #ifndef _SWAY_TRANSACTION_H
 #define _SWAY_TRANSACTION_H
-#include <wlr/render/wlr_texture.h>
-#include "sway/tree/container.h"
+#include <stdint.h>
 
 /**
  * Transactions enable us to perform atomic layout updates.
@@ -21,6 +20,7 @@
  */
 
 struct sway_transaction_instruction;
+struct sway_view;
 
 /**
  * Find all dirty containers, create and commit a transaction containing them,

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -37,10 +37,10 @@ struct sway_input_manager {
 struct sway_input_manager *input_manager_create(struct sway_server *server);
 
 bool input_manager_has_focus(struct sway_input_manager *input,
-		struct sway_container *container);
+		struct sway_node *node);
 
 void input_manager_set_focus(struct sway_input_manager *input,
-		struct sway_container *container);
+		struct sway_node *node);
 
 void input_manager_configure_xcursor(struct sway_input_manager *input);
 

--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -7,8 +7,8 @@
 json_object *ipc_json_get_version();
 
 json_object *ipc_json_describe_disabled_output(struct sway_output *o);
-json_object *ipc_json_describe_container(struct sway_container *c);
-json_object *ipc_json_describe_container_recursive(struct sway_container *c);
+json_object *ipc_json_describe_node(struct sway_node *node);
+json_object *ipc_json_describe_node_recursive(struct sway_node *node);
 json_object *ipc_json_describe_input(struct sway_input_device *device);
 json_object *ipc_json_describe_seat(struct sway_seat *seat);
 json_object *ipc_json_describe_bar_config(struct bar_config *bar);

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -11,8 +11,8 @@ void ipc_init(struct sway_server *server);
 
 struct sockaddr_un *ipc_user_sockaddr(void);
 
-void ipc_event_workspace(struct sway_container *old,
-		struct sway_container *new, const char *change);
+void ipc_event_workspace(struct sway_workspace *old,
+		struct sway_workspace *new, const char *change);
 void ipc_event_window(struct sway_container *window, const char *change);
 void ipc_event_barconfig_update(struct bar_config *bar);
 void ipc_event_mode(const char *mode, bool pango);

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -28,6 +28,9 @@ struct sway_output {
 	struct timespec last_frame;
 	struct wlr_output_damage *damage;
 
+	int lx, ly;
+	int width, height;
+
 	bool enabled;
 	list_t *workspaces;
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -6,14 +6,20 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 #include "config.h"
+#include "sway/tree/node.h"
 #include "sway/tree/view.h"
 
 struct sway_server;
 struct sway_container;
 
+struct sway_output_state {
+	list_t *workspaces;
+	struct sway_workspace *active_workspace;
+};
+
 struct sway_output {
+	struct sway_node node;
 	struct wlr_output *wlr_output;
-	struct sway_container *swayc;
 	struct sway_server *server;
 
 	struct wl_list layers[4]; // sway_layer_surface::link
@@ -22,11 +28,15 @@ struct sway_output {
 	struct timespec last_frame;
 	struct wlr_output_damage *damage;
 
+	bool enabled;
+	list_t *workspaces;
+
+	struct sway_output_state current;
+
 	struct wl_listener destroy;
 	struct wl_listener mode;
 	struct wl_listener transform;
 	struct wl_listener scale;
-
 	struct wl_listener damage_destroy;
 	struct wl_listener damage_frame;
 
@@ -39,13 +49,19 @@ struct sway_output {
 	} events;
 };
 
-struct sway_container *output_create(struct sway_output *sway_output);
+struct sway_output *output_create(struct wlr_output *wlr_output);
 
-void output_destroy(struct sway_container *output);
+void output_destroy(struct sway_output *output);
 
-void output_begin_destroy(struct sway_container *output);
+void output_begin_destroy(struct sway_output *output);
 
-struct sway_container *output_from_wlr_output(struct wlr_output *output);
+struct sway_output *output_from_wlr_output(struct wlr_output *output);
+
+struct sway_output *output_get_in_direction(struct sway_output *reference,
+		enum movement_direction direction);
+
+void output_add_workspace(struct sway_output *output,
+		struct sway_workspace *workspace);
 
 typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
 	struct wlr_surface *surface, struct wlr_box *box, float rotation,
@@ -64,15 +80,19 @@ void output_damage_box(struct sway_output *output, struct wlr_box *box);
 void output_damage_whole_container(struct sway_output *output,
 	struct sway_container *con);
 
-struct sway_container *output_by_name(const char *name);
+struct sway_output *output_by_name(const char *name);
 
-void output_sort_workspaces(struct sway_container *output);
+void output_sort_workspaces(struct sway_output *output);
 
-void output_enable(struct sway_output *output);
+struct output_config *output_find_config(struct sway_output *output);
+
+void output_enable(struct sway_output *output, struct output_config *oc);
+
+void output_disable(struct sway_output *output);
 
 bool output_has_opaque_overlay_layer_surface(struct sway_output *output);
 
-struct sway_container *output_get_active_workspace(struct sway_output *output);
+struct sway_workspace *output_get_active_workspace(struct sway_output *output);
 
 void output_render(struct sway_output *output, struct timespec *when,
 	pixman_region32_t *damage);
@@ -103,16 +123,23 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 	struct wl_list *drag_icons, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
-void output_for_each_workspace(struct sway_container *output,
+void output_for_each_workspace(struct sway_output *output,
+		void (*f)(struct sway_workspace *ws, void *data), void *data);
+
+void output_for_each_container(struct sway_output *output,
 		void (*f)(struct sway_container *con, void *data), void *data);
 
-void output_for_each_container(struct sway_container *output,
-		void (*f)(struct sway_container *con, void *data), void *data);
+struct sway_workspace *output_find_workspace(struct sway_output *output,
+		bool (*test)(struct sway_workspace *ws, void *data), void *data);
 
-struct sway_container *output_find_workspace(struct sway_container *output,
+struct sway_container *output_find_container(struct sway_output *output,
 		bool (*test)(struct sway_container *con, void *data), void *data);
 
-struct sway_container *output_find_container(struct sway_container *output,
-		bool (*test)(struct sway_container *con, void *data), void *data);
+void output_get_box(struct sway_output *output, struct wlr_box *box);
+
+enum sway_container_layout output_get_default_layout(
+		struct sway_output *output);
+
+void output_add_listeners(struct sway_output *output);
 
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -56,7 +56,7 @@ struct sway_server {
 
 	size_t txn_timeout_ms;
 	list_t *transactions;
-	list_t *dirty_containers;
+	list_t *dirty_nodes;
 };
 
 struct sway_server server;

--- a/include/sway/tree/arrange.h
+++ b/include/sway/tree/arrange.h
@@ -1,16 +1,19 @@
 #ifndef _SWAY_ARRANGE_H
 #define _SWAY_ARRANGE_H
 
+struct sway_output;
+struct sway_workspace;
 struct sway_container;
+struct sway_node;
 
 void arrange_container(struct sway_container *container);
 
-void arrange_workspace(struct sway_container *workspace);
+void arrange_workspace(struct sway_workspace *workspace);
 
-void arrange_output(struct sway_container *output);
+void arrange_output(struct sway_output *output);
 
 void arrange_root(void);
 
-void arrange_windows(struct sway_container *container);
+void arrange_node(struct sway_node *node);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -279,7 +279,7 @@ void container_insert_child(struct sway_container *parent,
 		struct sway_container *child, int i);
 
 void container_add_sibling(struct sway_container *parent,
-		struct sway_container *child, int offset);
+		struct sway_container *child);
 
 void container_detach(struct sway_container *child);
 

--- a/include/sway/tree/node.h
+++ b/include/sway/tree/node.h
@@ -1,0 +1,74 @@
+#ifndef _SWAY_NODE_H
+#define _SWAY_NODE_H
+#include <stdbool.h>
+#include "list.h"
+
+struct sway_root;
+struct sway_output;
+struct sway_workspace;
+struct sway_container;
+struct sway_transaction_instruction;
+struct wlr_box;
+
+enum sway_node_type {
+	N_ROOT,
+	N_OUTPUT,
+	N_WORKSPACE,
+	N_CONTAINER,
+};
+
+struct sway_node {
+	enum sway_node_type type;
+	union {
+		struct sway_root *sway_root;
+		struct sway_output *sway_output;
+		struct sway_workspace *sway_workspace;
+		struct sway_container *sway_container;
+	};
+
+	/**
+	 * A unique ID to identify this node.
+	 * Primarily used in the get_tree JSON output.
+	 */
+	size_t id;
+
+	struct sway_transaction_instruction *instruction;
+	size_t ntxnrefs;
+	bool destroying;
+
+	// If true, indicates that the container has pending state that differs from
+	// the current.
+	bool dirty;
+
+	struct {
+		struct wl_signal destroy;
+	} events;
+};
+
+void node_init(struct sway_node *node, enum sway_node_type type, void *thing);
+
+const char *node_type_to_str(enum sway_node_type type);
+
+/**
+ * Mark a node as dirty if it isn't already. Dirty nodes will be included in the
+ * next transaction then unmarked as dirty.
+ */
+void node_set_dirty(struct sway_node *node);
+
+bool node_is_view(struct sway_node *node);
+
+char *node_get_name(struct sway_node *node);
+
+void node_get_box(struct sway_node *node, struct wlr_box *box);
+
+struct sway_output *node_get_output(struct sway_node *node);
+
+enum sway_container_layout node_get_layout(struct sway_node *node);
+
+struct sway_node *node_get_parent(struct sway_node *node);
+
+list_t *node_get_children(struct sway_node *node);
+
+bool node_has_ancestor(struct sway_node *node, struct sway_node *ancestor);
+
+#endif

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -5,12 +5,14 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/render/wlr_texture.h>
 #include "sway/tree/container.h"
+#include "sway/tree/node.h"
 #include "config.h"
 #include "list.h"
 
-extern struct sway_container root_container;
+extern struct sway_root *root;
 
 struct sway_root {
+	struct sway_node node;
 	struct wlr_output_layout *output_layout;
 
 	struct wl_listener output_layout_change;
@@ -24,17 +26,21 @@ struct sway_root {
 	// Includes disabled outputs
 	struct wl_list all_outputs; // sway_output::link
 
+	double x, y;
+	double width, height;
+
+	list_t *outputs; // struct sway_output
 	list_t *scratchpad; // struct sway_container
 	list_t *saved_workspaces; // For when there's no connected outputs
 
 	struct {
-		struct wl_signal new_container;
+		struct wl_signal new_node;
 	} events;
 };
 
-void root_create(void);
+struct sway_root *root_create(void);
 
-void root_destroy(void);
+void root_destroy(struct sway_root *root);
 
 /**
  * Move a container to the scratchpad.
@@ -56,23 +62,25 @@ void root_scratchpad_show(struct sway_container *con);
  */
 void root_scratchpad_hide(struct sway_container *con);
 
-struct sway_container *root_workspace_for_pid(pid_t pid);
+struct sway_workspace *root_workspace_for_pid(pid_t pid);
 
 void root_record_workspace_pid(pid_t pid);
 
-void root_for_each_workspace(void (*f)(struct sway_container *con, void *data),
+void root_for_each_workspace(void (*f)(struct sway_workspace *ws, void *data),
 		void *data);
 
 void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 		void *data);
 
-struct sway_container *root_find_output(
-		bool (*test)(struct sway_container *con, void *data), void *data);
+struct sway_output *root_find_output(
+		bool (*test)(struct sway_output *output, void *data), void *data);
 
-struct sway_container *root_find_workspace(
-		bool (*test)(struct sway_container *con, void *data), void *data);
+struct sway_workspace *root_find_workspace(
+		bool (*test)(struct sway_workspace *ws, void *data), void *data);
 
 struct sway_container *root_find_container(
 		bool (*test)(struct sway_container *con, void *data), void *data);
+
+void root_get_box(struct sway_root *root, struct wlr_box *box);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -58,7 +58,7 @@ struct sway_view {
 	enum sway_view_type type;
 	const struct sway_view_impl *impl;
 
-	struct sway_container *swayc; // NULL for unmapped views
+	struct sway_container *container; // NULL if unmapped and transactions finished
 	struct wlr_surface *surface; // NULL for unmapped views
 
 	// Geometry of the view itself (excludes borders) in layout coordinates
@@ -254,7 +254,7 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 	int height);
 
 /**
- * Configure the view's position and size based on the swayc's position and
+ * Configure the view's position and size based on the container's position and
  * size, taking borders into consideration.
  */
 void view_autoconfigure(struct sway_view *view);

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -3,66 +3,98 @@
 
 #include <stdbool.h>
 #include "sway/tree/container.h"
+#include "sway/tree/node.h"
 
 struct sway_view;
 
-struct sway_workspace {
-	struct sway_container *swayc;
+struct sway_workspace_state {
 	struct sway_container *fullscreen;
-	list_t *floating; // struct sway_container
+	double x, y;
+	int width, height;
+	enum sway_container_layout layout;
+	struct sway_output *output;
+	list_t *floating;
+	list_t *tiling;
+
+	struct sway_container *focused_inactive_child;
+	bool focused;
+};
+
+struct sway_workspace {
+	struct sway_node node;
+	struct sway_container *fullscreen;
+
+	char *name;
+	char *representation;
+
+	double x, y;
+	int width, height;
+	enum sway_container_layout layout;
+	enum sway_container_layout prev_split_layout;
+
+	double current_gaps;
+	bool has_gaps;
+	double gaps_inner;
+	double gaps_outer;
+
+	struct sway_output *output; // NULL if no outputs are connected
+	list_t *floating;           // struct sway_container
+	list_t *tiling;             // struct sway_container
 	list_t *output_priority;
 	bool urgent;
+
+	struct sway_workspace_state current;
 };
 
 extern char *prev_workspace_name;
 
-struct sway_container *workspace_get_initial_output(const char *name);
+struct sway_output *workspace_get_initial_output(const char *name);
 
-struct sway_container *workspace_create(struct sway_container *output,
+struct sway_workspace *workspace_create(struct sway_output *output,
 		const char *name);
 
-void workspace_destroy(struct sway_container *workspace);
+void workspace_destroy(struct sway_workspace *workspace);
 
-void workspace_begin_destroy(struct sway_container *workspace);
+void workspace_begin_destroy(struct sway_workspace *workspace);
 
-void workspace_consider_destroy(struct sway_container *ws);
+void workspace_consider_destroy(struct sway_workspace *ws);
 
 char *workspace_next_name(const char *output_name);
 
-bool workspace_switch(struct sway_container *workspace,
+bool workspace_switch(struct sway_workspace *workspace,
 		bool no_auto_back_and_forth);
 
-struct sway_container *workspace_by_number(const char* name);
+struct sway_workspace *workspace_by_number(const char* name);
 
-struct sway_container *workspace_by_name(const char*);
+struct sway_workspace *workspace_by_name(const char*);
 
-struct sway_container *workspace_output_next(struct sway_container *current);
+struct sway_workspace *workspace_output_next(struct sway_workspace *current);
 
-struct sway_container *workspace_next(struct sway_container *current);
+struct sway_workspace *workspace_next(struct sway_workspace *current);
 
-struct sway_container *workspace_output_prev(struct sway_container *current);
+struct sway_workspace *workspace_output_prev(struct sway_workspace *current);
 
-struct sway_container *workspace_prev(struct sway_container *current);
+struct sway_workspace *workspace_prev(struct sway_workspace *current);
 
-bool workspace_is_visible(struct sway_container *ws);
+bool workspace_is_visible(struct sway_workspace *ws);
 
-bool workspace_is_empty(struct sway_container *ws);
+bool workspace_is_empty(struct sway_workspace *ws);
 
-void workspace_output_raise_priority(struct sway_container *workspace,
-		struct sway_container *old_output, struct sway_container *new_output);
+void workspace_output_raise_priority(struct sway_workspace *workspace,
+		struct sway_output *old_output, struct sway_output *new_output);
 
-void workspace_output_add_priority(struct sway_container *workspace,
-		struct sway_container *output);
+void workspace_output_add_priority(struct sway_workspace *workspace,
+		struct sway_output *output);
 
-struct sway_container *workspace_output_get_highest_available(
-		struct sway_container *ws, struct sway_container *exclude);
+struct sway_output *workspace_output_get_highest_available(
+		struct sway_workspace *ws, struct sway_output *exclude);
 
-void workspace_detect_urgent(struct sway_container *workspace);
+void workspace_detect_urgent(struct sway_workspace *workspace);
 
-void workspace_for_each_container(struct sway_container *ws,
+void workspace_for_each_container(struct sway_workspace *ws,
 		void (*f)(struct sway_container *con, void *data), void *data);
 
-struct sway_container *workspace_find_container(struct sway_container *ws,
+struct sway_container *workspace_find_container(struct sway_workspace *ws,
 		bool (*test)(struct sway_container *con, void *data), void *data);
 
 /**
@@ -70,13 +102,28 @@ struct sway_container *workspace_find_container(struct sway_container *ws,
  * The new container will be the only direct tiling child of the workspace.
  * The new container is returned.
  */
-struct sway_container *workspace_wrap_children(struct sway_container *ws);
+struct sway_container *workspace_wrap_children(struct sway_workspace *ws);
 
-void workspace_add_floating(struct sway_container *workspace,
+void workspace_detach(struct sway_workspace *workspace);
+
+void workspace_add_tiling(struct sway_workspace *workspace,
 		struct sway_container *con);
 
-void workspace_remove_gaps(struct sway_container *ws);
+void workspace_add_floating(struct sway_workspace *workspace,
+		struct sway_container *con);
 
-void workspace_add_gaps(struct sway_container *ws);
+void workspace_insert_tiling(struct sway_workspace *workspace,
+		struct sway_container *con, int index);
+
+void workspace_remove_gaps(struct sway_workspace *ws);
+
+void workspace_add_gaps(struct sway_workspace *ws);
+
+struct sway_container *workspace_split(struct sway_workspace *workspace,
+		enum sway_container_layout layout);
+
+void workspace_update_representation(struct sway_workspace *ws);
+
+void workspace_get_box(struct sway_workspace *workspace, struct wlr_box *box);
 
 #endif

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -13,13 +13,12 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 		return error;
 	}
 
-	struct sway_container *container =
-		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
+	struct sway_container *container = config->handler_context.container;
+	if (!container->view) {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Only views can have borders");
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = container->view;
 
 	if (strcmp(argv[0], "none") == 0) {
 		view->border = B_NONE;
@@ -38,11 +37,11 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 		view->border_thickness = atoi(argv[1]);
 	}
 
-	if (container_is_floating(view->swayc)) {
-		container_set_geometry_from_floating_view(view->swayc);
+	if (container_is_floating(view->container)) {
+		container_set_geometry_from_floating_view(view->container);
 	}
 
-	arrange_windows(view->swayc);
+	arrange_container(view->container);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	if (seat->cursor) {

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -95,9 +95,6 @@ static struct sway_node *get_node_in_output_direction(
 
 static struct sway_node *node_get_in_direction(struct sway_container *container,
 		struct sway_seat *seat, enum movement_direction dir) {
-	if (dir == MOVE_CHILD) {
-		return seat_get_active_child(seat, &container->node);
-	}
 	if (container->is_fullscreen) {
 		if (dir == MOVE_PARENT) {
 			return NULL;
@@ -256,8 +253,20 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 			"or 'focus output <direction|name>'");
 	}
 
+	if (direction == MOVE_CHILD) {
+		struct sway_node *focus = seat_get_active_child(seat, node);
+		if (focus) {
+			seat_set_focus(seat, focus);
+		}
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
 	if (node->type == N_WORKSPACE) {
-		// A workspace is focused, so just jump to the next output
+		if (direction == MOVE_PARENT) {
+			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		}
+
+		// Jump to the next output
 		struct sway_output *new_output =
 			output_get_in_direction(workspace->output, direction);
 		if (!new_output) {

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -54,7 +54,7 @@ static struct sway_node *get_node_in_output_direction(
 			} else {
 				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
-			return &container->node;
+			break;
 		case MOVE_RIGHT:
 			if (ws->layout == L_HORIZ || ws->layout == L_TABBED) {
 				// get most left child of new output
@@ -62,7 +62,7 @@ static struct sway_node *get_node_in_output_direction(
 			} else {
 				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
-			return &container->node;
+			break;
 		case MOVE_UP:
 			if (ws->layout == L_VERT || ws->layout == L_STACKED) {
 				// get most bottom child of new output
@@ -70,7 +70,7 @@ static struct sway_node *get_node_in_output_direction(
 			} else {
 				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
-			return &container->node;
+			break;
 		case MOVE_DOWN: {
 			if (ws->layout == L_VERT || ws->layout == L_STACKED) {
 				// get most top child of new output
@@ -78,11 +78,16 @@ static struct sway_node *get_node_in_output_direction(
 			} else {
 				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
-			return &container->node;
+			break;
 		}
 		default:
 			break;
 		}
+	}
+
+	if (container) {
+		container = seat_get_focus_inactive_view(seat, &container->node);
+		return &container->node;
 	}
 
 	return &ws->node;

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -34,211 +34,139 @@ static bool parse_movement_direction(const char *name,
 }
 
 /**
- * Get swayc in the direction of newly entered output.
+ * Get node in the direction of newly entered output.
  */
-static struct sway_container *get_swayc_in_output_direction(
-		struct sway_container *output, enum movement_direction dir,
-		struct sway_seat *seat) {
-	if (!output) {
-		return NULL;
+static struct sway_node *get_node_in_output_direction(
+		struct sway_output *output, enum movement_direction dir) {
+	struct sway_seat *seat = config->handler_context.seat;
+	struct sway_workspace *ws = output_get_active_workspace(output);
+	if (ws->fullscreen) {
+		return seat_get_focus_inactive(seat, &ws->fullscreen->node);
 	}
+	struct sway_container *container = NULL;
 
-	struct sway_container *ws = seat_get_focus_inactive(seat, output);
-	if (ws->type != C_WORKSPACE) {
-		ws = container_parent(ws, C_WORKSPACE);
-	}
-
-	if (ws == NULL) {
-		wlr_log(WLR_ERROR, "got an output without a workspace");
-		return NULL;
-	}
-
-	if (ws->children->length > 0) {
+	if (ws->tiling->length > 0) {
 		switch (dir) {
 		case MOVE_LEFT:
 			if (ws->layout == L_HORIZ || ws->layout == L_TABBED) {
 				// get most right child of new output
-				return ws->children->items[ws->children->length-1];
+				container = ws->tiling->items[ws->tiling->length-1];
 			} else {
-				return seat_get_focus_inactive(seat, ws);
+				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
+			return &container->node;
 		case MOVE_RIGHT:
 			if (ws->layout == L_HORIZ || ws->layout == L_TABBED) {
 				// get most left child of new output
-				return ws->children->items[0];
+				container = ws->tiling->items[0];
 			} else {
-				return seat_get_focus_inactive(seat, ws);
+				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
+			return &container->node;
 		case MOVE_UP:
-		case MOVE_DOWN: {
-			struct sway_container *focused =
-				seat_get_focus_inactive(seat, ws);
-			if (focused && focused->parent) {
-				struct sway_container *parent = focused->parent;
-				if (parent->layout == L_VERT) {
-					if (dir == MOVE_UP) {
-						// get child furthest down on new output
-						int idx = parent->children->length - 1;
-						return parent->children->items[idx];
-					} else if (dir == MOVE_DOWN) {
-						// get child furthest up on new output
-						return parent->children->items[0];
-					}
-				}
-				return focused;
+			if (ws->layout == L_VERT || ws->layout == L_STACKED) {
+				// get most bottom child of new output
+				container = ws->tiling->items[ws->tiling->length-1];
+			} else {
+				container = seat_get_focus_inactive_tiling(seat, ws);
 			}
-			break;
+			return &container->node;
+		case MOVE_DOWN: {
+			if (ws->layout == L_VERT || ws->layout == L_STACKED) {
+				// get most top child of new output
+				container = ws->tiling->items[0];
+			} else {
+				container = seat_get_focus_inactive_tiling(seat, ws);
+			}
+			return &container->node;
 		}
 		default:
 			break;
 		}
 	}
 
-	return ws;
+	return &ws->node;
 }
 
-static struct sway_container *container_get_in_direction(
-		struct sway_container *container, struct sway_seat *seat,
-		enum movement_direction dir) {
-	struct sway_container *parent = container->parent;
-
+static struct sway_node *node_get_in_direction(struct sway_container *container,
+		struct sway_seat *seat, enum movement_direction dir) {
 	if (dir == MOVE_CHILD) {
-		return seat_get_focus_inactive(seat, container);
+		return seat_get_active_child(seat, &container->node);
 	}
 	if (container->is_fullscreen) {
 		if (dir == MOVE_PARENT) {
 			return NULL;
 		}
-		container = container_parent(container, C_OUTPUT);
-		parent = container->parent;
-	} else {
-		if (dir == MOVE_PARENT) {
-			if (parent->type == C_OUTPUT || container_is_floating(container)) {
-				return NULL;
-			} else {
-				return parent;
-			}
-		}
+		// Fullscreen container with a direction - go straight to outputs
+		struct sway_output *output = container->workspace->output;
+		struct sway_output *new_output = output_get_in_direction(output, dir);
+		return get_node_in_output_direction(new_output, dir);
+	}
+	if (dir == MOVE_PARENT) {
+		return node_get_parent(&container->node);
 	}
 
 	struct sway_container *wrap_candidate = NULL;
-	while (true) {
+	struct sway_container *current = container;
+	while (current) {
 		bool can_move = false;
 		int desired;
-		int idx = list_find(container->parent->children, container);
-		if (idx == -1) {
-			return NULL;
-		}
-		if (parent->type == C_ROOT) {
-			enum wlr_direction wlr_dir = 0;
-			if (!sway_assert(sway_dir_to_wlr(dir, &wlr_dir),
-						"got invalid direction: %d", dir)) {
-				return NULL;
-			}
-			int lx = container->x + container->width / 2;
-			int ly = container->y + container->height / 2;
-			struct wlr_output_layout *layout =
-				root_container.sway_root->output_layout;
-			struct wlr_output *wlr_adjacent =
-				wlr_output_layout_adjacent_output(layout, wlr_dir,
-					container->sway_output->wlr_output, lx, ly);
-			struct sway_container *adjacent =
-				output_from_wlr_output(wlr_adjacent);
+		int idx = container_sibling_index(current);
+		enum sway_container_layout parent_layout =
+			container_parent_layout(current);
+		list_t *siblings = container_get_siblings(current);
 
-			if (!adjacent || adjacent == container) {
-				if (!wrap_candidate) {
-					return NULL;
-				}
-				return seat_get_focus_inactive_view(seat, wrap_candidate);
-			}
-			struct sway_container *next =
-				get_swayc_in_output_direction(adjacent, dir, seat);
-			if (next == NULL) {
-				return NULL;
-			}
-			struct sway_container *next_workspace = next;
-			if (next_workspace->type != C_WORKSPACE) {
-				next_workspace = container_parent(next_workspace, C_WORKSPACE);
-			}
-			sway_assert(next_workspace, "Next container has no workspace");
-			if (next_workspace->sway_workspace->fullscreen) {
-				return seat_get_focus_inactive(seat,
-						next_workspace->sway_workspace->fullscreen);
-			}
-			if (next->children && next->children->length) {
-				// TODO consider floating children as well
-				return seat_get_focus_inactive_view(seat, next);
-			} else {
-				return next;
+		if (dir == MOVE_LEFT || dir == MOVE_RIGHT) {
+			if (parent_layout == L_HORIZ || parent_layout == L_TABBED) {
+				can_move = true;
+				desired = idx + (dir == MOVE_LEFT ? -1 : 1);
 			}
 		} else {
-			if (dir == MOVE_LEFT || dir == MOVE_RIGHT) {
-				if (parent->layout == L_HORIZ || parent->layout == L_TABBED) {
-					can_move = true;
-					desired = idx + (dir == MOVE_LEFT ? -1 : 1);
-				}
-			} else {
-				if (parent->layout == L_VERT || parent->layout == L_STACKED) {
-					can_move = true;
-					desired = idx + (dir == MOVE_UP ? -1 : 1);
-				}
+			if (parent_layout == L_VERT || parent_layout == L_STACKED) {
+				can_move = true;
+				desired = idx + (dir == MOVE_UP ? -1 : 1);
 			}
 		}
 
 		if (can_move) {
-			// TODO handle floating
-			if (desired < 0 || desired >= parent->children->length) {
+			if (desired < 0 || desired >= siblings->length) {
 				can_move = false;
-				int len = parent->children->length;
+				int len = siblings->length;
 				if (config->focus_wrapping != WRAP_NO && !wrap_candidate
 						&& len > 1) {
 					if (desired < 0) {
-						wrap_candidate = parent->children->items[len-1];
+						wrap_candidate = siblings->items[len-1];
 					} else {
-						wrap_candidate = parent->children->items[0];
+						wrap_candidate = siblings->items[0];
 					}
 					if (config->focus_wrapping == WRAP_FORCE) {
-						return seat_get_focus_inactive_view(seat,
-								wrap_candidate);
+						struct sway_container *c = seat_get_focus_inactive_view(
+								seat, &wrap_candidate->node);
+						return &c->node;
 					}
 				}
 			} else {
-				struct sway_container *desired_con =
-					parent->children->items[desired];
-				wlr_log(WLR_DEBUG,
-					"cont %d-%p dir %i sibling %d: %p", idx,
-					container, dir, desired, desired_con);
-				return seat_get_focus_inactive_view(seat, desired_con);
+				struct sway_container *desired_con = siblings->items[desired];
+				struct sway_container *c = seat_get_focus_inactive_view(
+						seat, &desired_con->node);
+				return &c->node;
 			}
 		}
 
-		if (!can_move) {
-			container = parent;
-			parent = parent->parent;
-			if (!parent) {
-				// wrapping is the last chance
-				if (!wrap_candidate) {
-					return NULL;
-				}
-				return seat_get_focus_inactive_view(seat, wrap_candidate);
-			}
-		}
+		current = current->parent;
 	}
+
+	// Check a different output
+	struct sway_output *output = container->workspace->output;
+	struct sway_output *new_output = output_get_in_direction(output, dir);
+	if (new_output) {
+		return get_node_in_output_direction(new_output, dir);
+	}
+	return NULL;
 }
 
-static struct cmd_results *focus_mode(struct sway_container *con,
+static struct cmd_results *focus_mode(struct sway_workspace *ws,
 		struct sway_seat *seat, bool floating) {
-	struct sway_container *ws = con->type == C_WORKSPACE ?
-		con : container_parent(con, C_WORKSPACE);
-
-	// If the container is in a floating split container,
-	// operate on the split container instead of the child.
-	if (container_is_floating_or_child(con)) {
-		while (con->parent->type != C_WORKSPACE) {
-			con = con->parent;
-		}
-	}
-
 	struct sway_container *new_focus = NULL;
 	if (floating) {
 		new_focus = seat_get_focus_inactive_floating(seat, ws);
@@ -246,7 +174,7 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 		new_focus = seat_get_focus_inactive_tiling(seat, ws);
 	}
 	if (new_focus) {
-		seat_set_focus(seat, new_focus);
+		seat_set_focus(seat, &new_focus->node);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "focus",
 				"Failed to find a %s container in workspace",
@@ -255,14 +183,14 @@ static struct cmd_results *focus_mode(struct sway_container *con,
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
-static struct cmd_results *focus_output(struct sway_container *con,
-		struct sway_seat *seat, int argc, char **argv) {
+static struct cmd_results *focus_output(struct sway_seat *seat,
+		int argc, char **argv) {
 	if (!argc) {
 		return cmd_results_new(CMD_INVALID, "focus",
 			"Expected 'focus output <direction|name>'");
 	}
 	char *identifier = join_args(argv, argc);
-	struct sway_container *output = output_by_name(identifier);
+	struct sway_output *output = output_by_name(identifier);
 
 	if (!output) {
 		enum movement_direction direction;
@@ -272,14 +200,13 @@ static struct cmd_results *focus_output(struct sway_container *con,
 			return cmd_results_new(CMD_INVALID, "focus",
 				"There is no output with that name");
 		}
-		struct sway_container *focus = seat_get_focus(seat);
-		focus = container_parent(focus, C_OUTPUT);
-		output = container_get_in_direction(focus, seat, direction);
+		struct sway_workspace *ws = seat_get_focused_workspace(seat);
+		output = output_get_in_direction(ws->output, direction);
 	}
 
 	free(identifier);
 	if (output) {
-		seat_set_focus(seat, seat_get_focus_inactive(seat, output));
+		seat_set_focus(seat, seat_get_focus_inactive(seat, &output->node));
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
@@ -289,29 +216,32 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (config->reading || !config->active) {
 		return cmd_results_new(CMD_DEFER, NULL, NULL);
 	}
-	struct sway_container *con = config->handler_context.current_container;
+	struct sway_node *node = config->handler_context.node;
+	struct sway_container *container = config->handler_context.container;
+	struct sway_workspace *workspace = config->handler_context.workspace;
 	struct sway_seat *seat = config->handler_context.seat;
-	if (con->type < C_WORKSPACE) {
+	if (node->type < N_WORKSPACE) {
 		return cmd_results_new(CMD_FAILURE, "focus",
 			"Command 'focus' cannot be used above the workspace level");
 	}
 
 	if (argc == 0) {
-		seat_set_focus(seat, con);
+		seat_set_focus(seat, node);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
 	if (strcmp(argv[0], "floating") == 0) {
-		return focus_mode(con, seat, true);
+		return focus_mode(workspace, seat, true);
 	} else if (strcmp(argv[0], "tiling") == 0) {
-		return focus_mode(con, seat, false);
+		return focus_mode(workspace, seat, false);
 	} else if (strcmp(argv[0], "mode_toggle") == 0) {
-		return focus_mode(con, seat, !container_is_floating_or_child(con));
+		bool floating = container && container_is_floating_or_child(container);
+		return focus_mode(workspace, seat, !floating);
 	}
 
 	if (strcmp(argv[0], "output") == 0) {
 		argc--; argv++;
-		return focus_output(con, seat, argc, argv);
+		return focus_output(seat, argc, argv);
 	}
 
 	enum movement_direction direction = 0;
@@ -321,8 +251,18 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 			"or 'focus output <direction|name>'");
 	}
 
-	struct sway_container *next_focus = container_get_in_direction(
-			con, seat, direction);
+	if (node->type == N_WORKSPACE) {
+		// A workspace is focused, so just jump to the next output
+		struct sway_output *new_output =
+			output_get_in_direction(workspace->output, direction);
+		struct sway_node *node =
+			get_node_in_output_direction(new_output, direction);
+		seat_set_focus(seat, node);
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
+	struct sway_node *next_focus =
+		node_get_in_direction(container, seat, direction);
 	if (next_focus) {
 		seat_set_focus(seat, next_focus);
 	}

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -255,6 +255,10 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		// A workspace is focused, so just jump to the next output
 		struct sway_output *new_output =
 			output_get_in_direction(workspace->output, direction);
+		if (!new_output) {
+			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		}
+
 		struct sway_node *node =
 			get_node_in_output_direction(new_output, direction);
 		seat_set_focus(seat, node);

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -12,18 +12,18 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	if ((error = checkarg(argc, "fullscreen", EXPECTED_LESS_THAN, 2))) {
 		return error;
 	}
-	struct sway_container *container =
-		config->handler_context.current_container;
-	if (container->type == C_WORKSPACE && container->children->length == 0) {
+	struct sway_node *node = config->handler_context.node;
+	struct sway_container *container = config->handler_context.container;
+	struct sway_workspace *workspace = config->handler_context.workspace;
+	if (node->type == N_WORKSPACE && workspace->tiling->length == 0) {
 		return cmd_results_new(CMD_INVALID, "fullscreen",
 				"Can't fullscreen an empty workspace");
 	}
-	if (container->type == C_WORKSPACE) {
+	if (node->type == N_WORKSPACE) {
 		// Wrap the workspace's children in a container so we can fullscreen it
-		struct sway_container *workspace = container;
-		container = workspace_wrap_children(container);
+		container = workspace_wrap_children(workspace);
 		workspace->layout = L_HORIZ;
-		seat_set_focus(config->handler_context.seat, container);
+		seat_set_focus(config->handler_context.seat, &container->node);
 	}
 	bool enable = !container->is_fullscreen;
 
@@ -32,9 +32,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	}
 
 	container_set_fullscreen(container, enable);
-
-	struct sway_container *workspace = container_parent(container, C_WORKSPACE);
-	arrange_windows(workspace->parent);
+	arrange_workspace(workspace);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -5,8 +5,8 @@
 #include "sway/tree/view.h"
 
 static void _configure_view(struct sway_container *con, void *data) {
-	if (con->type == C_VIEW) {
-		view_autoconfigure(con->sway_view);
+	if (con->view) {
+		view_autoconfigure(con->view);
 	}
 }
 

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -2,15 +2,27 @@
 #include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
-#include "sway/tree/view.h"
 #include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "sway/commands.h"
 
-struct cmd_results *cmd_kill(int argc, char **argv) {
-	struct sway_container *con =
-		config->handler_context.current_container;
+static void close_container_iterator(struct sway_container *con, void *data) {
+	if (con->view) {
+		view_close(con->view);
+	}
+}
 
-	container_close(con);
+struct cmd_results *cmd_kill(int argc, char **argv) {
+	struct sway_container *con = config->handler_context.container;
+	struct sway_workspace *ws = config->handler_context.workspace;
+
+	if (con) {
+		close_container_iterator(con, NULL);
+		container_for_each_child(con, close_container_iterator, NULL);
+	} else {
+		workspace_for_each_container(ws, close_container_iterator, NULL);
+	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -88,7 +88,6 @@ static enum sway_container_layout get_layout(int argc, char **argv,
 	}
 
 	if (strcasecmp(argv[0], "toggle") == 0) {
-		argc--; argv++;
 		return get_layout_toggle(argc, argv, layout, prev_split_layout);
 	}
 

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -18,13 +18,12 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	if ((error = checkarg(argc, "mark", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct sway_container *container =
-		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
+	struct sway_container *container = config->handler_context.container;
+	if (!container->view) {
 		return cmd_results_new(CMD_INVALID, "mark",
 				"Only views can have marks");
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = container->view;
 
 	bool add = false, toggle = false;
 	while (argc > 0 && strncmp(*argv, "--", 2) == 0) {

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -622,7 +622,8 @@ static void workspace_move_to_output(struct sway_workspace *workspace,
 	workspace_consider_destroy(new_output_old_ws);
 
 	output_sort_workspaces(output);
-	seat_set_focus(seat, &output->node);
+	struct sway_node *focus = seat_get_focus_inactive(seat, &workspace->node);
+	seat_set_focus(seat, focus);
 	workspace_output_raise_priority(workspace, old_output, output);
 	ipc_event_workspace(NULL, workspace, "move");
 }

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -233,7 +233,7 @@ static void container_move_to_container(struct sway_container *container,
 	container->saved_width = container->saved_height = 0;
 
 	if (destination->view) {
-		container_add_sibling(destination, container, 1);
+		container_add_sibling(destination, container);
 	} else {
 		container_add_child(destination, container);
 	}

--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -19,8 +19,7 @@ struct cmd_results *cmd_opacity(int argc, char **argv) {
 		return error;
 	}
 
-	struct sway_container *con =
-		config->handler_context.current_container;
+	struct sway_container *con = config->handler_context.container;
 
 	float opacity = 0.0f;
 

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -42,7 +42,7 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 	}
 	list_free(bar_ids);
 
-	arrange_windows(&root_container);
+	arrange_root();
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -25,14 +25,11 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	}
 
 	int argn = 1;
-	struct sway_container *workspace;
+	struct sway_workspace *workspace = NULL;
 
 	if (strcasecmp(argv[1], "to") == 0) {
 		// 'rename workspace to new_name'
-		workspace = config->handler_context.current_container;
-		if (workspace->type != C_WORKSPACE) {
-			workspace = container_parent(workspace, C_WORKSPACE);
-		}
+		workspace = config->handler_context.workspace;
 	} else if (strcasecmp(argv[1], "number") == 0) {
 		// 'rename workspace number x to new_name'
 		if (!isdigit(argv[2][0])) {
@@ -78,7 +75,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "rename",
 				"Cannot use special workspace name '%s'", argv[argn]);
 	}
-	struct sway_container *tmp_workspace = workspace_by_name(new_name);
+	struct sway_workspace *tmp_workspace = workspace_by_name(new_name);
 	if (tmp_workspace) {
 		free(new_name);
 		return cmd_results_new(CMD_INVALID, "rename",
@@ -89,7 +86,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	free(workspace->name);
 	workspace->name = new_name;
 
-	output_sort_workspaces(workspace->parent);
+	output_sort_workspaces(workspace->output);
 	ipc_event_workspace(NULL, workspace, "rename");
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -42,8 +42,8 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);
 		}
 		// map absolute coords (0..1,0..1) to root container coords
-		float x = strtof(argv[1], NULL) / root_container.width;
-		float y = strtof(argv[2], NULL) / root_container.height;
+		float x = strtof(argv[1], NULL) / root->width;
+		float y = strtof(argv[2], NULL) / root->height;
 		wlr_cursor_warp_absolute(cursor->cursor, NULL, x, y);
 		cursor_send_pointer_motion(cursor, 0, true);
 	} else {

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -11,8 +11,8 @@
 #include "util.h"
 
 static void rebuild_marks_iterator(struct sway_container *con, void *data) {
-	if (con->type == C_VIEW) {
-		view_update_marks_textures(con->sway_view);
+	if (con->view) {
+		view_update_marks_textures(con->view);
 	}
 }
 
@@ -28,9 +28,9 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 		root_for_each_container(rebuild_marks_iterator, NULL);
 	}
 
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *con = root_container.children->items[i];
-		output_damage_whole(con->sway_output);
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_whole(output);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/smart_gaps.c
+++ b/sway/commands/smart_gaps.c
@@ -23,7 +23,7 @@ struct cmd_results *cmd_smart_gaps(int argc, char **argv) {
 			"Expected 'smart_gaps <on|off>' ");
 	}
 
-	arrange_windows(&root_container);
+	arrange_root();
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -4,15 +4,21 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "log.h"
 
 static struct cmd_results *do_split(int layout) {
-	struct sway_container *con = config->handler_context.current_container;
-	struct sway_container *parent = container_split(con, layout);
-	container_create_notify(parent);
-	arrange_windows(parent->parent);
+	struct sway_container *con = config->handler_context.container;
+	struct sway_workspace *ws = config->handler_context.workspace;
+	if (con) {
+		container_split(con, layout);
+	} else {
+		workspace_split(ws, layout);
+	}
+
+	arrange_workspace(ws);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
@@ -29,10 +35,9 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 		return do_split(L_HORIZ);
 	} else if (strcasecmp(argv[0], "t") == 0 ||
 			strcasecmp(argv[0], "toggle") == 0) {
-		struct sway_container *focused =
-			config->handler_context.current_container;
+		struct sway_container *focused = config->handler_context.container;
 
-		if (focused->parent->layout == L_VERT) {
+		if (focused && container_parent_layout(focused) == L_VERT) {
 			return do_split(L_HORIZ);
 		} else {
 			return do_split(L_VERT);
@@ -66,9 +71,9 @@ struct cmd_results *cmd_splitt(int argc, char **argv) {
 		return error;
 	}
 
-	struct sway_container *con = config->handler_context.current_container;
+	struct sway_container *con = config->handler_context.container;
 
-	if (con->parent->layout == L_VERT) {
+	if (con && container_parent_layout(con) == L_VERT) {
 		return do_split(L_HORIZ);
 	} else {
 		return do_split(L_VERT);

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -11,13 +11,12 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	if ((error = checkarg(argc, "title_format", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct sway_container *container =
-		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
+	struct sway_container *container = config->handler_context.container;
+	if (!container->view) {
 		return cmd_results_new(CMD_INVALID, "title_format",
 				"Only views can have a title_format");
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = container->view;
 	char *format = join_args(argv, argc);
 	if (view->title_format) {
 		free(view->title_format);

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -9,9 +9,9 @@
 #include "stringop.h"
 
 static void remove_all_marks_iterator(struct sway_container *con, void *data) {
-	if (con->type == C_VIEW) {
-		view_clear_marks(con->sway_view);
-		view_update_marks_textures(con->sway_view);
+	if (con->view) {
+		view_clear_marks(con->view);
+		view_update_marks_textures(con->view);
 	}
 }
 
@@ -24,13 +24,12 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 	// Determine the view
 	struct sway_view *view = NULL;
 	if (config->handler_context.using_criteria) {
-		struct sway_container *container =
-			config->handler_context.current_container;
-		if (container->type != C_VIEW) {
+		struct sway_container *container = config->handler_context.container;
+		if (!container->view) {
 			return cmd_results_new(CMD_INVALID, "unmark",
 					"Only views can have marks");
 		}
-		view = container->sway_view;
+		view = container->view;
 	}
 
 	// Determine the mark

--- a/sway/commands/urgent.c
+++ b/sway/commands/urgent.c
@@ -11,13 +11,12 @@ struct cmd_results *cmd_urgent(int argc, char **argv) {
 	if ((error = checkarg(argc, "urgent", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct sway_container *container =
-		config->handler_context.current_container;
-	if (container->type != C_VIEW) {
+	struct sway_container *container = config->handler_context.container;
+	if (!container->view) {
 		return cmd_results_new(CMD_INVALID, "urgent",
 				"Only views can be urgent");
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = container->view;
 
 	if (strcmp(argv[0], "allow") == 0) {
 		view->allow_request_urgent = true;

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -58,7 +58,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 
 
-		struct sway_container *ws = NULL;
+		struct sway_workspace *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
 			if (argc < 2) {
 				return cmd_results_new(CMD_INVALID, "workspace",

--- a/sway/config.c
+++ b/sway/config.c
@@ -825,6 +825,6 @@ void config_update_font_height(bool recalculate) {
 	root_for_each_container(find_font_height_iterator, &recalculate);
 
 	if (config->font_height != prev_max_height) {
-		arrange_windows(&root_container);
+		arrange_root();
 	}
 }

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -12,6 +12,7 @@
 #include <strings.h>
 #include <signal.h>
 #include "sway/config.h"
+#include "sway/output.h"
 #include "stringop.h"
 #include "list.h"
 #include "log.h"
@@ -218,17 +219,6 @@ void invoke_swaybar(struct bar_config *bar) {
 	close(filedes[1]);
 }
 
-static bool active_output(const char *name) {
-	struct sway_container *cont = NULL;
-	for (int i = 0; i < root_container.children->length; ++i) {
-		cont = root_container.children->items[i];
-		if (cont->type == C_OUTPUT && strcasecmp(name, cont->name) == 0) {
-			return true;
-		}
-	}
-	return false;
-}
-
 void load_swaybars() {
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *bar = config->bars->items[i];
@@ -236,7 +226,7 @@ void load_swaybars() {
 		if (bar->outputs) {
 			for (int j = 0; j < bar->outputs->length; ++j) {
 				char *o = bar->outputs->items[j];
-				if (!strcmp(o, "*") || active_output(o)) {
+				if (!strcmp(o, "*") || output_by_name(o)) {
 					apply = true;
 					break;
 				}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -9,6 +9,7 @@
 #include "sway/config.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "stringop.h"
 #include "list.h"
 #include "log.h"
@@ -87,12 +88,12 @@ static int cmp_urgent(const void *_a, const void *_b) {
 	return 0;
 }
 
-static void find_urgent_iterator(struct sway_container *swayc, void *data) {
-	if (swayc->type != C_VIEW || !view_is_urgent(swayc->sway_view)) {
+static void find_urgent_iterator(struct sway_container *con, void *data) {
+	if (!con->view || !view_is_urgent(con->view)) {
 		return;
 	}
 	list_t *urgent_views = data;
-	list_add(urgent_views, swayc->sway_view);
+	list_add(urgent_views, con->view);
 }
 
 static bool criteria_matches_view(struct criteria *criteria,
@@ -132,7 +133,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->con_id) { // Internal ID
-		if (!view->swayc || view->swayc->id != criteria->con_id) {
+		if (!view->container || view->container->node.id != criteria->con_id) {
 			return false;
 		}
 	}
@@ -174,13 +175,13 @@ static bool criteria_matches_view(struct criteria *criteria,
 #endif
 
 	if (criteria->floating) {
-		if (!container_is_floating(view->swayc)) {
+		if (!container_is_floating(view->container)) {
 			return false;
 		}
 	}
 
 	if (criteria->tiling) {
-		if (container_is_floating(view->swayc)) {
+		if (container_is_floating(view->container)) {
 			return false;
 		}
 	}
@@ -205,10 +206,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 	}
 
 	if (criteria->workspace) {
-		if (!view->swayc) {
-			return false;
-		}
-		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+		struct sway_workspace *ws = view->container->workspace;
 		if (!ws || strcmp(ws->name, criteria->workspace) != 0) {
 			return false;
 		}
@@ -237,9 +235,9 @@ struct match_data {
 static void criteria_get_views_iterator(struct sway_container *container,
 		void *data) {
 	struct match_data *match_data = data;
-	if (container->type == C_VIEW) {
-		if (criteria_matches_view(match_data->criteria, container->sway_view)) {
-			list_add(match_data->matches, container->sway_view);
+	if (!container->view) {
+		if (criteria_matches_view(match_data->criteria, container->view)) {
+			list_add(match_data->matches, container->view);
 		}
 	}
 }
@@ -355,12 +353,12 @@ static enum criteria_token token_from_name(char *name) {
  */
 static char *get_focused_prop(enum criteria_token token) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus = seat_get_focus(seat);
+	struct sway_container *focus = seat_get_focused_container(seat);
 
-	if (!focus || focus->type != C_VIEW) {
+	if (!focus || !focus->view) {
 		return NULL;
 	}
-	struct sway_view *view = focus->sway_view;
+	struct sway_view *view = focus->view;
 	const char *value = NULL;
 
 	switch (token) {
@@ -374,18 +372,15 @@ static char *get_focused_prop(enum criteria_token token) {
 		value = view_get_title(view);
 		break;
 	case T_WORKSPACE:
-		{
-			struct sway_container *ws = container_parent(focus, C_WORKSPACE);
-			if (ws) {
-				value = ws->name;
-			}
+		if (focus->workspace) {
+			value = focus->workspace->name;
 		}
 		break;
 	case T_CON_ID:
-		if (view->swayc == NULL) {
+		if (view->container == NULL) {
 			return NULL;
 		}
-		size_t id = view->swayc->id;
+		size_t id = view->container->node.id;
 		size_t id_size = snprintf(NULL, 0, "%zu", id) + 1;
 		char *id_str = malloc(id_size);
 		snprintf(id_str, id_size, "%zu", id);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -118,7 +118,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 			return false;
 		}
 	}
-	
+
 	if (criteria->con_mark) {
 		bool exists = false;
 		for (int i = 0; i < view->marks->length; ++i) {
@@ -235,7 +235,7 @@ struct match_data {
 static void criteria_get_views_iterator(struct sway_container *container,
 		void *data) {
 	struct match_data *match_data = data;
-	if (!container->view) {
+	if (container->view) {
 		if (criteria_matches_view(match_data->criteria, container->view)) {
 			list_add(match_data->matches, container->view);
 		}

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -43,10 +43,10 @@ static char *get_string(struct sway_node *node) {
 	case N_OUTPUT:
 		snprintf(buffer, 512, "N_OUTPUT id:%zd '%s' %dx%d@%d,%d", node->id,
 				node->sway_output->wlr_output->name,
-				node->sway_output->wlr_output->width,
-				node->sway_output->wlr_output->height,
-				node->sway_output->wlr_output->lx,
-				node->sway_output->wlr_output->ly);
+				node->sway_output->width,
+				node->sway_output->height,
+				node->sway_output->lx,
+				node->sway_output->ly);
 		break;
 	case N_WORKSPACE:
 		snprintf(buffer, 512, "N_WORKSPACE id:%zd '%s' %s %dx%d@%.f,%.f",
@@ -128,11 +128,11 @@ void update_debug_tree() {
 	int width = 640, height = 480;
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		if (output->wlr_output->width > width) {
-			width = output->wlr_output->width;
+		if (output->width > width) {
+			width = output->width;
 		}
-		if (output->wlr_output->height > height) {
-			height = output->wlr_output->height;
+		if (output->height > height) {
+			height = output->height;
 		}
 	}
 	cairo_surface_t *surface =

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -10,6 +10,7 @@
 #include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
+#include "sway/tree/workspace.h"
 #include "cairo.h"
 #include "config.h"
 #include "pango.h"
@@ -32,28 +33,78 @@ static const char *layout_to_str(enum sway_container_layout layout) {
 	return "L_NONE";
 }
 
-static int draw_container(cairo_t *cairo, struct sway_container *container,
-		struct sway_container *focus, int x, int y) {
+static char *get_string(struct sway_node *node) {
+	char *buffer = malloc(512);
+	switch (node->type) {
+	case N_ROOT:
+		snprintf(buffer, 512, "N_ROOT id:%zd %.fx%.f@%.f,%.f", node->id,
+				root->width, root->height, root->x, root->y);
+		break;
+	case N_OUTPUT:
+		snprintf(buffer, 512, "N_OUTPUT id:%zd '%s' %dx%d@%d,%d", node->id,
+				node->sway_output->wlr_output->name,
+				node->sway_output->wlr_output->width,
+				node->sway_output->wlr_output->height,
+				node->sway_output->wlr_output->lx,
+				node->sway_output->wlr_output->ly);
+		break;
+	case N_WORKSPACE:
+		snprintf(buffer, 512, "N_WORKSPACE id:%zd '%s' %s %dx%d@%.f,%.f",
+				node->id, node->sway_workspace->name,
+				layout_to_str(node->sway_workspace->layout),
+				node->sway_workspace->width, node->sway_workspace->height,
+				node->sway_workspace->x, node->sway_workspace->y);
+		break;
+	case N_CONTAINER:
+		snprintf(buffer, 512, "N_CONTAINER id:%zd '%s' %s %.fx%.f@%.f,%.f",
+				node->id, node->sway_container->title,
+				layout_to_str(node->sway_container->layout),
+				node->sway_container->width, node->sway_container->height,
+				node->sway_container->x, node->sway_container->y);
+		break;
+	}
+	return buffer;
+}
+
+static list_t *get_children(struct sway_node *node) {
+	switch (node->type) {
+	case N_ROOT:
+		return root->outputs;
+	case N_OUTPUT:
+		return node->sway_output->workspaces;
+	case N_WORKSPACE:
+		return node->sway_workspace->tiling;
+	case N_CONTAINER:
+		return node->sway_container->children;
+	}
+	return NULL;
+}
+
+static int draw_node(cairo_t *cairo, struct sway_node *node,
+		struct sway_node *focus, int x, int y) {
 	int text_width, text_height;
+	char *buffer = get_string(node);
 	get_text_size(cairo, "monospace", &text_width, &text_height,
-		1, false, "%s id:%zd '%s' %s %.fx%.f@%.f,%.f",
-		container_type_to_str(container->type), container->id, container->name,
-		layout_to_str(container->layout),
-		container->width, container->height, container->x, container->y);
+		1, false, buffer);
 	cairo_save(cairo);
 	cairo_rectangle(cairo, x + 2, y, text_width - 2, text_height);
 	cairo_set_source_u32(cairo, 0xFFFFFFE0);
 	cairo_fill(cairo);
 	int height = text_height;
-	if (container->children) {
-		for (int i = 0; i < container->children->length; ++i) {
-			struct sway_container *child = container->children->items[i];
-			if (child->parent == container) {
+	list_t *children = get_children(node);
+	if (children) {
+		for (int i = 0; i < children->length; ++i) {
+			// This is really dirty - the list contains specific structs but
+			// we're casting them as nodes. This works because node is the first
+			// item in each specific struct. This is acceptable because this is
+			// debug code.
+			struct sway_node *child = children->items[i];
+			if (node_get_parent(child) == node) {
 				cairo_set_source_u32(cairo, 0x000000FF);
 			} else {
 				cairo_set_source_u32(cairo, 0xFF0000FF);
 			}
-			height += draw_container(cairo, child, focus, x + 10, y + height);
+			height += draw_node(cairo, child, focus, x + 10, y + height);
 		}
 	}
 	cairo_set_source_u32(cairo, 0xFFFFFFE0);
@@ -61,13 +112,11 @@ static int draw_container(cairo_t *cairo, struct sway_container *container,
 	cairo_fill(cairo);
 	cairo_restore(cairo);
 	cairo_move_to(cairo, x, y);
-	if (focus == container) {
+	if (focus == node) {
 		cairo_set_source_u32(cairo, 0x0000FFFF);
 	}
-	pango_printf(cairo, "monospace", 1, false, "%s id:%zd '%s' %s %.fx%.f@%.f,%.f",
-		container_type_to_str(container->type), container->id, container->name,
-		layout_to_str(container->layout),
-		container->width, container->height, container->x, container->y);
+	pango_printf(cairo, "monospace", 1, false, buffer);
+	free(buffer);
 	return height;
 }
 
@@ -77,13 +126,13 @@ void update_debug_tree() {
 	}
 
 	int width = 640, height = 480;
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *container = root_container.children->items[i];
-		if (container->width > width) {
-			width = container->width;
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		if (output->wlr_output->width > width) {
+			width = output->wlr_output->width;
 		}
-		if (container->height > height) {
-			height = container->height;
+		if (output->wlr_output->height > height) {
+			height = output->wlr_output->height;
 		}
 	}
 	cairo_surface_t *surface =
@@ -91,28 +140,22 @@ void update_debug_tree() {
 	cairo_t *cairo = cairo_create(surface);
 	PangoContext *pango = pango_cairo_create_context(cairo);
 
-	struct sway_seat *seat = NULL;
-	wl_list_for_each(seat, &input_manager->seats, link) {
-		break;
-	}
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_node *focus = seat_get_focus(seat);
 
-	struct sway_container *focus = NULL;
-	if (seat != NULL) {
-		focus = seat_get_focus(seat);
-	}
 	cairo_set_source_u32(cairo, 0x000000FF);
-	draw_container(cairo, &root_container, focus, 0, 0);
+	draw_node(cairo, &root->node, focus, 0, 0);
 
 	cairo_surface_flush(surface);
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(server.backend);
-	if (root_container.sway_root->debug_tree) {
-		wlr_texture_destroy(root_container.sway_root->debug_tree);
+	if (root->debug_tree) {
+		wlr_texture_destroy(root->debug_tree);
 	}
 	unsigned char *data = cairo_image_surface_get_data(surface);
 	int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, width);
 	struct wlr_texture *texture = wlr_texture_from_pixels(renderer,
 		WL_SHM_FORMAT_ARGB8888, stride, width, height, data);
-	root_container.sway_root->debug_tree = texture;
+	root->debug_tree = texture;
 	cairo_surface_destroy(surface);
 	g_object_unref(pango);
 	cairo_destroy(cairo);

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -4,37 +4,32 @@
 
 void desktop_damage_surface(struct wlr_surface *surface, double lx, double ly,
 		bool whole) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *cont = root_container.children->items[i];
-		if (cont->type == C_OUTPUT) {
-			output_damage_surface(cont->sway_output,
-				lx - cont->current.swayc_x, ly - cont->current.swayc_y,
-				surface, whole);
-		}
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_surface(output, lx - output->wlr_output->lx,
+				ly - output->wlr_output->ly, surface, whole);
 	}
 }
 
 void desktop_damage_whole_container(struct sway_container *con) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *cont = root_container.children->items[i];
-		if (cont->type == C_OUTPUT) {
-			output_damage_whole_container(cont->sway_output, con);
-		}
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_whole_container(output, con);
 	}
 }
 
 void desktop_damage_box(struct wlr_box *box) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *cont = root_container.children->items[i];
-		output_damage_box(cont->sway_output, box);
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_box(output, box);
 	}
 }
 
 void desktop_damage_view(struct sway_view *view) {
-	desktop_damage_whole_container(view->swayc);
+	desktop_damage_whole_container(view->container);
 	struct wlr_box box = {
-		.x = view->swayc->current.view_x - view->geometry.x,
-		.y = view->swayc->current.view_y - view->geometry.y,
+		.x = view->container->current.view_x - view->geometry.x,
+		.y = view->container->current.view_y - view->geometry.y,
 		.width = view->surface->current.width,
 		.height = view->surface->current.height,
 	};

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -547,7 +547,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	struct output_config *oc = output_find_config(output);
 
-	if (oc && oc->enabled) {
+	if (!oc || oc->enabled) {
 		output_enable(output, oc);
 	}
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -98,8 +98,8 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	wlr_box_rotated_bounds(&box, data->rotation, &rotated_box);
 
 	struct wlr_box output_box = {
-		.width = output->wlr_output->width,
-		.height = output->wlr_output->height,
+		.width = output->width,
+		.height = output->height,
 	};
 
 	struct wlr_box intersection;
@@ -249,8 +249,8 @@ bool output_has_opaque_overlay_layer_surface(struct sway_output *output) {
 		struct sway_layer_surface *sway_layer_surface =
 			layer_from_wlr_layer_surface(wlr_layer_surface);
 		pixman_box32_t output_box = {
-			.x2 = output->wlr_output->width,
-			.y2 = output->wlr_output->height,
+			.x2 = output->width,
+			.y2 = output->height,
 		};
 		pixman_region32_t surface_opaque_box;
 		pixman_region32_init(&surface_opaque_box);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -505,10 +505,6 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
-	output->lx = output->wlr_output->lx;
-	output->ly = output->wlr_output->ly;
-	wlr_output_effective_resolution(output->wlr_output,
-			&output->width, &output->height);
 	arrange_layers(output);
 	arrange_output(output);
 	transaction_commit_dirty();

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -505,6 +505,10 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
+	output->lx = output->wlr_output->lx;
+	output->ly = output->wlr_output->ly;
+	wlr_output_effective_resolution(output->wlr_output,
+			&output->width, &output->height);
 	arrange_layers(output);
 	arrange_output(output);
 	transaction_commit_dirty();

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -28,10 +28,10 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 
-struct sway_container *output_by_name(const char *name) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *output = root_container.children->items[i];
-		if (strcasecmp(output->name, name) == 0) {
+struct sway_output *output_by_name(const char *name) {
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		if (strcasecmp(output->wlr_output->name, name) == 0) {
 			return output;
 		}
 	}
@@ -98,8 +98,8 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	wlr_box_rotated_bounds(&box, data->rotation, &rotated_box);
 
 	struct wlr_box output_box = {
-		.width = output->swayc->current.swayc_width,
-		.height = output->swayc->current.swayc_height,
+		.width = output->wlr_output->width,
+		.height = output->wlr_output->height,
 	};
 
 	struct wlr_box intersection;
@@ -145,12 +145,12 @@ void output_view_for_each_surface(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->swayc->current.view_x - output->swayc->current.swayc_x
+		.ox = view->container->current.view_x - output->wlr_output->lx
 			- view->geometry.x,
-		.oy = view->swayc->current.view_y - output->swayc->current.swayc_y
+		.oy = view->container->current.view_y - output->wlr_output->ly
 			- view->geometry.y,
-		.width = view->swayc->current.view_width,
-		.height = view->swayc->current.view_height,
+		.width = view->container->current.view_width,
+		.height = view->container->current.view_height,
 		.rotation = 0, // TODO
 	};
 
@@ -164,12 +164,12 @@ void output_view_for_each_popup(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->swayc->current.view_x - output->swayc->current.swayc_x
+		.ox = view->container->current.view_x - output->wlr_output->lx
 			- view->geometry.x,
-		.oy = view->swayc->current.view_y - output->swayc->current.swayc_y
+		.oy = view->container->current.view_y - output->wlr_output->ly
 			- view->geometry.y,
-		.width = view->swayc->current.view_width,
-		.height = view->swayc->current.view_height,
+		.width = view->container->current.view_width,
+		.height = view->container->current.view_height,
 		.rotation = 0, // TODO
 	};
 
@@ -197,8 +197,8 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 	wl_list_for_each(unmanaged_surface, unmanaged, link) {
 		struct wlr_xwayland_surface *xsurface =
 			unmanaged_surface->wlr_xwayland_surface;
-		double ox = unmanaged_surface->lx - output->swayc->current.swayc_x;
-		double oy = unmanaged_surface->ly - output->swayc->current.swayc_y;
+		double ox = unmanaged_surface->lx - output->wlr_output->lx;
+		double oy = unmanaged_surface->ly - output->wlr_output->ly;
 
 		output_surface_for_each_surface(output, xsurface->surface, ox, oy,
 			iterator, user_data);
@@ -211,8 +211,8 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 		void *user_data) {
 	struct sway_drag_icon *drag_icon;
 	wl_list_for_each(drag_icon, drag_icons, link) {
-		double ox = drag_icon->x - output->swayc->x;
-		double oy = drag_icon->y - output->swayc->y;
+		double ox = drag_icon->x - output->wlr_output->lx;
+		double oy = drag_icon->y - output->wlr_output->ly;
 
 		if (drag_icon->wlr_drag_icon->mapped) {
 			output_surface_for_each_surface(output,
@@ -229,19 +229,13 @@ static void scale_box(struct wlr_box *box, float scale) {
 	box->height *= scale;
 }
 
-struct sway_container *output_get_active_workspace(struct sway_output *output) {
+struct sway_workspace *output_get_active_workspace(struct sway_output *output) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *focus =
-		seat_get_focus_inactive(seat, output->swayc);
+	struct sway_node *focus = seat_get_active_child(seat, &output->node);
 	if (!focus) {
-		// We've never been to this output before
-		focus = output->swayc->current.children->items[0];
+		return output->workspaces->items[0];
 	}
-	struct sway_container *workspace = focus;
-	if (workspace->type != C_WORKSPACE) {
-		workspace = container_parent(workspace, C_WORKSPACE);
-	}
-	return workspace;
+	return focus->sway_workspace;
 }
 
 bool output_has_opaque_overlay_layer_surface(struct sway_output *output) {
@@ -255,8 +249,8 @@ bool output_has_opaque_overlay_layer_surface(struct sway_output *output) {
 		struct sway_layer_surface *sway_layer_surface =
 			layer_from_wlr_layer_surface(wlr_layer_surface);
 		pixman_box32_t output_box = {
-			.x2 = output->swayc->current.swayc_width,
-			.y2 = output->swayc->current.swayc_height,
+			.x2 = output->wlr_output->width,
+			.y2 = output->wlr_output->height,
 		};
 		pixman_region32_t surface_opaque_box;
 		pixman_region32_init(&surface_opaque_box);
@@ -307,15 +301,15 @@ struct send_frame_done_data {
 
 static void send_frame_done_container_iterator(struct sway_container *con,
 		void *_data) {
-	if (con->type != C_VIEW) {
+	if (!con->view) {
 		return;
 	}
-	if (!view_is_visible(con->sway_view)) {
+	if (!view_is_visible(con->view)) {
 		return;
 	}
 
 	struct send_frame_done_data *data = _data;
-	output_view_for_each_surface(data->output, con->sway_view,
+	output_view_for_each_surface(data->output, con->view,
 		send_frame_done_iterator, data->when);
 }
 
@@ -328,15 +322,14 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 		.output = output,
 		.when = when,
 	};
-	struct sway_container *workspace = output_get_active_workspace(output);
-	if (workspace->current.ws_fullscreen) {
+	struct sway_workspace *workspace = output_get_active_workspace(output);
+	if (workspace->current.fullscreen) {
 		send_frame_done_container_iterator(
-				workspace->current.ws_fullscreen, &data);
-		container_for_each_child(workspace->current.ws_fullscreen,
+				workspace->current.fullscreen, &data);
+		container_for_each_child(workspace->current.fullscreen,
 				send_frame_done_container_iterator, &data);
 #ifdef HAVE_XWAYLAND
-		send_frame_done_unmanaged(output,
-			&root_container.sway_root->xwayland_unmanaged, when);
+		send_frame_done_unmanaged(output, &root->xwayland_unmanaged, when);
 #endif
 	} else {
 		send_frame_done_layer(output,
@@ -348,8 +341,7 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 				send_frame_done_container_iterator, &data);
 
 #ifdef HAVE_XWAYLAND
-		send_frame_done_unmanaged(output,
-			&root_container.sway_root->xwayland_unmanaged, when);
+		send_frame_done_unmanaged(output, &root->xwayland_unmanaged, when);
 #endif
 		send_frame_done_layer(output,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], when);
@@ -358,8 +350,7 @@ static void send_frame_done(struct sway_output *output, struct timespec *when) {
 send_frame_overlay:
 	send_frame_done_layer(output,
 		&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], when);
-	send_frame_done_drag_icons(output, &root_container.sway_root->drag_icons,
-		when);
+	send_frame_done_drag_icons(output, &root->drag_icons, when);
 }
 
 static void damage_handle_frame(struct wl_listener *listener, void *data) {
@@ -391,7 +382,11 @@ static void damage_handle_frame(struct wl_listener *listener, void *data) {
 }
 
 void output_damage_whole(struct sway_output *output) {
-	wlr_output_damage_add_whole(output->damage);
+	// The output can exist with no wlr_output if it's just been disconnected
+	// and the transaction to evacuate it has't completed yet.
+	if (output && output->wlr_output) {
+		wlr_output_damage_add_whole(output->damage);
+	}
 }
 
 static void damage_surface_iterator(struct sway_output *output,
@@ -446,14 +441,9 @@ void output_damage_surface(struct sway_output *output, double ox, double oy,
 
 static void output_damage_view(struct sway_output *output,
 		struct sway_view *view, bool whole) {
-	if (!sway_assert(view->swayc != NULL, "expected a view in the tree")) {
-		return;
-	}
-
 	if (!view_is_visible(view)) {
 		return;
 	}
-
 	output_view_for_each_surface(output, view, damage_surface_iterator, &whole);
 }
 
@@ -466,31 +456,29 @@ void output_damage_from_view(struct sway_output *output,
 void output_damage_box(struct sway_output *output, struct wlr_box *_box) {
 	struct wlr_box box;
 	memcpy(&box, _box, sizeof(struct wlr_box));
-	box.x -= output->swayc->current.swayc_x;
-	box.y -= output->swayc->current.swayc_y;
+	box.x -= output->wlr_output->lx;
+	box.y -= output->wlr_output->ly;
 	scale_box(&box, output->wlr_output->scale);
 	wlr_output_damage_add_box(output->damage, &box);
 }
 
 static void output_damage_whole_container_iterator(struct sway_container *con,
 		void *data) {
-	struct sway_output *output = data;
-
-	if (!sway_assert(con->type == C_VIEW, "expected a view")) {
+	if (!sway_assert(con->view, "expected a view")) {
 		return;
 	}
-
-	output_damage_view(output, con->sway_view, true);
+	struct sway_output *output = data;
+	output_damage_view(output, con->view, true);
 }
 
 void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	// Pad the box by 1px, because the width is a double and might be a fraction
 	struct wlr_box box = {
-		.x = con->current.swayc_x - output->wlr_output->lx - 1,
-		.y = con->current.swayc_y - output->wlr_output->ly - 1,
-		.width = con->current.swayc_width + 2,
-		.height = con->current.swayc_height + 2,
+		.x = con->current.con_x - output->wlr_output->lx - 1,
+		.y = con->current.con_y - output->wlr_output->ly - 1,
+		.width = con->current.con_width + 2,
+		.height = con->current.con_height + 2,
 	};
 	scale_box(&box, output->wlr_output->scale);
 	wlr_output_damage_add_box(output->damage, &box);
@@ -499,44 +487,48 @@ void output_damage_whole_container(struct sway_output *output,
 static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output =
 		wl_container_of(listener, output, damage_destroy);
-	output_begin_destroy(output->swayc);
+	output_disable(output);
+	transaction_commit_dirty();
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, destroy);
 	wl_signal_emit(&output->events.destroy, output);
 
-	if (output->swayc) {
-		output_begin_destroy(output->swayc);
+	if (output->enabled) {
+		output_disable(output);
 	}
+	output_begin_destroy(output);
 
-	wl_list_remove(&output->link);
-	wl_list_remove(&output->destroy.link);
-	output->wlr_output->data = NULL;
-	free(output);
-
-	arrange_windows(&root_container);
+	transaction_commit_dirty();
 }
 
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
 	arrange_layers(output);
-	arrange_windows(output->swayc);
+	arrange_output(output);
 	transaction_commit_dirty();
 }
 
 static void handle_transform(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, transform);
 	arrange_layers(output);
-	arrange_windows(output->swayc);
+	arrange_output(output);
 	transaction_commit_dirty();
+}
+
+static void update_textures(struct sway_container *con, void *data) {
+	container_update_title_textures(con);
+	if (con->view) {
+		view_update_marks_textures(con->view);
+	}
 }
 
 static void handle_scale(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, scale);
 	arrange_layers(output);
-	container_update_textures_recursive(output->swayc);
-	arrange_windows(output->swayc);
+	output_for_each_container(output, update_textures, NULL);
+	arrange_output(output);
 	transaction_commit_dirty();
 }
 
@@ -545,57 +537,27 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	struct wlr_output *wlr_output = data;
 	wlr_log(WLR_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
 
-	struct sway_output *output = calloc(1, sizeof(struct sway_output));
+	struct sway_output *output = output_create(wlr_output);
 	if (!output) {
 		return;
 	}
-	output->wlr_output = wlr_output;
-	wlr_output->data = output;
 	output->server = server;
 	output->damage = wlr_output_damage_create(wlr_output);
-
-	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->destroy.notify = handle_destroy;
 
-	wl_list_insert(&root_container.sway_root->all_outputs, &output->link);
+	struct output_config *oc = output_find_config(output);
 
-	output_enable(output);
+	if (oc && oc->enabled) {
+		output_enable(output, oc);
+	}
+
+	transaction_commit_dirty();
 }
 
-void output_enable(struct sway_output *output) {
-	struct wlr_output *wlr_output = output->wlr_output;
-
-	if (!sway_assert(output->swayc == NULL, "output is already enabled")) {
-		return;
-	}
-
-	output->swayc = output_create(output);
-	if (!output->swayc) {
-		// Output is disabled
-		return;
-	}
-
-	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
-	for (size_t i = 0; i < len; ++i) {
-		wl_list_init(&output->layers[i]);
-	}
-	wl_signal_init(&output->events.destroy);
-
-	input_manager_configure_xcursor(input_manager);
-
-	wl_signal_add(&wlr_output->events.mode, &output->mode);
+void output_add_listeners(struct sway_output *output) {
 	output->mode.notify = handle_mode;
-	wl_signal_add(&wlr_output->events.transform, &output->transform);
 	output->transform.notify = handle_transform;
-	wl_signal_add(&wlr_output->events.scale, &output->scale);
 	output->scale.notify = handle_scale;
-
-	wl_signal_add(&output->damage->events.frame, &output->damage_frame);
 	output->damage_frame.notify = damage_handle_frame;
-	wl_signal_add(&output->damage->events.destroy, &output->damage_destroy);
 	output->damage_destroy.notify = damage_handle_destroy;
-
-	arrange_layers(output);
-	arrange_windows(&root_container);
-	transaction_commit_dirty();
 }

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -238,8 +238,8 @@ static void render_saved_view(struct sway_view *view,
 	};
 
 	struct wlr_box output_box = {
-		.width = output->wlr_output->width,
-		.height = output->wlr_output->height,
+		.width = output->width,
+		.height = output->height,
 	};
 
 	struct wlr_box intersection;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -11,10 +11,12 @@
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/output.h"
 #include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 
 static const struct sway_view_child_impl popup_impl;
 
@@ -52,15 +54,15 @@ static void popup_unconstrain(struct sway_xdg_popup *popup) {
 	struct sway_view *view = popup->child.view;
 	struct wlr_xdg_popup *wlr_popup = popup->wlr_xdg_surface->popup;
 
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
+	struct sway_output *output = view->container->workspace->output;
 
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->x - view->x,
-		.y = output->y - view->y,
-		.width = output->width,
-		.height = output->height,
+		.x = output->wlr_output->lx - view->x,
+		.y = output->wlr_output->ly - view->y,
+		.width = output->wlr_output->width,
+		.height = output->wlr_output->height,
 	};
 
 	wlr_xdg_popup_unconstrain_from_box(wlr_popup, &output_toplevel_sx_box);
@@ -252,11 +254,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_view->view;
 	struct wlr_xdg_surface *xdg_surface = view->wlr_xdg_surface;
 
-	if (!view->swayc) {
-		return;
-	}
-
-	if (view->swayc->instruction) {
+	if (view->container->node.instruction) {
 		wlr_xdg_surface_get_geometry(xdg_surface, &view->geometry);
 		transaction_notify_view_ready_by_serial(view,
 				xdg_surface->configure_serial);
@@ -265,7 +263,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		wlr_xdg_surface_get_geometry(xdg_surface, &new_geo);
 
 		if ((new_geo.width != view->width || new_geo.height != view->height) &&
-				container_is_floating(view->swayc)) {
+				container_is_floating(view->container)) {
 			// A floating view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);
@@ -319,10 +317,9 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		return;
 	}
 
-	container_set_fullscreen(view->swayc, e->fullscreen);
+	container_set_fullscreen(view->container, e->fullscreen);
 
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
-	arrange_windows(output);
+	arrange_workspace(view->container->workspace);
 	transaction_commit_dirty();
 }
 
@@ -330,13 +327,13 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_move);
 	struct sway_view *view = &xdg_shell_view->view;
-	if (!container_is_floating(view->swayc)) {
+	if (!container_is_floating(view->container)) {
 		return;
 	}
 	struct wlr_xdg_toplevel_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move(seat, view->swayc, seat->last_button);
+		seat_begin_move(seat, view->container, seat->last_button);
 	}
 }
 
@@ -344,13 +341,13 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_resize);
 	struct sway_view *view = &xdg_shell_view->view;
-	if (!container_is_floating(view->swayc)) {
+	if (!container_is_floating(view->container)) {
 		return;
 	}
 	struct wlr_xdg_toplevel_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize_floating(seat, view->swayc,
+		seat_begin_resize_floating(seat, view->container,
 				seat->last_button, e->edges);
 	}
 }
@@ -399,11 +396,14 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface->surface);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
-		container_set_fullscreen(view->swayc, true);
-		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-		arrange_windows(ws);
+		container_set_fullscreen(view->container, true);
+		arrange_workspace(view->container->workspace);
 	} else {
-		arrange_windows(view->swayc->parent);
+		if (view->container->parent) {
+			arrange_container(view->container->parent);
+		} else {
+			arrange_workspace(view->container->workspace);
+		}
 	}
 	transaction_commit_dirty();
 
@@ -440,8 +440,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, destroy);
 	struct sway_view *view = &xdg_shell_view->view;
-	if (!sway_assert(view->swayc == NULL || view->swayc->destroying,
-				"Tried to destroy a mapped view")) {
+	if (!sway_assert(view->surface == NULL, "Tried to destroy a mapped view")) {
 		return;
 	}
 	wl_list_remove(&xdg_shell_view->destroy.link);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -59,10 +59,10 @@ static void popup_unconstrain(struct sway_xdg_popup *popup) {
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->wlr_output->lx - view->x,
-		.y = output->wlr_output->ly - view->y,
-		.width = output->wlr_output->width,
-		.height = output->wlr_output->height,
+		.x = output->lx - view->x,
+		.y = output->ly - view->y,
+		.width = output->width,
+		.height = output->height,
 	};
 
 	wlr_xdg_popup_unconstrain_from_box(wlr_popup, &output_toplevel_sx_box);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -58,10 +58,10 @@ static void popup_unconstrain(struct sway_xdg_popup_v6 *popup) {
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->wlr_output->lx - view->x,
-		.y = output->wlr_output->ly - view->y,
-		.width = output->wlr_output->width,
-		.height = output->wlr_output->height,
+		.x = output->lx - view->x,
+		.y = output->ly - view->y,
+		.width = output->width,
+		.height = output->height,
 	};
 
 	wlr_xdg_popup_v6_unconstrain_from_box(wlr_popup, &output_toplevel_sx_box);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -10,10 +10,12 @@
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/output.h"
 #include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 
 static const struct sway_view_child_impl popup_impl;
 
@@ -51,15 +53,15 @@ static void popup_unconstrain(struct sway_xdg_popup_v6 *popup) {
 	struct sway_view *view = popup->child.view;
 	struct wlr_xdg_popup_v6 *wlr_popup = popup->wlr_xdg_surface_v6->popup;
 
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
+	struct sway_output *output = view->container->workspace->output;
 
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->x - view->x,
-		.y = output->y - view->y,
-		.width = output->width,
-		.height = output->height,
+		.x = output->wlr_output->lx - view->x,
+		.y = output->wlr_output->ly - view->y,
+		.width = output->wlr_output->width,
+		.height = output->wlr_output->height,
 	};
 
 	wlr_xdg_popup_v6_unconstrain_from_box(wlr_popup, &output_toplevel_sx_box);
@@ -249,11 +251,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_v6_view->view;
 	struct wlr_xdg_surface_v6 *xdg_surface_v6 = view->wlr_xdg_surface_v6;
 
-	if (!view->swayc) {
-		return;
-	}
-
-	if (view->swayc->instruction) {
+	if (view->container->node.instruction) {
 		wlr_xdg_surface_v6_get_geometry(xdg_surface_v6, &view->geometry);
 		transaction_notify_view_ready_by_serial(view,
 				xdg_surface_v6->configure_serial);
@@ -262,7 +260,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		wlr_xdg_surface_v6_get_geometry(xdg_surface_v6, &new_geo);
 
 		if ((new_geo.width != view->width || new_geo.height != view->height) &&
-				container_is_floating(view->swayc)) {
+				container_is_floating(view->container)) {
 			// A floating view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);
@@ -316,10 +314,9 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		return;
 	}
 
-	container_set_fullscreen(view->swayc, e->fullscreen);
+	container_set_fullscreen(view->container, e->fullscreen);
 
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
-	arrange_windows(output);
+	arrange_workspace(view->container->workspace);
 	transaction_commit_dirty();
 }
 
@@ -327,13 +324,13 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, request_move);
 	struct sway_view *view = &xdg_shell_v6_view->view;
-	if (!container_is_floating(view->swayc)) {
+	if (!container_is_floating(view->container)) {
 		return;
 	}
 	struct wlr_xdg_toplevel_v6_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move(seat, view->swayc, seat->last_button);
+		seat_begin_move(seat, view->container, seat->last_button);
 	}
 }
 
@@ -341,13 +338,13 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, request_resize);
 	struct sway_view *view = &xdg_shell_v6_view->view;
-	if (!container_is_floating(view->swayc)) {
+	if (!container_is_floating(view->container)) {
 		return;
 	}
 	struct wlr_xdg_toplevel_v6_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize_floating(seat, view->swayc,
+		seat_begin_resize_floating(seat, view->container,
 				seat->last_button, e->edges);
 	}
 }
@@ -396,11 +393,14 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface_v6->surface);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
-		container_set_fullscreen(view->swayc, true);
-		struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-		arrange_windows(ws);
+		container_set_fullscreen(view->container, true);
+		arrange_workspace(view->container->workspace);
 	} else {
-		arrange_windows(view->swayc->parent);
+		if (view->container->parent) {
+			arrange_container(view->container->parent);
+		} else {
+			arrange_workspace(view->container->workspace);
+		}
 	}
 	transaction_commit_dirty();
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -91,7 +91,7 @@ static struct sway_node *node_at_coords(
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
 				ox, oy, sx, sy))) {
-		return &ws->node;
+		return NULL;
 	}
 	if (ws->fullscreen) {
 		struct sway_container *con =
@@ -104,7 +104,7 @@ static struct sway_node *node_at_coords(
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
 				ox, oy, sx, sy))) {
-		return &ws->node;
+		return NULL;
 	}
 
 	struct sway_container *c;
@@ -115,12 +115,12 @@ static struct sway_node *node_at_coords(
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
 				ox, oy, sx, sy))) {
-		return &ws->node;
+		return NULL;
 	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
 				ox, oy, sx, sy))) {
-		return &ws->node;
+		return NULL;
 	}
 
 	return &ws->node;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -464,7 +464,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 				struct sway_node *next_focus =
 					seat_get_focus_inactive(seat, &root->node);
 				if (next_focus && next_focus->type == N_CONTAINER &&
-						node->sway_container->view &&
+						next_focus->sway_container->view &&
 						view_is_visible(next_focus->sway_container->view)) {
 					seat_set_focus_warp(seat, next_focus, false, true);
 				}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -20,6 +20,7 @@
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
@@ -50,15 +51,15 @@ static struct wlr_surface *layer_surface_at(struct sway_output *output,
 }
 
 /**
- * Returns the container at the cursor's position. If there is a surface at that
+ * Returns the node at the cursor's position. If there is a surface at that
  * location, it is stored in **surface (it may not be a view).
  */
-static struct sway_container *container_at_coords(
+static struct sway_node *node_at_coords(
 		struct sway_seat *seat, double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	// check for unmanaged views first
 #ifdef HAVE_XWAYLAND
-	struct wl_list *unmanaged = &root_container.sway_root->xwayland_unmanaged;
+	struct wl_list *unmanaged = &root->xwayland_unmanaged;
 	struct sway_xwayland_unmanaged *unmanaged_surface;
 	wl_list_for_each_reverse(unmanaged_surface, unmanaged, link) {
 		struct wlr_xwayland_surface *xsurface =
@@ -75,67 +76,64 @@ static struct sway_container *container_at_coords(
 	}
 #endif
 	// find the output the cursor is on
-	struct wlr_output_layout *output_layout =
-		root_container.sway_root->output_layout;
 	struct wlr_output *wlr_output = wlr_output_layout_output_at(
-			output_layout, lx, ly);
+			root->output_layout, lx, ly);
 	if (wlr_output == NULL) {
 		return NULL;
 	}
 	struct sway_output *output = wlr_output->data;
 	double ox = lx, oy = ly;
-	wlr_output_layout_output_coords(output_layout, wlr_output, &ox, &oy);
+	wlr_output_layout_output_coords(root->output_layout, wlr_output, &ox, &oy);
 
 	// find the focused workspace on the output for this seat
-	struct sway_container *ws = seat_get_focus_inactive(seat, output->swayc);
-	if (ws && ws->type != C_WORKSPACE) {
-		ws = container_parent(ws, C_WORKSPACE);
-	}
-	if (!ws) {
-		return output->swayc;
-	}
+	struct sway_workspace *ws = output_get_active_workspace(output);
 
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
 				ox, oy, sx, sy))) {
-		return ws;
+		return &ws->node;
 	}
-	if (ws->sway_workspace->fullscreen) {
-		return tiling_container_at(ws->sway_workspace->fullscreen, lx, ly,
-				surface, sx, sy);
+	if (ws->fullscreen) {
+		struct sway_container *con =
+			tiling_container_at(&ws->fullscreen->node, lx, ly, surface, sx, sy);
+		if (con) {
+			return &con->node;
+		}
+		return NULL;
 	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
 				ox, oy, sx, sy))) {
-		return ws;
+		return &ws->node;
 	}
 
 	struct sway_container *c;
 	if ((c = container_at(ws, lx, ly, surface, sx, sy))) {
-		return c;
+		return &c->node;
 	}
 
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM],
 				ox, oy, sx, sy))) {
-		return ws;
+		return &ws->node;
 	}
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND],
 				ox, oy, sx, sy))) {
-		return ws;
+		return &ws->node;
 	}
 
-	c = seat_get_active_child(seat, output->swayc);
-	if (c) {
-		return c;
-	}
-	if (!c && output->swayc->children->length) {
-		c = output->swayc->children->items[0];
-		return c;
-	}
+	return &ws->node;
+}
 
-	return output->swayc;
+static struct sway_container *container_at_coords(struct sway_seat *seat,
+		double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy) {
+	struct sway_node *node = node_at_coords(seat, lx, ly, surface, sx, sy);
+	if (node && node->type == N_CONTAINER) {
+		return node->sway_container;
+	}
+	return NULL;
 }
 
 /**
@@ -160,13 +158,14 @@ static bool edge_is_external(struct sway_container *cont, enum wlr_edges edge) {
 
 	// Iterate the parents until we find one with the layout we want,
 	// then check if the child has siblings between it and the edge.
-	while (cont->type != C_OUTPUT) {
-		if (cont->parent->layout == layout) {
-			int index = list_find(cont->parent->children, cont);
+	while (cont) {
+		if (container_parent_layout(cont) == layout) {
+			list_t *siblings = container_get_siblings(cont);
+			int index = list_find(siblings, cont);
 			if (index > 0 && (edge == WLR_EDGE_LEFT || edge == WLR_EDGE_TOP)) {
 				return false;
 			}
-			if (index < cont->parent->children->length - 1 &&
+			if (index < siblings->length - 1 &&
 					(edge == WLR_EDGE_RIGHT || edge == WLR_EDGE_BOTTOM)) {
 				return false;
 			}
@@ -178,10 +177,10 @@ static bool edge_is_external(struct sway_container *cont, enum wlr_edges edge) {
 
 static enum wlr_edges find_edge(struct sway_container *cont,
 		struct sway_cursor *cursor) {
-	if (cont->type != C_VIEW) {
+	if (!cont->view) {
 		return WLR_EDGE_NONE;
 	}
-	struct sway_view *view = cont->sway_view;
+	struct sway_view *view = cont->view;
 	if (view->border == B_NONE || !view->border_thickness || view->using_csd) {
 		return WLR_EDGE_NONE;
 	}
@@ -219,7 +218,7 @@ static enum wlr_edges find_resize_edge(struct sway_container *cont,
 static void handle_down_motion(struct sway_seat *seat,
 		struct sway_cursor *cursor, uint32_t time_msec) {
 	struct sway_container *con = seat->op_container;
-	if (seat_is_input_allowed(seat, con->sway_view->surface)) {
+	if (seat_is_input_allowed(seat, con->view->surface)) {
 		double moved_x = cursor->cursor->x - seat->op_ref_lx;
 		double moved_y = cursor->cursor->y - seat->op_ref_ly;
 		double sx = seat->op_ref_con_lx + moved_x;
@@ -260,8 +259,7 @@ static void calculate_floating_constraints(struct sway_container *con,
 	if (config->floating_maximum_width == -1) { // no maximum
 		*max_width = INT_MAX;
 	} else if (config->floating_maximum_width == 0) { // automatic
-		struct sway_container *ws = container_parent(con, C_WORKSPACE);
-		*max_width = ws->width;
+		*max_width = con->workspace->width;
 	} else {
 		*max_width = config->floating_maximum_width;
 	}
@@ -269,8 +267,7 @@ static void calculate_floating_constraints(struct sway_container *con,
 	if (config->floating_maximum_height == -1) { // no maximum
 		*max_height = INT_MAX;
 	} else if (config->floating_maximum_height == 0) { // automatic
-		struct sway_container *ws = container_parent(con, C_WORKSPACE);
-		*max_height = ws->height;
+		*max_height = con->workspace->height;
 	} else {
 		*max_height = config->floating_maximum_height;
 	}
@@ -314,9 +311,9 @@ static void handle_resize_floating_motion(struct sway_seat *seat,
 	height = fmax(min_height, fmin(height, max_height));
 
 	// Apply the view's min/max size
-	if (con->type == C_VIEW) {
+	if (con->view) {
 		double view_min_width, view_max_width, view_min_height, view_max_height;
-		view_get_constraints(con->sway_view, &view_min_width, &view_max_width,
+		view_get_constraints(con->view, &view_min_width, &view_max_width,
 				&view_min_height, &view_max_height);
 		width = fmax(view_min_width, fmin(width, view_max_width));
 		height = fmax(view_min_height, fmin(height, view_max_height));
@@ -357,15 +354,15 @@ static void handle_resize_floating_motion(struct sway_seat *seat,
 	con->width += relative_grow_width;
 	con->height += relative_grow_height;
 
-	if (con->type == C_VIEW) {
-		struct sway_view *view = con->sway_view;
+	if (con->view) {
+		struct sway_view *view = con->view;
 		view->x += relative_grow_x;
 		view->y += relative_grow_y;
 		view->width += relative_grow_width;
 		view->height += relative_grow_height;
 	}
 
-	arrange_windows(con);
+	arrange_container(con);
 }
 
 static void handle_resize_tiling_motion(struct sway_seat *seat,
@@ -435,44 +432,40 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
 
-	// Find the container beneath the pointer's previous position
-	struct sway_container *prev_c = container_at_coords(seat,
+	// Find the node beneath the pointer's previous position
+	struct sway_node *prev_node = node_at_coords(seat,
 			cursor->previous.x, cursor->previous.y, &surface, &sx, &sy);
 	// Update the stored previous position
 	cursor->previous.x = cursor->cursor->x;
 	cursor->previous.y = cursor->cursor->y;
 
-	struct sway_container *c = container_at_coords(seat,
+	struct sway_node *node = node_at_coords(seat,
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
-	if (c && config->focus_follows_mouse && allow_refocusing) {
-		struct sway_container *focus = seat_get_focus(seat);
-		if (focus && c->type == C_WORKSPACE) {
+	if (node && config->focus_follows_mouse && allow_refocusing) {
+		struct sway_node *focus = seat_get_focus(seat);
+		if (focus && node->type == N_WORKSPACE) {
 			// Only follow the mouse if it would move to a new output
 			// Otherwise we'll focus the workspace, which is probably wrong
-			if (focus->type != C_OUTPUT) {
-				focus = container_parent(focus, C_OUTPUT);
+			struct sway_output *focused_output = node_get_output(focus);
+			struct sway_output *output = node_get_output(node);
+			if (output != focused_output) {
+				seat_set_focus_warp(seat, node, false, true);
 			}
-			struct sway_container *output = c;
-			if (output->type != C_OUTPUT) {
-				output = container_parent(c, C_OUTPUT);
-			}
-			if (output != focus) {
-				seat_set_focus_warp(seat, c, false, true);
-			}
-		} else if (c->type == C_VIEW) {
-			// Focus c if the following are true:
+		} else if (node->type == N_CONTAINER && node->sway_container->view) {
+			// Focus node if the following are true:
 			// - cursor is over a new view, i.e. entered a new window; and
 			// - the new view is visible, i.e. not hidden in a stack or tab; and
 			// - the seat does not have a keyboard grab
 			if (!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
-					c != prev_c &&
-					view_is_visible(c->sway_view)) {
-				seat_set_focus_warp(seat, c, false, true);
+					node != prev_node &&
+					view_is_visible(node->sway_container->view)) {
+				seat_set_focus_warp(seat, node, false, true);
 			} else {
-				struct sway_container *next_focus =
-					seat_get_focus_inactive(seat, &root_container);
-				if (next_focus && next_focus->type == C_VIEW &&
-						view_is_visible(next_focus->sway_view)) {
+				struct sway_node *next_focus =
+					seat_get_focus_inactive(seat, &root->node);
+				if (next_focus && next_focus->type == N_CONTAINER &&
+						node->sway_container->view &&
+						view_is_visible(next_focus->sway_container->view)) {
 					seat_set_focus_warp(seat, next_focus, false, true);
 				}
 			}
@@ -486,12 +479,12 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		if (client != cursor->image_client) {
 			cursor_set_image(cursor, "left_ptr", client);
 		}
-	} else if (c) {
-		// Try a container's resize edge
-		enum wlr_edges edge = find_resize_edge(c, cursor);
+	} else if (node && node->type == N_CONTAINER) {
+		// Try a node's resize edge
+		enum wlr_edges edge = find_resize_edge(node->sway_container, cursor);
 		if (edge == WLR_EDGE_NONE) {
 			cursor_set_image(cursor, "left_ptr", NULL);
-		} else if (container_is_floating(c)) {
+		} else if (container_is_floating(node->sway_container)) {
 			cursor_set_image(cursor, wlr_xcursor_get_resize_name(edge), NULL);
 		} else {
 			if (edge & (WLR_EDGE_LEFT | WLR_EDGE_RIGHT)) {
@@ -684,7 +677,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle tiling resize via border
 	if (resize_edge && button == BTN_LEFT && state == WLR_BUTTON_PRESSED &&
 			!is_floating) {
-		seat_set_focus(seat, cont);
+		seat_set_focus(seat, &cont->node);
 		seat_begin_resize_tiling(seat, cont, button, edge);
 		return;
 	}
@@ -713,7 +706,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 				image = "sw-resize";
 			}
 			cursor_set_image(seat->cursor, image, NULL);
-			seat_set_focus(seat, cont);
+			seat_set_focus(seat, &cont->node);
 			seat_begin_resize_tiling(seat, cont, button, edge);
 			return;
 		}
@@ -725,7 +718,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
 		if (button == btn_move && state == WLR_BUTTON_PRESSED &&
 				(mod_pressed || on_titlebar)) {
-			while (cont->parent->type != C_WORKSPACE) {
+			while (cont->parent) {
 				cont = cont->parent;
 			}
 			seat_begin_move(seat, cont, button);
@@ -747,7 +740,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			BTN_LEFT : BTN_RIGHT;
 		if (mod_pressed && button == btn_resize) {
 			struct sway_container *floater = cont;
-			while (floater->parent->type != C_WORKSPACE) {
+			while (floater->parent) {
 				floater = floater->parent;
 			}
 			edge = 0;
@@ -762,7 +755,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	// Handle mousedown on a container surface
 	if (surface && cont && state == WLR_BUTTON_PRESSED) {
-		seat_set_focus(seat, cont);
+		seat_set_focus(seat, &cont->node);
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		seat_begin_down(seat, cont, button, sx, sy);
 		return;
@@ -770,7 +763,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	// Handle clicking a container surface
 	if (cont) {
-		seat_set_focus(seat, cont);
+		seat_set_focus(seat, &cont->node);
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;
 	}
@@ -1025,8 +1018,7 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 	cursor->previous.y = wlr_cursor->y;
 
 	cursor->seat = seat;
-	wlr_cursor_attach_output_layout(wlr_cursor,
-		root_container.sway_root->output_layout);
+	wlr_cursor_attach_output_layout(wlr_cursor, root->output_layout);
 
 	// input events
 	wl_signal_add(&wlr_cursor->events.motion, &cursor->motion);

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -293,12 +293,10 @@ static void handle_inhibit_deactivate(struct wl_listener *listener, void *data) 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &input_manager->seats, link) {
 		seat_set_exclusive_client(seat, NULL);
-		struct sway_container *previous = seat_get_focus(seat);
+		struct sway_node *previous = seat_get_focus(seat);
 		if (previous) {
-			wlr_log(WLR_DEBUG, "Returning focus to %p %s '%s'", previous,
-					container_type_to_str(previous->type), previous->name);
 			// Hack to get seat to re-focus the return value of get_focus
-			seat_set_focus(seat, previous->parent);
+			seat_set_focus(seat, NULL);
 			seat_set_focus(seat, previous);
 		}
 	}
@@ -369,10 +367,10 @@ struct sway_input_manager *input_manager_create(
 }
 
 bool input_manager_has_focus(struct sway_input_manager *input,
-		struct sway_container *container) {
+		struct sway_node *node) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &input->seats, link) {
-		if (seat_get_focus(seat) == container) {
+		if (seat_get_focus(seat) == node) {
 			return true;
 		}
 	}
@@ -381,10 +379,10 @@ bool input_manager_has_focus(struct sway_input_manager *input,
 }
 
 void input_manager_set_focus(struct sway_input_manager *input,
-		struct sway_container *container) {
+		struct sway_node *node) {
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &input->seats, link) {
-		seat_set_focus(seat, container);
+		seat_set_focus(seat, node);
 	}
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -614,6 +614,13 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 		new_output_last_ws = output_get_active_workspace(new_output);
 	}
 
+	// Unfocus the previous focus
+	if (last_focus) {
+		seat_send_unfocus(last_focus, seat);
+		node_set_dirty(last_focus);
+		node_set_dirty(node_get_parent(last_focus));
+	}
+
 	// Put the container parents on the focus stack, then the workspace, then
 	// the focused container.
 	if (container) {
@@ -640,15 +647,6 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 		wl_list_remove(&seat_node->link);
 		wl_list_insert(&seat->focus_stack, &seat_node->link);
 		node_set_dirty(&container->node);
-
-		if (last_focus) {
-			seat_send_unfocus(last_focus, seat);
-			node_set_dirty(last_focus);
-			struct sway_node *last_parent = node_get_parent(last_focus);
-			if (last_parent) {
-				node_set_dirty(last_parent);
-			}
-		}
 		seat_send_focus(&container->node, seat);
 	}
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -618,7 +618,10 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 	if (last_focus) {
 		seat_send_unfocus(last_focus, seat);
 		node_set_dirty(last_focus);
-		node_set_dirty(node_get_parent(last_focus));
+		struct sway_node *parent = node_get_parent(last_focus);
+		if (parent) {
+			node_set_dirty(parent);
+		}
 	}
 
 	// Put the container parents on the focus stack, then the workspace, then

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -709,13 +709,20 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 		}
 
 		if (config->mouse_warping && warp && new_output != last_output) {
-				double x = container->x + container->width / 2.0;
-				double y = container->y + container->height / 2.0;
-				if (!wlr_output_layout_contains_point(root->output_layout,
-						new_output->wlr_output, seat->cursor->cursor->x,
-						seat->cursor->cursor->y)) {
-					wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
-					cursor_send_pointer_motion(seat->cursor, 0, true);
+			double x = 0;
+			double y = 0;
+			if (container) {
+				x = container->x + container->width / 2.0;
+				y = container->y + container->height / 2.0;
+			} else {
+				x = new_workspace->x + new_workspace->width / 2.0;
+				y = new_workspace->y + new_workspace->height / 2.0;
+			}
+			if (!wlr_output_layout_contains_point(root->output_layout,
+					new_output->wlr_output, seat->cursor->cursor->x,
+					seat->cursor->cursor->y)) {
+				wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
+				cursor_send_pointer_motion(seat->cursor, 0, true);
 			}
 		}
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -485,13 +485,13 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	json_object_object_add(json, "colors", colors);
 
 	// Add outputs if defined
-	json_object *outputs = json_object_new_array();
 	if (bar->outputs && bar->outputs->length > 0) {
+		json_object *outputs = json_object_new_array();
 		for (int i = 0; i < bar->outputs->length; ++i) {
 			const char *name = bar->outputs->items[i];
 			json_object_array_add(outputs, json_object_new_string(name));
 		}
+		json_object_object_add(json, "outputs", outputs);
 	}
-	json_object_object_add(json, "outputs", outputs);
 	return json;
 }

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -46,18 +46,18 @@ json_object *ipc_json_get_version() {
 	return version;
 }
 
-static json_object *ipc_json_create_rect(struct sway_container *c) {
+static json_object *ipc_json_create_rect(struct wlr_box *box) {
 	json_object *rect = json_object_new_object();
 
-	json_object_object_add(rect, "x", json_object_new_int((int32_t)c->x));
-	json_object_object_add(rect, "y", json_object_new_int((int32_t)c->y));
-	json_object_object_add(rect, "width", json_object_new_int((int32_t)c->width));
-	json_object_object_add(rect, "height", json_object_new_int((int32_t)c->height));
+	json_object_object_add(rect, "x", json_object_new_int(box->x));
+	json_object_object_add(rect, "y", json_object_new_int(box->y));
+	json_object_object_add(rect, "width", json_object_new_int(box->width));
+	json_object_object_add(rect, "height", json_object_new_int(box->height));
 
 	return rect;
 }
 
-static void ipc_json_describe_root(struct sway_container *root, json_object *object) {
+static void ipc_json_describe_root(struct sway_root *root, json_object *object) {
 	json_object_object_add(object, "type", json_object_new_string("root"));
 	json_object_object_add(object, "layout", json_object_new_string("splith"));
 }
@@ -84,17 +84,13 @@ static const char *ipc_json_get_output_transform(enum wl_output_transform transf
 	return NULL;
 }
 
-static void ipc_json_describe_output(struct sway_container *container,
+static void ipc_json_describe_output(struct sway_output *output,
 		json_object *object) {
-	struct wlr_output *wlr_output = container->sway_output->wlr_output;
-	json_object_object_add(object, "type",
-			json_object_new_string("output"));
-	json_object_object_add(object, "active",
-			json_object_new_boolean(true));
-	json_object_object_add(object, "primary",
-			json_object_new_boolean(false));
-	json_object_object_add(object, "layout",
-			json_object_new_string("output"));
+	struct wlr_output *wlr_output = output->wlr_output;
+	json_object_object_add(object, "type", json_object_new_string("output"));
+	json_object_object_add(object, "active", json_object_new_boolean(true));
+	json_object_object_add(object, "primary", json_object_new_boolean(false));
+	json_object_object_add(object, "layout", json_object_new_string("output"));
 	json_object_object_add(object, "make",
 			json_object_new_string(wlr_output->make));
 	json_object_object_add(object, "model",
@@ -109,20 +105,9 @@ static void ipc_json_describe_output(struct sway_container *container,
 		json_object_new_string(
 			ipc_json_get_output_transform(wlr_output->transform)));
 
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
-	const char *ws = NULL;
-	if (seat) {
-		struct sway_container *focus =
-			seat_get_focus_inactive(seat, container);
-		if (focus && focus->type != C_WORKSPACE) {
-			focus = container_parent(focus, C_WORKSPACE);
-		}
-		if (focus) {
-			ws = focus->name;
-		}
-	}
+	struct sway_workspace *ws = output_get_active_workspace(output);
 	json_object_object_add(object, "current_workspace",
-			json_object_new_string(ws));
+			json_object_new_string(ws->name));
 
 	json_object *modes_array = json_object_new_array();
 	struct wlr_output_mode *mode;
@@ -161,60 +146,57 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	return object;
 }
 
-static void ipc_json_describe_workspace(struct sway_container *workspace,
+static void ipc_json_describe_workspace(struct sway_workspace *workspace,
 		json_object *object) {
 	int num = isdigit(workspace->name[0]) ? atoi(workspace->name) : -1;
 
 	json_object_object_add(object, "num", json_object_new_int(num));
-	json_object_object_add(object, "output", workspace->parent ?
-			json_object_new_string(workspace->parent->name) : NULL);
+	json_object_object_add(object, "output", workspace->output ?
+			json_object_new_string(workspace->output->wlr_output->name) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("workspace"));
 	json_object_object_add(object, "urgent",
-			json_object_new_boolean(workspace->sway_workspace->urgent));
-	json_object_object_add(object, "representation", workspace->formatted_title ?
-			json_object_new_string(workspace->formatted_title) : NULL);
+			json_object_new_boolean(workspace->urgent));
+	json_object_object_add(object, "representation", workspace->representation ?
+			json_object_new_string(workspace->representation) : NULL);
 
 	const char *layout = ipc_json_layout_description(workspace->layout);
 	json_object_object_add(object, "layout", json_object_new_string(layout));
 
 	// Floating
 	json_object *floating_array = json_object_new_array();
-	list_t *floating = workspace->sway_workspace->floating;
-	for (int i = 0; i < floating->length; ++i) {
-		struct sway_container *floater = floating->items[i];
+	for (int i = 0; i < workspace->floating->length; ++i) {
+		struct sway_container *floater = workspace->floating->items[i];
 		json_object_array_add(floating_array,
-				ipc_json_describe_container_recursive(floater));
+				ipc_json_describe_node_recursive(&floater->node));
 	}
 	json_object_object_add(object, "floating_nodes", floating_array);
 }
 
 static void ipc_json_describe_view(struct sway_container *c, json_object *object) {
 	json_object_object_add(object, "name",
-			c->name ? json_object_new_string(c->name) : NULL);
+			c->title ? json_object_new_string(c->title) : NULL);
 	json_object_object_add(object, "type", json_object_new_string("con"));
 
-	if (c->type == C_VIEW) {
-		const char *app_id = view_get_app_id(c->sway_view);
+	if (c->view) {
+		const char *app_id = view_get_app_id(c->view);
 		json_object_object_add(object, "app_id",
 				app_id ? json_object_new_string(app_id) : NULL);
 
-		const char *class = view_get_class(c->sway_view);
+		const char *class = view_get_class(c->view);
 		json_object_object_add(object, "class",
 				class ? json_object_new_string(class) : NULL);
 	}
 
-	if (c->parent) {
-		json_object_object_add(object, "layout",
-			json_object_new_string(ipc_json_layout_description(c->layout)));
-	}
+	json_object_object_add(object, "layout",
+		json_object_new_string(ipc_json_layout_description(c->layout)));
 
-	bool urgent = c->type == C_VIEW ?
-		view_is_urgent(c->sway_view) : container_has_urgent_child(c);
+	bool urgent = c->view ?
+		view_is_urgent(c->view) : container_has_urgent_child(c);
 	json_object_object_add(object, "urgent", json_object_new_boolean(urgent));
 
-	if (c->type == C_VIEW) {
+	if (c->view) {
 		json_object *marks = json_object_new_array();
-		list_t *view_marks = c->sway_view->marks;
+		list_t *view_marks = c->view->marks;
 		for (int i = 0; i < view_marks->length; ++i) {
 			json_object_array_add(marks, json_object_new_string(view_marks->items[i]));
 		}
@@ -222,64 +204,97 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	}
 }
 
-static void focus_inactive_children_iterator(struct sway_container *c, void *data) {
-	json_object *focus = data;
-	json_object_array_add(focus, json_object_new_int(c->id));
+struct focus_inactive_data {
+	struct sway_node *node;
+	json_object *object;
+};
+
+static void focus_inactive_children_iterator(struct sway_node *node,
+		void *_data) {
+	struct focus_inactive_data *data = _data;
+	if (node_get_parent(node) == data->node) {
+		json_object_array_add(data->object, json_object_new_int(node->id));
+	}
 }
 
-json_object *ipc_json_describe_container(struct sway_container *c) {
-	if (!(sway_assert(c, "Container must not be null."))) {
-		return NULL;
-	}
-
+json_object *ipc_json_describe_node(struct sway_node *node) {
 	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
-	bool focused = seat_get_focus(seat) == c;
+	bool focused = seat_get_focus(seat) == node;
 
 	json_object *object = json_object_new_object();
+	char *name = node_get_name(node);
 
-	json_object_object_add(object, "id", json_object_new_int((int)c->id));
+	struct wlr_box box;
+	node_get_box(node, &box);
+	json_object_object_add(object, "id", json_object_new_int((int)node->id));
 	json_object_object_add(object, "name",
-			c->name ? json_object_new_string(c->name) : NULL);
-	json_object_object_add(object, "rect", ipc_json_create_rect(c));
-	json_object_object_add(object, "focused",
-			json_object_new_boolean(focused));
+			name ? json_object_new_string(name) : NULL);
+	json_object_object_add(object, "rect", ipc_json_create_rect(&box));
+	json_object_object_add(object, "focused", json_object_new_boolean(focused));
 
 	json_object *focus = json_object_new_array();
-	seat_focus_inactive_children_for_each(seat, c,
-		focus_inactive_children_iterator, focus);
+	struct focus_inactive_data data = {
+		.node = node,
+		.object = focus,
+	};
+	seat_for_each_node(seat, focus_inactive_children_iterator, &data);
 	json_object_object_add(object, "focus", focus);
 
-	switch (c->type) {
-	case C_ROOT:
-		ipc_json_describe_root(c, object);
+	switch (node->type) {
+	case N_ROOT:
+		ipc_json_describe_root(root, object);
 		break;
-	case C_OUTPUT:
-		ipc_json_describe_output(c, object);
+	case N_OUTPUT:
+		ipc_json_describe_output(node->sway_output, object);
 		break;
-	case C_CONTAINER:
-	case C_VIEW:
-		ipc_json_describe_view(c, object);
+	case N_CONTAINER:
+		ipc_json_describe_view(node->sway_container, object);
 		break;
-	case C_WORKSPACE:
-		ipc_json_describe_workspace(c, object);
-		break;
-	case C_TYPES:
-	default:
+	case N_WORKSPACE:
+		ipc_json_describe_workspace(node->sway_workspace, object);
 		break;
 	}
 
 	return object;
 }
 
-json_object *ipc_json_describe_container_recursive(struct sway_container *c) {
-	json_object *object = ipc_json_describe_container(c);
+json_object *ipc_json_describe_node_recursive(struct sway_node *node) {
+	json_object *object = ipc_json_describe_node(node);
 	int i;
 
 	json_object *children = json_object_new_array();
-	if (c->type != C_VIEW && c->children) {
-		for (i = 0; i < c->children->length; ++i) {
-			json_object_array_add(children, ipc_json_describe_container_recursive(c->children->items[i]));
+	switch (node->type) {
+	case N_ROOT:
+		for (i = 0; i < root->outputs->length; ++i) {
+			struct sway_output *output = root->outputs->items[i];
+			json_object_array_add(children,
+					ipc_json_describe_node_recursive(&output->node));
 		}
+		break;
+	case N_OUTPUT:
+		for (i = 0; i < node->sway_output->workspaces->length; ++i) {
+			struct sway_workspace *ws = node->sway_output->workspaces->items[i];
+			json_object_array_add(children,
+					ipc_json_describe_node_recursive(&ws->node));
+		}
+		break;
+	case N_WORKSPACE:
+		for (i = 0; i < node->sway_workspace->tiling->length; ++i) {
+			struct sway_container *con = node->sway_workspace->tiling->items[i];
+			json_object_array_add(children,
+					ipc_json_describe_node_recursive(&con->node));
+		}
+		break;
+	case N_CONTAINER:
+		if (node->sway_container->children) {
+			for (i = 0; i < node->sway_container->children->length; ++i) {
+				struct sway_container *child =
+					node->sway_container->children->items[i];
+				json_object_array_add(children,
+						ipc_json_describe_node_recursive(&child->node));
+			}
+		}
+		break;
 	}
 	json_object_object_add(object, "nodes", children);
 
@@ -329,7 +344,7 @@ json_object *ipc_json_describe_seat(struct sway_seat *seat) {
 	}
 
 	json_object *object = json_object_new_object();
-	struct sway_container *focus = seat_get_focus(seat);
+	struct sway_node *focus = seat_get_focus(seat);
 
 	json_object_object_add(object, "name",
 		json_object_new_string(seat->wlr_seat->name));
@@ -470,13 +485,13 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	json_object_object_add(json, "colors", colors);
 
 	// Add outputs if defined
+	json_object *outputs = json_object_new_array();
 	if (bar->outputs && bar->outputs->length > 0) {
-		json_object *outputs = json_object_new_array();
 		for (int i = 0; i < bar->outputs->length; ++i) {
 			const char *name = bar->outputs->items[i];
 			json_object_array_add(outputs, json_object_new_string(name));
 		}
-		json_object_object_add(json, "outputs", outputs);
 	}
+	json_object_object_add(json, "outputs", outputs);
 	return json;
 }

--- a/sway/main.c
+++ b/sway/main.c
@@ -42,7 +42,6 @@ void sway_terminate(int exit_code) {
 }
 
 void sig_handler(int signal) {
-	//close_views(&root_container);
 	sway_terminate(EXIT_SUCCESS);
 }
 
@@ -395,7 +394,7 @@ int main(int argc, char **argv) {
 
 	wlr_log(WLR_INFO, "Starting sway version " SWAY_VERSION);
 
-	root_create();
+	root = root_create();
 
 	if (!server_init(&server)) {
 		return 1;
@@ -450,7 +449,8 @@ int main(int argc, char **argv) {
 	wlr_log(WLR_INFO, "Shutting down sway");
 
 	server_fini(&server);
-	root_destroy();
+	root_destroy(root);
+	root = NULL;
 
 	if (config) {
 		free_config(config);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -151,6 +151,7 @@ sway_sources = files(
 
 	'tree/arrange.c',
 	'tree/container.c',
+	'tree/node.c',
 	'tree/root.c',
 	'tree/view.c',
 	'tree/workspace.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -61,8 +61,7 @@ bool server_init(struct sway_server *server) {
 	server->new_output.notify = handle_new_output;
 	wl_signal_add(&server->backend->events.new_output, &server->new_output);
 
-	wlr_xdg_output_manager_create(server->wl_display,
-			root_container.sway_root->output_layout);
+	wlr_xdg_output_manager_create(server->wl_display, root->output_layout);
 
 	server->idle = wlr_idle_create(server->wl_display);
 	server->idle_inhibit_manager_v1 =
@@ -131,7 +130,7 @@ bool server_init(struct sway_server *server) {
 		server->txn_timeout_ms = 200;
 	}
 
-	server->dirty_containers = create_list();
+	server->dirty_nodes = create_list();
 	server->transactions = create_list();
 
 	input_manager = input_manager_create(server);
@@ -145,7 +144,7 @@ void server_fini(struct sway_server *server) {
 #endif
 	wl_display_destroy_clients(server->wl_display);
 	wl_display_destroy(server->wl_display);
-	list_free(server->dirty_containers);
+	list_free(server->dirty_nodes);
 	list_free(server->transactions);
 }
 

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -217,8 +217,8 @@ void arrange_workspace(struct sway_workspace *workspace) {
 			workspace->x, workspace->y);
 	if (workspace->fullscreen) {
 		struct sway_container *fs = workspace->fullscreen;
-		fs->x = output->wlr_output->lx;
-		fs->y = output->wlr_output->ly;
+		fs->x = output->lx;
+		fs->y = output->ly;
 		fs->width = output->width;
 		fs->height = output->height;
 		arrange_container(fs);
@@ -234,8 +234,13 @@ void arrange_output(struct sway_output *output) {
 	if (config->reloading) {
 		return;
 	}
-	// Outputs have no pending x/y/width/height,
-	// so all we do here is arrange the workspaces.
+	const struct wlr_box *output_box = wlr_output_layout_get_box(
+			root->output_layout, output->wlr_output);
+	output->lx = output_box->x;
+	output->ly = output_box->y;
+	output->width = output_box->width;
+	output->height = output_box->height;
+
 	for (int i = 0; i < output->workspaces->length; ++i) {
 		struct sway_workspace *workspace = output->workspaces->items[i];
 		arrange_workspace(workspace);

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -166,29 +166,23 @@ void arrange_container(struct sway_container *container) {
 	if (config->reloading) {
 		return;
 	}
-	if (container->type == C_VIEW) {
-		view_autoconfigure(container->sway_view);
-		container_set_dirty(container);
-		return;
-	}
-	if (!sway_assert(container->type == C_CONTAINER, "Expected a container")) {
+	if (container->view) {
+		view_autoconfigure(container->view);
+		node_set_dirty(&container->node);
 		return;
 	}
 	struct wlr_box box;
 	container_get_box(container, &box);
 	arrange_children(container->children, container->layout, &box);
-	container_set_dirty(container);
+	node_set_dirty(&container->node);
 }
 
-void arrange_workspace(struct sway_container *workspace) {
+void arrange_workspace(struct sway_workspace *workspace) {
 	if (config->reloading) {
 		return;
 	}
-	if (!sway_assert(workspace->type == C_WORKSPACE, "Expected a workspace")) {
-		return;
-	}
-	struct sway_container *output = workspace->parent;
-	struct wlr_box *area = &output->sway_output->usable_area;
+	struct sway_output *output = workspace->output;
+	struct wlr_box *area = &output->usable_area;
 	wlr_log(WLR_DEBUG, "Usable area for ws: %dx%d@%d,%d",
 			area->width, area->height, area->x, area->y);
 	workspace_remove_gaps(workspace);
@@ -197,21 +191,20 @@ void arrange_workspace(struct sway_container *workspace) {
 	double prev_y = workspace->y;
 	workspace->width = area->width;
 	workspace->height = area->height;
-	workspace->x = output->x + area->x;
-	workspace->y = output->y + area->y;
+	workspace->x = output->wlr_output->lx + area->x;
+	workspace->y = output->wlr_output->ly + area->y;
 
 	// Adjust any floating containers
 	double diff_x = workspace->x - prev_x;
 	double diff_y = workspace->y - prev_y;
 	if (diff_x != 0 || diff_y != 0) {
-		for (int i = 0; i < workspace->sway_workspace->floating->length; ++i) {
-			struct sway_container *floater =
-				workspace->sway_workspace->floating->items[i];
+		for (int i = 0; i < workspace->floating->length; ++i) {
+			struct sway_container *floater = workspace->floating->items[i];
 			container_floating_translate(floater, diff_x, diff_y);
 			double center_x = floater->x + floater->width / 2;
 			double center_y = floater->y + floater->height / 2;
 			struct wlr_box workspace_box;
-			container_get_box(workspace, &workspace_box);
+			workspace_get_box(workspace, &workspace_box);
 			if (!wlr_box_contains_point(&workspace_box, center_x, center_y)) {
 				container_floating_move_to_center(floater);
 			}
@@ -219,43 +212,32 @@ void arrange_workspace(struct sway_container *workspace) {
 	}
 
 	workspace_add_gaps(workspace);
-	container_set_dirty(workspace);
+	node_set_dirty(&workspace->node);
 	wlr_log(WLR_DEBUG, "Arranging workspace '%s' at %f, %f", workspace->name,
 			workspace->x, workspace->y);
-	if (workspace->sway_workspace->fullscreen) {
-		struct sway_container *fs = workspace->sway_workspace->fullscreen;
-		fs->x = workspace->parent->x;
-		fs->y = workspace->parent->y;
-		fs->width = workspace->parent->width;
-		fs->height = workspace->parent->height;
+	if (workspace->fullscreen) {
+		struct sway_container *fs = workspace->fullscreen;
+		fs->x = output->wlr_output->lx;
+		fs->y = output->wlr_output->ly;
+		fs->width = output->wlr_output->width;
+		fs->height = output->wlr_output->height;
 		arrange_container(fs);
 	} else {
 		struct wlr_box box;
-		container_get_box(workspace, &box);
-		arrange_children(workspace->children, workspace->layout, &box);
-		arrange_floating(workspace->sway_workspace->floating);
+		workspace_get_box(workspace, &box);
+		arrange_children(workspace->tiling, workspace->layout, &box);
+		arrange_floating(workspace->floating);
 	}
 }
 
-void arrange_output(struct sway_container *output) {
+void arrange_output(struct sway_output *output) {
 	if (config->reloading) {
 		return;
 	}
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return;
-	}
-	const struct wlr_box *output_box = wlr_output_layout_get_box(
-			root_container.sway_root->output_layout,
-			output->sway_output->wlr_output);
-	output->x = output_box->x;
-	output->y = output_box->y;
-	output->width = output_box->width;
-	output->height = output_box->height;
-	container_set_dirty(output);
-	wlr_log(WLR_DEBUG, "Arranging output '%s' at %f,%f",
-			output->name, output->x, output->y);
-	for (int i = 0; i < output->children->length; ++i) {
-		struct sway_container *workspace = output->children->items[i];
+	// Outputs have no pending x/y/width/height,
+	// so all we do here is arrange the workspaces.
+	for (int i = 0; i < output->workspaces->length; ++i) {
+		struct sway_workspace *workspace = output->workspaces->items[i];
 		arrange_workspace(workspace);
 	}
 }
@@ -264,37 +246,31 @@ void arrange_root(void) {
 	if (config->reloading) {
 		return;
 	}
-	struct wlr_output_layout *output_layout =
-		root_container.sway_root->output_layout;
 	const struct wlr_box *layout_box =
-		wlr_output_layout_get_box(output_layout, NULL);
-	root_container.x = layout_box->x;
-	root_container.y = layout_box->y;
-	root_container.width = layout_box->width;
-	root_container.height = layout_box->height;
-	container_set_dirty(&root_container);
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *output = root_container.children->items[i];
+		wlr_output_layout_get_box(root->output_layout, NULL);
+	root->x = layout_box->x;
+	root->y = layout_box->y;
+	root->width = layout_box->width;
+	root->height = layout_box->height;
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
 		arrange_output(output);
 	}
 }
 
-void arrange_windows(struct sway_container *container) {
-	switch (container->type) {
-	case C_ROOT:
+void arrange_node(struct sway_node *node) {
+	switch (node->type) {
+	case N_ROOT:
 		arrange_root();
 		break;
-	case C_OUTPUT:
-		arrange_output(container);
+	case N_OUTPUT:
+		arrange_output(node->sway_output);
 		break;
-	case C_WORKSPACE:
-		arrange_workspace(container);
+	case N_WORKSPACE:
+		arrange_workspace(node->sway_workspace);
 		break;
-	case C_CONTAINER:
-	case C_VIEW:
-		arrange_container(container);
-		break;
-	case C_TYPES:
+	case N_CONTAINER:
+		arrange_container(node->sway_container);
 		break;
 	}
 }

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -219,8 +219,8 @@ void arrange_workspace(struct sway_workspace *workspace) {
 		struct sway_container *fs = workspace->fullscreen;
 		fs->x = output->wlr_output->lx;
 		fs->y = output->wlr_output->ly;
-		fs->width = output->wlr_output->width;
-		fs->height = output->wlr_output->height;
+		fs->width = output->width;
+		fs->height = output->height;
 		arrange_container(fs);
 	} else {
 		struct wlr_box box;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1116,9 +1116,11 @@ void container_detach(struct sway_container *child) {
 	struct sway_container *old_parent = child->parent;
 	struct sway_workspace *old_workspace = child->workspace;
 	list_t *siblings = container_get_siblings(child);
-	int index = list_find(siblings, child);
-	if (index != -1) {
-		list_del(siblings, index);
+	if (siblings) {
+		int index = list_find(siblings, child);
+		if (index != -1) {
+			list_del(siblings, index);
+		}
 	}
 	child->parent = NULL;
 	child->workspace = NULL;
@@ -1127,7 +1129,7 @@ void container_detach(struct sway_container *child) {
 	if (old_parent) {
 		container_update_representation(old_parent);
 		node_set_dirty(&old_parent->node);
-	} else {
+	} else if (old_workspace) {
 		workspace_update_representation(old_workspace);
 		node_set_dirty(&old_workspace->node);
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1148,6 +1148,8 @@ struct sway_container *container_split(struct sway_container *child,
 	struct sway_container *cont = container_create(NULL);
 	cont->width = child->width;
 	cont->height = child->height;
+	cont->x = child->x;
+	cont->y = child->y;
 	cont->current_gaps = child->current_gaps;
 	cont->layout = layout;
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1079,13 +1079,13 @@ void container_insert_child(struct sway_container *parent,
 }
 
 void container_add_sibling(struct sway_container *fixed,
-		struct sway_container *active, int offset) {
+		struct sway_container *active) {
 	if (active->workspace) {
 		container_detach(active);
 	}
 	list_t *siblings = container_get_siblings(fixed);
 	int index = list_find(siblings, fixed);
-	list_insert(siblings, index + offset, active);
+	list_insert(siblings, index + 1, active);
 	active->parent = fixed->parent;
 	active->workspace = fixed->workspace;
 	container_for_each_child(active, set_workspace, NULL);
@@ -1136,7 +1136,7 @@ void container_detach(struct sway_container *child) {
 
 void container_replace(struct sway_container *container,
 		struct sway_container *replacement) {
-	container_add_sibling(container, replacement, 1);
+	container_add_sibling(container, replacement);
 	container_detach(container);
 }
 

--- a/sway/tree/node.c
+++ b/sway/tree/node.c
@@ -1,0 +1,151 @@
+#define _POSIX_C_SOURCE 200809L
+#include "sway/output.h"
+#include "sway/server.h"
+#include "sway/tree/container.h"
+#include "sway/tree/node.h"
+#include "sway/tree/root.h"
+#include "sway/tree/workspace.h"
+#include "log.h"
+
+void node_init(struct sway_node *node, enum sway_node_type type, void *thing) {
+	static size_t next_id = 1;
+	node->id = next_id++;
+	node->type = type;
+	node->sway_root = thing;
+	wl_signal_init(&node->events.destroy);
+}
+
+const char *node_type_to_str(enum sway_node_type type) {
+	switch (type) {
+	case N_ROOT:
+		return "N_ROOT";
+	case N_OUTPUT:
+		return "N_OUTPUT";
+	case N_WORKSPACE:
+		return "N_WORKSPACE";
+	case N_CONTAINER:
+		return "N_CONTAINER";
+	}
+	return "";
+}
+
+void node_set_dirty(struct sway_node *node) {
+	if (node->dirty) {
+		return;
+	}
+	node->dirty = true;
+	list_add(server.dirty_nodes, node);
+}
+
+bool node_is_view(struct sway_node *node) {
+	return node->type == N_CONTAINER && node->sway_container->view;
+}
+
+char *node_get_name(struct sway_node *node) {
+	switch (node->type) {
+	case N_ROOT:
+		return "root";
+	case N_OUTPUT:
+		return node->sway_output->wlr_output->name;
+	case N_WORKSPACE:
+		return node->sway_workspace->name;
+	case N_CONTAINER:
+		return node->sway_container->title;
+	}
+	return NULL;
+}
+
+void node_get_box(struct sway_node *node, struct wlr_box *box) {
+	switch (node->type) {
+	case N_ROOT:
+		root_get_box(root, box);
+		break;
+	case N_OUTPUT:
+		output_get_box(node->sway_output, box);
+		break;
+	case N_WORKSPACE:
+		workspace_get_box(node->sway_workspace, box);
+		break;
+	case N_CONTAINER:
+		container_get_box(node->sway_container, box);
+		break;
+	}
+}
+
+struct sway_output *node_get_output(struct sway_node *node) {
+	switch (node->type) {
+	case N_CONTAINER:
+		return node->sway_container->workspace->output;
+	case N_WORKSPACE:
+		return node->sway_workspace->output;
+	case N_OUTPUT:
+		return node->sway_output;
+	case N_ROOT:
+		return NULL;
+	}
+	return NULL;
+}
+
+enum sway_container_layout node_get_layout(struct sway_node *node) {
+	switch (node->type) {
+	case N_CONTAINER:
+		return node->sway_container->layout;
+	case N_WORKSPACE:
+		return node->sway_workspace->layout;
+	case N_OUTPUT:
+	case N_ROOT:
+		return L_NONE;
+	}
+	return L_NONE;
+}
+
+struct sway_node *node_get_parent(struct sway_node *node) {
+	switch (node->type) {
+	case N_CONTAINER: {
+			struct sway_container *con = node->sway_container;
+			if (con->parent) {
+				return &con->parent->node;
+			}
+			if (con->workspace) {
+				return &con->workspace->node;
+			}
+		}
+		return NULL;
+	case N_WORKSPACE: {
+			struct sway_workspace *ws = node->sway_workspace;
+			if (ws->output) {
+				return &ws->output->node;
+			}
+		}
+		return NULL;
+	case N_OUTPUT:
+		return &root->node;
+	case N_ROOT:
+		return NULL;
+	}
+	return NULL;
+}
+
+list_t *node_get_children(struct sway_node *node) {
+	switch (node->type) {
+	case N_CONTAINER:
+		return node->sway_container->children;
+	case N_WORKSPACE:
+		return node->sway_workspace->tiling;
+	case N_OUTPUT:
+	case N_ROOT:
+		return NULL;
+	}
+	return NULL;
+}
+
+bool node_has_ancestor(struct sway_node *node, struct sway_node *ancestor) {
+	struct sway_node *parent = node_get_parent(node);
+	while (parent) {
+		if (parent == ancestor) {
+			return true;
+		}
+		parent = node_get_parent(parent);
+	}
+	return false;
+}

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -253,9 +253,6 @@ struct output_config *output_find_config(struct sway_output *output) {
 		oc = all;
 	}
 
-	if (oc && !oc->enabled) {
-		return NULL;
-	}
 	return oc;
 }
 

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -2,28 +2,31 @@
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
+#include <wlr/types/wlr_output_damage.h>
 #include "sway/ipc-server.h"
+#include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/output.h"
 #include "sway/tree/workspace.h"
 #include "log.h"
+#include "util.h"
 
-static void restore_workspaces(struct sway_container *output) {
+static void restore_workspaces(struct sway_output *output) {
 	// Workspace output priority
-	for (int i = 0; i < root_container.children->length; i++) {
-		struct sway_container *other = root_container.children->items[i];
+	for (int i = 0; i < root->outputs->length; i++) {
+		struct sway_output *other = root->outputs->items[i];
 		if (other == output) {
 			continue;
 		}
 
-		for (int j = 0; j < other->children->length; j++) {
-			struct sway_container *ws = other->children->items[j];
-			struct sway_container *highest =
+		for (int j = 0; j < other->workspaces->length; j++) {
+			struct sway_workspace *ws = other->workspaces->items[j];
+			struct sway_output *highest =
 				workspace_output_get_highest_available(ws, NULL);
 			if (highest == output) {
-				container_remove_child(ws);
-				container_add_child(output, ws);
+				workspace_detach(ws);
+				output_add_workspace(output, ws);
 				ipc_event_workspace(NULL, ws, "move");
 				j--;
 			}
@@ -31,22 +34,197 @@ static void restore_workspaces(struct sway_container *output) {
 	}
 
 	// Saved workspaces
-	list_t *saved = root_container.sway_root->saved_workspaces;
-	for (int i = 0; i < saved->length; ++i) {
-		struct sway_container *ws = saved->items[i];
-		container_add_child(output, ws);
+	for (int i = 0; i < root->saved_workspaces->length; ++i) {
+		struct sway_workspace *ws = root->saved_workspaces->items[i];
+		output_add_workspace(output, ws);
 		ipc_event_workspace(NULL, ws, "move");
 	}
-	saved->length = 0;
+	root->saved_workspaces->length = 0;
 
 	output_sort_workspaces(output);
 }
 
-struct sway_container *output_create(
-		struct sway_output *sway_output) {
-	const char *name = sway_output->wlr_output->name;
+struct sway_output *output_create(struct wlr_output *wlr_output) {
+	struct sway_output *output = calloc(1, sizeof(struct sway_output));
+	node_init(&output->node, N_OUTPUT, output);
+	output->wlr_output = wlr_output;
+	wlr_output->data = output;
+
+	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
+
+	wl_list_insert(&root->all_outputs, &output->link);
+
+	if (!wl_list_empty(&wlr_output->modes)) {
+		struct wlr_output_mode *mode =
+			wl_container_of(wlr_output->modes.prev, mode, link);
+		wlr_output_set_mode(wlr_output, mode);
+	}
+
+	output->workspaces = create_list();
+	output->current.workspaces = create_list();
+
+	return output;
+}
+
+void output_enable(struct sway_output *output, struct output_config *oc) {
+	if (!sway_assert(!output->enabled, "output is already enabled")) {
+		return;
+	}
+	struct wlr_output *wlr_output = output->wlr_output;
+	output->enabled = true;
+	apply_output_config(oc, output);
+	list_add(root->outputs, output);
+
+	restore_workspaces(output);
+
+	if (!output->workspaces->length) {
+		// Create workspace
+		char *ws_name = workspace_next_name(wlr_output->name);
+		wlr_log(WLR_DEBUG, "Creating default workspace %s", ws_name);
+		struct sway_workspace *ws = workspace_create(output, ws_name);
+		// Set each seat's focus if not already set
+		struct sway_seat *seat = NULL;
+		wl_list_for_each(seat, &input_manager->seats, link) {
+			if (!seat->has_focus) {
+				seat_set_focus(seat, &ws->node);
+			}
+		}
+		free(ws_name);
+	}
+
+	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
+	for (size_t i = 0; i < len; ++i) {
+		wl_list_init(&output->layers[i]);
+	}
+	wl_signal_init(&output->events.destroy);
+
+	input_manager_configure_xcursor(input_manager);
+
+	wl_signal_add(&wlr_output->events.mode, &output->mode);
+	wl_signal_add(&wlr_output->events.transform, &output->transform);
+	wl_signal_add(&wlr_output->events.scale, &output->scale);
+	wl_signal_add(&output->damage->events.frame, &output->damage_frame);
+	wl_signal_add(&output->damage->events.destroy, &output->damage_destroy);
+
+	output_add_listeners(output);
+
+	wl_signal_emit(&root->events.new_node, &output->node);
+
+	load_swaybars();
+
+	arrange_layers(output);
+	arrange_root();
+}
+
+static void output_evacuate(struct sway_output *output) {
+	if (!output->workspaces->length) {
+		return;
+	}
+	struct sway_output *fallback_output = NULL;
+	if (root->outputs->length > 1) {
+		fallback_output = root->outputs->items[0];
+		if (fallback_output == output) {
+			fallback_output = root->outputs->items[1];
+		}
+	}
+
+	while (output->workspaces->length) {
+		struct sway_workspace *workspace = output->workspaces->items[0];
+
+		workspace_detach(workspace);
+
+		if (workspace_is_empty(workspace)) {
+			workspace_begin_destroy(workspace);
+			continue;
+		}
+
+		struct sway_output *new_output =
+			workspace_output_get_highest_available(workspace, output);
+		if (!new_output) {
+			new_output = fallback_output;
+		}
+
+		if (new_output) {
+			workspace_output_add_priority(workspace, new_output);
+			output_add_workspace(new_output, workspace);
+			output_sort_workspaces(new_output);
+			ipc_event_workspace(NULL, workspace, "move");
+		} else {
+			list_add(root->saved_workspaces, workspace);
+		}
+	}
+}
+
+void output_destroy(struct sway_output *output) {
+	if (!sway_assert(output->node.destroying,
+				"Tried to free output which wasn't marked as destroying")) {
+		return;
+	}
+	if (!sway_assert(output->wlr_output == NULL,
+				"Tried to free output which still had a wlr_output")) {
+		return;
+	}
+	if (!sway_assert(output->node.ntxnrefs == 0, "Tried to free output "
+				"which is still referenced by transactions")) {
+		return;
+	}
+	list_free(output->workspaces);
+	list_free(output->current.workspaces);
+	free(output);
+}
+
+static void untrack_output(struct sway_container *con, void *data) {
+	struct sway_output *output = data;
+	int index = list_find(con->outputs, output);
+	if (index != -1) {
+		list_del(con->outputs, index);
+	}
+}
+
+void output_disable(struct sway_output *output) {
+	if (!sway_assert(output->enabled, "Expected an enabled output")) {
+		return;
+	}
+	wlr_log(WLR_DEBUG, "Disabling output '%s'", output->wlr_output->name);
+	wl_signal_emit(&output->events.destroy, output);
+
+	output_evacuate(output);
+
+	root_for_each_container(untrack_output, output);
+
+	int index = list_find(root->outputs, output);
+	list_del(root->outputs, index);
+
+	wl_list_remove(&output->mode.link);
+	wl_list_remove(&output->transform.link);
+	wl_list_remove(&output->scale.link);
+	wl_list_remove(&output->damage_destroy.link);
+	wl_list_remove(&output->damage_frame.link);
+
+	output->enabled = false;
+
+	arrange_root();
+}
+
+void output_begin_destroy(struct sway_output *output) {
+	if (!sway_assert(!output->enabled, "Expected a disabled output")) {
+		return;
+	}
+	wlr_log(WLR_DEBUG, "Destroying output '%s'", output->wlr_output->name);
+
+	output->node.destroying = true;
+	node_set_dirty(&output->node);
+
+	wl_list_remove(&output->link);
+	wl_list_remove(&output->destroy.link);
+	output->wlr_output->data = NULL;
+	output->wlr_output = NULL;
+}
+
+struct output_config *output_find_config(struct sway_output *output) {
+	const char *name = output->wlr_output->name;
 	char identifier[128];
-	output_get_identifier(identifier, sizeof(identifier), sway_output);
+	output_get_identifier(identifier, sizeof(identifier), output);
 
 	struct output_config *oc = NULL, *all = NULL;
 	for (int i = 0; i < config->output_configs->length; ++i) {
@@ -73,189 +251,61 @@ struct sway_container *output_create(
 	if (oc && !oc->enabled) {
 		return NULL;
 	}
+	return oc;
+}
 
-	struct sway_container *output = container_create(C_OUTPUT);
-	output->sway_output = sway_output;
-	output->name = strdup(name);
-	if (output->name == NULL) {
-		output_begin_destroy(output);
+struct sway_output *output_from_wlr_output(struct wlr_output *output) {
+	return output->data;
+}
+
+struct sway_output *output_get_in_direction(struct sway_output *reference,
+		enum movement_direction direction) {
+	enum wlr_direction wlr_dir = 0;
+	if (!sway_assert(sway_dir_to_wlr(direction, &wlr_dir),
+				"got invalid direction: %d", direction)) {
 		return NULL;
 	}
-
-	apply_output_config(oc, output);
-	container_add_child(&root_container, output);
-	load_swaybars();
-
-	struct wlr_box size;
-	wlr_output_effective_resolution(sway_output->wlr_output, &size.width,
-		&size.height);
-	output->width = size.width;
-	output->height = size.height;
-
-	restore_workspaces(output);
-
-	if (!output->children->length) {
-		// Create workspace
-		char *ws_name = workspace_next_name(output->name);
-		wlr_log(WLR_DEBUG, "Creating default workspace %s", ws_name);
-		struct sway_container *ws = workspace_create(output, ws_name);
-		// Set each seat's focus if not already set
-		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &input_manager->seats, link) {
-			if (!seat->has_focus) {
-				seat_set_focus(seat, ws);
-			}
-		}
-		free(ws_name);
-	}
-
-	container_create_notify(output);
-	return output;
-}
-
-static void output_evacuate(struct sway_container *output) {
-	if (!output->children->length) {
-		return;
-	}
-	struct sway_container *fallback_output = NULL;
-	if (root_container.children->length > 1) {
-		fallback_output = root_container.children->items[0];
-		if (fallback_output == output) {
-			fallback_output = root_container.children->items[1];
-		}
-	}
-
-	while (output->children->length) {
-		struct sway_container *workspace = output->children->items[0];
-
-		container_remove_child(workspace);
-
-		if (workspace_is_empty(workspace)) {
-			workspace_begin_destroy(workspace);
-			continue;
-		}
-
-		struct sway_container *new_output =
-			workspace_output_get_highest_available(workspace, output);
-		if (!new_output) {
-			new_output = fallback_output;
-		}
-
-		if (new_output) {
-			workspace_output_add_priority(workspace, new_output);
-			container_add_child(new_output, workspace);
-			output_sort_workspaces(new_output);
-			ipc_event_workspace(NULL, workspace, "move");
-		} else {
-			list_add(root_container.sway_root->saved_workspaces, workspace);
-		}
-	}
-}
-
-void output_destroy(struct sway_container *output) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return;
-	}
-	if (!sway_assert(output->destroying,
-				"Tried to free output which wasn't marked as destroying")) {
-		return;
-	}
-	if (!sway_assert(output->ntxnrefs == 0, "Tried to free output "
-				"which is still referenced by transactions")) {
-		return;
-	}
-	free(output->name);
-	free(output->formatted_title);
-	wlr_texture_destroy(output->title_focused);
-	wlr_texture_destroy(output->title_focused_inactive);
-	wlr_texture_destroy(output->title_unfocused);
-	wlr_texture_destroy(output->title_urgent);
-	list_free(output->children);
-	list_free(output->current.children);
-	list_free(output->outputs);
-	free(output);
-
-	// NOTE: We don't actually destroy the sway_output here
-}
-
-static void untrack_output(struct sway_container *con, void *data) {
-	struct sway_output *output = data;
-	int index = list_find(con->outputs, output);
-	if (index != -1) {
-		list_del(con->outputs, index);
-	}
-}
-
-void output_begin_destroy(struct sway_container *output) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return;
-	}
-	wlr_log(WLR_DEBUG, "OUTPUT: Destroying output '%s'", output->name);
-	wl_signal_emit(&output->events.destroy, output);
-
-	output_evacuate(output);
-
-	output->destroying = true;
-	container_set_dirty(output);
-
-	root_for_each_container(untrack_output, output->sway_output);
-
-	wl_list_remove(&output->sway_output->mode.link);
-	wl_list_remove(&output->sway_output->transform.link);
-	wl_list_remove(&output->sway_output->scale.link);
-	wl_list_remove(&output->sway_output->damage_destroy.link);
-	wl_list_remove(&output->sway_output->damage_frame.link);
-
-	output->sway_output->swayc = NULL;
-	output->sway_output = NULL;
-
-	if (output->parent) {
-		container_remove_child(output);
-	}
-}
-
-struct sway_container *output_from_wlr_output(struct wlr_output *output) {
-	if (output == NULL) {
+	int lx = reference->wlr_output->lx + reference->wlr_output->width / 2;
+	int ly = reference->wlr_output->ly + reference->wlr_output->height / 2;
+	struct wlr_output *wlr_adjacent = wlr_output_layout_adjacent_output(
+			root->output_layout, wlr_dir, reference->wlr_output, lx, ly);
+	if (!wlr_adjacent) {
 		return NULL;
 	}
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *o = root_container.children->items[i];
-		if (o->type == C_OUTPUT && o->sway_output->wlr_output == output) {
-			return o;
-		}
-	}
-	return NULL;
+	return output_from_wlr_output(wlr_adjacent);
 }
 
-void output_for_each_workspace(struct sway_container *output,
-		void (*f)(struct sway_container *con, void *data), void *data) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return;
+void output_add_workspace(struct sway_output *output,
+		struct sway_workspace *workspace) {
+	if (workspace->output) {
+		workspace_detach(workspace);
 	}
-	for (int i = 0; i < output->children->length; ++i) {
-		struct sway_container *workspace = output->children->items[i];
+	list_add(output->workspaces, workspace);
+	workspace->output = output;
+	node_set_dirty(&output->node);
+	node_set_dirty(&workspace->node);
+}
+
+void output_for_each_workspace(struct sway_output *output,
+		void (*f)(struct sway_workspace *ws, void *data), void *data) {
+	for (int i = 0; i < output->workspaces->length; ++i) {
+		struct sway_workspace *workspace = output->workspaces->items[i];
 		f(workspace, data);
 	}
 }
 
-void output_for_each_container(struct sway_container *output,
+void output_for_each_container(struct sway_output *output,
 		void (*f)(struct sway_container *con, void *data), void *data) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return;
-	}
-	for (int i = 0; i < output->children->length; ++i) {
-		struct sway_container *workspace = output->children->items[i];
+	for (int i = 0; i < output->workspaces->length; ++i) {
+		struct sway_workspace *workspace = output->workspaces->items[i];
 		workspace_for_each_container(workspace, f, data);
 	}
 }
 
-struct sway_container *output_find_workspace(struct sway_container *output,
-		bool (*test)(struct sway_container *con, void *data), void *data) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return NULL;
-	}
-	for (int i = 0; i < output->children->length; ++i) {
-		struct sway_container *workspace = output->children->items[i];
+struct sway_workspace *output_find_workspace(struct sway_output *output,
+		bool (*test)(struct sway_workspace *ws, void *data), void *data) {
+	for (int i = 0; i < output->workspaces->length; ++i) {
+		struct sway_workspace *workspace = output->workspaces->items[i];
 		if (test(workspace, data)) {
 			return workspace;
 		}
@@ -263,14 +313,11 @@ struct sway_container *output_find_workspace(struct sway_container *output,
 	return NULL;
 }
 
-struct sway_container *output_find_container(struct sway_container *output,
+struct sway_container *output_find_container(struct sway_output *output,
 		bool (*test)(struct sway_container *con, void *data), void *data) {
-	if (!sway_assert(output->type == C_OUTPUT, "Expected an output")) {
-		return NULL;
-	}
 	struct sway_container *result = NULL;
-	for (int i = 0; i < output->children->length; ++i) {
-		struct sway_container *workspace = output->children->items[i];
+	for (int i = 0; i < output->workspaces->length; ++i) {
+		struct sway_workspace *workspace = output->workspaces->items[i];
 		if ((result = workspace_find_container(workspace, test, data))) {
 			return result;
 		}
@@ -279,8 +326,8 @@ struct sway_container *output_find_container(struct sway_container *output,
 }
 
 static int sort_workspace_cmp_qsort(const void *_a, const void *_b) {
-	struct sway_container *a = *(void **)_a;
-	struct sway_container *b = *(void **)_b;
+	struct sway_workspace *a = *(void **)_a;
+	struct sway_workspace *b = *(void **)_b;
 
 	if (isdigit(a->name[0]) && isdigit(b->name[0])) {
 		int a_num = strtol(a->name, NULL, 10);
@@ -294,6 +341,27 @@ static int sort_workspace_cmp_qsort(const void *_a, const void *_b) {
 	return 0;
 }
 
-void output_sort_workspaces(struct sway_container *output) {
-	list_stable_sort(output->children, sort_workspace_cmp_qsort);
+void output_sort_workspaces(struct sway_output *output) {
+	list_stable_sort(output->workspaces, sort_workspace_cmp_qsort);
+}
+
+void output_get_box(struct sway_output *output, struct wlr_box *box) {
+	box->x = output->wlr_output->lx;
+	box->y = output->wlr_output->ly;
+	box->width = output->wlr_output->width;
+	box->height = output->wlr_output->height;
+}
+
+enum sway_container_layout output_get_default_layout(
+		struct sway_output *output) {
+	if (config->default_layout != L_NONE) {
+		return config->default_layout;
+	}
+	if (config->default_orientation != L_NONE) {
+		return config->default_orientation;
+	}
+	if (output->wlr_output->height > output->wlr_output->width) {
+		return L_VERT;
+	}
+	return L_HORIZ;
 }

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -75,6 +75,11 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	apply_output_config(oc, output);
 	list_add(root->outputs, output);
 
+	output->lx = wlr_output->lx;
+	output->ly = wlr_output->ly;
+	wlr_output_transformed_resolution(wlr_output,
+			&output->width, &output->height);
+
 	restore_workspaces(output);
 
 	if (!output->workspaces->length) {
@@ -265,8 +270,8 @@ struct sway_output *output_get_in_direction(struct sway_output *reference,
 				"got invalid direction: %d", direction)) {
 		return NULL;
 	}
-	int lx = reference->wlr_output->lx + reference->wlr_output->width / 2;
-	int ly = reference->wlr_output->ly + reference->wlr_output->height / 2;
+	int lx = reference->wlr_output->lx + reference->width / 2;
+	int ly = reference->wlr_output->ly + reference->height / 2;
 	struct wlr_output *wlr_adjacent = wlr_output_layout_adjacent_output(
 			root->output_layout, wlr_dir, reference->wlr_output, lx, ly);
 	if (!wlr_adjacent) {
@@ -346,10 +351,10 @@ void output_sort_workspaces(struct sway_output *output) {
 }
 
 void output_get_box(struct sway_output *output, struct wlr_box *box) {
-	box->x = output->wlr_output->lx;
-	box->y = output->wlr_output->ly;
-	box->width = output->wlr_output->width;
-	box->height = output->wlr_output->height;
+	box->x = output->lx;
+	box->y = output->ly;
+	box->width = output->width;
+	box->height = output->height;
 }
 
 enum sway_container_layout output_get_default_layout(
@@ -360,7 +365,7 @@ enum sway_container_layout output_get_default_layout(
 	if (config->default_orientation != L_NONE) {
 		return config->default_orientation;
 	}
-	if (output->wlr_output->height > output->wlr_output->width) {
+	if (output->height > output->width) {
 		return L_VERT;
 	}
 	return L_HORIZ;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -515,7 +515,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 
 	view->container = container_create(view);
 	if (target_sibling) {
-		container_add_sibling(target_sibling, view->container, 1);
+		container_add_sibling(target_sibling, view->container);
 	} else {
 		workspace_add_tiling(ws, view->container);
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1028,7 +1028,9 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 
 	ipc_event_window(view->container, "urgent");
 
-	workspace_detect_urgent(view->container->workspace);
+	if (view->container->workspace) {
+		workspace_detect_urgent(view->container->workspace);
+	}
 }
 
 bool view_is_urgent(struct sway_view *view) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -167,10 +167,10 @@ void view_autoconfigure(struct sway_view *view) {
 	struct sway_output *output = view->container->workspace->output;
 
 	if (view->container->is_fullscreen) {
-		view->x = output->wlr_output->lx;
-		view->y = output->wlr_output->ly;
-		view->width = output->wlr_output->width;
-		view->height = output->wlr_output->height;
+		view->x = output->lx;
+		view->y = output->ly;
+		view->width = output->width;
+		view->height = output->height;
 		return;
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -164,6 +164,10 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 }
 
 void view_autoconfigure(struct sway_view *view) {
+	if (!view->container->workspace) {
+		// Hidden in the scratchpad
+		return;
+	}
 	struct sway_output *output = view->container->workspace->output;
 
 	if (view->container->is_fullscreen) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -33,6 +33,8 @@ void view_init(struct sway_view *view, enum sway_view_type type,
 	view->marks = create_list();
 	view->allow_request_urgent = true;
 	wl_signal_init(&view->events.unmap);
+
+	view->container = container_create(view);
 }
 
 void view_destroy(struct sway_view *view) {
@@ -43,8 +45,8 @@ void view_destroy(struct sway_view *view) {
 				"Tried to free view which wasn't marked as destroying")) {
 		return;
 	}
-	if (!sway_assert(view->swayc == NULL,
-				"Tried to free view which still has a swayc "
+	if (!sway_assert(view->container == NULL,
+				"Tried to free view which still has a container "
 				"(might have a pending transaction?)")) {
 		return;
 	}
@@ -57,6 +59,7 @@ void view_destroy(struct sway_view *view) {
 	wlr_texture_destroy(view->marks_focused_inactive);
 	wlr_texture_destroy(view->marks_unfocused);
 	wlr_texture_destroy(view->marks_urgent);
+	free(view->title_format);
 
 	if (view->impl->destroy) {
 		view->impl->destroy(view);
@@ -65,23 +68,13 @@ void view_destroy(struct sway_view *view) {
 	}
 }
 
-/**
- * The view may or may not be involved in a transaction. For example, a view may
- * unmap then attempt to destroy itself before we've applied the new layout. If
- * an unmapping view is still involved in a transaction then it'll still have a
- * swayc.
- *
- * If there's no transaction we can simply free the view. Otherwise the
- * destroying flag will make the view get freed when the transaction is
- * finished.
- */
 void view_begin_destroy(struct sway_view *view) {
 	if (!sway_assert(view->surface == NULL, "Tried to destroy a mapped view")) {
 		return;
 	}
 	view->destroying = true;
 
-	if (!view->swayc) {
+	if (!view->container) {
 		view_destroy(view);
 	}
 }
@@ -171,30 +164,27 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 }
 
 void view_autoconfigure(struct sway_view *view) {
-	if (!sway_assert(view->swayc,
-				"Called view_autoconfigure() on a view without a swayc")) {
+	struct sway_output *output = view->container->workspace->output;
+
+	if (view->container->is_fullscreen) {
+		view->x = output->wlr_output->lx;
+		view->y = output->wlr_output->ly;
+		view->width = output->wlr_output->width;
+		view->height = output->wlr_output->height;
 		return;
 	}
 
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
+	struct sway_workspace *ws = view->container->workspace;
 
-	if (view->swayc->is_fullscreen) {
-		view->x = output->x;
-		view->y = output->y;
-		view->width = output->width;
-		view->height = output->height;
-		return;
-	}
-
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-
-	int other_views = 0;
+	bool other_views = false;
 	if (config->hide_edge_borders == E_SMART) {
-		struct sway_container *con = view->swayc;
-		while (con != output) {
-			if (con->layout != L_TABBED && con->layout != L_STACKED) {
-				other_views += con->children ? con->children->length - 1 : 0;
-				if (other_views > 0) {
+		struct sway_container *con = view->container;
+		while (con) {
+			enum sway_container_layout layout = container_parent_layout(con);
+			if (layout != L_TABBED && layout != L_STACKED) {
+				list_t *siblings = container_get_siblings(con);
+				if (siblings && siblings->length > 1) {
+					other_views = true;
 					break;
 				}
 			}
@@ -202,7 +192,7 @@ void view_autoconfigure(struct sway_view *view) {
 		}
 	}
 
-	struct sway_container *con = view->swayc;
+	struct sway_container *con = view->container;
 
 	view->border_top = view->border_bottom = true;
 	view->border_left = view->border_right = true;
@@ -228,7 +218,8 @@ void view_autoconfigure(struct sway_view *view) {
 	// In a tabbed or stacked container, the swayc's y is the bottom of the
 	// title area. We have to disable any top border because the title bar is
 	// rendered by the parent.
-	if (con->parent->layout == L_TABBED || con->parent->layout == L_STACKED) {
+	enum sway_container_layout layout = container_parent_layout(con);
+	if (layout == L_TABBED || layout == L_STACKED) {
 		view->border_top = false;
 	} else {
 		y_offset = container_titlebar_height();
@@ -281,13 +272,16 @@ void view_set_activated(struct sway_view *view, bool activated) {
 }
 
 void view_request_activate(struct sway_view *view) {
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+	struct sway_workspace *ws = view->container->workspace;
+	if (!ws) { // hidden scratchpad container
+		return;
+	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 
 	switch (config->focus_on_window_activation) {
 	case FOWA_SMART:
 		if (workspace_is_visible(ws)) {
-			seat_set_focus(seat, view->swayc);
+			seat_set_focus(seat, &view->container->node);
 		} else {
 			view_set_urgent(view, true);
 		}
@@ -296,7 +290,7 @@ void view_request_activate(struct sway_view *view) {
 		view_set_urgent(view, true);
 		break;
 	case FOWA_FOCUS:
-		seat_set_focus(seat, view->swayc);
+		seat_set_focus(seat, &view->container->node);
 		break;
 	case FOWA_NONE:
 		break;
@@ -331,21 +325,10 @@ void view_close_popups(struct sway_view *view) {
 }
 
 void view_damage_from(struct sway_view *view) {
-	for (int i = 0; i < root_container.children->length; ++i) {
-		struct sway_container *cont = root_container.children->items[i];
-		if (cont->type == C_OUTPUT) {
-			output_damage_from_view(cont->sway_output, view);
-		}
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_from_view(output, view);
 	}
-}
-
-static void view_get_layout_box(struct sway_view *view, struct wlr_box *box) {
-	struct sway_container *output = container_parent(view->swayc, C_OUTPUT);
-
-	box->x = output->x + view->swayc->x;
-	box->y = output->y + view->swayc->y;
-	box->width = view->width;
-	box->height = view->height;
 }
 
 void view_for_each_surface(struct sway_view *view,
@@ -396,11 +379,8 @@ static bool view_has_executed_criteria(struct sway_view *view,
 }
 
 void view_execute_criteria(struct sway_view *view) {
-	if (!view->swayc) {
-		return;
-	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *prior_focus = seat_get_focus(seat);
+	struct sway_node *prior_focus = seat_get_focus(seat);
 	list_t *criterias = criteria_for_view(view, CT_COMMAND);
 	for (int i = 0; i < criterias->length; i++) {
 		struct criteria *criteria = criterias->items[i];
@@ -411,7 +391,7 @@ void view_execute_criteria(struct sway_view *view) {
 		}
 		wlr_log(WLR_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
 				criteria->raw, view, criteria->cmdlist);
-		seat_set_focus(seat, view->swayc);
+		seat_set_focus(seat, &view->container->node);
 		list_add(view->executed_criteria, criteria);
 		struct cmd_results *res = execute_command(criteria->cmdlist, NULL);
 		if (res->status != CMD_SUCCESS) {
@@ -423,19 +403,19 @@ void view_execute_criteria(struct sway_view *view) {
 	seat_set_focus(seat, prior_focus);
 }
 
-static struct sway_container *select_workspace(struct sway_view *view) {
+static struct sway_workspace *select_workspace(struct sway_view *view) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 
 	// Check if there's any `assign` criteria for the view
 	list_t *criterias = criteria_for_view(view,
 			CT_ASSIGN_WORKSPACE | CT_ASSIGN_WORKSPACE_NUMBER | CT_ASSIGN_OUTPUT);
-	struct sway_container *ws = NULL;
+	struct sway_workspace *ws = NULL;
 	for (int i = 0; i < criterias->length; ++i) {
 		struct criteria *criteria = criterias->items[i];
 		if (criteria->type == CT_ASSIGN_OUTPUT) {
-			struct sway_container *output = output_by_name(criteria->target);
+			struct sway_output *output = output_by_name(criteria->target);
 			if (output) {
-				ws = seat_get_active_child(seat, output);
+				ws = output_get_active_workspace(output);
 				break;
 			}
 		} else {
@@ -484,20 +464,14 @@ static struct sway_container *select_workspace(struct sway_view *view) {
 	}
 
 	// Use the focused workspace
-	ws = seat_get_focus_inactive(seat, &root_container);
-	if (ws->type != C_WORKSPACE) {
-		ws = container_parent(ws, C_WORKSPACE);
-	}
-	return ws;
+	return seat_get_focused_workspace(seat);
 }
 
 static bool should_focus(struct sway_view *view) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *prev_focus =
-		seat_get_focus_inactive(seat, &root_container);
-	struct sway_container *prev_ws = prev_focus->type == C_WORKSPACE ?
-		prev_focus : container_parent(prev_focus, C_WORKSPACE);
-	struct sway_container *map_ws = container_parent(view->swayc, C_WORKSPACE);
+	struct sway_container *prev_con = seat_get_focused_container(seat);
+	struct sway_workspace *prev_ws = seat_get_focused_workspace(seat);
+	struct sway_workspace *map_ws = view->container->workspace;
 
 	// Views can only take focus if they are mapped into the active workspace
 	if (prev_ws != map_ws) {
@@ -506,10 +480,9 @@ static bool should_focus(struct sway_view *view) {
 
 	// If the view is the only one in the focused workspace, it'll get focus
 	// regardless of any no_focus criteria.
-	struct sway_container *parent = view->swayc->parent;
-	if (parent->type == C_WORKSPACE && prev_focus == parent) {
-		size_t num_children = parent->children->length +
-			parent->sway_workspace->floating->length;
+	if (!view->container->parent && !prev_con) {
+		size_t num_children = view->container->workspace->tiling->length +
+			view->container->workspace->floating->length;
 		if (num_children == 1) {
 			return true;
 		}
@@ -529,16 +502,24 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	view->surface = wlr_surface;
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *ws = select_workspace(view);
-	struct sway_container *target_sibling = seat_get_focus_inactive(seat, ws);
+	struct sway_workspace *ws = select_workspace(view);
+	struct sway_node *node = seat_get_focus_inactive(seat, &ws->node);
+	struct sway_container *target_sibling = node->type == N_CONTAINER ?
+		node->sway_container : NULL;
 
 	// If we're about to launch the view into the floating container, then
 	// launch it as a tiled view in the root of the workspace instead.
-	if (container_is_floating(target_sibling)) {
-		target_sibling = target_sibling->parent;
+	if (target_sibling && container_is_floating(target_sibling)) {
+		target_sibling = NULL;
 	}
 
-	view->swayc = container_view_create(target_sibling, view);
+	view->container = container_create(view);
+	if (target_sibling) {
+		container_add_sibling(target_sibling, view->container, 1);
+	} else {
+		workspace_add_tiling(ws, view->container);
+	}
+	ipc_event_window(view->container, "new");
 
 	view_init_subsurfaces(view, wlr_surface);
 	wl_signal_add(&wlr_surface->events.new_subsurface,
@@ -548,7 +529,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	if (view->impl->wants_floating && view->impl->wants_floating(view)) {
 		view->border = config->floating_border;
 		view->border_thickness = config->floating_border_thickness;
-		container_set_floating(view->swayc, true);
+		container_set_floating(view->container, true);
 	} else {
 		view->border = config->border;
 		view->border_thickness = config->border_thickness;
@@ -556,11 +537,11 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 	}
 
 	if (should_focus(view)) {
-		input_manager_set_focus(input_manager, view->swayc);
+		input_manager_set_focus(input_manager, &view->container->node);
 	}
 
 	view_update_title(view, false);
-	container_notify_subtree_changed(view->swayc->parent);
+	container_update_representation(view->container);
 	view_execute_criteria(view);
 }
 
@@ -574,17 +555,17 @@ void view_unmap(struct sway_view *view) {
 		view->urgent_timer = NULL;
 	}
 
-	bool was_fullscreen = view->swayc->is_fullscreen;
-	struct sway_container *parent = view->swayc->parent;
-	container_begin_destroy(view->swayc);
-	struct sway_container *surviving_ancestor = container_reap_empty(parent);
+	struct sway_container *parent = view->container->parent;
+	struct sway_workspace *ws = view->container->workspace;
+	container_begin_destroy(view->container);
+	if (parent) {
+		container_reap_empty(parent);
+	} else {
+		workspace_consider_destroy(ws);
+	}
 
-	// If the workspace wasn't reaped
-	if (surviving_ancestor && surviving_ancestor->type >= C_WORKSPACE) {
-		struct sway_container *ws = surviving_ancestor->type == C_WORKSPACE ?
-			surviving_ancestor :
-			container_parent(surviving_ancestor, C_WORKSPACE);
-		arrange_windows(was_fullscreen ? ws : surviving_ancestor);
+	if (!ws->node.destroying) {
+		arrange_workspace(ws);
 		workspace_detect_urgent(ws);
 	}
 
@@ -593,15 +574,15 @@ void view_unmap(struct sway_view *view) {
 }
 
 void view_update_size(struct sway_view *view, int width, int height) {
-	if (!sway_assert(container_is_floating(view->swayc),
+	if (!sway_assert(container_is_floating(view->container),
 				"Expected a floating container")) {
 		return;
 	}
 	view->width = width;
 	view->height = height;
-	view->swayc->current.view_width = width;
-	view->swayc->current.view_height = height;
-	container_set_geometry_from_floating_view(view->swayc);
+	view->container->current.view_width = width;
+	view->container->current.view_height = height;
+	container_set_geometry_from_floating_view(view->container);
 }
 
 static void view_subsurface_create(struct sway_view *view,
@@ -670,27 +651,18 @@ void view_child_init(struct sway_view_child *child,
 	wl_signal_add(&view->events.unmap, &child->view_unmap);
 	child->view_unmap.notify = view_child_handle_view_unmap;
 
-	struct sway_container *output = child->view->swayc->parent;
-	if (output != NULL) {
-		if (output->type != C_OUTPUT) {
-			output = container_parent(output, C_OUTPUT);
-		}
-		wlr_surface_send_enter(child->surface, output->sway_output->wlr_output);
-	}
+	struct sway_output *output = child->view->container->workspace->output;
+	wlr_surface_send_enter(child->surface, output->wlr_output);
 
 	view_init_subsurfaces(child->view, surface);
 
 	// TODO: only damage the whole child
-	if (child->view->swayc) {
-		container_damage_whole(child->view->swayc);
-	}
+	container_damage_whole(child->view->container);
 }
 
 void view_child_destroy(struct sway_view_child *child) {
 	// TODO: only damage the whole child
-	if (child->view->swayc) {
-		container_damage_whole(child->view->swayc);
-	}
+	container_damage_whole(child->view->container);
 
 	wl_list_remove(&child->surface_commit.link);
 	wl_list_remove(&child->surface_destroy.link);
@@ -808,22 +780,20 @@ static char *escape_title(char *buffer) {
 }
 
 void view_update_title(struct sway_view *view, bool force) {
-	if (!view->swayc) {
-		return;
-	}
 	const char *title = view_get_title(view);
 
 	if (!force) {
-		if (title && view->swayc->name && strcmp(title, view->swayc->name) == 0) {
+		if (title && view->container->title &&
+				strcmp(title, view->container->title) == 0) {
 			return;
 		}
-		if (!title && !view->swayc->name) {
+		if (!title && !view->container->title) {
 			return;
 		}
 	}
 
-	free(view->swayc->name);
-	free(view->swayc->formatted_title);
+	free(view->container->title);
+	free(view->container->formatted_title);
 	if (title) {
 		size_t len = parse_title_format(view, NULL);
 		char *buffer = calloc(len + 1, sizeof(char));
@@ -836,25 +806,25 @@ void view_update_title(struct sway_view *view, bool force) {
 			buffer = escape_title(buffer);
 		}
 
-		view->swayc->name = strdup(title);
-		view->swayc->formatted_title = buffer;
+		view->container->title = strdup(title);
+		view->container->formatted_title = buffer;
 	} else {
-		view->swayc->name = NULL;
-		view->swayc->formatted_title = NULL;
+		view->container->title = NULL;
+		view->container->formatted_title = NULL;
 	}
-	container_calculate_title_height(view->swayc);
+	container_calculate_title_height(view->container);
 	config_update_font_height(false);
 
 	// Update title after the global font height is updated
-	container_update_title_textures(view->swayc);
+	container_update_title_textures(view->container);
 
-	ipc_event_window(view->swayc, "title");
+	ipc_event_window(view->container, "title");
 }
 
 static bool find_by_mark_iterator(struct sway_container *con,
 		void *data) {
 	char *mark = data;
-	return con->type == C_VIEW && view_has_mark(con->sway_view, mark);
+	return con->view && view_has_mark(con->view, mark);
 }
 
 struct sway_view *view_find_mark(char *mark) {
@@ -863,7 +833,7 @@ struct sway_view *view_find_mark(char *mark) {
 	if (!container) {
 		return NULL;
 	}
-	return container->sway_view;
+	return container->view;
 }
 
 bool view_find_and_unmark(char *mark) {
@@ -872,7 +842,7 @@ bool view_find_and_unmark(char *mark) {
 	if (!container) {
 		return false;
 	}
-	struct sway_view *view = container->sway_view;
+	struct sway_view *view = container->view;
 
 	for (int i = 0; i < view->marks->length; ++i) {
 		char *view_mark = view->marks->items[i];
@@ -888,10 +858,9 @@ bool view_find_and_unmark(char *mark) {
 }
 
 void view_clear_marks(struct sway_view *view) {
-	while (view->marks->length) {
-		list_del(view->marks, 0);
-		ipc_event_window(view->swayc, "mark");
-	}
+	list_foreach(view->marks, free);
+	view->marks->length = 0;
+	ipc_event_window(view->container, "mark");
 }
 
 bool view_has_mark(struct sway_view *view, char *mark) {
@@ -906,12 +875,13 @@ bool view_has_mark(struct sway_view *view, char *mark) {
 
 void view_add_mark(struct sway_view *view, char *mark) {
 	list_add(view->marks, strdup(mark));
-	ipc_event_window(view->swayc, "mark");
+	ipc_event_window(view->container, "mark");
 }
 
 static void update_marks_texture(struct sway_view *view,
 		struct wlr_texture **texture, struct border_colors *class) {
-	struct sway_output *output = container_get_effective_output(view->swayc);
+	struct sway_output *output =
+		container_get_effective_output(view->container);
 	if (!output) {
 		return;
 	}
@@ -949,7 +919,7 @@ static void update_marks_texture(struct sway_view *view,
 
 	double scale = output->wlr_output->scale;
 	int width = 0;
-	int height = view->swayc->title_height * scale;
+	int height = view->container->title_height * scale;
 
 	cairo_t *c = cairo_create(NULL);
 	get_text_size(c, config->font, &width, NULL, scale, false, "%s", buffer);
@@ -994,44 +964,40 @@ void view_update_marks_textures(struct sway_view *view) {
 			&config->border_colors.unfocused);
 	update_marks_texture(view, &view->marks_urgent,
 			&config->border_colors.urgent);
-	container_damage_whole(view->swayc);
+	container_damage_whole(view->container);
 }
 
 bool view_is_visible(struct sway_view *view) {
-	if (!view->swayc || view->swayc->destroying) {
+	if (view->container->node.destroying) {
 		return false;
 	}
-	struct sway_container *workspace =
-		container_parent(view->swayc, C_WORKSPACE);
+	struct sway_workspace *workspace = view->container->workspace;
 	if (!workspace) {
 		return false;
 	}
-	// Determine if view is nested inside a floating container which is sticky.
-	// A simple floating view will have this ancestry:
-	// C_VIEW -> floating -> workspace
-	// A more complex ancestry could be:
-	// C_VIEW -> C_CONTAINER (tabbed) -> floating -> workspace
-	struct sway_container *floater = view->swayc;
-	while (floater->parent->type != C_WORKSPACE
-			&& floater->parent->parent->type != C_WORKSPACE) {
+	// Determine if view is nested inside a floating container which is sticky
+	struct sway_container *floater = view->container;
+	while (floater->parent) {
 		floater = floater->parent;
 	}
 	bool is_sticky = container_is_floating(floater) && floater->is_sticky;
 	// Check view isn't in a tabbed or stacked container on an inactive tab
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_container *container = view->swayc;
-	while (container->type != C_WORKSPACE) {
-		if (container->parent->layout == L_TABBED ||
-				container->parent->layout == L_STACKED) {
-			if (seat_get_active_child(seat, container->parent) != container) {
+	struct sway_container *container = view->container;
+	while (container) {
+		enum sway_container_layout layout = container_parent_layout(container);
+		if (layout == L_TABBED || layout == L_STACKED) {
+			struct sway_node *parent = container->parent ?
+				&container->parent->node : &container->workspace->node;
+			if (seat_get_active_child(seat, parent) != &container->node) {
 				return false;
 			}
 		}
 		container = container->parent;
 	}
 	// Check view isn't hidden by another fullscreen view
-	if (workspace->sway_workspace->fullscreen &&
-			!container_is_fullscreen_or_child(view->swayc)) {
+	if (workspace->fullscreen &&
+			!container_is_fullscreen_or_child(view->container)) {
 		return false;
 	}
 	// Check the workspace is visible
@@ -1047,7 +1013,7 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 	}
 	if (enable) {
 		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		if (seat_get_focus(seat) == view->swayc) {
+		if (seat_get_focused_container(seat) == view->container) {
 			return;
 		}
 		clock_gettime(CLOCK_MONOTONIC, &view->urgent);
@@ -1058,12 +1024,11 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 			view->urgent_timer = NULL;
 		}
 	}
-	container_damage_whole(view->swayc);
+	container_damage_whole(view->container);
 
-	ipc_event_window(view->swayc, "urgent");
+	ipc_event_window(view->container, "urgent");
 
-	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	workspace_detect_urgent(ws);
+	workspace_detect_urgent(view->container->workspace);
 }
 
 bool view_is_urgent(struct sway_view *view) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -560,11 +560,11 @@ void view_unmap(struct sway_view *view) {
 	container_begin_destroy(view->container);
 	if (parent) {
 		container_reap_empty(parent);
-	} else {
+	} else if (ws) {
 		workspace_consider_destroy(ws);
 	}
 
-	if (!ws->node.destroying) {
+	if (ws && !ws->node.destroying) {
 		arrange_workspace(ws);
 		workspace_detect_urgent(ws);
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -53,10 +53,10 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 		return NULL;
 	}
 	node_init(&ws->node, N_WORKSPACE, ws);
-	ws->x = output->wlr_output->lx;
-	ws->y = output->wlr_output->ly;
-	ws->width = output->wlr_output->width;
-	ws->height = output->wlr_output->height;
+	ws->x = output->lx;
+	ws->y = output->ly;
+	ws->width = output->width;
+	ws->height = output->height;
 	ws->name = name ? strdup(name) : NULL;
 	ws->prev_split_layout = L_NONE;
 	ws->layout = output_get_default_layout(output);


### PR DESCRIPTION
This commit changes the meaning of `sway_container` so that it only refers to layout containers and view containers. Workspaces, outputs and the root are no longer known as containers. Instead, root, outputs, workspaces and containers are all a type of `node`, and containers come in two types: layout containers and view containers.

In addition to the above, this implements type safe variables. This means we use specific types such as `sway_output` and `sway_workspace` instead of generic containers or nodes. However, it's worth noting that in a few places places (eg. seat focus and transactions) referring to them in a generic way is unavoidable which is why we still use nodes in some places.

If you want a TL;DR, look at `node.h`, as well as the struct definitions for root, output, workspace and container. Note that `sway_output` now contains a workspaces list, and workspaces now contain a tiling and floating list, and containers now contain a pointer back to the workspace.

--------------------------------------------------------------------------------

There are now functions for `seat_get_focused_workspace` and `seat_get_focused_container`. The latter will return `NULL` if a workspace itself is focused. Most other seat functions like `seat_get_focus` and `seat_set_focus` now accept and return nodes.

In the `config->handler_context` struct, `current_container` has been replaced with three pointers: `node`, `container` and `workspace`. `node` is the same as what `current_container` was, while `workspace` is the workspace that the node resides on and `container` is the actual container, which may be `NULL` if a workspace itself is focused.

The global `root_container` variable has been replaced with one simply called `root`, which is a pointer to the `sway_root` instance.

The way outputs are created, enabled, disabled and destroyed has changed. Previously we'd wrap the `sway_output` in a container when it is enabled, but as we don't have containers any more it needs a different approach. The `output_create` and `output_destroy` functions previously created/destroyed the container, but now they create/destroy the `sway_output`. There is a new function `output_disable` to disable an output without destroying it.

Containers have a new `view` property. If this is populated then the container is a view container, otherwise it's a layout container. Like before, this property is immutable for the life of the container.

Containers have both a `sway_container *parent` and `sway_workspace *workspace`. As we use specific types now, `parent` cannot point to a workspace so it'll be `NULL` for containers which are direct children of the workspace. The `workspace` property is set for all containers except those which are hidden in the scratchpad as they have no workspace.

In some cases we need to refer to workspaces in a container-like way. For example, workspaces have layout and children, but when using specific types this makes it difficult. Likewise, it's difficult for a container to get its parent's layout when the parent could be another container or a workspace. To make it easier, some helper functions have been created: `container_parent_layout` and `container_get_siblings`.

`container_remove_child` has been renamed to `container_detach` and `container_replace_child` has been renamed to `container_replace`.

`container_handle_fullscreen_reparent(con, old_parent)` has had the `old_parent` removed. We now unfullscreen the workspace when detaching the container, so this function is simplified and only needs one argument now.

`container_notify_subtree_changed` has been renamed to `container_update_representation`. This is more descriptive of its purpose. I also wanted to be able to call it with whatever container was changed rather than the container's parent, which makes bubbling up to the workspace easier.

There are now state structs per node thing. ie. `sway_output_state`, `sway_workspace_state` and `sway_container_state`.

The `focus`, `move` and `layout` commands have been completely refactored to work with the specific types. I considered making these a separate PR, but I'd be backporting my changes only to replace them again, and it's easier just to test everything at once.

Obviously this needs a ton of testing. I'm going to run this as my daily from now on.

Closes #2343 
Fixes #2552