### PR TITLE
Fix workspace switching

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -605,7 +605,7 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 		last_workspace->output : NULL;
 	struct sway_output *new_output = new_workspace->output;
 
-	if (last_workspace != new_workspace && last_output == new_output) {
+	if (last_workspace != new_workspace && new_output) {
 		node_set_dirty(&new_output->node);
 	}
 


### PR DESCRIPTION
The output also needs to be made dirty when focusing a new output.

Fixes #2599.