### PR TITLE
Move sticky containers when switching workspace via criteria

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -369,7 +369,6 @@ struct sway_workspace *workspace_prev(struct sway_workspace *current) {
 bool workspace_switch(struct sway_workspace *workspace,
 		bool no_auto_back_and_forth) {
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
-	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
 	struct sway_workspace *active_ws = seat_get_focused_workspace(seat);
 
 	if (!no_auto_back_and_forth && config->auto_back_and_forth
@@ -390,27 +389,6 @@ bool workspace_switch(struct sway_workspace *workspace,
 			return false;
 		}
 		strcpy(prev_workspace_name, active_ws->name);
-	}
-
-	// Move sticky containers to new workspace
-	struct sway_output *next_output = workspace->output;
-	struct sway_workspace *next_output_prev_ws =
-		output_get_active_workspace(next_output);
-	if (workspace != next_output_prev_ws) {
-		for (int i = 0; i < next_output_prev_ws->floating->length; ++i) {
-			struct sway_container *floater =
-				next_output_prev_ws->floating->items[i];
-			if (floater->is_sticky) {
-				container_detach(floater);
-				workspace_add_floating(workspace, floater);
-				if (&floater->node == focus) {
-					seat_set_focus(seat, NULL);
-					seat_set_focus_container(seat, floater);
-					cursor_send_pointer_motion(seat->cursor, 0, true);
-				}
-				--i;
-			}
-		}
 	}
 
 	wlr_log(WLR_DEBUG, "Switching to workspace %p:%s",


### PR DESCRIPTION
* Create a view on workspace 1
* Switch to workspace 2 (on the same output) and create a floating sticky view
* Use criteria to focus the view on workspace 1

In master, the sticky container remains on workspace 2 and is not rendered. In this PR it is relocated to workspace 1. This is because the code that moves the sticky containers was in `workspace_switch` which is not called when using the above method. This patch relocates the sticky-moving code into `seat_set_focus_warp`.

A side effect of this patch is that if you have a sticky container focused and then switch workspaces, the sticky container will no longer be focused. It would previously retain focus. I think unfocusing is desirable though, as the user's intention is to focus whatever's on the workspace.

In `seat_set_focus_warp`, `new_output_last_ws` was only set when changing outputs, but now it's always set. This means `new_output_last_ws` and `last_workspace` might point to the same workspace, which means we have to make sure we don't destroy it twice. It now checks to make sure they're different, and to make this more obvious I've moved both calls to `workspace_consider_destroy` to be next to each other.