### PR TITLE
Call wlr_output_enable on enable/disable if needed

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -54,12 +54,6 @@ struct sway_output *output_create(struct wlr_output *wlr_output) {
 
 	wl_list_insert(&root->all_outputs, &output->link);
 
-	if (!wl_list_empty(&wlr_output->modes)) {
-		struct wlr_output_mode *mode =
-			wl_container_of(wlr_output->modes.prev, mode, link);
-		wlr_output_set_mode(wlr_output, mode);
-	}
-
 	output->workspaces = create_list();
 	output->current.workspaces = create_list();
 


### PR DESCRIPTION
Fixes #2557 

This PR:
- Calls `wlr_output_enable(wlr_output, false)` when disabling an output.
- Calls `wlr_output_enable(wlr_output, true)` when (re-)enabling an output **_if_** DPMS is not set to `DPMS_OFF`

I also refactored `apply_output_config` to:
- ~Take in a `struct sway_output` instead of `struct sway_container`~ (Taken care of by typesafety)
- Handle (re-)enabling the output instead of having it done before in `apply_output_config_to_outputs`
   - ~This also required setting `sway_output->swayc` in `output_create` instead of `output_enable` to avoid an infinite loop~ (No longer needed with typesafety)

Since typesafety accidentally reverted part of #2553, I also removed the modeset from `output_create`.