### PR TITLE
Fix segfault when executing command without focus

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -215,18 +215,23 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 
 static void set_config_node(struct sway_node *node) {
 	config->handler_context.node = node;
+	config->handler_context.container = NULL;
+	config->handler_context.workspace = NULL;
+
+	if (node == NULL) {
+		return;
+	}
+
 	switch (node->type) {
 	case N_CONTAINER:
 		config->handler_context.container = node->sway_container;
 		config->handler_context.workspace = node->sway_container->workspace;
 		break;
 	case N_WORKSPACE:
-		config->handler_context.container = NULL;
 		config->handler_context.workspace = node->sway_workspace;
 		break;
-	default:
-		config->handler_context.container = NULL;
-		config->handler_context.workspace = NULL;
+	case N_ROOT:
+	case N_OUTPUT:
 		break;
 	}
 }


### PR DESCRIPTION
This happens because I have [a daemon](https://github.com/emersion/kanshi) executing commands on hotplug (changing output configuration). I think there's a state in which there's no output and my daemon sends commands. Sway crashes with:

```
#0  0x000055d0dd0d7a11 in set_config_node (node=0x0) at ../sway/commands.c:218
#1  0x000055d0dd0d77aa in execute_command (_exec=0x55d0dd5b0100 "output LVDS-1 enable position 0,0 resolution 1600x900 scale 1", seat=0x55d0dd93bbf0) at ../sway/commands.c:317
#2  0x000055d0dd0e1201 in ipc_client_handle_command (client=0x55d0ddc32090) at ../sway/ipc-server.c:583
#3  0x000055d0dd0e0e53 in ipc_client_handle_readable (client_fd=54, mask=1, data=0x55d0ddc32090) at ../sway/ipc-server.c:261
#4  0x00007f0da3791702 in wl_event_loop_dispatch () at /home/simon/src/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#5  0x00007f0da37902ac in wl_display_run () at /home/simon/src/sway/build/sway/../../../../../../lib64/libwayland-server.so.0
#6  0x000055d0dd0e4eaa in server_run (server=0x55d0dd13b960 <server>) at ../sway/server.c:165
#7  0x000055d0dd0e3f12 in main (argc=1, argv=0x7ffd3a9168f8) at ../sway/main.c:447
```