### PR TITLE
Allow running commands on containers without focusing them

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -4,6 +4,8 @@
 #include <wlr/util/edges.h>
 #include "config.h"
 
+struct sway_container;
+
 typedef struct cmd_results *sway_cmd(int argc, char **argv);
 
 struct cmd_handler {
@@ -50,8 +52,13 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 		int handlers_size);
 /**
  * Parse and executes a command.
+ *
+ * If the command string contains criteria then the command will be executed on
+ * all matching containers. Otherwise, it'll run on the `con` container. If
+ * `con` is NULL then it'll run on the currently focused container.
  */
-struct cmd_results *execute_command(char *command,  struct sway_seat *seat);
+struct cmd_results *execute_command(char *command,  struct sway_seat *seat,
+		struct sway_container *con);
 /**
  * Parse and handles a command during config file loading.
  *

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -321,7 +321,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	}
 
 	config->handler_context.seat = seat;
-	struct cmd_results *results = execute_command(binding->command, NULL);
+	struct cmd_results *results = execute_command(binding->command, NULL, NULL);
 	if (results->status == CMD_SUCCESS) {
 		ipc_event_binding(binding_copy);
 	} else {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -401,7 +401,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	} else {
 		if (view->container->parent) {
 			arrange_container(view->container->parent);
-		} else {
+		} else if (view->container->workspace) {
 			arrange_workspace(view->container->workspace);
 		}
 	}

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -398,7 +398,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	} else {
 		if (view->container->parent) {
 			arrange_container(view->container->parent);
-		} else {
+		} else if (view->container->workspace) {
 			arrange_workspace(view->container->workspace);
 		}
 	}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -394,7 +394,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	} else {
 		if (view->container->parent) {
 			arrange_container(view->container->parent);
-		} else {
+		} else if (view->container->workspace) {
 			arrange_workspace(view->container->workspace);
 		}
 	}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -580,7 +580,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	switch (client->current_command) {
 	case IPC_COMMAND:
 	{
-		struct cmd_results *results = execute_command(buf, NULL);
+		struct cmd_results *results = execute_command(buf, NULL, NULL);
 		transaction_commit_dirty();
 		char *json = cmd_results_to_json(results);
 		int length = strlen(json);

--- a/sway/main.c
+++ b/sway/main.c
@@ -429,7 +429,7 @@ int main(int argc, char **argv) {
 	wlr_log(WLR_DEBUG, "Running deferred commands");
 	while (config->cmd_queue->length) {
 		char *line = config->cmd_queue->items[0];
-		struct cmd_results *res = execute_command(line, NULL);
+		struct cmd_results *res = execute_command(line, NULL, NULL);
 		if (res->status != CMD_SUCCESS) {
 			wlr_log(WLR_ERROR, "Error on line '%s': %s", line, res->error);
 		}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -391,8 +391,6 @@ static bool view_has_executed_criteria(struct sway_view *view,
 }
 
 void view_execute_criteria(struct sway_view *view) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_node *prior_focus = seat_get_focus(seat);
 	list_t *criterias = criteria_for_view(view, CT_COMMAND);
 	for (int i = 0; i < criterias->length; i++) {
 		struct criteria *criteria = criterias->items[i];
@@ -403,16 +401,12 @@ void view_execute_criteria(struct sway_view *view) {
 		}
 		wlr_log(WLR_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
 				criteria->raw, view, criteria->cmdlist);
-		seat_set_focus_container(seat, view->container);
 		list_add(view->executed_criteria, criteria);
-		struct cmd_results *res = execute_command(criteria->cmdlist, NULL);
-		if (res->status != CMD_SUCCESS) {
-			wlr_log(WLR_ERROR, "Command '%s' failed: %s", res->input, res->error);
-		}
+		struct cmd_results *res = execute_command(
+				criteria->cmdlist, NULL, view->container);
 		free_cmd_results(res);
 	}
 	list_free(criterias);
-	seat_set_focus(seat, prior_focus);
 }
 
 static struct sway_workspace *select_workspace(struct sway_view *view) {


### PR DESCRIPTION
This adds a `con` argument to `execute_command` which allows you to specify the container to execute the command on. In most cases it leaves it as `NULL` which makes it use the focused node. We only set it when executing `for_window` criteria such as when a view maps. This means we don't send unnecessary IPC focus events, and fixes a crash when the criteria command is `move scratchpad` (because we can't give focus to a hidden scratchpad container).

Each of the shell map handlers now check to see if the view has a workspace. It won't have a workspace if criteria has moved it to the scratchpad.

To test:

* `for_window [class="Firefox"] move scratchpad` and then launch Firefox
* Try other criteria commands

Fixes #2656.