### PR TITLE
Fix crash when disconnecting output

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -985,7 +985,8 @@ void container_discover_outputs(struct sway_container *con) {
 		}
 	}
 	struct sway_output *new_output = container_get_effective_output(con);
-	double old_scale = old_output ? old_output->wlr_output->scale : -1;
+	double old_scale = old_output && old_output->enabled ?
+		old_output->wlr_output->scale : -1;
 	double new_scale = new_output ? new_output->wlr_output->scale : -1;
 	if (old_scale != new_scale) {
 		container_update_title_textures(con);


### PR DESCRIPTION
If the output being disconnected contains views, and the views are being relocated to another output of a different size, a transaction must occur to reconfigure them. This means by the time `container_discover_outputs` is called, the output is already disabled and `wlr_output` is `NULL`.

I considered making it check `output->wlr_output`, but `output->enabled` should work just as well and is more descriptive.

Untested on DRM. Someone please test this on DRM before merging.

Fixes #2705.