### PR TITLE
handle_layer_shell_surface: Do not crash if seat doesn't have focus

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -337,7 +337,10 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 		struct sway_seat *seat = input_manager_get_default_seat(input_manager);
 		if (seat) {
 			struct sway_workspace *ws = seat_get_focused_workspace(seat);
-			output = ws->output;
+
+			if (ws != NULL) {
+				output = ws->output;
+			}
 		}
 		if (!output) {
 			if (!sway_assert(root->outputs->length,


### PR DESCRIPTION
Sway crashed with this backtrace when I was afk.

```
0  0x0000556e7e904ec7 in handle_layer_shell_surface (listener=0x556e7e956aa8 <server+104>, data=0x556e7f316490) at ../../sway/desktop/layer_shell.c:340
#1  0x00007f7d8a0fb636 in wlr_signal_emit_safe (signal=0x556e7ed80c60, data=0x556e7f316490)
    at ../../util/signal.c:29
#2  0x00007f7d8a0e4b3c in layer_surface_role_commit (wlr_surface=0x556e7f316190)
    at ../../types/wlr_layer_shell.c:293
#3  0x00007f7d8a0ef4db in surface_commit_pending (surface=0x556e7f316190)
    at ../../types/wlr_surface.c:398
#4  0x00007f7d8a0ef742 in surface_commit (client=0x556e7f13ca10, resource=0x556e7f1b5c10)
    at ../../types/wlr_surface.c:470
#5  0x00007f7d885aa1c8 in ffi_call_unix64 () at /usr/lib/libffi.so.6
#6  0x00007f7d885a9c2a in ffi_call () at /usr/lib/libffi.so.6
#7  0x00007f7d8a13a6ff in  () at /usr/lib/libwayland-server.so.0
#8  0x00007f7d8a1370a3 in  () at /usr/lib/libwayland-server.so.0
#9  0x00007f7d8a138702 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#10 0x00007f7d8a1372ac in wl_display_run () at /usr/lib/libwayland-server.so.0
#11 0x0000556e7e9035bc in server_run (server=0x556e7e956a40 <server>) at ../../sway/server.c:165
#12 0x0000556e7e902d37 in main (argc=1, argv=0x7ffe45f083d8) at ../../sway/main.c:446
```

This check tries to avoid this.