### PR TITLE
Give windows pointer focus immediately

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
 #include "sway/tree/arrange.h"
@@ -180,6 +181,7 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 	}
 	if (new_focus) {
 		seat_set_focus_container(seat, new_focus);
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "focus",
 				"Failed to find a %s container in workspace",
@@ -212,6 +214,7 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 	free(identifier);
 	if (output) {
 		seat_set_focus(seat, seat_get_focus_inactive(seat, &output->node));
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
@@ -232,6 +235,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 
 	if (argc == 0 && container) {
 		seat_set_focus_container(seat, container);
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
@@ -260,6 +264,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		struct sway_node *focus = seat_get_active_child(seat, node);
 		if (focus) {
 			seat_set_focus(seat, focus);
+			cursor_send_pointer_motion(seat->cursor, 0, true);
 		}
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
@@ -279,6 +284,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		struct sway_node *node =
 			get_node_in_output_direction(new_output, direction);
 		seat_set_focus(seat, node);
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
@@ -286,6 +292,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		node_get_in_direction(container, seat, direction);
 	if (next_focus) {
 		seat_set_focus(seat, next_focus);
+		cursor_send_pointer_motion(seat->cursor, 0, true);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -246,7 +246,7 @@ static struct sway_container *container_at_stacked(struct sway_node *parent,
 
 	// Surfaces
 	struct sway_node *current = seat_get_active_child(seat, parent);
-	return tiling_container_at(current, lx, ly, surface, sx, sy);
+	return current ? tiling_container_at(current, lx, ly, surface, sx, sy) : NULL;
 }
 
 /**

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -218,7 +218,7 @@ static struct sway_container *container_at_tabbed(struct sway_node *parent,
 
 	// Surfaces
 	struct sway_node *current = seat_get_active_child(seat, parent);
-	return tiling_container_at(current, lx, ly, surface, sx, sy);
+	return current ? tiling_container_at(current, lx, ly, surface, sx, sy) : NULL;
 }
 
 /**

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -583,9 +583,10 @@ void view_unmap(struct sway_view *view) {
 		workspace_detect_urgent(ws);
 	}
 
+	cursor_send_pointer_motion(config->handler_context.seat->cursor, 0, true);
+
 	transaction_commit_dirty();
 	view->surface = NULL;
-	cursor_send_pointer_motion(config->handler_context.seat->cursor, 0, true);
 }
 
 void view_update_size(struct sway_view *view, int width, int height) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -584,8 +584,8 @@ void view_unmap(struct sway_view *view) {
 	}
 
 	transaction_commit_dirty();
-	cursor_send_pointer_motion(config->handler_context.seat->cursor, 0, true);
 	view->surface = NULL;
+	cursor_send_pointer_motion(config->handler_context.seat->cursor, 0, true);
 }
 
 void view_update_size(struct sway_view *view, int width, int height) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -14,6 +14,7 @@
 #include "sway/criteria.h"
 #include "sway/commands.h"
 #include "sway/desktop/transaction.h"
+#include "sway/input/cursor.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
 #include "sway/input/seat.h"
@@ -583,6 +584,7 @@ void view_unmap(struct sway_view *view) {
 	}
 
 	transaction_commit_dirty();
+	cursor_send_pointer_motion(config->handler_context.seat->cursor, 0, true);
 	view->surface = NULL;
 }
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -7,6 +7,7 @@
 #include <strings.h>
 #include "stringop.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
@@ -400,6 +401,7 @@ bool workspace_switch(struct sway_workspace *workspace,
 				if (&floater->node == focus) {
 					seat_set_focus(seat, NULL);
 					seat_set_focus_container(seat, floater);
+					cursor_send_pointer_motion(seat->cursor, 0, true);
 				}
 				--i;
 			}
@@ -422,6 +424,7 @@ bool workspace_switch(struct sway_workspace *workspace,
 	}
 	seat_set_focus(seat, next);
 	arrange_workspace(workspace);
+	cursor_send_pointer_motion(seat->cursor, 0, true);
 	return true;
 }
 


### PR DESCRIPTION
Fixes #2401 (aka #2558)

Based on feedback on #2612

Previously, when switching windows, pointer focus was not changed until the pointer was moved. This makes the pointer enter happen immediately, without the side effects of other attempted fixes.