### PR TITLE
Don't send never-ending transactions when a focused layer surface commits

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -176,7 +176,7 @@ void arrange_layers(struct sway_output *output) {
 				sizeof(struct wlr_box)) != 0) {
 		wlr_log(WLR_DEBUG, "Usable area changed, rearranging output");
 		memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
-		container_set_dirty(output->swayc);
+		arrange_output(output->swayc);
 	}
 
 	// Arrange non-exlusive surfaces from top->bottom
@@ -247,7 +247,6 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 			layer_surface->surface, false);
 	}
 
-	arrange_windows(output->swayc);
 	transaction_commit_dirty();
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -779,7 +779,7 @@ void seat_set_focus_layer(struct sway_seat *seat,
 			wlr_log(WLR_DEBUG, "Returning focus to %p %s '%s'", previous,
 					container_type_to_str(previous->type), previous->name);
 			// Hack to get seat to re-focus the return value of get_focus
-			seat_set_focus(seat, previous->parent);
+			seat_set_focus(seat, NULL);
 			seat_set_focus(seat, previous);
 		}
 		return;


### PR DESCRIPTION
This moves the `arrange_windows` call into the `arrange_layers` function, where we know the output actually needs to be arranged.

Additionally, we shouldn't set focus to the parent of an unknown container type, because the parent may be an output and this causes a crash because outputs can't have direct focus.

Fixes #2543