### PR TITLE
Float views when min == max on either dimension

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -170,8 +170,8 @@ static bool wants_floating(struct sway_view *view) {
 	struct wlr_xdg_toplevel *toplevel = view->wlr_xdg_surface->toplevel;
 	struct wlr_xdg_toplevel_state *state = &toplevel->current;
 	return (state->min_width != 0 && state->min_height != 0
-		&& state->min_width == state->max_width
-		&& state->min_height == state->max_height)
+		&& (state->min_width == state->max_width
+		|| state->min_height == state->max_height))
 		|| toplevel->parent;
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -166,8 +166,8 @@ static bool wants_floating(struct sway_view *view) {
 		view->wlr_xdg_surface_v6->toplevel;
 	struct wlr_xdg_toplevel_v6_state *state = &toplevel->current;
 	return (state->min_width != 0 && state->min_height != 0
-		&& state->min_width == state->max_width
-		&& state->min_height == state->max_height)
+		&& (state->min_width == state->max_width
+		|| state->min_height == state->max_height))
 		|| toplevel->parent;
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -235,8 +235,8 @@ static bool wants_floating(struct sway_view *view) {
 	struct wlr_xwayland_surface_size_hints *size_hints = surface->size_hints;
 	if (size_hints != NULL &&
 			size_hints->min_width != 0 && size_hints->min_height != 0 &&
-			size_hints->max_width == size_hints->min_width &&
-			size_hints->max_height == size_hints->min_height) {
+			(size_hints->max_width == size_hints->min_width ||
+			size_hints->max_height == size_hints->min_height)) {
 		return true;
 	}
 


### PR DESCRIPTION
This fixes pinentry-gtk-2, but might make other views floating which would otherwise be tiled. This patch is more of a trial which could end up becoming a permanent fix.

Fixes #2181.