### PR TITLE
[WIP] Address new_output == NULL in seat_set_focus_warp

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -710,7 +710,8 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 			workspace_consider_destroy(last_workspace);
 		}
 
-		if (config->mouse_warping && warp && new_output != last_output) {
+		if (config->mouse_warping && warp &&
+				new_output != last_output && new_output) {
 			double x = 0;
 			double y = 0;
 			if (container) {


### PR DESCRIPTION
This addresses the specific crash in https://github.com/swaywm/sway/issues/2598, but now I'm facing another, more difficult crash:

```
#0  0x000055735007e356 in container_for_each_child (container=0x5573510e3730, f=0x557350060e8b <send_unfocus>, data=0x557350e422c0) at ../sway/tree/container.c:402
        i = 0
#1  0x0000557350060f39 in seat_send_unfocus (node=0x557351079640, seat=0x557350e422c0) at ../sway/input/seat.c:559
#2  0x0000557350061159 in seat_set_focus_warp (seat=0x557350e422c0, node=0x5573510876c0, warp=true, notify=true) at ../sway/input/seat.c:620
        parent = 0x55735008adc2 <list_add+28>
        last_focus = 0x557351079640
        last_workspace = 0x0
        new_workspace = 0x5573511dd720
        container = 0x5573510876c0
        last_output = 0x0
        new_output = 0x557350e81830
        new_output_last_ws = 0x5573510e3e60
#3  0x0000557350061786 in seat_set_focus_container (seat=0x557350e422c0, con=0x5573510876c0) at ../sway/input/seat.c:744
#4  0x000055735008316b in view_execute_criteria (view=0x55735117f650) at ../sway/tree/view.c:407
        criteria = 0x557350e473f0
        res = 0x5573510876c0
        i = 0
        seat = 0x557350e422c0
        prior_focus = 0x557351079640
        criterias = 0x5573510e2ef0
#5  0x00005573500837c7 in view_map (view=0x55735117f650, wlr_surface=0x5573511b4610) at ../sway/tree/view.c:558
        __func__ = "view_map"
        seat = 0x557350e422c0
        ws = 0x5573511dd720
        node = 0x5573511dd720
        target_sibling = 0x0
#6  0x00005573500893da in handle_map (listener=0x55735117f898, data=0x557350f88020) at ../sway/desktop/xwayland.c:389
        xwayland_view = 0x55735117f650
        xsurface = 0x557350f88020
        view = 0x55735117f650
#7  0x00007fee4da9c26e in wlr_signal_emit_safe (signal=signal@entry=0x557350f88188, data=data@entry=0x557350f88020) at ../util/signal.c:29
        pos = 0x55735117f898
        l = 0x55735117f898
        cursor = {link = {prev = 0x55735117f898, next = 0x7ffef88d8430}, notify = 0x7fee4da9c1e0 <handle_noop>}
        end = {link = {prev = 0x7ffef88d8410, next = 0x557350f88188}, notify = 0x7fee4da9c1e0 <handle_noop>}
#8  0x00007fee4da655f6 in xwayland_surface_role_commit (wlr_surface=<optimized out>) at ../xwayland/xwm.c:686
        surface = 0x557350f88020
        __PRETTY_FUNCTION__ = "xwayland_surface_role_commit"
#9  0x00007fee4da94402 in surface_commit_pending (surface=0x5573511b4610) at ../types/wlr_surface.c:398
        invalid_buffer = true
        subsurface = 0x5573511b47e0
#10 0x00007fee4da947f5 in surface_commit (client=<optimized out>, resource=<optimized out>) at ../types/wlr_surface.c:470
        surface = 0x5573511b4610
        subsurface = <optimized out>
#11 0x00007fee4bf631c8 in ffi_call_unix64 () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libffi.so.6
#12 0x00007fee4bf62c2a in ffi_call () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libffi.so.6
#13 0x00007fee4dad56ff in  () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#14 0x00007fee4dad20a3 in  () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#15 0x00007fee4dad3702 in wl_event_loop_dispatch () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#16 0x00007fee4dad22ac in wl_display_run () at /home/sircmpwn/sources/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#17 0x0000557350053e6f in server_run (server=0x5573500a6a40 <server>) at ../sway/server.c:165
#18 0x00005573500535ea in main (argc=3, argv=0x7ffef88d8c38) at ../sway/main.c:446
        verbose = 0
        debug = 1
        validate = 0
        long_options = 
            {{name = 0x557350090a4c "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x557350090a51 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x557350090a58 "validate", has_arg = 0, flag = 0x0, val = 67}, {name = 0x557350090a61 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x557350090a67 "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x557350090a6f "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x557350090a77 "get-socketpath", has_arg = 0, flag = 0x0, val = 112}, {name = 0x0, has_arg = 0, flag = 0x0, val = 0}}
        config_path = 0x0
        usage = 0x5573500905d0 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
        c = -1
        suid = false
```

Digging into this a little, it seems that `last_focus` is an invalid pointer at `sway/input/seat.c:620`