### PR TITLE
Implement tiling drag

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -161,6 +161,7 @@ sway_cmd cmd_sticky;
 sway_cmd cmd_swaybg_command;
 sway_cmd cmd_swaynag_command;
 sway_cmd cmd_swap;
+sway_cmd cmd_tiling_drag;
 sway_cmd cmd_title_format;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -365,6 +365,7 @@ struct sway_config {
 	bool validating;
 	bool auto_back_and_forth;
 	bool show_marks;
+	bool tiling_drag;
 
 	bool edge_gaps;
 	bool smart_gaps;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -38,7 +38,7 @@ struct sway_drag_icon {
 enum sway_seat_operation {
 	OP_NONE,
 	OP_DOWN,
-	OP_MOVE,
+	OP_MOVE_FLOATING,
 	OP_RESIZE_FLOATING,
 	OP_RESIZE_TILING,
 };
@@ -172,8 +172,8 @@ void drag_icon_update_position(struct sway_drag_icon *icon);
 void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
 		uint32_t button, double sx, double sy);
 
-void seat_begin_move(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button);
+void seat_begin_move_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button);
 
 void seat_begin_resize_floating(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge);

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -39,6 +39,7 @@ enum sway_seat_operation {
 	OP_NONE,
 	OP_DOWN,
 	OP_MOVE_FLOATING,
+	OP_MOVE_TILING,
 	OP_RESIZE_FLOATING,
 	OP_RESIZE_TILING,
 };
@@ -64,6 +65,9 @@ struct sway_seat {
 	// Operations (drag and resize)
 	enum sway_seat_operation operation;
 	struct sway_container *op_container;
+	struct sway_node *op_target_node; // target for tiling move
+	enum wlr_edges op_target_edge;
+	struct wlr_box op_drop_box;
 	enum wlr_edges op_resize_edge;
 	uint32_t op_button;
 	bool op_resize_preserve_ratio;
@@ -173,6 +177,9 @@ void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
 		uint32_t button, double sx, double sy);
 
 void seat_begin_move_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button);
+
+void seat_begin_move_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
 
 void seat_begin_resize_floating(struct sway_seat *seat,

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -279,8 +279,11 @@ void container_add_child(struct sway_container *parent,
 void container_insert_child(struct sway_container *parent,
 		struct sway_container *child, int i);
 
+/**
+ * Side should be 0 to add before, or 1 to add after.
+ */
 void container_add_sibling(struct sway_container *parent,
-		struct sway_container *child);
+		struct sway_container *child, int side);
 
 void container_detach(struct sway_container *child);
 

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -126,4 +126,6 @@ void workspace_update_representation(struct sway_workspace *ws);
 
 void workspace_get_box(struct sway_workspace *workspace, struct wlr_box *box);
 
+size_t workspace_num_tiling_views(struct sway_workspace *ws);
+
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -127,6 +127,7 @@ static struct cmd_handler handlers[] = {
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },
 	{ "smart_gaps", cmd_smart_gaps },
+	{ "tiling_drag", cmd_tiling_drag },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -235,7 +235,7 @@ static void container_move_to_container(struct sway_container *container,
 	container->saved_width = container->saved_height = 0;
 
 	if (destination->view) {
-		container_add_sibling(destination, container);
+		container_add_sibling(destination, container, 1);
 	} else {
 		container_add_child(destination, container);
 	}

--- a/sway/commands/tiling_drag.c
+++ b/sway/commands/tiling_drag.c
@@ -1,0 +1,13 @@
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_tiling_drag(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "tiling_drag", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	config->tiling_drag = parse_boolean(argv[0], config->tiling_drag);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -225,6 +225,7 @@ static void config_defaults(struct sway_config *config) {
 	config->auto_back_and_forth = false;
 	config->reading = false;
 	config->show_marks = true;
+	config->tiling_drag = true;
 
 	config->edge_gaps = true;
 	config->smart_gaps = false;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -891,6 +891,21 @@ static void render_floating(struct sway_output *soutput,
 	}
 }
 
+static void render_dropzones(struct sway_output *output,
+		pixman_region32_t *damage) {
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &input_manager->seats, link) {
+		if (seat->operation == OP_MOVE_TILING && seat->op_target_node
+				&& node_get_output(seat->op_target_node) == output) {
+			float color[4];
+			memcpy(&color, config->border_colors.focused.indicator,
+					sizeof(float) * 4);
+			premultiply_alpha(color, 0.5);
+			render_rect(output->wlr_output, damage, &seat->op_drop_box, color);
+		}
+	}
+}
+
 void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
@@ -972,6 +987,8 @@ void output_render(struct sway_output *output, struct timespec *when,
 		render_layer(output, damage,
 			&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]);
 	}
+
+	render_dropzones(output, damage);
 
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = seat_get_focused_container(seat);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -333,7 +333,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move(seat, view->container, seat->last_button);
+		seat_begin_move_floating(seat, view->container, seat->last_button);
 	}
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -330,7 +330,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_v6_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move(seat, view->container, seat->last_button);
+		seat_begin_move_floating(seat, view->container, seat->last_button);
 	}
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -449,7 +449,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 		return;
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	seat_begin_move(seat, view->container, seat->last_button);
+	seat_begin_move_floating(seat, view->container, seat->last_button);
 }
 
 static void handle_request_resize(struct wl_listener *listener, void *data) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -228,6 +228,141 @@ static void handle_move_floating_motion(struct sway_seat *seat,
 	desktop_damage_whole_container(con);
 }
 
+static void resize_box(struct wlr_box *box, enum wlr_edges edge,
+		size_t thickness) {
+	switch (edge) {
+	case WLR_EDGE_TOP:
+		box->height = thickness;
+		break;
+	case WLR_EDGE_LEFT:
+		box->width = thickness;
+		break;
+	case WLR_EDGE_RIGHT:
+		box->x = box->x + box->width - thickness;
+		box->width = thickness;
+		break;
+	case WLR_EDGE_BOTTOM:
+		box->y = box->y + box->height - thickness;
+		box->height = thickness;
+		break;
+	case WLR_EDGE_NONE:
+		box->x += thickness;
+		box->y += thickness;
+		box->width -= thickness * 2;
+		box->height -= thickness * 2;
+		break;
+	}
+}
+
+static void handle_move_tiling_motion(struct sway_seat *seat,
+		struct sway_cursor *cursor) {
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+	struct sway_node *node = node_at_coords(seat,
+			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	// Damage the old location
+	desktop_damage_box(&seat->op_drop_box);
+
+	if (!node) {
+		// Eg. hovered over a layer surface such as swaybar
+		seat->op_target_node = NULL;
+		seat->op_target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	if (node->type == N_WORKSPACE) {
+		// Emtpy workspace
+		seat->op_target_node = node;
+		seat->op_target_edge = WLR_EDGE_NONE;
+		workspace_get_box(node->sway_workspace, &seat->op_drop_box);
+		desktop_damage_box(&seat->op_drop_box);
+		return;
+	}
+
+	// Deny moving within own workspace if this is the only child
+	struct sway_container *con = node->sway_container;
+	if (workspace_num_tiling_views(seat->op_container->workspace) == 1 &&
+			con->workspace == seat->op_container->workspace) {
+		seat->op_target_node = NULL;
+		seat->op_target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	// Traverse the ancestors, trying to find a layout container perpendicular
+	// to the edge. Eg. close to the top or bottom of a horiz layout.
+	while (con) {
+		enum wlr_edges edge = WLR_EDGE_NONE;
+		enum sway_container_layout layout = container_parent_layout(con);
+		struct wlr_box parent;
+		con->parent ? container_get_box(con->parent, &parent) :
+			workspace_get_box(con->workspace, &parent);
+		if (layout == L_HORIZ || layout == L_TABBED) {
+			if (cursor->cursor->y < parent.y + 30) {
+				edge = WLR_EDGE_TOP;
+			} else if (cursor->cursor->y > parent.y + parent.height - 30) {
+				edge = WLR_EDGE_BOTTOM;
+			}
+		} else if (layout == L_VERT || layout == L_STACKED) {
+			if (cursor->cursor->x < parent.x + 30) {
+				edge = WLR_EDGE_LEFT;
+			} else if (cursor->cursor->x > parent.x + parent.width - 30) {
+				edge = WLR_EDGE_RIGHT;
+			}
+		}
+		if (edge) {
+			seat->op_target_node = node_get_parent(&con->node);
+			seat->op_target_edge = edge;
+			node_get_box(seat->op_target_node, &seat->op_drop_box);
+			resize_box(&seat->op_drop_box, edge, 30);
+			desktop_damage_box(&seat->op_drop_box);
+			return;
+		}
+		con = con->parent;
+	}
+
+	// Use the hovered view - but we must be over the actual surface
+	con = node->sway_container;
+	if (!con->view->surface || node == &seat->op_container->node) {
+		seat->op_target_node = NULL;
+		seat->op_target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	// Find the closest edge
+	size_t thickness = fmin(con->view->width, con->view->height) * 0.3;
+	size_t closest_dist = INT_MAX;
+	size_t dist;
+	seat->op_target_edge = WLR_EDGE_NONE;
+	if ((dist = cursor->cursor->y - con->y) < closest_dist) {
+		closest_dist = dist;
+		seat->op_target_edge = WLR_EDGE_TOP;
+	}
+	if ((dist = cursor->cursor->x - con->x) < closest_dist) {
+		closest_dist = dist;
+		seat->op_target_edge = WLR_EDGE_LEFT;
+	}
+	if ((dist = con->x + con->width - cursor->cursor->x) < closest_dist) {
+		closest_dist = dist;
+		seat->op_target_edge = WLR_EDGE_RIGHT;
+	}
+	if ((dist = con->y + con->height - cursor->cursor->y) < closest_dist) {
+		closest_dist = dist;
+		seat->op_target_edge = WLR_EDGE_BOTTOM;
+	}
+
+	if (closest_dist > thickness) {
+		seat->op_target_edge = WLR_EDGE_NONE;
+	}
+
+	seat->op_target_node = node;
+	seat->op_drop_box.x = con->view->x;
+	seat->op_drop_box.y = con->view->y;
+	seat->op_drop_box.width = con->view->width;
+	seat->op_drop_box.height = con->view->height;
+	resize_box(&seat->op_drop_box, seat->op_target_edge, thickness);
+	desktop_damage_box(&seat->op_drop_box);
+}
+
 static void calculate_floating_constraints(struct sway_container *con,
 		int *min_width, int *max_width, int *min_height, int *max_height) {
 	if (config->floating_minimum_width == -1) { // no minimum
@@ -404,6 +539,9 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			break;
 		case OP_MOVE_FLOATING:
 			handle_move_floating_motion(seat, cursor);
+			break;
+		case OP_MOVE_TILING:
+			handle_move_tiling_motion(seat, cursor);
 			break;
 		case OP_RESIZE_FLOATING:
 			handle_resize_floating_motion(seat, cursor);
@@ -749,6 +887,14 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			seat_begin_resize_floating(seat, floater, button, edge);
 			return;
 		}
+	}
+
+	// Handle moving a tiling container
+	if (config->tiling_drag && mod_pressed && !is_floating_or_child &&
+			!cont->is_fullscreen) {
+		seat_pointer_notify_button(seat, time_msec, button, state);
+		seat_begin_move_tiling(seat, cont, button);
+		return;
 	}
 
 	// Handle mousedown on a container surface

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -218,7 +218,7 @@ static void handle_down_motion(struct sway_seat *seat,
 	seat->op_moved = true;
 }
 
-static void handle_move_motion(struct sway_seat *seat,
+static void handle_move_floating_motion(struct sway_seat *seat,
 		struct sway_cursor *cursor) {
 	struct sway_container *con = seat->op_container;
 	desktop_damage_whole_container(con);
@@ -402,8 +402,8 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		case OP_DOWN:
 			handle_down_motion(seat, cursor, time_msec);
 			break;
-		case OP_MOVE:
-			handle_move_motion(seat, cursor);
+		case OP_MOVE_FLOATING:
+			handle_move_floating_motion(seat, cursor);
 			break;
 		case OP_RESIZE_FLOATING:
 			handle_resize_floating_motion(seat, cursor);
@@ -719,7 +719,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			while (cont->parent) {
 				cont = cont->parent;
 			}
-			seat_begin_move(seat, cont, button);
+			seat_begin_move_floating(seat, cont, button);
 			return;
 		}
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -975,6 +975,16 @@ void seat_begin_move_floating(struct sway_seat *seat,
 	cursor_set_image(seat->cursor, "grab", NULL);
 }
 
+void seat_begin_move_tiling(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
+	seat->operation = OP_MOVE_TILING;
+	seat->op_container = con;
+	seat->op_button = button;
+	seat->op_target_node = NULL;
+	seat->op_target_edge = 0;
+	cursor_set_image(seat->cursor, "grab", NULL);
+}
+
 void seat_begin_resize_floating(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
 	if (!seat->cursor) {
@@ -1015,6 +1025,68 @@ void seat_begin_resize_tiling(struct sway_seat *seat,
 	seat->op_ref_height = con->height;
 }
 
+static bool is_parallel(enum sway_container_layout layout,
+		enum wlr_edges edge) {
+	bool layout_is_horiz = layout == L_HORIZ || layout == L_TABBED;
+	bool edge_is_horiz = edge == WLR_EDGE_LEFT || edge == WLR_EDGE_RIGHT;
+	return layout_is_horiz == edge_is_horiz;
+}
+
+static void seat_end_move_tiling(struct sway_seat *seat) {
+	struct sway_container *con = seat->op_container;
+	struct sway_container *old_parent = con->parent;
+	struct sway_workspace *old_ws = con->workspace;
+	struct sway_node *target_node = seat->op_target_node;
+	struct sway_workspace *new_ws = target_node->type == N_WORKSPACE ?
+		target_node->sway_workspace : target_node->sway_container->workspace;
+	enum wlr_edges edge = seat->op_target_edge;
+	int after = edge != WLR_EDGE_TOP && edge != WLR_EDGE_LEFT;
+
+	container_detach(con);
+	if (old_parent) {
+		container_reap_empty(old_parent);
+	}
+
+	// Moving container into empty workspace
+	if (target_node->type == N_WORKSPACE && edge == WLR_EDGE_NONE) {
+		workspace_add_tiling(new_ws, con);
+
+	// Moving container before/after another
+	} else if (target_node->type == N_CONTAINER) {
+		struct sway_container *target = target_node->sway_container;
+		enum sway_container_layout layout = container_parent_layout(target);
+		if (edge && !is_parallel(layout, edge)) {
+			enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
+				edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
+			container_split(target, new_layout);
+		}
+		container_add_sibling(target, con, after);
+
+	// Target is a workspace which requires splitting
+	} else {
+		enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
+			edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
+		workspace_split(new_ws, new_layout);
+		workspace_insert_tiling(new_ws, con, after);
+	}
+
+	// This is a bit dirty, but we'll set the dimensions to that of a sibling.
+	// I don't think there's any other way to make it consistent without
+	// changing how we auto-size containers.
+	list_t *siblings = container_get_siblings(con);
+	if (siblings->length > 1) {
+		int index = list_find(siblings, con);
+		struct sway_container *sibling = index == 0 ? siblings->items[1] : siblings->items[index - 1];
+		con->width = sibling->width;
+		con->height = sibling->height;
+	}
+
+	arrange_workspace(old_ws);
+	if (new_ws != old_ws) {
+		arrange_workspace(new_ws);
+	}
+}
+
 void seat_end_mouse_operation(struct sway_seat *seat) {
 	enum sway_seat_operation operation = seat->operation;
 	if (seat->operation == OP_MOVE_FLOATING) {
@@ -1022,6 +1094,8 @@ void seat_end_mouse_operation(struct sway_seat *seat) {
 		// output again.
 		struct sway_container *con = seat->op_container;
 		container_floating_move_to(con, con->x, con->y);
+	} else if (seat->operation == OP_MOVE_TILING && seat->op_target_node) {
+		seat_end_move_tiling(seat);
 	}
 	seat->operation = OP_NONE;
 	seat->op_container = NULL;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -963,13 +963,13 @@ void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
 	seat->op_moved = false;
 }
 
-void seat_begin_move(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button) {
+void seat_begin_move_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
 	if (!seat->cursor) {
 		wlr_log(WLR_DEBUG, "Ignoring move request due to no cursor device");
 		return;
 	}
-	seat->operation = OP_MOVE;
+	seat->operation = OP_MOVE_FLOATING;
 	seat->op_container = con;
 	seat->op_button = button;
 	cursor_set_image(seat->cursor, "grab", NULL);
@@ -1017,7 +1017,7 @@ void seat_begin_resize_tiling(struct sway_seat *seat,
 
 void seat_end_mouse_operation(struct sway_seat *seat) {
 	enum sway_seat_operation operation = seat->operation;
-	if (seat->operation == OP_MOVE) {
+	if (seat->operation == OP_MOVE_FLOATING) {
 		// We "move" the container to its own location so it discovers its
 		// output again.
 		struct sway_container *con = seat->op_container;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -83,6 +83,7 @@ sway_sources = files(
 	'commands/swaybg_command.c',
 	'commands/swaynag_command.c',
 	'commands/swap.c',
+	'commands/tiling_drag.c',
 	'commands/title_format.c',
 	'commands/unmark.c',
 	'commands/urgent.c',

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -835,7 +835,13 @@ void container_end_mouse_operation(struct sway_container *container) {
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &input_manager->seats, link) {
 		if (seat->op_container == container) {
+			seat->op_target_node = NULL; // ensure tiling move doesn't apply
 			seat_end_mouse_operation(seat);
+		}
+		// If the user is doing a tiling drag over this container,
+		// keep the operation active but unset the target container.
+		if (seat->op_target_node == &container->node) {
+			seat->op_target_node = NULL;
 		}
 	}
 }
@@ -1086,13 +1092,13 @@ void container_insert_child(struct sway_container *parent,
 }
 
 void container_add_sibling(struct sway_container *fixed,
-		struct sway_container *active) {
+		struct sway_container *active, int side) {
 	if (active->workspace) {
 		container_detach(active);
 	}
 	list_t *siblings = container_get_siblings(fixed);
 	int index = list_find(siblings, fixed);
-	list_insert(siblings, index + 1, active);
+	list_insert(siblings, index + side, active);
 	active->parent = fixed->parent;
 	active->workspace = fixed->workspace;
 	container_for_each_child(active, set_workspace, NULL);
@@ -1145,7 +1151,7 @@ void container_detach(struct sway_container *child) {
 
 void container_replace(struct sway_container *container,
 		struct sway_container *replacement) {
-	container_add_sibling(container, replacement);
+	container_add_sibling(container, replacement, 1);
 	container_detach(container);
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -529,7 +529,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface) {
 
 	view->container = container_create(view);
 	if (target_sibling) {
-		container_add_sibling(target_sibling, view->container);
+		container_add_sibling(target_sibling, view->container, 1);
 	} else {
 		workspace_add_tiling(ws, view->container);
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -694,3 +694,16 @@ void workspace_get_box(struct sway_workspace *workspace, struct wlr_box *box) {
 	box->width = workspace->width;
 	box->height = workspace->height;
 }
+
+static void count_tiling_views(struct sway_container *con, void *data) {
+	if (con->view && !container_is_floating_or_child(con)) {
+		size_t *count = data;
+		*count += 1;
+	}
+}
+
+size_t workspace_num_tiling_views(struct sway_workspace *ws) {
+	size_t count = 0;
+	workspace_for_each_container(ws, count_tiling_views, &count);
+	return count;
+}


### PR DESCRIPTION
Hold `floating_modifier` then click and drag a tiling view to move it around.

This is based of an open PR in i3: https://github.com/i3/i3/pull/3085#issuecomment-379487507

* A new config directive `tiling_drag` can disable the functionality (as per i3). It's enabled by default.
* The colour of the drop zone is the indicator colour. In i3 this is a solid colour, but in sway I gave it 50% transparency. I don't think i3 can make it transparent without introducing compositing into i3, so we have an advantage here.
* Views within a floating container cannot be moved around (we do the move-floating behaviour instead)
* This functionality intentionally cannot be triggered by a regular click and drag on the title bar. i3 doesn't do this - instead i3 starts resizing the split. We should probably do the same.

Some more specific stuff:

* While dragging, move the cursor to the edges of a another container. If the edge is parallel to the container's parent layout then the view will be inserted as a sibling, otherwise it'll split the container and insert it into the split.
* You can also drop a view into the center of another container, which adds it as a sibling regardless of the container's parent layout.
* If you hover close to the perpendicular edge of a layout container then you can insert it as a sibling of the layout container. For example, create layout `H[view V[view view]]` then move one of the right views to the left edge of the vertical container.
* You can do the same for workspaces: `H[view view]` then move a view to the top.
* You can drop a view into an empty workspace.