### PR TITLE
Remove __PRETTY_FUNCTION__

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -15,7 +15,7 @@ void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
 
 bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
 #define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, "[%s:%d] %s:" FMT, _wlr_strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+	_sway_assert(COND, "[%s:%d] %s:" FMT, _wlr_strip_path(__FILE__), __LINE__, __func__, ##__VA_ARGS__)
 
 void error_handler(int sig);
 


### PR DESCRIPTION
This is a non-standard extension as well as completely useless in C.
__func__ is the standard way of doing this.