### PR TITLE
Add support for installing binaries with DT_RPATH

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,16 @@ else
 endif
 add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
 
-add_project_arguments('-D_LD_LIBRARY_PATH="@0@"'.format(get_option('ld-library-path')), language: 'c')
+if get_option('use_rpath')
+	if get_option('custom_rpath') == ''
+		# default to platform specific libdir, one level up from the binary
+		rpathdir = join_paths('$ORIGIN', '..', '$LIB')
+	else
+		rpathdir = get_option('custom_rpath')
+	endif
+else
+	rpathdir = ''
+endif
 
 sway_inc = include_directories('include')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('sway-version', type : 'string', description: 'The version string reported in `sway --version`.')
-option('ld-library-path', type: 'string', value: '', description: 'The LD_LIBRARY_PATH environment variable.')
+option('use_rpath', type: 'boolean', value: false, description: 'install binaries with rpath set')
+option('custom_rpath', type: 'string', value: '', description: 'override rpath with a custom one')
 option('default-wallpaper', type: 'boolean', value: true, description: 'Install the default wallpaper.')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')

--- a/sway/main.c
+++ b/sway/main.c
@@ -241,14 +241,6 @@ int main(int argc, char **argv) {
 		"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
 		"\n";
 
-	// Security:
-	unsetenv("LD_PRELOAD");
-#ifdef _LD_LIBRARY_PATH
-	setenv("LD_LIBRARY_PATH", _LD_LIBRARY_PATH, 1);
-#else
-	unsetenv("LD_LIBRARY_PATH");
-#endif
-
 	int c;
 	while (1) {
 		int option_index = 0;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -187,5 +187,6 @@ executable(
 	include_directories: [sway_inc],
 	dependencies: sway_deps,
 	link_with: [lib_sway_common],
+	install_rpath : rpathdir,
 	install: true
 )

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -24,5 +24,6 @@ executable(
 		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
+	install_rpath : rpathdir,
 	install: true
 )

--- a/swaybg/meson.build
+++ b/swaybg/meson.build
@@ -14,5 +14,6 @@ executable(
 		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
+	install_rpath : rpathdir,
 	install: true
 )

--- a/swayidle/meson.build
+++ b/swayidle/meson.build
@@ -14,5 +14,6 @@ executable(
 		swayidle_deps,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
+	install_rpath : rpathdir,
 	install: true
 )

--- a/swaylock/meson.build
+++ b/swaylock/meson.build
@@ -33,6 +33,7 @@ executable('swaylock',
 	include_directories: [sway_inc],
 	dependencies: dependencies,
 	link_with: [lib_sway_common, lib_sway_client],
+	install_rpath : rpathdir,
 	install: true
 )
 

--- a/swaymsg/meson.build
+++ b/swaymsg/meson.build
@@ -4,5 +4,6 @@ executable(
     include_directories: [sway_inc],
     dependencies: [jsonc, wlroots],
     link_with: [lib_sway_common],
+    install_rpath : rpathdir,
     install: true
 )

--- a/swaynag/meson.build
+++ b/swaynag/meson.build
@@ -19,5 +19,6 @@ executable(
 		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
+	install_rpath : rpathdir,
 	install: true
 )


### PR DESCRIPTION
It's better to use DT_RPATH dynamic section of the elf binary to store
the paths of libraries to load instead of overwriting LD_LIBRARY_PATH
for the whole environment, causing surprises. This solution is much more
transparent and perfectly suitable for running contained installations
of wayland/wlroots/sway.

The code unsetting the LD_LIBRARY_PATH/LD_PRELOAD was also deleted as
it's a placebo security at best - we should trust the execution path
that leads us to running sway, and it's way too late to care about those
variables since we already started executing our compositor, thus we
would be compromised anyway.