### PR TITLE
Add a missing null check for moving tiling containers

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -897,7 +897,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 	// Handle moving a tiling container
 	if (config->tiling_drag && mod_pressed && state == WLR_BUTTON_PRESSED &&
-			!is_floating_or_child && !cont->is_fullscreen) {
+			!is_floating_or_child && cont && !cont->is_fullscreen) {
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		seat_begin_move_tiling(seat, cont, button);
 		return;


### PR DESCRIPTION
Trying to move the About window in Android Studio causes a crash without this check.