### PR TITLE
Fix crash on reload

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -401,3 +401,17 @@ char *argsep(char **stringp, const char *delim) {
 	found:
 	return start;
 }
+
+const char *strcasestr(const char *haystack, const char *needle) {
+	size_t needle_len = strlen(needle);
+	const char *pos = haystack;
+	const char *end = pos + strlen(haystack) - needle_len;
+
+	while (pos <= end) {
+		if (strncasecmp(pos, needle, needle_len) == 0) {
+			return pos;
+		}
+		++pos;
+	}
+	return NULL;
+}

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -46,4 +46,6 @@ char *cmdsep(char **stringp, const char *delim);
 // Split string into 2 by delim, handle quotes
 char *argsep(char **stringp, const char *delim);
 
+const char *strcasestr(const char *haystack, const char *needle);
+
 #endif

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -310,7 +310,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	bool reload = false;
 	// if this is a reload command we need to make a duplicate of the
 	// binding since it will be gone after the reload has completed.
-	if (strncasecmp(binding->command, "reload", 6) == 0) {
+	if (strcasestr(binding->command, "reload")) {
 		reload = true;
 		binding_copy = sway_binding_dup(binding);
 		if (!binding_copy) {

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -310,7 +310,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	bool reload = false;
 	// if this is a reload command we need to make a duplicate of the
 	// binding since it will be gone after the reload has completed.
-	if (strcasecmp(binding->command, "reload") == 0) {
+	if (strncasecmp(binding->command, "reload", 6) == 0) {
 		reload = true;
 		binding_copy = sway_binding_dup(binding);
 		if (!binding_copy) {


### PR DESCRIPTION
If sway is reloaded using a bindsym which has multiple commands, it failed to detect the reload command, didn't create a duplicate of the binding and would crash because the reload command frees the bindings.

For example:

    mode system {
        bindsym r reload, mode default
    }

In this example, the `binding->command` is "reload, mode default".

Fixes #2545