### PR TITLE
Only show cursor if pointer configured

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1006,8 +1006,7 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 	if (seat_is_input_allowed(seat, surface)) {
 		wlr_seat_touch_notify_down(wlr_seat, surface, event->time_msec,
 				event->touch_id, sx, sy);
-		cursor->image_client = NULL;
-		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+		cursor_set_image(cursor, NULL, NULL);
 	}
 }
 
@@ -1175,11 +1174,13 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
 		struct wl_client *client) {
-	if (!cursor->image || strcmp(cursor->image, image) != 0) {
+	if (!image) {
+		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+	} else if (!cursor->image || strcmp(cursor->image, image) != 0) {
 		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager, image,
 				cursor->cursor);
-		cursor->image = image;
 	}
+	cursor->image = image;
 	cursor->image_client = client;
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -368,11 +368,20 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 			caps |= WL_SEAT_CAPABILITY_TOUCH;
 			break;
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
+			caps |= WL_SEAT_CAPABILITY_POINTER;
+			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
 			break;
 		}
 	}
 	wlr_seat_set_capabilities(seat->wlr_seat, caps);
+
+	// Hide cursor if seat doesn't have pointer capability
+	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
+		wlr_cursor_set_image(seat->cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+	} else {
+		cursor_set_image(seat->cursor, "left_ptr", NULL);
+	}
 }
 
 static void seat_apply_input_config(struct sway_seat *seat,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -378,7 +378,7 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 
 	// Hide cursor if seat doesn't have pointer capability
 	if ((caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
-		wlr_cursor_set_image(seat->cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+		cursor_set_image(seat->cursor, NULL, NULL);
 	} else {
 		cursor_set_image(seat->cursor, "left_ptr", NULL);
 	}
@@ -561,8 +561,7 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 			output->name, (double)output->scale);
 	}
 
-	wlr_xcursor_manager_set_cursor_image(seat->cursor->xcursor_manager,
-		"left_ptr", seat->cursor->cursor);
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
 	wlr_cursor_warp(seat->cursor->cursor, NULL, seat->cursor->cursor->x,
 		seat->cursor->cursor->y);
 }


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/1568

The implementation works, idk if it's any good though. Also haven't dealt with tablet pads because I don't have one.

Possible FR: some sort of seat sub-command `show_cursor yes|no|auto`