### PR TITLE
i3bar: count references to blocks

### DIFF
--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -36,6 +36,7 @@ struct i3bar_protocol_state {
 
 struct i3bar_block {
 	struct wl_list link;
+	int ref_count;
 	char *full_text, *short_text, *align;
 	bool urgent;
 	uint32_t *color;
@@ -73,7 +74,7 @@ void status_line_free(struct status_line *status);
 bool i3bar_handle_readable(struct status_line *status);
 enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, int x, int y, enum x11_button button);
-void i3bar_block_free(struct i3bar_block *block);
+void i3bar_block_unref(struct i3bar_block *block);
 enum x11_button wl_button_to_x11_button(uint32_t button);
 enum x11_button wl_axis_to_x11_button(uint32_t axis, wl_fixed_t value);
 

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -115,6 +115,10 @@ static enum hotspot_event_handling block_hotspot_callback(struct swaybar_output 
 	return i3bar_block_send_click(status, block, x, y, button);
 }
 
+static void i3bar_block_unref_callback(void *data) {
+	i3bar_block_unref(data);
+}
+
 static uint32_t render_status_block(cairo_t *cairo,
 		struct swaybar_config *config, struct swaybar_output *output,
 		struct i3bar_block *block, double *x,
@@ -179,8 +183,9 @@ static uint32_t render_status_block(cairo_t *cairo,
 	hotspot->width = width;
 	hotspot->height = height;
 	hotspot->callback = block_hotspot_callback;
-	hotspot->destroy = NULL;
+	hotspot->destroy = i3bar_block_unref_callback;
 	hotspot->data = block;
+	block->ref_count++;
 	wl_list_insert(&output->hotspots, &hotspot->link);
 
 	double pos = *x;

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -130,7 +130,7 @@ void status_line_free(struct status_line *status) {
 	case PROTOCOL_I3BAR:;
 		struct i3bar_block *block, *tmp;
 		wl_list_for_each_safe(block, tmp, &status->blocks, link) {
-			i3bar_block_free(block);
+			i3bar_block_unref(block);
 		}
 		free(status->i3bar_state.buffer);
 		break;


### PR DESCRIPTION
This prevents blocks from being destroyed before their hotspots are destroyed,
in case it is used for a pending click event that fires between the bar
receiving a new status, which destroys the block, and the bar rendering the new
status, which destroys the hotspot.

This problem can be easily produced by
scrolling on a block that immediately causes a new status to be sent, with
multiple outputs.

Whether this is the best way to fix this problem I'm not sure.