### PR TITLE
Make gaps implementation consistent with i3-gaps

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -173,6 +173,8 @@ struct output_config {
 struct workspace_config {
 	char *workspace;
 	char *output;
+	int gaps_inner;
+	int gaps_outer;
 };
 
 struct bar_config {

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -94,9 +94,6 @@ struct sway_container {
 
 	// The gaps currently applied to the container.
 	double current_gaps;
-	bool has_gaps;
-	double gaps_inner;
-	double gaps_outer;
 
 	struct sway_workspace *workspace; // NULL when hidden in the scratchpad
 	struct sway_container *parent;    // NULL if container in root of workspace

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -32,10 +32,9 @@ struct sway_workspace {
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_split_layout;
 
-	double current_gaps;
-	bool has_gaps;
-	double gaps_inner;
-	double gaps_outer;
+	int current_gaps;
+	int gaps_inner;
+	int gaps_outer;
 
 	struct sway_output *output; // NULL if no outputs are connected
 	list_t *floating;           // struct sway_container

--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -68,6 +68,9 @@ static struct cmd_results *gaps_set_defaults(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "gaps",
 				"Expected 'gaps inner|outer <px>'");
 	}
+	if (amount < 0) {
+		amount = 0;
+	}
 
 	if (inner) {
 		config->gaps_inner = amount;
@@ -91,6 +94,9 @@ static void configure_gaps(struct sway_workspace *ws, void *_data) {
 	case GAPS_OP_SUBTRACT:
 		*prop -= data->amount;
 		break;
+	}
+	if (*prop < 0) {
+		*prop = 0;
 	}
 	arrange_workspace(ws);
 }

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -138,15 +138,14 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 			}
 			container->layout = new_layout;
 			container_update_representation(container);
-			arrange_container(container);
 		} else {
 			if (old_layout != L_TABBED && old_layout != L_STACKED) {
 				workspace->prev_split_layout = old_layout;
 			}
 			workspace->layout = new_layout;
 			workspace_update_representation(workspace);
-			arrange_workspace(workspace);
 		}
+		arrange_workspace(workspace);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -419,19 +419,17 @@ The default colors are:
 	inner gap is nonzero. When _off_, gaps will only be added between views.
 	_toggle_ cannot be used in the configuration file.
 
-*gaps* <amount>
-	Sets _amount_ pixels of gap between windows and around each workspace.
-
 *gaps* inner|outer <amount>
-	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the former
-	affects spacing between views and the latter affects the space around each
-	workspace.
+	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the inner
+	affects spacing around each view and outer affects the spacing around each
+	workspace. Outer gaps are in addition to inner gaps.
 
-*gaps* inner|outer all|workspace|current set|plus|minus <amount>
-	Changes the gaps for the _inner_ or _outer_ gap. _all_ changes the gaps for
-	all views or workspace, _workspace_ changes gaps for all views in current
-	workspace (or current workspace), and _current_ changes gaps for the current
-	view or workspace.
+	This affects new workspaces only, and is used when the workspace doesn't
+	have its own gaps settings (see: workspace <ws> gaps inner|outer <amount>).
+
+*gaps* inner|outer all|current set|plus|minus <amount>
+	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
+	_current_ workspace.
 
 *hide\_edge\_borders* none|vertical|horizontal|both|smart
 	Hides window borders adjacent to the screen edges. Default is _none_.
@@ -579,6 +577,10 @@ match any output by using the output name "\*".
 
 *workspace* back_and_forth
 	Switches to the previously focused workspace.
+
+*workspace* <name> gaps inner|outer <amount>
+	Specifies that workspace _name_ should have the given gaps settings when it
+	is created.
 
 *workspace* <name> output <output>
 	Specifies that workspace _name_ should be shown on the specified _output_.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1022,7 +1022,7 @@ void container_add_gaps(struct sway_container *c) {
 
 	struct sway_workspace *ws = c->workspace;
 
-	c->current_gaps = ws->has_gaps ? ws->gaps_inner : config->gaps_inner;
+	c->current_gaps = ws->gaps_inner;
 	c->x += c->current_gaps;
 	c->y += c->current_gaps;
 	c->width -= 2 * c->current_gaps;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -68,6 +68,20 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 	ws->output_priority = create_list();
 	workspace_output_add_priority(ws, output);
 
+	ws->gaps_outer = config->gaps_outer;
+	ws->gaps_inner = config->gaps_inner;
+	if (name) {
+		struct workspace_config *wsc = workspace_find_config(name);
+		if (wsc) {
+			if (wsc->gaps_outer != -1) {
+				ws->gaps_outer = wsc->gaps_outer;
+			}
+			if (wsc->gaps_inner != -1) {
+				ws->gaps_inner = wsc->gaps_inner;
+			}
+		}
+	}
+
 	output_add_workspace(output, ws);
 	output_sort_workspaces(output);
 
@@ -632,13 +646,13 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 		return;
 	}
 
-	ws->current_gaps = ws->has_gaps ? ws->gaps_outer : config->gaps_outer;
+	ws->current_gaps = ws->gaps_outer;
 
 	if (ws->layout == L_TABBED || ws->layout == L_STACKED) {
 		// We have to add inner gaps for this, because children of tabbed and
 		// stacked containers don't apply their own gaps - they assume the
 		// tabbed/stacked container is using gaps.
-		ws->current_gaps += ws->has_gaps ? ws->gaps_inner : config->gaps_inner;
+		ws->current_gaps += ws->gaps_inner;
 	}
 
 	ws->x += ws->current_gaps;


### PR DESCRIPTION
This changes our gaps implementation to behave like i3-gaps.

Our previous implementation allowed you to set gaps on a per container basis. This is no longer possible as it isn't supported by i3-gaps and doesn't seem to have a practical use case. The `gaps_outer` and `gaps_inner` properties on containers are now removed as they just read the `gaps_inner` from the workspace.

`gaps inner|outer <px>` no longer changes the gaps for all workspaces. It only sets defaults for new workspaces.

`gaps inner|outer current|workspace|all set|plus|minus <px>` is now runtime only, and the workspace option is now removed. `current` now sets gaps for the current workspace as opposed to the current container.

`workspace <ws> gaps inner|outer <px>` is now implemented. This sets defaults for a workspace.

This also fixes a bug where changing the layout of a split container from linear to tabbed would cause gaps to not be applied to it until you switch to another workspace and back.

i3-gaps docs: https://github.com/Airblader/i3#gaps

Supersedes/closes #2131.