### PR TITLE
Overhaul swaybar protocol handling (+fixes)

### DIFF
--- a/common/readline.c
+++ b/common/readline.c
@@ -70,28 +70,3 @@ char *peek_line(FILE *file, int line_offset, long *position) {
 	fseek(file, pos, SEEK_SET);
 	return line;
 }
-
-char *read_line_buffer(FILE *file, char *string, size_t string_len) {
-	size_t length = 0;
-	if (!string) {
-		return NULL;
-	}
-	while (1) {
-		int c = getc(file);
-		if (c == EOF || c == '\n' || c == '\0') {
-			break;
-		}
-		if (c == '\r') {
-			continue;
-		}
-		string[length++] = c;
-		if (string_len <= length) {
-			return NULL;
-		}
-	}
-	if (length + 1 == string_len) {
-		return NULL;
-	}
-	string[length] = '\0';
-	return string;
-}

--- a/include/swaybar/event_loop.h
+++ b/include/swaybar/event_loop.h
@@ -19,8 +19,8 @@ bool remove_event(int fd);
 bool remove_timer(timer_t timer);
 
 // Blocks and returns after sending callbacks
-void event_loop_poll();
+void event_loop_poll(void);
 
-void init_event_loop();
+void init_event_loop(void);
 
 #endif

--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -1,5 +1,6 @@
 #ifndef _SWAYBAR_STATUS_LINE_H
 #define _SWAYBAR_STATUS_LINE_H
+#include <json-c/json.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -10,23 +11,6 @@ enum status_protocol {
 	PROTOCOL_ERROR,
 	PROTOCOL_TEXT,
 	PROTOCOL_I3BAR,
-};
-
-enum json_node_type {
-	JSON_NODE_UNKNOWN,
-	JSON_NODE_ARRAY,
-	JSON_NODE_STRING,
-};
-
-struct i3bar_protocol_state {
-	bool click_events;
-	char *buffer;
-	size_t buffer_size;
-	size_t buffer_index;
-	const char *current_node;
-	bool escape;
-	size_t depth;
-	enum json_node_type nodes[16];
 };
 
 struct i3bar_block {
@@ -58,9 +42,13 @@ struct status_line {
 	const char *text;
 	struct wl_list blocks; // i3bar_block::link
 
+	bool click_events;
 	char *buffer;
 	size_t buffer_size;
-	struct i3bar_protocol_state i3bar_state;
+	size_t buffer_index;
+	bool started;
+	bool expecting_comma;
+	json_tokener *tokener;
 };
 
 struct status_line *status_line_init(char *cmd);

--- a/include/swaybar/status_line.h
+++ b/include/swaybar/status_line.h
@@ -12,11 +12,6 @@ enum status_protocol {
 	PROTOCOL_I3BAR,
 };
 
-struct text_protocol_state {
-	char *buffer;
-	size_t buffer_size;
-};
-
 enum json_node_type {
 	JSON_NODE_UNKNOWN,
 	JSON_NODE_ARRAY,
@@ -63,7 +58,8 @@ struct status_line {
 	const char *text;
 	struct wl_list blocks; // i3bar_block::link
 
-	struct text_protocol_state text_state;
+	char *buffer;
+	size_t buffer_size;
 	struct i3bar_protocol_state i3bar_state;
 };
 

--- a/swaybar/event_loop.c
+++ b/swaybar/event_loop.c
@@ -105,7 +105,7 @@ bool remove_timer(timer_t timer) {
 	return false;
 }
 
-void event_loop_poll() {
+void event_loop_poll(void) {
 	poll(event_loop.fds.items, event_loop.fds.length, -1);
 
 	for (int i = 0; i < event_loop.fds.length; ++i) {
@@ -146,7 +146,7 @@ void event_loop_poll() {
 	}
 }
 
-void init_event_loop() {
+void init_event_loop(void) {
 	event_loop.fds.length = 0;
 	event_loop.fds.capacity = 10;
 	event_loop.fds.items = malloc(

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -214,7 +214,7 @@ enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 	json_object_object_add(event_json, "button", json_object_new_int(button));
 	json_object_object_add(event_json, "x", json_object_new_int(x));
 	json_object_object_add(event_json, "y", json_object_new_int(y));
-	if (dprintf(status->write_fd, "%s\n",
+	if (dprintf(status->write_fd, "%s,\n",
 				json_object_to_json_string(event_json)) < 0) {
 		status_error(status, "[failed to write click event]");
 	}

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -120,14 +120,14 @@ static void i3bar_block_unref_callback(void *data) {
 }
 
 static uint32_t render_status_block(cairo_t *cairo,
-		struct swaybar_config *config, struct swaybar_output *output,
-		struct i3bar_block *block, double *x,
+		struct swaybar_output *output, struct i3bar_block *block, double *x,
 		uint32_t surface_height, bool focused, bool edge) {
 	if (!block->full_text || !*block->full_text) {
 		return 0;
 	}
 
 	uint32_t height = surface_height * output->scale;
+	struct swaybar_config *config = output->bar->config;
 
 	int text_width, text_height;
 	get_text_size(cairo, config->font, &text_width, &text_height, NULL,
@@ -177,16 +177,18 @@ static uint32_t render_status_block(cairo_t *cairo,
 		*x -= margin;
 	}
 
-	struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
-	hotspot->x = *x;
-	hotspot->y = 0;
-	hotspot->width = width;
-	hotspot->height = height;
-	hotspot->callback = block_hotspot_callback;
-	hotspot->destroy = i3bar_block_unref_callback;
-	hotspot->data = block;
-	block->ref_count++;
-	wl_list_insert(&output->hotspots, &hotspot->link);
+	if (output->bar->status->i3bar_state.click_events) {
+		struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
+		hotspot->x = *x;
+		hotspot->y = 0;
+		hotspot->width = width;
+		hotspot->height = height;
+		hotspot->callback = block_hotspot_callback;
+		hotspot->destroy = i3bar_block_unref_callback;
+		hotspot->data = block;
+		block->ref_count++;
+		wl_list_insert(&output->hotspots, &hotspot->link);
+	}
 
 	double pos = *x;
 	if (block->background) {
@@ -268,7 +270,7 @@ static uint32_t render_status_line_i3bar(cairo_t *cairo,
 	bool edge = true;
 	struct i3bar_block *block;
 	wl_list_for_each(block, &status->blocks, link) {
-		uint32_t h = render_status_block(cairo, config, output,
+		uint32_t h = render_status_block(cairo, output,
 				block, x, surface_height, focused, edge);
 		max_height = h > max_height ? h : max_height;
 		edge = false;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -177,7 +177,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 		*x -= margin;
 	}
 
-	if (output->bar->status->i3bar_state.click_events) {
+	if (output->bar->status->click_events) {
 		struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
 		hotspot->x = *x;
 		hotspot->y = 0;

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -147,8 +147,8 @@ void status_line_free(struct status_line *status) {
 			wl_list_remove(&block->link);
 			i3bar_block_unref(block);
 		}
+		json_tokener_free(status->tokener);
 	}
-	json_tokener_free(status->tokener);
 	free(status->buffer);
 	free(status);
 }

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -127,13 +127,15 @@ void status_line_free(struct status_line *status) {
 	close(status->write_fd);
 	kill(status->pid, SIGTERM);
 	switch (status->protocol) {
-	case PROTOCOL_I3BAR:;
+	case PROTOCOL_I3BAR: {
 		struct i3bar_block *block, *tmp;
 		wl_list_for_each_safe(block, tmp, &status->blocks, link) {
+			wl_list_remove(&block->link);
 			i3bar_block_unref(block);
 		}
 		free(status->i3bar_state.buffer);
 		break;
+	}
 	default:
 		free(status->text_state.buffer);
 		break;


### PR DESCRIPTION
Should fix #2177

This replaces the somewhat dodgy old implementation with something a bit more sensible, I think.

Both protocols now properly handle long and multiple statuses. The old i3bar handling also allowed dodgy JSON to be sent, as long as it starts with a valid array, which this fixes.

I've tried it with many different status commands, but I may have missed something so please test if you have anything unconventional. Might also want to test performance as well, seems fine but I haven't tested it thoroughly.

~One annoying thing is that since everything works in the one buffer, it is not trivial to print received JSON for debugging (since we cannot simply add a null-terminator). Ideas for adding it back in:~
~1. copy the string each time a valid array is encountered, then print it at the end; good if we assume that most of the time, only one status with be sent at a time;~
~2. don't drop the last json object, keep it around in the buffer, then add a null-terminator at the end and print it; good if we assume that most of the time, the buffer won't in fact overflow.~
~Thoughts? I think the second option is probably better.~

In the end, I didn't go with either of the above options, instead, I printed each object as they came (using some buffer shenanigans to avoid copying the string), but printed another message for what actually gets rendered.


Also leave comments about ~function/~ variable names, they may not be the best.

One thing I did realise afterwards is that `read_line_buffer` skips over `\r` but I haven't bothered to do that, not sure if that's wanted.

Note: there is a small issue with the bar immediately exiting due to invalid JSON which I thought I had fixed but still occurs occasionally. I'm also not sure why it exits rather than just display the error message. I think it might have something to do with receiving null bytes from the stream.