### PR TITLE
Second attempt at restoring focus when closing a fullscreen view

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -84,6 +84,11 @@ void container_begin_destroy(struct sway_container *con) {
 	if (con->view) {
 		ipc_event_window(con, "close");
 	}
+	// The workspace must have the fullscreen pointer cleared so that the
+	// seat code can find an appropriate new focus.
+	if (con->is_fullscreen && con->workspace) {
+		con->workspace->fullscreen = NULL;
+	}
 	wl_signal_emit(&con->node.events.destroy, &con->node);
 
 	container_end_mouse_operation(con);


### PR DESCRIPTION
To reproduce the problem this is fixing, create `H[view view view]`, fullscreen one of the views and close it. The entire workspace will be given focus rather than one of the siblings.

This happens because we emit the `destroy` event, so the seat code tries to find a new focus, but the view it finds is still believed to be hidden by the fullscreen view so it's discarded and the workspace is used instead.

This clears the workspace's fullscreen pointer prior to emitting the destroy event so that the seat code finds an appropriate new focus.