### PR TITLE
Implement tab cycling using mouse wheel

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -215,8 +215,7 @@ static struct sway_container *container_at_tabbed(struct sway_node *parent,
 			child_index = children->length - 1;
 		}
 		struct sway_container *child = children->items[child_index];
-		struct sway_node *node = seat_get_focus_inactive(seat, &child->node);
-		return node->sway_container;
+		return child;
 	}
 
 	// Surfaces
@@ -243,8 +242,7 @@ static struct sway_container *container_at_stacked(struct sway_node *parent,
 	int child_index = (ly - box.y) / title_height;
 	if (child_index < children->length) {
 		struct sway_container *child = children->items[child_index];
-		struct sway_node *node = seat_get_focus_inactive(seat, &child->node);
-		return node->sway_container;
+		return child;
 	}
 
 	// Surfaces


### PR DESCRIPTION
Firstly, a change had to be made to the `container_at` functions. If you create layout `T[view H[view view]]` and hover the second tab, the `container_at` functions would return the `focus_inactive` child. They now return the split container itself. To compensate for this, `dispatch_cursor_button` has been adjusted to find the `focus_inactive` child before focusing it.

The actual implementation of wheel scrolling is pretty straightforward. This uses `handle_cursor_axis`, so I took a similar approach to `handle_cursor_button` (ie. creating a `dispatch_cursor_axis` function).

To test, create a tabbed or stacked layout, hover the title bar and scroll with the wheel.

Closes #2684.