### PR TITLE
Fix crash when unmapping last child of a tabbed workspace

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -202,6 +202,9 @@ static struct sway_container *container_at_tabbed(struct sway_node *parent,
 	}
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	list_t *children = node_get_children(parent);
+	if (!children->length) {
+		return NULL;
+	}
 
 	// Tab titles
 	int title_height = container_titlebar_height();


### PR DESCRIPTION
* Create layout `T[view view]`
* Move the cursor into the title bar area
* Close both views

Sway would crash because `container_at_tabbed` would attempt to divide by zero when there are no children.

The children check isn't needed for `container_at_stacked` because it doesn't divide anything by the number of children.

Fixes #2636.