### PR TITLE
[WIP] Add CSD to border modes

### DIFF
--- a/include/sway/decoration.h
+++ b/include/sway/decoration.h
@@ -5,6 +5,7 @@
 
 struct sway_server_decoration {
 	struct wlr_server_decoration *wlr_server_decoration;
+	struct sway_view *view;
 	struct wl_list link;
 
 	struct wl_listener destroy;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -28,6 +28,7 @@ enum sway_container_border {
 	B_NONE,
 	B_PIXEL,
 	B_NORMAL,
+	B_CSD,
 };
 
 struct sway_root;
@@ -63,7 +64,6 @@ struct sway_container_state {
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
-	bool using_csd;
 };
 
 struct sway_container {

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -60,6 +60,7 @@ struct sway_view {
 
 	struct sway_container *container; // NULL if unmapped and transactions finished
 	struct wlr_surface *surface; // NULL for unmapped views
+	struct sway_server_decoration *decoration;
 
 	pid_t pid;
 
@@ -81,7 +82,6 @@ struct sway_view {
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
-	bool using_csd;
 
 	struct timespec urgent;
 	bool allow_request_urgent;
@@ -267,6 +267,8 @@ void view_set_activated(struct sway_view *view, bool activated);
  * Called when the view requests to be focused.
  */
 void view_request_activate(struct sway_view *view);
+
+void view_set_csd(struct sway_view *view, bool enabled);
 
 void view_set_tiled(struct sway_view *view, bool tiled);
 

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -7,6 +7,16 @@
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 
+static void set_border(struct sway_view *view,
+		enum sway_container_border new_border) {
+	if (view->border == B_CSD && new_border != B_CSD) {
+		view_set_csd(view, false);
+	} else if (view->border != B_CSD && new_border == B_CSD) {
+		view_set_csd(view, true);
+	}
+	view->border = new_border;
+}
+
 struct cmd_results *cmd_border(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "border", EXPECTED_AT_LEAST, 1))) {
@@ -21,13 +31,15 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	struct sway_view *view = container->view;
 
 	if (strcmp(argv[0], "none") == 0) {
-		view->border = B_NONE;
+		set_border(view, B_NONE);
 	} else if (strcmp(argv[0], "normal") == 0) {
-		view->border = B_NORMAL;
+		set_border(view, B_NORMAL);
 	} else if (strcmp(argv[0], "pixel") == 0) {
-		view->border = B_PIXEL;
+		set_border(view, B_PIXEL);
+	} else if (strcmp(argv[0], "csd") == 0) {
+		set_border(view, B_CSD);
 	} else if (strcmp(argv[0], "toggle") == 0) {
-		view->border = (view->border + 1) % 3;
+		set_border(view, (view->border + 1) % 4);
 	} else {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Expected 'border <none|normal|pixel|toggle>' "

--- a/sway/decoration.c
+++ b/sway/decoration.c
@@ -8,6 +8,7 @@ static void server_decoration_handle_destroy(struct wl_listener *listener,
 		void *data) {
 	struct sway_server_decoration *deco =
 		wl_container_of(listener, deco, destroy);
+	deco->view->decoration = NULL;
 	wl_list_remove(&deco->destroy.link);
 	wl_list_remove(&deco->mode.link);
 	wl_list_remove(&deco->link);
@@ -49,6 +50,8 @@ void handle_server_decoration(struct wl_listener *listener, void *data) {
 	}
 
 	deco->wlr_server_decoration = wlr_deco;
+	deco->view = view_from_wlr_surface(wlr_deco->surface);
+	deco->view->decoration = deco;
 
 	wl_signal_add(&wlr_deco->events.destroy, &deco->destroy);
 	deco->destroy.notify = server_decoration_handle_destroy;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -167,7 +167,6 @@ static void copy_container_state(struct sway_container *container,
 		state->border_left = view->border_left;
 		state->border_right = view->border_right;
 		state->border_bottom = view->border_bottom;
-		state->using_csd = view->using_csd;
 	} else {
 		state->children = create_list();
 		list_cat(state->children, container->children);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -175,7 +175,8 @@ static enum wlr_edges find_edge(struct sway_container *cont,
 		return WLR_EDGE_NONE;
 	}
 	struct sway_view *view = cont->view;
-	if (view->border == B_NONE || !view->border_thickness || view->using_csd) {
+	if (view->border == B_NONE || !view->border_thickness ||
+			view->border == B_CSD) {
 		return WLR_EDGE_NONE;
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -216,6 +216,8 @@ static const char *describe_container_border(enum sway_container_border border) 
 		return "pixel";
 	case B_NORMAL:
 		return "normal";
+	case B_CSD:
+		return "csd";
 	}
 	return "unknown";
 }

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -717,7 +717,7 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 	size_t border_width = 0;
 	size_t top = 0;
 
-	if (!view->using_csd) {
+	if (view->border != B_CSD) {
 		border_width = view->border_thickness * (view->border != B_NONE);
 		top = view->border == B_NORMAL ?
 			container_titlebar_height() : border_width;


### PR DESCRIPTION
I need some help with this one. Currently implementing #2429 but the client doesn't seem to respect the new decoration mode. See `view_set_csd`. For example, run `border toggle` several times on an `xdg_shell` view.

Depends on https://github.com/swaywm/wlroots/pull/1259