### PR TITLE
Fix race condition crash when view unmaps + maps quickly

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -67,12 +67,10 @@ void container_destroy(struct sway_container *con) {
 	list_free(con->outputs);
 
 	if (con->view) {
-		struct sway_view *view = con->view;
-		view->container = NULL;
-		free(view->title_format);
-		view->title_format = NULL;
-
-		if (view->destroying) {
+		if (con->view->container == con) {
+			con->view->container = NULL;
+		}
+		if (con->view->destroying) {
 			view_destroy(con->view);
 		}
 	}


### PR DESCRIPTION
When a view unmaps, we start a transaction to destroy the container, then when the transaction completes we destroy the container and unset the view's container pointer. But if the view has remapped in the meantime, the view's container pointer will be pointing to a different container which should not be cleared.

This adds a check to make sure the view is still pointing to the container being destroyed before clearing the pointer. The freeing of the title format is also removed as it is already freed when the view destroys in `view_destroy`.

Fixes #2710.