### PR TITLE
Implement focus_on_window_activation

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -117,6 +117,7 @@ sway_cmd cmd_floating_modifier;
 sway_cmd cmd_floating_scroll;
 sway_cmd cmd_focus;
 sway_cmd cmd_focus_follows_mouse;
+sway_cmd cmd_focus_on_window_activation;
 sway_cmd cmd_focus_wrapping;
 sway_cmd cmd_font;
 sway_cmd cmd_for_window;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -60,7 +60,7 @@ struct sway_mouse_binding {
 /**
  * Focus on window activation.
  */
-enum fowa {
+enum sway_fowa {
 	FOWA_SMART,
 	FOWA_URGENT,
 	FOWA_FOCUS,
@@ -350,7 +350,7 @@ struct sway_config {
 	size_t font_height;
 	bool pango_markup;
 	size_t urgent_timeout;
-	enum fowa focus_on_window_activation;
+	enum sway_fowa focus_on_window_activation;
 
 	// Flags
 	bool focus_follows_mouse;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -58,6 +58,16 @@ struct sway_mouse_binding {
 };
 
 /**
+ * Focus on window activation.
+ */
+enum fowa {
+	FOWA_SMART,
+	FOWA_URGENT,
+	FOWA_FOCUS,
+	FOWA_NONE,
+};
+
+/**
  * A "mode" of keybindings created via the `mode` command.
  */
 struct sway_mode {
@@ -340,6 +350,7 @@ struct sway_config {
 	size_t font_height;
 	bool pango_markup;
 	size_t urgent_timeout;
+	enum fowa focus_on_window_activation;
 
 	// Flags
 	bool focus_follows_mouse;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -167,6 +167,7 @@ struct sway_xwayland_view {
 	struct wl_listener request_maximize;
 	struct wl_listener request_configure;
 	struct wl_listener request_fullscreen;
+	struct wl_listener request_activate;
 	struct wl_listener set_title;
 	struct wl_listener set_class;
 	struct wl_listener set_window_type;
@@ -258,6 +259,11 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 void view_autoconfigure(struct sway_view *view);
 
 void view_set_activated(struct sway_view *view, bool activated);
+
+/**
+ * Called when the view requests to be focused.
+ */
+void view_request_activate(struct sway_view *view);
 
 void view_set_tiled(struct sway_view *view, bool tiled);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -106,6 +106,7 @@ static struct cmd_handler handlers[] = {
 	{ "floating_modifier", cmd_floating_modifier },
 	{ "focus", cmd_focus },
 	{ "focus_follows_mouse", cmd_focus_follows_mouse },
+	{ "focus_on_window_activation", cmd_focus_on_window_activation },
 	{ "focus_wrapping", cmd_focus_wrapping },
 	{ "font", cmd_font },
 	{ "for_window", cmd_for_window },

--- a/sway/commands/focus_on_window_activation.c
+++ b/sway/commands/focus_on_window_activation.c
@@ -1,0 +1,25 @@
+#include "sway/commands.h"
+
+struct cmd_results *cmd_focus_on_window_activation(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "focus_on_window_activation",
+					EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	if (strcmp(argv[0], "smart") == 0) {
+		config->focus_on_window_activation = FOWA_SMART;
+	} else if (strcmp(argv[0], "urgent") == 0) {
+		config->focus_on_window_activation = FOWA_URGENT;
+	} else if (strcmp(argv[0], "focus") == 0) {
+		config->focus_on_window_activation = FOWA_FOCUS;
+	} else if (strcmp(argv[0], "none") == 0) {
+		config->focus_on_window_activation = FOWA_NONE;
+	} else {
+		return cmd_results_new(CMD_INVALID, "focus_on_window_activation",
+				"Expected "
+				"'focus_on_window_activation smart|urgent|focus|none'");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -46,6 +46,7 @@ sway_sources = files(
 	'commands/floating_modifier.c',
 	'commands/focus.c',
 	'commands/focus_follows_mouse.c',
+	'commands/focus_on_window_activation.c',
 	'commands/focus_wrapping.c',
 	'commands/font.c',
 	'commands/for_window.c',

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -280,6 +280,29 @@ void view_set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
+void view_request_activate(struct sway_view *view) {
+	if (config->focus_on_window_activation == FOWA_NONE) {
+		return;
+	}
+	if (config->focus_on_window_activation == FOWA_FOCUS) {
+		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		seat_set_focus(seat, view->swayc);
+		return;
+	}
+	if (config->focus_on_window_activation == FOWA_URGENT) {
+		view_set_urgent(view, true);
+		return;
+	}
+	// FOWA_SMART
+	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
+	if (workspace_is_visible(ws)) {
+		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		seat_set_focus(seat, view->swayc);
+	} else {
+		view_set_urgent(view, true);
+	}
+}
+
 void view_set_tiled(struct sway_view *view, bool tiled) {
 	if (!tiled) {
 		view->using_csd = true;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -281,25 +281,25 @@ void view_set_activated(struct sway_view *view, bool activated) {
 }
 
 void view_request_activate(struct sway_view *view) {
-	if (config->focus_on_window_activation == FOWA_NONE) {
-		return;
-	}
-	if (config->focus_on_window_activation == FOWA_FOCUS) {
-		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		seat_set_focus(seat, view->swayc);
-		return;
-	}
-	if (config->focus_on_window_activation == FOWA_URGENT) {
-		view_set_urgent(view, true);
-		return;
-	}
-	// FOWA_SMART
 	struct sway_container *ws = container_parent(view->swayc, C_WORKSPACE);
-	if (workspace_is_visible(ws)) {
-		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		seat_set_focus(seat, view->swayc);
-	} else {
+	struct sway_seat *seat = input_manager_current_seat(input_manager);
+
+	switch (config->focus_on_window_activation) {
+	case FOWA_SMART:
+		if (workspace_is_visible(ws)) {
+			seat_set_focus(seat, view->swayc);
+		} else {
+			view_set_urgent(view, true);
+		}
+		break;
+	case FOWA_URGENT:
 		view_set_urgent(view, true);
+		break;
+	case FOWA_FOCUS:
+		seat_set_focus(seat, view->swayc);
+		break;
+	case FOWA_NONE:
+		break;
 	}
 }
 


### PR DESCRIPTION
Depends on https://github.com/swaywm/wlroots/pull/1223

i3 docs: https://i3wm.org/docs/userguide.html#focus_on_window_activation

To test, I opened Firefox along with a terminal and ran `firefox http://github.com` from the terminal.