### PR TITLE
Prevent sticky containers from jumping on workspace switch

### DIFF
--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -186,6 +186,7 @@ void arrange_workspace(struct sway_workspace *workspace) {
 			area->width, area->height, area->x, area->y);
 	workspace_remove_gaps(workspace);
 
+	bool first_arrange = workspace->width == 0 && workspace->height == 0;
 	double prev_x = workspace->x;
 	double prev_y = workspace->y;
 	workspace->width = area->width;
@@ -196,7 +197,7 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	// Adjust any floating containers
 	double diff_x = workspace->x - prev_x;
 	double diff_y = workspace->y - prev_y;
-	if (diff_x != 0 || diff_y != 0) {
+	if (!first_arrange && (diff_x != 0 || diff_y != 0)) {
 		for (int i = 0; i < workspace->floating->length; ++i) {
 			struct sway_container *floater = workspace->floating->items[i];
 			container_floating_translate(floater, diff_x, diff_y);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -54,10 +54,6 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 		return NULL;
 	}
 	node_init(&ws->node, N_WORKSPACE, ws);
-	ws->x = output->lx;
-	ws->y = output->ly;
-	ws->width = output->width;
-	ws->height = output->height;
 	ws->name = name ? strdup(name) : NULL;
 	ws->prev_split_layout = L_NONE;
 	ws->layout = output_get_default_layout(output);


### PR DESCRIPTION
If you have swaybar docked to the top, and you create a floating sticky container and switch workspaces on the same output, the sticky container would move down by the height of swaybar on each switch.

This happens because when creating the workspace we set the dimensions to the same as the output, then the subsequent arrange corrects it. During this arrange, floating containers are translated so they stay relative to the workspace. This translation needs to not occur for the initial arrange.

This patch makes workspaces have a zero width and height when first created, so we can detect whether this is the initial arrange and avoid translating the floating containers if so.