### PR TITLE
Call pango_cairo_context_set_font_options().

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "cairo.h"
 #include "log.h"
 #include "stringop.h"
 
@@ -113,6 +114,10 @@ void pango_printf(cairo_t *cairo, const char *font,
 	va_end(args);
 
 	PangoLayout *layout = get_pango_layout(cairo, font, buf, scale, markup);
+	cairo_font_options_t *fo = cairo_font_options_create();
+	cairo_get_font_options(cairo, fo);
+	pango_cairo_context_set_font_options(pango_layout_get_context(layout), fo);
+	cairo_font_options_destroy(fo);
 	pango_cairo_update_layout(cairo, layout);
 	pango_cairo_show_layout(cairo, layout);
 	g_object_unref(layout);


### PR DESCRIPTION
Call pango_cairo_context_set_font_options() before pango_cairo_update_layout() and pango_cairo_show_layout(). It looks like Pango defaults to merging the Cario font options with its own defaults, and the end result is no full hinting.

Comparison: ![comparison](https://i.imgur.com/CXNF701.png)
Master is on top and this PR is on bottom.

Notice the difference in smaller characters such as `°` and `%`. Also the top left of the `?` has a little more down curl (more accurate question mark shape). And the text is a little higher contrast.

The improvements are minor, but they're improvements.

You can see another example of pango+cairo usage in Chromium: https://chromium.googlesource.com/chromium/chromium/+/master/ui/gfx/pango_util.cc#197
