### PR TITLE
swaybg: fix increasingly smaller bg on hotplug

### DIFF
--- a/common/background-image.c
+++ b/common/background-image.c
@@ -58,6 +58,7 @@ void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 	double width = cairo_image_surface_get_width(image);
 	double height = cairo_image_surface_get_height(image);
 
+	cairo_save(cairo);
 	switch (mode) {
 	case BACKGROUND_MODE_STRETCH:
 		cairo_scale(cairo,
@@ -116,4 +117,5 @@ void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 		break;
 	}
 	cairo_paint(cairo);
+	cairo_restore(cairo);
 }

--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -73,6 +73,10 @@ static void render_frame(struct swaybg_state *state) {
 		return;
 	}
 	cairo_t *cairo = state->current_buffer->cairo;
+	cairo_save(cairo);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cairo);
+	cairo_restore(cairo);
 	if (state->args->mode == BACKGROUND_MODE_SOLID_COLOR) {
 		cairo_set_source_u32(cairo, state->context.color);
 		cairo_paint(cairo);


### PR DESCRIPTION
Fixes #2667 

render_background_image alters the scale that cairo uses. Depending on the image mode, resolution, and image size, this may cause the surface to be rendered increasingly smaller. By calling cairo_save and
cairo_restore, any changes to the cairo settings by the function are not kept as a side effect.

The surface that swaybg uses is also now cleared before rendering a frame. This is needed to avoid artifacts  with certain combinations of image modes, resolutions, and image sizes. This was also part of the increasingly smaller background visual since it made it so it was not obvious the region being rendered to was smaller and caused an increasing number of smaller images to be appear for each hotplug.