### PR TITLE
Use _C11_SOURCE feature test macro on FreeBSD (fixes #2616)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,10 @@ datadir = get_option('datadir')
 sysconfdir = get_option('sysconfdir')
 prefix = get_option('prefix')
 
+if is_freebsd
+	add_project_arguments('-D_C11_SOURCE', language: 'c')
+endif
+
 swayidle_deps = []
 
 jsonc          = dependency('json-c', version: '>=0.13')


### PR DESCRIPTION
This PR will add the `_C11_SOURCE` feature macro to meson.build on FreeBSD, thus narrows down the default namespace set (POSIX 2008 + XSI extensions, C11 + EXT1 extensions, BSD specific stuff) to only the C11 standard. This fixes #2616, and also prevents any future name clashes with FreeBSD-specific symbols.

This change would require to either define `__BSD_VISIBLE` or undefine `_C11_SOURCE` on sway/ipc-server.c because of the non-standatd `SOCK_NONBLOCK` and `SOCK_CLOEXEC` flags. I have replaced the usage of these flags with two `fcntl` calls instead, which makes the file POSIX 2001 compliant.