### PR TITLE
Move sticky containers in output_evacuate

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -823,9 +823,16 @@ void container_floating_move_to_center(struct sway_container *con) {
 		return;
 	}
 	struct sway_workspace *ws = con->workspace;
+	bool full = con->is_fullscreen;
+	if (full) {
+		container_set_fullscreen(con, false);
+	}
 	double new_lx = ws->x + (ws->width - con->width) / 2;
 	double new_ly = ws->y + (ws->height - con->height) / 2;
 	container_floating_translate(con, new_lx - con->x, new_ly - con->y);
+	if (full) {
+		container_set_fullscreen(con, true);
+	}
 }
 
 static bool find_urgent_iterator(struct sway_container *con, void *data) {


### PR DESCRIPTION
When evacuating an output, sticky containers need to be moved to a different output. Currently, they are not moved since `workspace_is_empty` returns `true` when there are only sticky containers.

This PR adds an additional check after the `workspace_is_empty` call that checks whether there are `floating` containers. If there are, they must all be sticky. The sticky containers get moved to another output and the workspace gets destroyed as normal.