### PR TITLE
Allow spaces in background file path

### DIFF
--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -61,7 +61,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 				"Missing background scaling mode.");
 		}
 
-		wordexp_t p;
+		wordexp_t p = {0};
 		char *src = join_args(argv, j);
 		while (strstr(src, "  ")) {
 			src = realloc(src, strlen(src) + 2);
@@ -123,6 +123,22 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			}
 			free(src);
 		} else {
+			// Escape spaces and quotes in the final path for swaybg
+			for (size_t i = 0; i < strlen(src); i++) {
+				switch (src[i]) {
+					case ' ':
+					case '\'':
+					case '\"':
+						src = realloc(src, strlen(src) + 2);
+						memmove(src + i + 1, src + i, strlen(src + i) + 1);
+						*(src + i) = '\\';
+						i++;
+						break;
+					default:
+						break;
+				}
+			}
+
 			output->background = src;
 			output->background_option = strdup(mode);
 		}

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -63,6 +63,12 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 
 		wordexp_t p;
 		char *src = join_args(argv, j);
+		while (strstr(src, "  ")) {
+			src = realloc(src, strlen(src) + 2);
+			char *ptr = strstr(src, "  ") + 1;
+			memmove(ptr + 1, ptr, strlen(ptr) + 1);
+			*ptr = '\\';
+		}
 		if (wordexp(src, &p, 0) != 0 || p.we_wordv[0] == NULL) {
 			struct cmd_results *cmd_res = cmd_results_new(CMD_INVALID, "output",
 				"Invalid syntax (%s)", src);

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -71,7 +71,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			return cmd_res;
 		}
 		free(src);
-		src = strdup(p.we_wordv[0]);
+		src = join_args(p.we_wordv, p.we_wordc);
 		wordfree(&p);
 		if (!src) {
 			wlr_log(WLR_ERROR, "Failed to duplicate string");

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -237,7 +237,7 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_log(WLR_DEBUG, "Setting background for output %d to %s",
 				output_i, oc->background);
 
-		size_t len = snprintf(NULL, 0, "%s %d %s %s %s",
+		size_t len = snprintf(NULL, 0, "%s %d \"%s\" %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
 				output_i, oc->background, oc->background_option,
 				oc->background_fallback ? oc->background_fallback : "");
@@ -246,7 +246,7 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 			wlr_log(WLR_DEBUG, "Unable to allocate swaybg command");
 			return;
 		}
-		snprintf(command, len + 1, "%s %d %s %s %s",
+		snprintf(command, len + 1, "%s %d \"%s\" %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
 				output_i, oc->background, oc->background_option,
 				oc->background_fallback ? oc->background_fallback : "");

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -237,7 +237,7 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_log(WLR_DEBUG, "Setting background for output %d to %s",
 				output_i, oc->background);
 
-		size_t len = snprintf(NULL, 0, "%s %d \"%s\" %s %s",
+		size_t len = snprintf(NULL, 0, "%s %d %s %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
 				output_i, oc->background, oc->background_option,
 				oc->background_fallback ? oc->background_fallback : "");
@@ -246,7 +246,7 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 			wlr_log(WLR_DEBUG, "Unable to allocate swaybg command");
 			return;
 		}
-		snprintf(command, len + 1, "%s %d \"%s\" %s %s",
+		snprintf(command, len + 1, "%s %d %s %s %s",
 				config->swaybg_command ? config->swaybg_command : "swaybg",
 				output_i, oc->background, oc->background_option,
 				oc->background_fallback ? oc->background_fallback : "");


### PR DESCRIPTION
Fixes #654 

`wordexp` splits the file path into multiple words if there are spaces. In `master`, only the first word is used. This caused `foo bar` to be truncated to just `foo`. Additionally, the path given to `swaybg` is not escaped in anyway and `wordexp` strips any backslash escaped spaces.

This first commit of this PR joins the words from `wordexp` together and encloses the path given to `swaybg` in quotes. This works well if there are not consecutive spaces in the file path or if consecutive spaces are backslash escaped.

The second commit of this PR will detect non-escaped consecutive spaces and escape them for the user. This allows for the path to be enclosed in quotes.

With both commits, the following methods for supplying the path should be working regardless the number of consecutive spaces:
- The path in quotes
- The path with spaces escaped with backslashes