### PR TITLE
Implement support for input wildcard

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -458,11 +458,9 @@ struct input_config *new_input_config(const char* identifier);
 
 void merge_input_config(struct input_config *dst, struct input_config *src);
 
-struct input_config *copy_input_config(struct input_config *ic);
+struct input_config *store_input_config(struct input_config *ic);
 
 void free_input_config(struct input_config *ic);
-
-void apply_input_config(struct input_config *input);
 
 int seat_name_cmp(const void *item, const void *data);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -55,22 +55,6 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 	return error;
 }
 
-void apply_input_config(struct input_config *input) {
-	int i;
-	i = list_seq_find(config->input_configs, input_identifier_cmp, input->identifier);
-	if (i >= 0) {
-		// merge existing config
-		struct input_config *ic = config->input_configs->items[i];
-		merge_input_config(ic, input);
-		free_input_config(input);
-		input = ic;
-	} else {
-		list_add(config->input_configs, input);
-	}
-
-	input_manager_apply_input_config(input_manager, input);
-}
-
 void apply_seat_config(struct seat_config *seat_config) {
 	int i;
 	i = list_seq_find(config->seat_configs, seat_name_cmp, seat_config->name);

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -66,7 +66,15 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			input_handlers, sizeof(input_handlers));
 	}
 
-	free_input_config(config->handler_context.input_config);
+	if (!res || res->status == CMD_SUCCESS) {
+		struct input_config *ic =
+			store_input_config(config->handler_context.input_config);
+
+		input_manager_apply_input_config(input_manager, ic);
+	} else {
+		free_input_config(config->handler_context.input_config);
+	}
+
 	config->handler_context.input_config = NULL;
 
 	return res;

--- a/sway/commands/input/accel_profile.c
+++ b/sway/commands/input/accel_profile.c
@@ -9,25 +9,20 @@ struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
 	if ((error = checkarg(argc, "accel_profile", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "accel_profile",
 				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "adaptive") == 0) {
-		new_config->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE;
+		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE;
 	} else if (strcasecmp(argv[0], "flat") == 0) {
-		new_config->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
+		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "accel_profile",
 				"Expected 'accel_profile <adaptive|flat>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/click_method.c
+++ b/sway/commands/input/click_method.c
@@ -10,27 +10,22 @@ struct cmd_results *input_cmd_click_method(int argc, char **argv) {
 	if ((error = checkarg(argc, "click_method", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "click_method",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "none") == 0) {
-		new_config->click_method = LIBINPUT_CONFIG_CLICK_METHOD_NONE;
+		ic->click_method = LIBINPUT_CONFIG_CLICK_METHOD_NONE;
 	} else if (strcasecmp(argv[0], "button_areas") == 0) {
-		new_config->click_method = LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS;
+		ic->click_method = LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS;
 	} else if (strcasecmp(argv[0], "clickfinger") == 0) {
-		new_config->click_method = LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER;
+		ic->click_method = LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "click_method",
 			"Expected 'click_method <none|button_areas|clickfinger'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/drag_lock.c
+++ b/sway/commands/input/drag_lock.c
@@ -10,21 +10,17 @@ struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 	if ((error = checkarg(argc, "drag_lock", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE,
 			"drag_lock", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (parse_boolean(argv[0], true)) {
-		new_config->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_ENABLED;
+		ic->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_ENABLED;
 	} else {
-		new_config->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
+		ic->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/dwt.c
+++ b/sway/commands/input/dwt.c
@@ -10,20 +10,16 @@ struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 	if ((error = checkarg(argc, "dwt", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "dwt", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (parse_boolean(argv[0], true)) {
-		new_config->dwt = LIBINPUT_CONFIG_DWT_ENABLED;
+		ic->dwt = LIBINPUT_CONFIG_DWT_ENABLED;
 	} else {
-		new_config->dwt = LIBINPUT_CONFIG_DWT_DISABLED;
+		ic->dwt = LIBINPUT_CONFIG_DWT_DISABLED;
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -10,30 +10,23 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 	if ((error = checkarg(argc, "events", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "events",
 			"No input device defined.");
 	}
-	wlr_log(WLR_DEBUG, "events for device: %s",
-		current_input_config->identifier);
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "enabled") == 0) {
-		new_config->send_events = LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
+		ic->send_events = LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
 	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->send_events = LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
+		ic->send_events = LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
 	} else if (strcasecmp(argv[0], "disabled_on_external_mouse") == 0) {
-		new_config->send_events =
+		ic->send_events =
 			LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "events",
 			"Expected 'events <enabled|disabled|disabled_on_external_mouse>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -10,17 +10,13 @@ struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
 	if ((error = checkarg(argc, "left_handed", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "left_handed",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->left_handed = parse_boolean(argv[0], true);
+	ic->left_handed = parse_boolean(argv[0], true);
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/map_from_region.c
+++ b/sway/commands/input/map_from_region.c
@@ -38,50 +38,44 @@ struct cmd_results *input_cmd_map_from_region(int argc, char **argv) {
 	if ((error = checkarg(argc, "map_from_region", EXPECTED_EQUAL_TO, 2))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "map_from_region",
 			"No input device defined");
 	}
 
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
-
-	new_config->mapped_from_region =
+	ic->mapped_from_region =
 		calloc(1, sizeof(struct input_config_mapped_from_region));
 
 	bool mm1, mm2;
-	if (!parse_coords(argv[0], &new_config->mapped_from_region->x1,
-			&new_config->mapped_from_region->y1, &mm1)) {
-		free(new_config->mapped_from_region);
-		free_input_config(new_config);
+	if (!parse_coords(argv[0], &ic->mapped_from_region->x1,
+			&ic->mapped_from_region->y1, &mm1)) {
+		free(ic->mapped_from_region);
+		ic->mapped_from_region = NULL;
 		return cmd_results_new(CMD_FAILURE, "map_from_region",
 			"Invalid top-left coordinates");
 	}
-	if (!parse_coords(argv[1], &new_config->mapped_from_region->x2,
-			&new_config->mapped_from_region->y2, &mm2)) {
-		free(new_config->mapped_from_region);
-		free_input_config(new_config);
+	if (!parse_coords(argv[1], &ic->mapped_from_region->x2,
+			&ic->mapped_from_region->y2, &mm2)) {
+		free(ic->mapped_from_region);
+		ic->mapped_from_region = NULL;
 		return cmd_results_new(CMD_FAILURE, "map_from_region",
 			"Invalid bottom-right coordinates");
 	}
-	if (new_config->mapped_from_region->x1 > new_config->mapped_from_region->x2 ||
-			new_config->mapped_from_region->y1 > new_config->mapped_from_region->y2) {
-		free(new_config->mapped_from_region);
-		free_input_config(new_config);
+	if (ic->mapped_from_region->x1 > ic->mapped_from_region->x2 ||
+			ic->mapped_from_region->y1 > ic->mapped_from_region->y2) {
+		free(ic->mapped_from_region);
+		ic->mapped_from_region = NULL;
 		return cmd_results_new(CMD_FAILURE, "map_from_region",
 			"Invalid rectangle");
 	}
 	if (mm1 != mm2) {
-		free(new_config->mapped_from_region);
-		free_input_config(new_config);
+		free(ic->mapped_from_region);
+		ic->mapped_from_region = NULL;
 		return cmd_results_new(CMD_FAILURE, "map_from_region",
 			"Both coordinates must be in the same unit");
 	}
-	new_config->mapped_from_region->mm = mm1;
-
-	apply_input_config(new_config);
+	ic->mapped_from_region->mm = mm1;
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/map_to_output.c
+++ b/sway/commands/input/map_to_output.c
@@ -11,17 +11,13 @@ struct cmd_results *input_cmd_map_to_output(int argc, char **argv) {
 	if ((error = checkarg(argc, "map_to_output", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "map_to_output",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->mapped_to_output = strdup(argv[0]);
-	apply_input_config(new_config);
+	ic->mapped_to_output = strdup(argv[0]);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/middle_emulation.c
+++ b/sway/commands/input/middle_emulation.c
@@ -10,22 +10,17 @@ struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 	if ((error = checkarg(argc, "middle_emulation", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "middle_emulation",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (parse_boolean(argv[0], true)) {
-		new_config->middle_emulation = LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED;
+		ic->middle_emulation = LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED;
 	} else {
-		new_config->middle_emulation =
-			LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
+		ic->middle_emulation = LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/natural_scroll.c
+++ b/sway/commands/input/natural_scroll.c
@@ -10,17 +10,13 @@ struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
 	if ((error = checkarg(argc, "natural_scroll", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "natural_scoll",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->natural_scroll = parse_boolean(argv[0], true);
+	ic->natural_scroll = parse_boolean(argv[0], true);
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -9,23 +9,18 @@ struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 	if ((error = checkarg(argc, "pointer_accel", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE,
 			"pointer_accel", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	float pointer_accel = atof(argv[0]);
 	if (pointer_accel < -1 || pointer_accel > 1) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "pointer_accel",
 			"Input out of range [-1, 1]");
 	}
-	new_config->pointer_accel = pointer_accel;
+	ic->pointer_accel = pointer_accel;
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/repeat_delay.c
+++ b/sway/commands/input/repeat_delay.c
@@ -9,23 +9,18 @@ struct cmd_results *input_cmd_repeat_delay(int argc, char **argv) {
 	if ((error = checkarg(argc, "repeat_delay", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE,
 			"repeat_delay", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	int repeat_delay = atoi(argv[0]);
 	if (repeat_delay < 0) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "repeat_delay",
 			"Repeat delay cannot be negative");
 	}
-	new_config->repeat_delay = repeat_delay;
+	ic->repeat_delay = repeat_delay;
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/repeat_rate.c
+++ b/sway/commands/input/repeat_rate.c
@@ -9,23 +9,18 @@ struct cmd_results *input_cmd_repeat_rate(int argc, char **argv) {
 	if ((error = checkarg(argc, "repeat_rate", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE,
 			"repeat_rate", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	int repeat_rate = atoi(argv[0]);
 	if (repeat_rate < 0) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "repeat_rate",
 			"Repeat rate cannot be negative");
 	}
-	new_config->repeat_rate = repeat_rate;
+	ic->repeat_rate = repeat_rate;
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -10,35 +10,28 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 	if ((error = checkarg(argc, "scroll_button", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "scroll_button",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	errno = 0;
 	char *endptr;
 	int scroll_button = strtol(*argv, &endptr, 10);
 	if (endptr == *argv && scroll_button == 0) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
 				"Scroll button identifier must be an integer.");
 	}
 	if (errno == ERANGE) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
 				"Scroll button identifier out of range.");
 	}
 	if (scroll_button < 0) {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_button",
 				"Scroll button identifier cannot be negative.");
 	}
-	new_config->scroll_button = scroll_button;
+	ic->scroll_button = scroll_button;
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/scroll_method.c
+++ b/sway/commands/input/scroll_method.c
@@ -9,29 +9,24 @@ struct cmd_results *input_cmd_scroll_method(int argc, char **argv) {
 	if ((error = checkarg(argc, "scroll_method", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "scroll_method",
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "none") == 0) {
-		new_config->scroll_method = LIBINPUT_CONFIG_SCROLL_NO_SCROLL;
+		ic->scroll_method = LIBINPUT_CONFIG_SCROLL_NO_SCROLL;
 	} else if (strcasecmp(argv[0], "two_finger") == 0) {
-		new_config->scroll_method = LIBINPUT_CONFIG_SCROLL_2FG;
+		ic->scroll_method = LIBINPUT_CONFIG_SCROLL_2FG;
 	} else if (strcasecmp(argv[0], "edge") == 0) {
-		new_config->scroll_method = LIBINPUT_CONFIG_SCROLL_EDGE;
+		ic->scroll_method = LIBINPUT_CONFIG_SCROLL_EDGE;
 	} else if (strcasecmp(argv[0], "on_button_down") == 0) {
-		new_config->scroll_method = LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
+		ic->scroll_method = LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "scroll_method",
 			"Expected 'scroll_method <none|two_finger|edge|on_button_down>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -11,22 +11,16 @@ struct cmd_results *input_cmd_tap(int argc, char **argv) {
 	if ((error = checkarg(argc, "tap", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "tap", "No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (parse_boolean(argv[0], true)) {
-		new_config->tap = LIBINPUT_CONFIG_TAP_ENABLED;
+		ic->tap = LIBINPUT_CONFIG_TAP_ENABLED;
 	} else {
-		new_config->tap = LIBINPUT_CONFIG_TAP_DISABLED;
+		ic->tap = LIBINPUT_CONFIG_TAP_DISABLED;
 	}
 
-	wlr_log(WLR_DEBUG, "apply-tap for device: %s",
-		current_input_config->identifier);
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/tap_button_map.c
+++ b/sway/commands/input/tap_button_map.c
@@ -9,25 +9,20 @@ struct cmd_results *input_cmd_tap_button_map(int argc, char **argv) {
 	if ((error = checkarg(argc, "tap_button_map", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "tap_button_map",
 				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "lrm") == 0) {
-		new_config->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LRM;
+		ic->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LRM;
 	} else if (strcasecmp(argv[0], "lmr") == 0) {
-		new_config->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LMR;
+		ic->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LMR;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "tap_button_map",
 			"Expected 'tap_button_map <lrm|lmr>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_capslock.c
+++ b/sway/commands/input/xkb_capslock.c
@@ -9,25 +9,20 @@ struct cmd_results *input_cmd_xkb_capslock(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_capslock", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "xkb_capslock", 
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "enabled") == 0) {
-		new_config->xkb_capslock = 1;
+		ic->xkb_capslock = 1;
 	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->xkb_capslock = 0; 
+		ic->xkb_capslock = 0;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "xkb_capslock",
 			"Expected 'xkb_capslock <enabled|disabled>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -9,18 +9,15 @@ struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_layout", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
-		return cmd_results_new(CMD_FAILURE, "xkb_layout", "No input device defined.");
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "xkb_layout",
+				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->xkb_layout = strdup(argv[0]);
+	ic->xkb_layout = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "apply-xkb_layout for device: %s layout: %s",
-		current_input_config->identifier, new_config->xkb_layout);
-	apply_input_config(new_config);
+	wlr_log(WLR_DEBUG, "set-xkb_layout for config: %s layout: %s",
+			ic->identifier, ic->xkb_layout);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -9,18 +9,15 @@ struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_model", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
-		return cmd_results_new(CMD_FAILURE, "xkb_model", "No input device defined.");
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "xkb_model",
+				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->xkb_model = strdup(argv[0]);
+	ic->xkb_model = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "apply-xkb_model for device: %s model: %s",
-		current_input_config->identifier, new_config->xkb_model);
-	apply_input_config(new_config);
+	wlr_log(WLR_DEBUG, "set-xkb_model for config: %s model: %s",
+			ic->identifier, ic->xkb_model);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_numlock.c
+++ b/sway/commands/input/xkb_numlock.c
@@ -9,25 +9,20 @@ struct cmd_results *input_cmd_xkb_numlock(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_numlock", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
 		return cmd_results_new(CMD_FAILURE, "xkb_numlock", 
 			"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
 	if (strcasecmp(argv[0], "enabled") == 0) {
-		new_config->xkb_numlock = 1;
+		ic->xkb_numlock = 1;
 	} else if (strcasecmp(argv[0], "disabled") == 0) {
-		new_config->xkb_numlock = 0; 
+		ic->xkb_numlock = 0;
 	} else {
-		free_input_config(new_config);
 		return cmd_results_new(CMD_INVALID, "xkb_numlock",
 			"Expected 'xkb_numlock <enabled|disabled>'");
 	}
 
-	apply_input_config(new_config);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -9,18 +9,15 @@ struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_options", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
-		return cmd_results_new(CMD_FAILURE, "xkb_options", "No input device defined.");
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "xkb_options",
+				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->xkb_options = strdup(argv[0]);
+	ic->xkb_options = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "apply-xkb_options for device: %s options: %s",
-		current_input_config->identifier, new_config->xkb_options);
-	apply_input_config(new_config);
+	wlr_log(WLR_DEBUG, "set-xkb_options for config: %s options: %s",
+			ic->identifier, ic->xkb_options);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -9,18 +9,15 @@ struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_rules", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
-		return cmd_results_new(CMD_FAILURE, "xkb_rules", "No input device defined.");
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "xkb_rules",
+				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->xkb_rules = strdup(argv[0]);
+	ic->xkb_rules = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "apply-xkb_rules for device: %s rules: %s",
-		current_input_config->identifier, new_config->xkb_rules);
-	apply_input_config(new_config);
+	wlr_log(WLR_DEBUG, "set-xkb_rules for config: %s rules: %s",
+			ic->identifier, ic->xkb_rules);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -9,18 +9,15 @@ struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
 	if ((error = checkarg(argc, "xkb_variant", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct input_config *current_input_config =
-		config->handler_context.input_config;
-	if (!current_input_config) {
-		return cmd_results_new(CMD_FAILURE, "xkb_variant", "No input device defined.");
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "xkb_variant",
+				"No input device defined.");
 	}
-	struct input_config *new_config =
-		new_input_config(current_input_config->identifier);
 
-	new_config->xkb_variant = strdup(argv[0]);
+	ic->xkb_variant = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "apply-xkb_variant for device: %s variant: %s",
-		current_input_config->identifier, new_config->xkb_variant);
-	apply_input_config(new_config);
+	wlr_log(WLR_DEBUG, "set-xkb_variant for config: %s variant: %s",
+			ic->identifier, ic->xkb_variant);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -389,8 +389,10 @@ void input_manager_set_focus(struct sway_input_manager *input,
 void input_manager_apply_input_config(struct sway_input_manager *input,
 		struct input_config *input_config) {
 	struct sway_input_device *input_device = NULL;
+	bool wildcard = strcmp(input_config->identifier, "*") == 0;
 	wl_list_for_each(input_device, &input->devices, link) {
-		if (strcmp(input_device->identifier, input_config->identifier) == 0) {
+		if (strcmp(input_device->identifier, input_config->identifier) == 0
+				|| wildcard) {
 			if (input_device->wlr_device->type == WLR_INPUT_DEVICE_POINTER) {
 				input_manager_libinput_config_pointer(input_device);
 			}
@@ -480,13 +482,16 @@ struct sway_seat *input_manager_get_default_seat(
 }
 
 struct input_config *input_device_get_config(struct sway_input_device *device) {
+	struct input_config *wildcard_config = NULL;
 	struct input_config *input_config = NULL;
 	for (int i = 0; i < config->input_configs->length; ++i) {
 		input_config = config->input_configs->items[i];
 		if (strcmp(input_config->identifier, device->identifier) == 0) {
 			return input_config;
+		} else if (strcmp(input_config->identifier, "*") == 0) {
+			wildcard_config = input_config;
 		}
 	}
 
-	return NULL;
+	return wildcard_config;
 }


### PR DESCRIPTION
Closes #2662 

Implements support for`input *`. The code is structured similar to the way `output *` is currently implemented.

This required restructuring the input subcommand handlers. Instead of creating a new input config and applying it in each subcommand, the one created by the main input command is used and the input config is stored/merged and applied after returning from the subcommand.