### PR TITLE
Adjust container box

### DIFF
--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -97,15 +97,14 @@ static void apply_tabbed_layout(list_t *children, struct wlr_box *parent) {
 	if (!children->length) {
 		return;
 	}
-	size_t parent_offset = container_titlebar_height();
-	size_t parent_height = parent->height - parent_offset;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
+		size_t parent_offset = child->view ? 0 : container_titlebar_height();
 		container_remove_gaps(child);
 		child->x = parent->x;
 		child->y = parent->y + parent_offset;
 		child->width = parent->width;
-		child->height = parent_height;
+		child->height = parent->height - parent_offset;
 		container_add_gaps(child);
 	}
 }
@@ -114,15 +113,15 @@ static void apply_stacked_layout(list_t *children, struct wlr_box *parent) {
 	if (!children->length) {
 		return;
 	}
-	size_t parent_offset = container_titlebar_height() * children->length;
-	size_t parent_height = parent->height - parent_offset;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
+		size_t parent_offset = child->view ?  0 :
+			container_titlebar_height() * children->length;
 		container_remove_gaps(child);
 		child->x = parent->x;
 		child->y = parent->y + parent_offset;
 		child->width = parent->width;
-		child->height = parent_height;
+		child->height = parent->height - parent_offset;
 		container_add_gaps(child);
 	}
 }


### PR DESCRIPTION
Prior to f5b9815128b6c000bb5d47c339480fa481a5e99d, children of tabbed and stacked containers would have their container size and position set to the same as the tabbed/stacked container. Normally this would be a problem for a layout such as `T[V[view]]`, but there was some code in the
arrange functions which would check if the grandparent of the view was a tabbed or stacked container and would offset the view's Y accordingly.

Commit f5b9815128b6c000bb5d47c339480fa481a5e99d changed the box to exclude the titlebar for all tabbed/stacked children so that the grandparent check could be removed. But this meant the title was not covered in the container and wasn't damaged when the child changed its title.

This patch changes it so that a child of a tabbed/stacked container will have its box include the title bar if the child is a view, but not if it's a layout container. This fixes the title damage issue while avoiding the grandparent check in the arrange functions, and matches what we see visually.

Fixes #2573.