### PR TITLE
Add tap and drag to sway-input

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -217,6 +217,7 @@ sway_cmd bar_colors_cmd_urgent_workspace;
 sway_cmd input_cmd_seat;
 sway_cmd input_cmd_accel_profile;
 sway_cmd input_cmd_click_method;
+sway_cmd input_cmd_drag;
 sway_cmd input_cmd_drag_lock;
 sway_cmd input_cmd_dwt;
 sway_cmd input_cmd_events;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -93,6 +93,7 @@ struct input_config {
 
 	int accel_profile;
 	int click_method;
+	int drag;
 	int drag_lock;
 	int dwt;
 	int left_handed;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -9,6 +9,7 @@
 static struct cmd_handler input_handlers[] = {
 	{ "accel_profile", input_cmd_accel_profile },
 	{ "click_method", input_cmd_click_method },
+	{ "drag", input_cmd_drag },
 	{ "drag_lock", input_cmd_drag_lock },
 	{ "dwt", input_cmd_dwt },
 	{ "events", input_cmd_events },

--- a/sway/commands/input/drag.c
+++ b/sway/commands/input/drag.c
@@ -1,0 +1,26 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_drag(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "drag", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE,
+			"drag", "No input device defined.");
+	}
+
+	if (parse_boolean(argv[0], true)) {
+		ic->drag = LIBINPUT_CONFIG_DRAG_ENABLED;
+	} else {
+		ic->drag = LIBINPUT_CONFIG_DRAG_DISABLED;
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -20,6 +20,7 @@ struct input_config *new_input_config(const char* identifier) {
 
 	input->tap = INT_MIN;
 	input->tap_button_map = INT_MIN;
+	input->drag = INT_MIN;
 	input->drag_lock = INT_MIN;
 	input->dwt = INT_MIN;
 	input->send_events = INT_MIN;
@@ -45,6 +46,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->click_method != INT_MIN) {
 		dst->click_method = src->click_method;
+	}
+	if (src->drag != INT_MIN) {
+		dst->drag = src->drag;
 	}
 	if (src->drag_lock != INT_MIN) {
 		dst->drag_lock = src->drag_lock;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -120,6 +120,13 @@ static void input_manager_libinput_config_pointer(
 		libinput_device_config_click_set_method(libinput_device,
 			ic->click_method);
 	}
+	if (ic->drag != INT_MIN) {
+		wlr_log(WLR_DEBUG,
+			"libinput_config_pointer(%s) tap_set_drag_enabled(%d)",
+			ic->identifier, ic->click_method);
+		libinput_device_config_tap_set_drag_enabled(libinput_device,
+			ic->drag);
+	}
 	if (ic->drag_lock != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -119,6 +119,7 @@ sway_sources = files(
 
 	'commands/input/accel_profile.c',
 	'commands/input/click_method.c',
+	'commands/input/drag.c',
 	'commands/input/drag_lock.c',
 	'commands/input/dwt.c',
 	'commands/input/events.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -68,6 +68,9 @@ The following commands may only be used in the configuration file.
 *input* <identifier> click\_method none|button\_areas|clickfinger
 	Changes the click method for the specified device.
 
+*input* <identifier> drag enabled|disabled
+	Enables or disables tap-and-drag for specified input device.
+
 *input* <identifier> drag\_lock enabled|disabled
 	Enables or disables drag lock for specified input device.
 


### PR DESCRIPTION
Add functionality to disable tap-and-drag to sway-input with `drag disable`.