### PR TITLE
Add test to run sway

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -217,3 +217,13 @@ if (get_option('fish_completions'))
 
 	install_data(fish_files, install_dir: fish_install_dir)
 endif
+
+if (get_option('interactive-tests'))
+	# A test to run the just built sway executable, with all the auxilliaries
+	# in the path.
+	sway_paths_find_cmd = 'find @0@ -maxdepth 1 -type d -name \'sway*\' -printf \':%p\''.format(meson.current_build_dir())
+	sway_paths = run_command('sh', '-c', sway_paths_find_cmd).stdout().strip()
+	current_env = environment()
+	current_env.append('PATH', sway_paths)
+	test('sway', sway_exec, env : current_env, is_parallel : false, timeout : 3600)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('zsh_completions', type: 'boolean', value: true, description: 'Install zs
 option('bash_completions', type: 'boolean', value: true, description: 'Install bash shell completions.')
 option('fish_completions', type: 'boolean', value: true, description: 'Install fish shell completions.')
 option('enable-xwayland', type: 'boolean', value: true, description: 'Enable support for X11 applications')
+option('interactive-tests', type: 'boolean', value: true, description: 'Enable interactive tests')

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -177,7 +177,7 @@ if get_option('enable-xwayland')
 	sway_deps += xcb
 endif
 
-executable(
+sway_exec = executable(
 	'sway',
 	sway_sources,
 	include_directories: [sway_inc],


### PR DESCRIPTION
Sets the PATH variable correctly so that it finds the auxilliary
executables.
To use: run "meson test -v sway" in the build directory.

Added an "interactive-tests" option for when actual tests are added.

---

Seems helpful for iterative testing. Input on naming/formatting welcome.