### PR TITLE
Rename workspace_outputs to workspace_configs and fix memory leak

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -167,13 +167,12 @@ struct output_config {
 };
 
 /**
- * Maps a workspace name to an output name.
- *
- * Set via `workspace <x> output <y>`
+ * Stores configuration for a workspace, regardless of whether the workspace
+ * exists.
  */
-struct workspace_output {
-	char *output;
+struct workspace_config {
 	char *workspace;
+	char *output;
 };
 
 struct bar_config {
@@ -327,7 +326,7 @@ struct sway_config {
 	list_t *modes;
 	list_t *bars;
 	list_t *cmd_queue;
-	list_t *workspace_outputs;
+	list_t *workspace_configs;
 	list_t *output_configs;
 	list_t *input_configs;
 	list_t *seat_configs;
@@ -517,6 +516,8 @@ void terminate_swaybg(pid_t pid);
 struct bar_config *default_bar_config(void);
 
 void free_bar_config(struct bar_config *bar);
+
+void free_workspace_config(struct workspace_config *wsc);
 
 /**
  * Updates the value of config->font_height based on the max title height

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -48,6 +48,8 @@ struct sway_workspace {
 
 extern char *prev_workspace_name;
 
+struct workspace_config *workspace_find_config(const char *ws_name);
+
 struct sway_output *workspace_get_initial_output(const char *name);
 
 struct sway_workspace *workspace_create(struct sway_output *output,

--- a/sway/config.c
+++ b/sway/config.c
@@ -95,7 +95,12 @@ void free_config(struct sway_config *config) {
 		list_free(config->bars);
 	}
 	list_free(config->cmd_queue);
-	list_free(config->workspace_outputs);
+	if (config->workspace_configs) {
+		for (int i = 0; i < config->workspace_configs->length; i++) {
+			free_workspace_config(config->workspace_configs->items[i]);
+		}
+		list_free(config->workspace_configs);
+	}
 	if (config->output_configs) {
 		for (int i = 0; i < config->output_configs->length; i++) {
 			free_output_config(config->output_configs->items[i]);
@@ -175,7 +180,7 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->symbols = create_list())) goto cleanup;
 	if (!(config->modes = create_list())) goto cleanup;
 	if (!(config->bars = create_list())) goto cleanup;
-	if (!(config->workspace_outputs = create_list())) goto cleanup;
+	if (!(config->workspace_configs = create_list())) goto cleanup;
 	if (!(config->criteria = create_list())) goto cleanup;
 	if (!(config->no_focus = create_list())) goto cleanup;
 	if (!(config->input_configs = create_list())) goto cleanup;
@@ -804,7 +809,7 @@ char *do_var_replacement(char *str) {
 // would compare two structs in full, while this method only compares the
 // workspace.
 int workspace_output_cmp_workspace(const void *a, const void *b) {
-	const struct workspace_output *wsa = a, *wsb = b;
+	const struct workspace_config *wsa = a, *wsb = b;
 	return lenient_strcmp(wsa->workspace, wsb->workspace);
 }
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -128,7 +128,7 @@ void next_name_map(struct sway_container *ws, void *data) {
 static bool workspace_valid_on_output(const char *output_name,
 		const char *ws_name) {
 	struct workspace_config *wsc = workspace_find_config(ws_name);
-	return !wsc || strcmp(wsc->output, output_name) == 0;
+	return !wsc || !wsc->output || strcmp(wsc->output, output_name) == 0;
 }
 
 static void workspace_name_from_binding(const struct sway_binding * binding,

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -20,17 +20,23 @@
 #include "log.h"
 #include "util.h"
 
+struct workspace_config *workspace_find_config(const char *ws_name) {
+	for (int i = 0; i < config->workspace_configs->length; ++i) {
+		struct workspace_config *wsc = config->workspace_configs->items[i];
+		if (strcmp(wsc->workspace, ws_name) == 0) {
+			return wsc;
+		}
+	}
+	return NULL;
+}
+
 struct sway_output *workspace_get_initial_output(const char *name) {
-	// Search for workspace<->output pair
-	for (int i = 0; i < config->workspace_outputs->length; ++i) {
-		struct workspace_output *wso = config->workspace_outputs->items[i];
-		if (strcasecmp(wso->workspace, name) == 0) {
-			// Find output to use if it exists
-			struct sway_output *output = output_by_name(wso->output);
-			if (output) {
-				return output;
-			}
-			break;
+	// Check workspace configs for a workspace<->output pair
+	struct workspace_config *wsc = workspace_find_config(name);
+	if (wsc && wsc->output) {
+		struct sway_output *output = output_by_name(wsc->output);
+		if (output) {
+			return output;
 		}
 	}
 	// Otherwise put it on the focused output
@@ -121,17 +127,8 @@ void next_name_map(struct sway_container *ws, void *data) {
 
 static bool workspace_valid_on_output(const char *output_name,
 		const char *ws_name) {
-	int i;
-	for (i = 0; i < config->workspace_outputs->length; ++i) {
-		struct workspace_output *wso = config->workspace_outputs->items[i];
-		if (strcasecmp(wso->workspace, ws_name) == 0) {
-			if (strcasecmp(wso->output, output_name) != 0) {
-				return false;
-			}
-		}
-	}
-
-	return true;
+	struct workspace_config *wsc = workspace_find_config(ws_name);
+	return !wsc || strcmp(wsc->output, output_name) == 0;
 }
 
 static void workspace_name_from_binding(const struct sway_binding * binding,
@@ -231,13 +228,13 @@ char *workspace_next_name(const char *output_name) {
 		workspace_name_from_binding(mode->keycode_bindings->items[i],
 				output_name, &order, &target);
 	}
-	for (int i = 0; i < config->workspace_outputs->length; ++i) {
+	for (int i = 0; i < config->workspace_configs->length; ++i) {
 		// Unlike with bindings, this does not guarantee order
-		const struct workspace_output *wso = config->workspace_outputs->items[i];
-		if (strcmp(wso->output, output_name) == 0
-				&& workspace_by_name(wso->workspace) == NULL) {
+		const struct workspace_config *wsc = config->workspace_configs->items[i];
+		if (wsc->output && strcmp(wsc->output, output_name) == 0
+				&& workspace_by_name(wsc->workspace) == NULL) {
 			free(target);
-			target = strdup(wso->workspace);
+			target = strdup(wsc->workspace);
 			break;
 		}
 	}


### PR DESCRIPTION
When we eventually implement `workspace <ws> gaps inner|outer <px>`, we'll need to store the gaps settings for workspaces before they're created. Rather than create a `workspace_gaps` struct, the approach I'm taking is to rename `workspace_outputs` to `workspace_configs` and then add gaps settings to that.

I've added a lookup function `workspace_find_config`. Note that we have a similar thing for outputs (`output_config` struct and `output_find_config`).

Lastly, when freeing config it would create a memory leak by freeing the list items but not the workspace or output names inside them. This has been rectified using a `free_workspace_config` function.