### PR TITLE
Introduce seat_set_focus_container and seat_set_focus_workspace

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -102,6 +102,12 @@ void seat_configure_xcursor(struct sway_seat *seat);
 
 void seat_set_focus(struct sway_seat *seat, struct sway_node *node);
 
+void seat_set_focus_container(struct sway_seat *seat,
+		struct sway_container *con);
+
+void seat_set_focus_workspace(struct sway_seat *seat,
+		struct sway_workspace *ws);
+
 void seat_set_focus_warp(struct sway_seat *seat,
 		struct sway_node *node, bool warp, bool notify);
 

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -25,7 +25,7 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		// Wrap the workspace's children in a container so we can float it
 		container = workspace_wrap_children(workspace);
 		workspace->layout = L_HORIZ;
-		seat_set_focus(config->handler_context.seat, &container->node);
+		seat_set_focus_container(config->handler_context.seat, container);
 	}
 
 	// If the container is in a floating split container,

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -179,7 +179,7 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 		new_focus = seat_get_focus_inactive_tiling(seat, ws);
 	}
 	if (new_focus) {
-		seat_set_focus(seat, &new_focus->node);
+		seat_set_focus_container(seat, new_focus);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "focus",
 				"Failed to find a %s container in workspace",
@@ -230,8 +230,8 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 			"Command 'focus' cannot be used above the workspace level");
 	}
 
-	if (argc == 0) {
-		seat_set_focus(seat, node);
+	if (argc == 0 && container) {
+		seat_set_focus_container(seat, container);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -23,7 +23,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		// Wrap the workspace's children in a container so we can fullscreen it
 		container = workspace_wrap_children(workspace);
 		workspace->layout = L_HORIZ;
-		seat_set_focus(config->handler_context.seat, &container->node);
+		seat_set_focus_container(config->handler_context.seat, container);
 	}
 	bool enable = !container->is_fullscreen;
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -624,7 +624,7 @@ static void workspace_move_to_output(struct sway_workspace *workspace,
 		char *ws_name = workspace_next_name(old_output->wlr_output->name);
 		struct sway_workspace *ws = workspace_create(old_output, ws_name);
 		free(ws_name);
-		seat_set_focus(seat, &ws->node);
+		seat_set_focus_workspace(seat, ws);
 	}
 
 	workspace_consider_destroy(new_output_old_ws);
@@ -734,8 +734,9 @@ static struct cmd_results *cmd_move_in_direction(
 		ipc_event_window(container, "move");
 	}
 
-	seat_set_focus(config->handler_context.seat, &new_ws->node);
-	seat_set_focus(config->handler_context.seat, &container->node);
+	// Hack to re-focus container
+	seat_set_focus_workspace(config->handler_context.seat, new_ws);
+	seat_set_focus_container(config->handler_context.seat, container);
 
 	if (old_ws != new_ws) {
 		ipc_event_workspace(old_ws, new_ws, "focus");

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -52,20 +52,20 @@ static void swap_focus(struct sway_container *con1,
 			if (workspace_is_visible(ws2)) {
 				seat_set_focus_warp(seat, &con2->node, false, true);
 			}
-			seat_set_focus(seat, ws1 != ws2 ? &con2->node : &con1->node);
+			seat_set_focus_container(seat, ws1 != ws2 ? con2 : con1);
 		} else if (focus == con2 && (layout1 == L_TABBED
 					|| layout1 == L_STACKED)) {
 			if (workspace_is_visible(ws1)) {
 				seat_set_focus_warp(seat, &con1->node, false, true);
 			}
-			seat_set_focus(seat, ws1 != ws2 ? &con1->node : &con2->node);
+			seat_set_focus_container(seat, ws1 != ws2 ? con1 : con2);
 		} else if (ws1 != ws2) {
-			seat_set_focus(seat, focus == con1 ? &con2->node : &con1->node);
+			seat_set_focus_container(seat, focus == con1 ? con2 : con1);
 		} else {
-			seat_set_focus(seat, &focus->node);
+			seat_set_focus_container(seat, focus);
 		}
 	} else {
-		seat_set_focus(seat, &focus->node);
+		seat_set_focus_container(seat, focus);
 	}
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -675,7 +675,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle tiling resize via border
 	if (resize_edge && button == BTN_LEFT && state == WLR_BUTTON_PRESSED &&
 			!is_floating) {
-		seat_set_focus(seat, &cont->node);
+		seat_set_focus_container(seat, cont);
 		seat_begin_resize_tiling(seat, cont, button, edge);
 		return;
 	}
@@ -704,7 +704,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 				image = "sw-resize";
 			}
 			cursor_set_image(seat->cursor, image, NULL);
-			seat_set_focus(seat, &cont->node);
+			seat_set_focus_container(seat, cont);
 			seat_begin_resize_tiling(seat, cont, button, edge);
 			return;
 		}
@@ -753,7 +753,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	// Handle mousedown on a container surface
 	if (surface && cont && state == WLR_BUTTON_PRESSED) {
-		seat_set_focus(seat, &cont->node);
+		seat_set_focus_container(seat, cont);
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		seat_begin_down(seat, cont, button, sx, sy);
 		return;
@@ -761,7 +761,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	// Handle clicking a container surface
 	if (cont) {
-		seat_set_focus(seat, &cont->node);
+		seat_set_focus_container(seat, cont);
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -734,6 +734,16 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 	seat_set_focus_warp(seat, node, true, true);
 }
 
+void seat_set_focus_container(struct sway_seat *seat,
+		struct sway_container *con) {
+	seat_set_focus_warp(seat, con ? &con->node : NULL, true, true);
+}
+
+void seat_set_focus_workspace(struct sway_seat *seat,
+		struct sway_workspace *ws) {
+	seat_set_focus_warp(seat, ws ? &ws->node : NULL, true, true);
+}
+
 void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus) {
 	if (seat->focused_layer != NULL) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -871,7 +871,7 @@ void container_set_fullscreen(struct sway_container *container, bool enable) {
 			focus_ws = seat_get_focused_workspace(seat);
 			if (focus_ws) {
 				if (focus_ws == workspace) {
-					seat_set_focus(seat, &container->node);
+					seat_set_focus_container(seat, container);
 				}
 			}
 		}
@@ -1159,8 +1159,8 @@ struct sway_container *container_split(struct sway_container *child,
 	container_add_child(cont, child);
 
 	if (set_focus) {
-		seat_set_focus(seat, &cont->node);
-		seat_set_focus(seat, &child->node);
+		seat_set_focus_container(seat, cont);
+		seat_set_focus_container(seat, child);
 	}
 
 	return cont;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -85,7 +85,7 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &input_manager->seats, link) {
 			if (!seat->has_focus) {
-				seat_set_focus(seat, &ws->node);
+				seat_set_focus_workspace(seat, ws);
 			}
 		}
 		free(ws_name);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -294,7 +294,7 @@ void view_request_activate(struct sway_view *view) {
 	switch (config->focus_on_window_activation) {
 	case FOWA_SMART:
 		if (workspace_is_visible(ws)) {
-			seat_set_focus(seat, &view->container->node);
+			seat_set_focus_container(seat, view->container);
 		} else {
 			view_set_urgent(view, true);
 		}
@@ -303,7 +303,7 @@ void view_request_activate(struct sway_view *view) {
 		view_set_urgent(view, true);
 		break;
 	case FOWA_FOCUS:
-		seat_set_focus(seat, &view->container->node);
+		seat_set_focus_container(seat, view->container);
 		break;
 	case FOWA_NONE:
 		break;
@@ -404,7 +404,7 @@ void view_execute_criteria(struct sway_view *view) {
 		}
 		wlr_log(WLR_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
 				criteria->raw, view, criteria->cmdlist);
-		seat_set_focus(seat, &view->container->node);
+		seat_set_focus_container(seat, view->container);
 		list_add(view->executed_criteria, criteria);
 		struct cmd_results *res = execute_command(criteria->cmdlist, NULL);
 		if (res->status != CMD_SUCCESS) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -399,7 +399,7 @@ bool workspace_switch(struct sway_workspace *workspace,
 				workspace_add_floating(workspace, floater);
 				if (&floater->node == focus) {
 					seat_set_focus(seat, NULL);
-					seat_set_focus(seat, &floater->node);
+					seat_set_focus_container(seat, floater);
 				}
 				--i;
 			}


### PR DESCRIPTION
These are the same as `seat_set_focus`, but accept a specific type rather than using nodes. Doing this adds more typesafety and lets us avoid using `&con->node` which looks a little ugly.

This fixes a crash that pretty much nobody would ever come across. If you have a bindsym for `focus` with no arguments and run it from an empty workspace, sway would crash because it assumes `container` is not `NULL` (fixed in `focus.c`).