### PR TITLE
Fix crash moving out of tab container

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -289,7 +289,7 @@ static void move_out_of_tabs_stacks(struct sway_container *container,
 	}
 
 	wlr_log(WLR_DEBUG, "Moving out of tab/stack into a split");
-	if (container->parent) {
+	if (current->parent) {
 		struct sway_container *new_parent =
 			container_split(current->parent, layout);
 		container_insert_child(new_parent, container, offs < 0 ? 0 : 1);


### PR DESCRIPTION
To reproduce issue:
1. Set an empty workspace to be tabbed
1. Open two windows
1. H split one
1. Open three windows, your tree should now be:
    ````
    Tabbed {
        Window,
        Tiled {
            Window,
            Window,
            Window
        }
    }
    ````
1. Move one of the inner windows down
1. Segfault

Stack trace: 
```
Thread 1 "sway" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff1fe39c0 (LWP 15042)]
0x000055555559b63f in container_split (child=0x0, layout=L_VERT)
    at ../sway/tree/container.c:1168
1168		cont->width = child->width;
(gdb) bt
#0  0x000055555559b63f in container_split (child=0x0, layout=L_VERT)
    at ../sway/tree/container.c:1168
#1  0x000055555558a470 in move_out_of_tabs_stacks
    (container=0x555555ab80f0, current=0x555555aab710, move_dir=MOVE_DOWN, offs=1)
    at ../sway/commands/move.c:294
#2  0x000055555558a7a4 in container_move_in_direction
    (container=0x555555ab80f0, move_dir=MOVE_DOWN) at ../sway/commands/move.c:374
#3  0x000055555558b911 in cmd_move_in_direction
    (direction=MOVE_DOWN, argc=1, argv=0x555555abb1d8)
    at ../sway/commands/move.c:730
#4  0x000055555558c238 in cmd_move (argc=1, argv=0x555555abb1d8)
    at ../sway/commands/move.c:894
#5  0x00005555555615c3 in execute_command
    (_exec=0x55555577e800 "move down", seat=0x55555585b150)
    at ../sway/commands.c:318
#6  0x00005555555853a2 in seat_execute_command
    (seat=0x55555585b150, binding=0x55555577e8d0) at ../sway/commands/bind.c:324
#7  0x0000555555580a50 in handle_keyboard_key
    (listener=0x5555555dd160, data=0x7fffffffe240) at ../sway/input/keyboard.c:284
#8  0x00007ffff6f56973 in wlr_signal_emit_safe
    (signal=0x5555555c86b8, data=0x7fffffffe240) at ../util/signal.c:29
#9  0x00007ffff6f3dd87 in wlr_keyboard_notify_key
    (keyboard=0x5555555c85c0, event=0x7fffffffe240) at ../types/wlr_keyboard.c:107
#10 0x00007ffff6f1efb9 in keyboard_handle_key
    (data=0x5555555c8cf0, wl_keyboard=0x5555558a7160, serial=70, time=4484117, key=108, state=1) at ../backend/wayland/wl_seat.c:230
#11 0x00007ffff54041c8 in ffi_call_unix64 () at /usr/lib/libffi.so.6
#12 0x00007ffff5403c2a in ffi_call () at /usr/lib/libffi.so.6
#13 0x00007ffff44fbf5f in  () at /usr/lib/libwayland-client.so.0
#14 0x00007ffff44f86ca in  () at /usr/lib/libwayland-client.so.0
#15 0x00007ffff44f9c0c in wl_display_dispatch_queue_pending ()
    at /usr/lib/libwayland-client.so.0
#16 0x00007ffff6f1c89f in dispatch_events (fd=4, mask=1, data=0x5555555d21d0)
    at ../backend/wayland/backend.c:28
#17 0x00007ffff6f94702 in wl_event_loop_dispatch ()
    at /usr/lib/libwayland-server.so.0
#18 0x00007ffff6f932ac in wl_display_run () at /usr/lib/libwayland-server.so.0
#19 0x000055555556d674 in server_run (server=0x5555555c1a60 <server>)
    at ../sway/server.c:165
#20 0x000055555556cdef in main (argc=1, argv=0x7fffffffe9c8) at ../sway/main.c:446
```