### PR TITLE
Add CSD to border modes

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -54,6 +54,10 @@ struct sway_server {
 	struct wl_listener server_decoration;
 	struct wl_list decorations; // sway_server_decoration::link
 
+	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager;
+	struct wl_listener xdg_decoration;
+	struct wl_list xdg_decorations; // sway_xdg_decoration::link
+
 	size_t txn_timeout_ms;
 	list_t *transactions;
 	list_t *dirty_nodes;
@@ -78,5 +82,6 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data);
 void handle_xwayland_surface(struct wl_listener *listener, void *data);
 #endif
 void handle_server_decoration(struct wl_listener *listener, void *data);
+void handle_xdg_decoration(struct wl_listener *listener, void *data);
 
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -28,6 +28,7 @@ enum sway_container_border {
 	B_NONE,
 	B_PIXEL,
 	B_NORMAL,
+	B_CSD,
 };
 
 struct sway_root;
@@ -63,7 +64,6 @@ struct sway_container_state {
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
-	bool using_csd;
 };
 
 struct sway_container {

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -275,7 +275,7 @@ void view_set_csd_from_server(struct sway_view *view, bool enabled);
  * Updates the view's border setting when the client unexpectedly changes their
  * decoration mode.
  */
-void view_set_csd_from_client(struct sway_view *view, bool enabled);
+void view_update_csd_from_client(struct sway_view *view, bool enabled);
 
 void view_set_tiled(struct sway_view *view, bool tiled);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -76,8 +76,19 @@ struct sway_view {
 	int natural_width, natural_height;
 
 	char *title_format;
+
+	// Our border types are B_NONE, B_PIXEL, B_NORMAL and B_CSD. We normally
+	// just assign this to the border property and ignore the other two.
+	// However, when a view using CSD is tiled, we want to render our own
+	// borders as well. So in this case the border property becomes one of the
+	// first three, and using_csd is true.
+	// Lastly, views can change their decoration mode at any time. When an SSD
+	// view becomes CSD without our approval, we save the SSD border type so it
+	// can be restored if/when the view returns from CSD to SSD.
 	enum sway_container_border border;
 	enum sway_container_border saved_border;
+	bool using_csd;
+
 	int border_thickness;
 	bool border_top;
 	bool border_bottom;

--- a/include/sway/xdg_decoration.h
+++ b/include/sway/xdg_decoration.h
@@ -10,7 +10,7 @@ struct sway_xdg_decoration {
 	struct sway_view *view;
 
 	struct wl_listener destroy;
-	struct wl_listener surface_commit;
+	struct wl_listener request_mode;
 };
 
 struct sway_xdg_decoration *xdg_decoration_from_surface(

--- a/include/sway/xdg_decoration.h
+++ b/include/sway/xdg_decoration.h
@@ -1,0 +1,19 @@
+#ifndef _SWAY_XDG_DECORATION_H
+#define _SWAY_XDG_DECORATION_H
+
+#include <wlr/types/wlr_xdg_decoration_v1.h>
+
+struct sway_xdg_decoration {
+	struct wlr_xdg_toplevel_decoration_v1 *wlr_xdg_decoration;
+	struct wl_list link;
+
+	struct sway_view *view;
+
+	struct wl_listener destroy;
+	struct wl_listener surface_commit;
+};
+
+struct sway_xdg_decoration *xdg_decoration_from_surface(
+	struct wlr_surface *surface);
+
+#endif

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -38,9 +38,14 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	} else if (strcmp(argv[0], "pixel") == 0) {
 		set_border(view, B_PIXEL);
 	} else if (strcmp(argv[0], "csd") == 0) {
+		if (!view->xdg_decoration) {
+			return cmd_results_new(CMD_INVALID, "border",
+					"This window doesn't support client side decorations");
+		}
 		set_border(view, B_CSD);
 	} else if (strcmp(argv[0], "toggle") == 0) {
-		set_border(view, (view->border + 1) % 4);
+		int num_available = view->xdg_decoration ? 4 : 3;
+		set_border(view, (view->border + 1) % num_available);
 	} else {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Expected 'border <none|normal|pixel|toggle>' "

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -7,6 +7,17 @@
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 
+static void set_border(struct sway_view *view,
+		enum sway_container_border new_border) {
+	if (view->border == B_CSD && new_border != B_CSD) {
+		view_set_csd_from_server(view, false);
+	} else if (view->border != B_CSD && new_border == B_CSD) {
+		view_set_csd_from_server(view, true);
+	}
+	view->saved_border = view->border;
+	view->border = new_border;
+}
+
 struct cmd_results *cmd_border(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "border", EXPECTED_AT_LEAST, 1))) {
@@ -21,13 +32,15 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	struct sway_view *view = container->view;
 
 	if (strcmp(argv[0], "none") == 0) {
-		view->border = B_NONE;
+		set_border(view, B_NONE);
 	} else if (strcmp(argv[0], "normal") == 0) {
-		view->border = B_NORMAL;
+		set_border(view, B_NORMAL);
 	} else if (strcmp(argv[0], "pixel") == 0) {
-		view->border = B_PIXEL;
+		set_border(view, B_PIXEL);
+	} else if (strcmp(argv[0], "csd") == 0) {
+		set_border(view, B_CSD);
 	} else if (strcmp(argv[0], "toggle") == 0) {
-		view->border = (view->border + 1) % 3;
+		set_border(view, (view->border + 1) % 4);
 	} else {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Expected 'border <none|normal|pixel|toggle>' "

--- a/sway/decoration.c
+++ b/sway/decoration.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include "sway/decoration.h"
+#include "sway/desktop/transaction.h"
 #include "sway/server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/view.h"
 #include "log.h"
 
@@ -24,20 +26,12 @@ static void server_decoration_handle_mode(struct wl_listener *listener,
 		return;
 	}
 
-	switch (view->type) {
-	case SWAY_VIEW_XDG_SHELL_V6:;
-		struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
-			(struct sway_xdg_shell_v6_view *)view;
-		xdg_shell_v6_view->deco_mode = deco->wlr_server_decoration->mode;
-		break;
-	case SWAY_VIEW_XDG_SHELL:;
-		struct sway_xdg_shell_view *xdg_shell_view =
-			(struct sway_xdg_shell_view *)view;
-		xdg_shell_view->deco_mode = deco->wlr_server_decoration->mode;
-		break;
-	default:
-		break;
-	}
+	bool csd = deco->wlr_server_decoration->mode ==
+			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
+	view_set_csd_from_client(view, csd);
+
+	arrange_container(view->container);
+	transaction_commit_dirty();
 }
 
 void handle_server_decoration(struct wl_listener *listener, void *data) {

--- a/sway/decoration.c
+++ b/sway/decoration.c
@@ -28,7 +28,7 @@ static void server_decoration_handle_mode(struct wl_listener *listener,
 
 	bool csd = deco->wlr_server_decoration->mode ==
 			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	view_set_csd_from_client(view, csd);
+	view_update_csd_from_client(view, csd);
 
 	arrange_container(view->container);
 	transaction_commit_dirty();

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -167,7 +167,6 @@ static void copy_container_state(struct sway_container *container,
 		state->border_left = view->border_left;
 		state->border_right = view->border_right;
 		state->border_bottom = view->border_bottom;
-		state->using_csd = view->using_csd;
 	} else {
 		state->children = create_list();
 		list_cat(state->children, container->children);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -381,7 +381,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		decoration_from_surface(xdg_surface->surface);
 	bool csd = !deco || deco->wlr_server_decoration->mode ==
 		WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	view_set_csd_from_client(view, csd);
+	view_update_csd_from_client(view, csd);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		container_set_fullscreen(view->container, true);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -175,15 +175,6 @@ static bool wants_floating(struct sway_view *view) {
 		|| toplevel->parent;
 }
 
-static bool has_client_side_decorations(struct sway_view *view) {
-	struct sway_xdg_shell_view *xdg_shell_view =
-		xdg_shell_view_from_view(view);
-	if (xdg_shell_view == NULL) {
-		return true;
-	}
-	return xdg_shell_view->deco_mode != WLR_SERVER_DECORATION_MANAGER_MODE_SERVER;
-}
-
 static void for_each_surface(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	if (xdg_shell_view_from_view(view) == NULL) {
@@ -240,7 +231,6 @@ static const struct sway_view_impl view_impl = {
 	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
-	.has_client_side_decorations = has_client_side_decorations,
 	.for_each_surface = for_each_surface,
 	.for_each_popup = for_each_popup,
 	.close = _close,
@@ -385,15 +375,13 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		view->natural_height = view->wlr_xdg_surface->surface->current.height;
 	}
 
+	view_map(view, view->wlr_xdg_surface->surface);
+
 	struct sway_server_decoration *deco =
 		decoration_from_surface(xdg_surface->surface);
-	if (deco != NULL) {
-		xdg_shell_view->deco_mode = deco->wlr_server_decoration->mode;
-	} else {
-		xdg_shell_view->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	}
-
-	view_map(view, view->wlr_xdg_surface->surface);
+	bool csd = !deco || deco->wlr_server_decoration->mode ==
+		WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
+	view_set_csd_from_client(view, csd);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		container_set_fullscreen(view->container, true);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -377,11 +377,13 @@ static void handle_map(struct wl_listener *listener, void *data) {
 
 	view_map(view, view->wlr_xdg_surface->surface);
 
-	struct sway_server_decoration *deco =
-		decoration_from_surface(xdg_surface->surface);
-	bool csd = !deco || deco->wlr_server_decoration->mode ==
-		WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	view_update_csd_from_client(view, csd);
+	if (!view->xdg_decoration) {
+		struct sway_server_decoration *deco =
+			decoration_from_surface(xdg_surface->surface);
+		bool csd = !deco || deco->wlr_server_decoration->mode ==
+			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
+		view_update_csd_from_client(view, csd);
+	}
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		container_set_fullscreen(view->container, true);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -378,7 +378,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		decoration_from_surface(xdg_surface->surface);
 	bool csd = !deco || deco->wlr_server_decoration->mode ==
 			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	view_set_csd_from_client(view, csd);
+	view_update_csd_from_client(view, csd);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		container_set_fullscreen(view->container, true);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -171,15 +171,6 @@ static bool wants_floating(struct sway_view *view) {
 		|| toplevel->parent;
 }
 
-static bool has_client_side_decorations(struct sway_view *view) {
-	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
-		xdg_shell_v6_view_from_view(view);
-	if (xdg_shell_v6_view == NULL) {
-		return true;
-	}
-	return xdg_shell_v6_view->deco_mode != WLR_SERVER_DECORATION_MANAGER_MODE_SERVER;
-}
-
 static void for_each_surface(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	if (xdg_shell_v6_view_from_view(view) == NULL) {
@@ -237,7 +228,6 @@ static const struct sway_view_impl view_impl = {
 	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
-	.has_client_side_decorations = has_client_side_decorations,
 	.for_each_surface = for_each_surface,
 	.for_each_popup = for_each_popup,
 	.close = _close,
@@ -382,15 +372,13 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		view->natural_height = view->wlr_xdg_surface_v6->surface->current.height;
 	}
 
+	view_map(view, view->wlr_xdg_surface_v6->surface);
+
 	struct sway_server_decoration *deco =
 		decoration_from_surface(xdg_surface->surface);
-	if (deco != NULL) {
-		xdg_shell_v6_view->deco_mode = deco->wlr_server_decoration->mode;
-	} else {
-		xdg_shell_v6_view->deco_mode = WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	}
-
-	view_map(view, view->wlr_xdg_surface_v6->surface);
+	bool csd = !deco || deco->wlr_server_decoration->mode ==
+			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
+	view_set_csd_from_client(view, csd);
 
 	if (xdg_surface->toplevel->client_pending.fullscreen) {
 		container_set_fullscreen(view->container, true);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -250,7 +250,7 @@ static void handle_set_decorations(struct wl_listener *listener, void *data) {
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 
 	bool csd = xsurface->decorations != WLR_XWAYLAND_SURFACE_DECORATIONS_ALL;
-	view_set_csd_from_client(view, csd);
+	view_update_csd_from_client(view, csd);
 }
 
 static void _close(struct sway_view *view) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -243,12 +243,14 @@ static bool wants_floating(struct sway_view *view) {
 	return false;
 }
 
-static bool has_client_side_decorations(struct sway_view *view) {
-	if (xwayland_view_from_view(view) == NULL) {
-		return false;
-	}
-	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
-	return surface->decorations != WLR_XWAYLAND_SURFACE_DECORATIONS_ALL;
+static void handle_set_decorations(struct wl_listener *listener, void *data) {
+	struct sway_xwayland_view *xwayland_view =
+		wl_container_of(listener, xwayland_view, set_decorations);
+	struct sway_view *view = &xwayland_view->view;
+	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
+
+	bool csd = xsurface->decorations != WLR_XWAYLAND_SURFACE_DECORATIONS_ALL;
+	view_set_csd_from_client(view, csd);
 }
 
 static void _close(struct sway_view *view) {
@@ -274,7 +276,6 @@ static const struct sway_view_impl view_impl = {
 	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
 	.wants_floating = wants_floating,
-	.has_client_side_decorations = has_client_side_decorations,
 	.close = _close,
 	.destroy = destroy,
 };
@@ -343,6 +344,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xwayland_view->set_role.link);
 	wl_list_remove(&xwayland_view->set_window_type.link);
 	wl_list_remove(&xwayland_view->set_hints.link);
+	wl_list_remove(&xwayland_view->set_decorations.link);
 	wl_list_remove(&xwayland_view->map.link);
 	wl_list_remove(&xwayland_view->unmap.link);
 	view_begin_destroy(&xwayland_view->view);
@@ -612,6 +614,10 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 
 	wl_signal_add(&xsurface->events.set_hints, &xwayland_view->set_hints);
 	xwayland_view->set_hints.notify = handle_set_hints;
+
+	wl_signal_add(&xsurface->events.set_decorations,
+			&xwayland_view->set_decorations);
+	xwayland_view->set_decorations.notify = handle_set_decorations;
 
 	wl_signal_add(&xsurface->events.unmap, &xwayland_view->unmap);
 	xwayland_view->unmap.notify = handle_unmap;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -175,7 +175,8 @@ static enum wlr_edges find_edge(struct sway_container *cont,
 		return WLR_EDGE_NONE;
 	}
 	struct sway_view *view = cont->view;
-	if (view->border == B_NONE || !view->border_thickness || view->using_csd) {
+	if (view->border == B_NONE || !view->border_thickness ||
+			view->border == B_CSD) {
 		return WLR_EDGE_NONE;
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -216,6 +216,8 @@ static const char *describe_container_border(enum sway_container_border border) 
 		return "pixel";
 	case B_NORMAL:
 		return "normal";
+	case B_CSD:
+		return "csd";
 	}
 	return "unknown";
 }

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -10,6 +10,7 @@ sway_sources = files(
 	'security.c',
 	'server.c',
 	'swaynag.c',
+	'xdg_decoration.c',
 
 	'desktop/desktop.c',
 	'desktop/idle_inhibit_v1.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/util/log.h>
 #include "list.h"
@@ -114,6 +115,14 @@ bool server_init(struct sway_server *server) {
 		&server->server_decoration);
 	server->server_decoration.notify = handle_server_decoration;
 	wl_list_init(&server->decorations);
+
+	server->xdg_decoration_manager =
+		wlr_xdg_decoration_manager_v1_create(server->wl_display);
+	wl_signal_add(
+			&server->xdg_decoration_manager->events.new_toplevel_decoration,
+			&server->xdg_decoration);
+	server->xdg_decoration.notify = handle_xdg_decoration;
+	wl_list_init(&server->xdg_decorations);
 
 	wlr_export_dmabuf_manager_v1_create(server->wl_display);
 	wlr_screencopy_manager_v1_create(server->wl_display);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -715,7 +715,7 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 	size_t border_width = 0;
 	size_t top = 0;
 
-	if (!view->using_csd) {
+	if (view->border != B_CSD) {
 		border_width = view->border_thickness * (view->border != B_NONE);
 		top = view->border == B_NORMAL ?
 			container_titlebar_height() : border_width;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -669,6 +669,9 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_init_floating(container);
 		if (container->view) {
 			view_set_tiled(container->view, false);
+			if (container->view->using_csd) {
+				container->view->border = B_CSD;
+			}
 		}
 		if (old_parent) {
 			container_reap_empty(old_parent);
@@ -695,6 +698,9 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		}
 		if (container->view) {
 			view_set_tiled(container->view, true);
+			if (container->view->using_csd) {
+				container->view->border = container->view->saved_border;
+			}
 		}
 		container->is_sticky = false;
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -309,6 +309,7 @@ void view_request_activate(struct sway_view *view) {
 }
 
 void view_set_csd_from_server(struct sway_view *view, bool enabled) {
+	wlr_log(WLR_DEBUG, "Telling view %p to set CSD to %i", view, enabled);
 	if (view->xdg_decoration) {
 		uint32_t mode = enabled ?
 			WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE :
@@ -316,15 +317,20 @@ void view_set_csd_from_server(struct sway_view *view, bool enabled) {
 		wlr_xdg_toplevel_decoration_v1_set_mode(
 				view->xdg_decoration->wlr_xdg_decoration, mode);
 	}
+	view->using_csd = enabled;
 }
 
 void view_update_csd_from_client(struct sway_view *view, bool enabled) {
+	wlr_log(WLR_DEBUG, "View %p updated CSD to %i", view, enabled);
 	if (enabled && view->border != B_CSD) {
 		view->saved_border = view->border;
-		view->border = B_CSD;
+		if (container_is_floating(view->container)) {
+			view->border = B_CSD;
+		}
 	} else if (!enabled && view->border == B_CSD) {
 		view->border = view->saved_border;
 	}
+	view->using_csd = enabled;
 }
 
 void view_set_tiled(struct sway_view *view, bool tiled) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -318,7 +318,7 @@ void view_set_csd_from_server(struct sway_view *view, bool enabled) {
 	}
 }
 
-void view_set_csd_from_client(struct sway_view *view, bool enabled) {
+void view_update_csd_from_client(struct sway_view *view, bool enabled) {
 	if (enabled && view->border != B_CSD) {
 		view->saved_border = view->border;
 		view->border = B_CSD;

--- a/sway/xdg_decoration.c
+++ b/sway/xdg_decoration.c
@@ -12,31 +12,22 @@ static void xdg_decoration_handle_destroy(struct wl_listener *listener,
 		wl_container_of(listener, deco, destroy);
 	deco->view->xdg_decoration = NULL;
 	wl_list_remove(&deco->destroy.link);
-	wl_list_remove(&deco->surface_commit.link);
+	wl_list_remove(&deco->request_mode.link);
 	wl_list_remove(&deco->link);
 	free(deco);
 }
 
-static void xdg_decoration_handle_surface_commit(struct wl_listener *listener,
+static void xdg_decoration_handle_request_mode(struct wl_listener *listener,
 		void *data) {
-	struct sway_xdg_decoration *decoration =
-		wl_container_of(listener, decoration, surface_commit);
-
-	bool csd = decoration->wlr_xdg_decoration->current_mode ==
-		WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
-	struct sway_view *view = decoration->view;
-
-	view_update_csd_from_client(view, csd);
-
-	arrange_container(view->container);
-	transaction_commit_dirty();
+	struct sway_xdg_decoration *deco =
+		wl_container_of(listener, deco, request_mode);
+	wlr_xdg_toplevel_decoration_v1_set_mode(deco->wlr_xdg_decoration,
+			WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
 }
 
 void handle_xdg_decoration(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_decoration_v1 *wlr_deco = data;
 	struct sway_xdg_shell_view *xdg_shell_view = wlr_deco->surface->data;
-	struct wlr_xdg_surface *wlr_xdg_surface =
-		xdg_shell_view->view.wlr_xdg_surface;
 
 	struct sway_xdg_decoration *deco = calloc(1, sizeof(*deco));
 	if (deco == NULL) {
@@ -50,13 +41,8 @@ void handle_xdg_decoration(struct wl_listener *listener, void *data) {
 	wl_signal_add(&wlr_deco->events.destroy, &deco->destroy);
 	deco->destroy.notify = xdg_decoration_handle_destroy;
 
-	// Note: We don't listen to the request_mode signal here, effectively
-	// ignoring any modes the client asks to set. The client can still force a
-	// mode upon us, in which case we get upset but live with it.
-
-	deco->surface_commit.notify = xdg_decoration_handle_surface_commit;
-	wl_signal_add(&wlr_xdg_surface->surface->events.commit,
-		&deco->surface_commit);
+	wl_signal_add(&wlr_deco->events.request_mode, &deco->request_mode);
+	deco->request_mode.notify = xdg_decoration_handle_request_mode;
 
 	wl_list_insert(&server.xdg_decorations, &deco->link);
 }

--- a/sway/xdg_decoration.c
+++ b/sway/xdg_decoration.c
@@ -26,7 +26,7 @@ static void xdg_decoration_handle_surface_commit(struct wl_listener *listener,
 		WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
 	struct sway_view *view = decoration->view;
 
-	view_set_csd_from_client(view, csd);
+	view_update_csd_from_client(view, csd);
 
 	arrange_container(view->container);
 	transaction_commit_dirty();

--- a/sway/xdg_decoration.c
+++ b/sway/xdg_decoration.c
@@ -1,0 +1,73 @@
+#include <stdlib.h>
+#include "sway/desktop/transaction.h"
+#include "sway/server.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "sway/xdg_decoration.h"
+#include "log.h"
+
+static void xdg_decoration_handle_destroy(struct wl_listener *listener,
+		void *data) {
+	struct sway_xdg_decoration *deco =
+		wl_container_of(listener, deco, destroy);
+	deco->view->xdg_decoration = NULL;
+	wl_list_remove(&deco->destroy.link);
+	wl_list_remove(&deco->surface_commit.link);
+	wl_list_remove(&deco->link);
+	free(deco);
+}
+
+static void xdg_decoration_handle_surface_commit(struct wl_listener *listener,
+		void *data) {
+	struct sway_xdg_decoration *decoration =
+		wl_container_of(listener, decoration, surface_commit);
+
+	bool csd = decoration->wlr_xdg_decoration->current_mode ==
+		WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
+	struct sway_view *view = decoration->view;
+
+	view_set_csd_from_client(view, csd);
+
+	arrange_container(view->container);
+	transaction_commit_dirty();
+}
+
+void handle_xdg_decoration(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_toplevel_decoration_v1 *wlr_deco = data;
+	struct sway_xdg_shell_view *xdg_shell_view = wlr_deco->surface->data;
+	struct wlr_xdg_surface *wlr_xdg_surface =
+		xdg_shell_view->view.wlr_xdg_surface;
+
+	struct sway_xdg_decoration *deco = calloc(1, sizeof(*deco));
+	if (deco == NULL) {
+		return;
+	}
+
+	deco->view = &xdg_shell_view->view;
+	deco->view->xdg_decoration = deco;
+	deco->wlr_xdg_decoration = wlr_deco;
+
+	wl_signal_add(&wlr_deco->events.destroy, &deco->destroy);
+	deco->destroy.notify = xdg_decoration_handle_destroy;
+
+	// Note: We don't listen to the request_mode signal here, effectively
+	// ignoring any modes the client asks to set. The client can still force a
+	// mode upon us, in which case we get upset but live with it.
+
+	deco->surface_commit.notify = xdg_decoration_handle_surface_commit;
+	wl_signal_add(&wlr_xdg_surface->surface->events.commit,
+		&deco->surface_commit);
+
+	wl_list_insert(&server.xdg_decorations, &deco->link);
+}
+
+struct sway_xdg_decoration *xdg_decoration_from_surface(
+		struct wlr_surface *surface) {
+	struct sway_xdg_decoration *deco;
+	wl_list_for_each(deco, &server.xdg_decorations, link) {
+		if (deco->wlr_xdg_decoration->surface->surface == surface) {
+			return deco;
+		}
+	}
+	return NULL;
+}


### PR DESCRIPTION
This replaces `view.using_csd` with a new border mode: `B_CSD`. This also removes `sway_xdg_shell{_v6}_view.deco_mode` and `view->has_client_side_decorations` as we can now get these from the border.

You can use `border toggle` to cycle through the modes including CSD, or use `border csd` to set it directly. The client must support the xdg-decoration protocol, and the only client I know of that does is the example in wlroots.

If the client switches from SSD to CSD without us expecting it (via the server-decoration protocol), we stash the previous border type into `view.saved_border` so we can restore it if the client returns to SSD. I haven't found a way to test this though.

Closes #2429.