### PR TITLE
[WIP] add support for cursor themes

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -507,11 +507,15 @@ void seat_remove_device(struct sway_seat *seat,
 
 void seat_configure_xcursor(struct sway_seat *seat) {
 	// TODO configure theme and size
-	const char *cursor_theme = NULL;
+	const char *cursor_theme = getenv("SWAY_CURSOR_THEME");
+	int cursor_size = atoi(getenv("SWAY_CURSOR_SIZE"));
+	if (cursor_size <= 0) {
+		cursor_size = 24;
+	}
 
 	if (!seat->cursor->xcursor_manager) {
 		seat->cursor->xcursor_manager =
-			wlr_xcursor_manager_create(cursor_theme, 24);
+			wlr_xcursor_manager_create(cursor_theme, cursor_size);
 		if (sway_assert(seat->cursor->xcursor_manager,
 					"Cannot create XCursor manager for theme %s",
 					cursor_theme)) {

--- a/sway/server.c
+++ b/sway/server.c
@@ -93,7 +93,13 @@ bool server_init(struct sway_server *server) {
 	server->xwayland_ready.notify = handle_xwayland_ready;
 
 	// TODO: configurable cursor theme and size
-	server->xwayland.xcursor_manager = wlr_xcursor_manager_create(NULL, 24);
+	char *cursor_theme = getenv("SWAY_CURSOR_THEME");
+	int cursor_size = atoi(getenv("SWAY_CURSOR_SIZE"));
+	if (cursor_size <= 0) {
+		cursor_size = 24;
+	}
+
+	server->xwayland.xcursor_manager = wlr_xcursor_manager_create(cursor_theme, cursor_size);
 	wlr_xcursor_manager_load(server->xwayland.xcursor_manager, 1);
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(
 		server->xwayland.xcursor_manager, "left_ptr", 1);
@@ -103,6 +109,7 @@ bool server_init(struct sway_server *server) {
 			image->width * 4, image->width, image->height, image->hotspot_x,
 			image->hotspot_y);
 	}
+
 #endif
 
 	server->server_decoration_manager =

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -417,8 +417,14 @@ void bar_setup(struct swaybar *bar,
 		}
 	}
 
+	const char *cursor_theme = getenv("SWAY_CURSOR_THEME");
+	int cursor_size = atoi(getenv("SWAY_CURSOR_SIZE"));
+	if (cursor_size <= 0) {
+		cursor_size = 24;
+	}
+
 	pointer->cursor_theme = wl_cursor_theme_load(
-				NULL, 24 * max_scale, bar->shm);
+				cursor_theme, cursor_size * max_scale, bar->shm);
 	assert(pointer->cursor_theme);
 	struct wl_cursor *cursor;
 	cursor = wl_cursor_theme_get_cursor(pointer->cursor_theme, "left_ptr");


### PR DESCRIPTION
- uses environment variables `SWAY_CURSOR_THEME` and `SWAY_CURSOR_SIZE`

First commit adds support in sway. Second commit adds support in swaybar
Currently, the code is also not very good (`getenv()` scattered everywhere).
Feedback is appreciated.

Thanks!