### PR TITLE
Deny repeating reload by holding key

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -31,10 +31,11 @@ enum binding_input_type {
 
 enum binding_flags {
 	BINDING_RELEASE=1,
-	BINDING_LOCKED=2, // keyboard only
-	BINDING_BORDER=4, // mouse only; trigger on container border
-	BINDING_CONTENTS=8, // mouse only; trigger on container contents
-	BINDING_TITLEBAR=16 // mouse only; trigger on container titlebar
+	BINDING_LOCKED=2,    // keyboard only
+	BINDING_BORDER=4,    // mouse only; trigger on container border
+	BINDING_CONTENTS=8,  // mouse only; trigger on container contents
+	BINDING_TITLEBAR=16, // mouse only; trigger on container titlebar
+	BINDING_RELOAD=32,   // the binding runs the reload command
 };
 
 /**

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -280,7 +280,10 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 		if (binding_pressed) {
 			seat_execute_command(seat, binding_pressed);
 			handled = true;
-			next_repeat_binding = binding_pressed;
+
+			if ((binding_pressed->flags & BINDING_RELOAD) == 0) {
+				next_repeat_binding = binding_pressed;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2568

The binding that gets stored in the keyboard's `repeat_binding` would get freed on reload, leaving a dangling pointer.

Rather than attempt to unset the keyboard's `repeat_binding` along with the other bindings, I opted to just not set it for the reload command because there's no point in reloading repeatedly by holding the binding. This disables repeat bindings for the reload command.

As we now need to detect whether it's a reload command in two places, I've added a binding flag to track whether it's a reload or not.