### PR TITLE
 commands: prevent running empty seat command

### DIFF
--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -14,7 +14,7 @@ static struct cmd_handler seat_handlers[] = {
 
 struct cmd_results *cmd_seat(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 2))) {
 		return error;
 	}
 


### PR DESCRIPTION
Fixes crash when running `seat <seat>` without a sub-command.