### PR TITLE
Fix crash when views rapidly map and unmap

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -266,7 +266,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 	struct sway_view *view = con->view;
 	if (view->saved_buffer) {
 		render_saved_view(view, output, damage, view->container->alpha);
-	} else {
+	} else if (view->surface) {
 		render_view_toplevels(view, output, damage, view->container->alpha);
 	}
 


### PR DESCRIPTION
Suppose the following:

* Transactions are already in progress - say transaction A.
* View A maps, which creates transaction B and appends it to the transaction queue.
* View B maps, which creates transaction C and appends it to the queue.
* View A unmaps, which creates transaction D and appends it to the queue.
* Transaction A completes, so transaction B attempts to save View A's buffer, but this doesn't exist so it saves nothing.
* Rendering code attempts to render View A, but there is no saved buffer nor live buffer that it can use.

Rather than implement an elaborate solution for a rare circumstance, I've take the safe option of just not rendering anything for that view. It means that if you reproduce the scenario above, you might get the title and borders rendered but no surface.

Fixes #2527.