### PR TITLE
Remove bad assertion in workspace_rejigger

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -259,9 +259,6 @@ static void container_move_to_container(struct sway_container *container,
  * In other words, rejigger it. */
 static void workspace_rejigger(struct sway_workspace *ws,
 		struct sway_container *child, enum movement_direction move_dir) {
-	if (!sway_assert(child->parent == NULL, "Expected a root child")) {
-		return;
-	}
 	container_detach(child);
 	workspace_wrap_children(ws);
 
@@ -270,6 +267,7 @@ static void workspace_rejigger(struct sway_workspace *ws,
 	ws->layout =
 		move_dir == MOVE_LEFT || move_dir == MOVE_RIGHT ? L_HORIZ : L_VERT;
 	workspace_update_representation(ws);
+	child->width = child->height = 0;
 }
 
 static void move_out_of_tabs_stacks(struct sway_container *container,


### PR DESCRIPTION
The assertion can be (rightfully) triggered by creating layout `V[H[view view] view]` and moving the top right view to the right.

After removing the assertion I found the container being moved needs its size reset to prevent it from being sized wrongly after arranging.