### PR TITLE
Fix crash when moving view across outputs

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -117,7 +117,8 @@ static void container_move_to_container_from_direction(
 		struct sway_container *container, struct sway_container *destination,
 		enum movement_direction move_dir) {
 	if (destination->view) {
-		if (destination->parent == container->parent) {
+		if (destination->parent == container->parent &&
+				destination->workspace == container->workspace) {
 			wlr_log(WLR_DEBUG, "Swapping siblings");
 			list_t *siblings = container_get_siblings(container);
 			int container_index = list_find(siblings, container);


### PR DESCRIPTION
It was incorrectly determining that the container being moved and the destination had the same parent, which resulted in tree corruption. Both parents can be `NULL` but the containers may belong to different
workspaces.

To reproduce, create layout `H[V[view] view]` in one workspace then move a view left or right from another output into that workspace.

Fixes #2581.