### PR TITLE
Fix crash when an idle-inhibiting client exits

### DIFF
--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -44,7 +44,7 @@ void idle_inhibit_v1_check_active(
 	struct sway_idle_inhibitor_v1 *inhibitor;
 	bool inhibited = false;
 	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
-		if (!inhibitor->view) {
+		if (!inhibitor->view || !inhibitor->view->container) {
 			/* Cannot guess if view is visible so assume it is */
 			inhibited = true;
 			break;


### PR DESCRIPTION
Note: I do not know if this is the right fix! Maybe `view_is_visible` should handle this case, or maybe something else should be reordered so `idle_inhibit_v1_check_active` does not check views in this state? Let me know if this should be fixed differently or you need more information on the crash.

This fixes a crash with sway built from head when running `mpv --gpu-context=wayland --fullscreen /some/video` followed by `killall -9 mpv` (I have seen this without manually killing mpv, but not reproducably: I suspect mpv was shutting down uncleanly):

```
#0  0x000055834707bbec in view_is_visible (view=0x558348bc6950) at ../sway-9999/sway/tree/view.c:989
#1  0x0000558347056ba5 in idle_inhibit_v1_check_active (manager=0x55834872b3b0)
    at ../sway-9999/sway/desktop/idle_inhibit_v1.c:52
#2  0x000055834705c432 in transaction_progress_queue () at ../sway-9999/sway/desktop/transaction.c:351
#3  0x000055834705ca95 in transaction_commit_dirty () at ../sway-9999/sway/desktop/transaction.c:533
#4  0x000055834707aed3 in view_unmap (view=view@entry=0x558348bc6950) at ../sway-9999/sway/tree/view.c:589
#5  0x000055834705da87 in handle_unmap (listener=0x558348bc6b58, data=<optimized out>)
    at ../sway-9999/sway/desktop/xdg_shell.c:364
#6  0x00007f0612aa2d9c in wlr_signal_emit_safe (signal=signal@entry=0x558348bbf638, data=data@entry=0x558348bbf530)
    at ../wlroots-9999/util/signal.c:29
#7  0x00007f0612a88e3f in unmap_xdg_surface (surface=0x558348bbf530)
    at ../wlroots-9999/types/xdg_shell/wlr_xdg_surface.c:34
#8  0x00007f0612a893a5 in destroy_xdg_surface (surface=0x558348bbf530)
    at ../wlroots-9999/types/xdg_shell/wlr_xdg_surface.c:456
#9  0x00007f0612adad9e in destroy_resource (element=0x558348bbf680, data=<optimized out>, flags=0)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-server.c:688
#10 0x00007f0612adf212 in for_each_helper (func=func@entry=0x7f0612adad30 <destroy_resource>,
    data=data@entry=0x7fffe4b21124, entries=<optimized out>, entries=<optimized out>)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-util.c:372
#11 0x00007f0612adf70f in wl_map_for_each (map=0x558348bb76f0, func=0x7f0612adad30 <destroy_resource>,
    data=0x7fffe4b21124) at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-util.c:385
#12 0x00007f0612adae9d in wl_client_destroy (client=client@entry=0x558348bb76c0)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-server.c:847
#13 0x00007f0612adaf75 in destroy_client_with_error (reason=<optimized out>, client=<optimized out>)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-server.c:307
#14 wl_client_connection_data (fd=<optimized out>, mask=<optimized out>, data=0x558348bb76c0)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-server.c:330
#15 0x00007f0612adcb72 in wl_event_loop_dispatch (loop=0x55834859df10, timeout=timeout@entry=-1)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/event-loop.c:641
#16 0x00007f0612adb33a in wl_display_run (display=0x5583485a0700)
    at /var/tmp/portage/dev-libs/wayland-1.15.0/work/wayland-1.15.0/src/wayland-server.c:1260
#17 0x000055834704d127 in main (argc=<optimized out>, argv=<optimized out>) at ../sway-9999/sway/main.c:446
```

mpv uses zwp_idle_inhibit_manager_v1, and it looks like it's still in the list of inhibitors. `view_is_visible` crashes because `view->container` is null:

```
(gdb) p *view
$1 = {type = SWAY_VIEW_XDG_SHELL, impl = 0x558347099ac0 <view_impl>, container = 0x0, surface = 0x558348bcb770,
  x = 1200, y = 220, width = 1920, height = 1200, saved_x = 0, saved_y = 0, saved_width = 0, saved_height = 0,
  natural_width = 1280, natural_height = 720, title_format = 0x0, border = B_NORMAL, border_thickness = 0,
  border_top = false, border_bottom = false, border_left = false, border_right = false, using_csd = false, urgent = {
    tv_sec = 0, tv_nsec = 0}, allow_request_urgent = true, urgent_timer = 0x0, saved_buffer = 0x0,
  saved_buffer_width = 1920, saved_buffer_height = 1200, geometry = {x = 0, y = 0, width = 1920, height = 1200},
  saved_geometry = {x = 0, y = 0, width = 1920, height = 1200}, destroying = false,
  executed_criteria = 0x558348ba75d0, marks = 0x558348bbde50, marks_focused = 0x0, marks_focused_inactive = 0x0,
  marks_unfocused = 0x0, marks_urgent = 0x0, {wlr_xdg_surface_v6 = 0x558348bbf530, wlr_xdg_surface = 0x558348bbf530,
    wlr_xwayland_surface = 0x558348bbf530, wlr_wl_shell_surface = 0x558348bbf530}, events = {unmap = {listener_list = {
        prev = 0x558348bc6a50, next = 0x558348bc6a50}}}, surface_new_subsurface = {link = {prev = 0x0, next = 0x0},
    notify = 0x55834707b130 <view_handle_surface_new_subsurface>}}
```

I didn't confirm it but assume it's null because `transaction_destroy` just destroyed it.

I can no longer reproduce the crash after adding this extra check to `idle_inhibit_v1_check_active`.