### PR TITLE
Implement deprecated new_window and new_float commands

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -118,6 +118,8 @@ static struct cmd_handler handlers[] = {
 	{ "input", cmd_input },
 	{ "mode", cmd_mode },
 	{ "mouse_warping", cmd_mouse_warping },
+	{ "new_float", cmd_default_floating_border },
+	{ "new_window", cmd_default_border },
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "seat", cmd_seat },

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -27,15 +27,15 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 		view->border = B_NORMAL;
 	} else if (strcmp(argv[0], "pixel") == 0) {
 		view->border = B_PIXEL;
-		if (argc == 2) {
-			view->border_thickness = atoi(argv[1]);
-		}
 	} else if (strcmp(argv[0], "toggle") == 0) {
 		view->border = (view->border + 1) % 3;
 	} else {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Expected 'border <none|normal|pixel|toggle>' "
 				"or 'border pixel <px>'");
+	}
+	if (argc == 2) {
+		view->border_thickness = atoi(argv[1]);
 	}
 
 	if (container_is_floating(view->swayc)) {


### PR DESCRIPTION
May as well make it as easy as possible for users who are coming from i3.

This also changes the `border` command to accept a thickness when setting the border to normal. This makes it work the same way as the `default_border` command. Eg. `border normal 5`