### PR TITLE
Fix management of bindings during reload

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -329,7 +329,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 			binding->command, results->error);
 	}
 
-	if (binding->flags & BINDING_RELOAD) { // free the binding if we made a copy
+	if (binding_copy->flags & BINDING_RELOAD) {
 		free_sway_binding(binding_copy);
 	}
 	free_cmd_results(results);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -278,12 +278,11 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 				raw_modifiers, false, input_inhibited);
 
 		if (binding_pressed) {
-			seat_execute_command(seat, binding_pressed);
-			handled = true;
-
 			if ((binding_pressed->flags & BINDING_RELOAD) == 0) {
 				next_repeat_binding = binding_pressed;
 			}
+			seat_execute_command(seat, binding_pressed);
+			handled = true;
 		}
 	}
 


### PR DESCRIPTION
`seat_execute_command` needs to check the flags on `binding_copy`, as `binding` will be a dangling pointer after a reload command.

`handle_keyboard_key` needs to set the `next_repeat_binding` for non-reloads prior to executing the command in case the binding is freed by the reload command.