### PR TITLE
Fix swaybar block background fill logic

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -111,7 +111,7 @@ static void render_block(struct window *window, struct config *config, struct st
 	// render background
 	if (block->background != 0x0) {
 		cairo_set_source_u32(window->cairo, block->background);
-		cairo_rectangle(window->cairo, pos - 0.5, 1, block_width, (window->height * window->scale) - 2);
+		cairo_rectangle(window->cairo, pos - 0.5, 1, width, (window->height * window->scale) - 2);
 		cairo_fill(window->cairo);
 	}
 


### PR DESCRIPTION
When a block is padded/offset to uphold `min_width`, the background colour is now applied to the whole block rather than just the original width before padding. This brings the behaviour in-line with i3bar.

Related issue: https://github.com/greshake/i3status-rust/issues/155