### PR TITLE
Fix crash when running "layout toggle"

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -29,7 +29,7 @@ static enum sway_container_layout get_layout_toggle(int argc, char **argv,
 		enum sway_container_layout layout,
 		enum sway_container_layout prev_split_layout) {
 	// "layout toggle"
-	if (argc == 0) {
+	if (argc == 1) {
 		return layout == L_HORIZ ? L_VERT : L_HORIZ;
 	}
 


### PR DESCRIPTION
The `argc` and `argv` used in this function are the same ones used by the layout command itself.