### PR TITLE
Fix double iteration of scratchpad containers

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -265,10 +265,10 @@ void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 	// Scratchpad
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *container = root->scratchpad->items[i];
-		// If the container has a parent then it's visible on a workspace
+		// If the container has a workspace then it's visible on a workspace
 		// and will have been iterated in the previous for loop. So we only
 		// iterate the hidden scratchpad containers here.
-		if (!container->parent) {
+		if (!container->workspace) {
 			f(container, data);
 			container_for_each_child(container, f, data);
 		}
@@ -311,7 +311,7 @@ struct sway_container *root_find_container(
 	// Scratchpad
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *container = root->scratchpad->items[i];
-		if (!container->parent) {
+		if (!container->workspace) {
 			if (test(container, data)) {
 				return container;
 			}


### PR DESCRIPTION
`root_for_each_container` and `root_find_container` were using incorrect logic to determine if a container was hidden in the scratchpad. Containers will have a `NULL` parent if they are a direct child of a workspace. Containers will have a `NULL` workspace if they are hidden in the scratchpad.

The incorrect check meant that `root_for_each_container` would run the callback on scratchpad containers twice. This meant that executing a command such as `[class="$something"] scratchpad show` would cause the command to run twice, resulting in the container being shown and hidden again which is effectively a no op.

Fixes #2655.