### PR TITLE
Fix drag-and-drop

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -80,7 +80,8 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	int sw = surface->current.width;
 	int sh = surface->current.height;
 
-	double _sx = sx, _sy = sy;
+	double _sx = sx + surface->sx;
+	double _sy = sy + surface->sy;
 	rotate_child_position(&_sx, &_sy, sw, sh, data->width, data->height,
 		data->rotation);
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -408,6 +408,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 	}
 
 	struct sway_seat *seat = cursor->seat;
+	struct wlr_seat *wlr_seat = seat->wlr_seat;
 
 	if (seat->operation != OP_NONE) {
 		switch (seat->operation) {
@@ -431,7 +432,6 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		return;
 	}
 
-	struct wlr_seat *wlr_seat = seat->wlr_seat;
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -240,16 +240,16 @@ void drag_icon_update_position(struct sway_drag_icon *icon) {
 	struct sway_seat *seat = icon->seat;
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	if (wlr_icon->is_pointer) {
-		icon->x = cursor->x + wlr_icon->sx;
-		icon->y = cursor->y + wlr_icon->sy;
+		icon->x = cursor->x;
+		icon->y = cursor->y;
 	} else {
 		struct wlr_touch_point *point =
 			wlr_seat_touch_get_point(seat->wlr_seat, wlr_icon->touch_id);
 		if (point == NULL) {
 			return;
 		}
-		icon->x = seat->touch_x + wlr_icon->sx;
-		icon->y = seat->touch_y + wlr_icon->sy;
+		icon->x = seat->touch_x;
+		icon->y = seat->touch_y;
 	}
 
 	drag_icon_damage_whole(icon);
@@ -308,6 +308,7 @@ static void handle_new_drag_icon(struct wl_listener *listener, void *data) {
 	wl_list_insert(&root_container.sway_root->drag_icons, &icon->link);
 
 	drag_icon_update_position(icon);
+	seat_end_mouse_operation(seat);
 }
 
 static void collect_focus_iter(struct sway_container *con, void *data) {


### PR DESCRIPTION
* Use surface `sx` and `sy` instead of `wlr_drag_icon` fields which have been removed
* End `DOWN` mouse operation when dragging

Test plan: `weston-dnd`