### PR TITLE
Do not strip quotes for exec or bind commands

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -391,7 +391,10 @@ struct cmd_results *config_command(char *exec) {
 	// Var replacement, for all but first argument of set
 	// TODO commands
 	for (i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
-		if (*argv[i] == '\"' || *argv[i] == '\'') {
+		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
+				&& handler->handle != cmd_bindsym
+				&& handler->handle != cmd_bindcode
+				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
 			strip_quotes(argv[i]);
 		}
 		argv[i] = do_var_replacement(argv[i]);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -394,6 +394,7 @@ struct cmd_results *config_command(char *exec) {
 		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
 				&& handler->handle != cmd_bindsym
 				&& handler->handle != cmd_bindcode
+				&& handler->handle != cmd_set
 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
 			strip_quotes(argv[i]);
 		}


### PR DESCRIPTION
Leave quotes intact for `cmd_exec`, `cmd_exec_always`, `cmd_bindcode`, `cmd_bindsym`, and `cmd_set`.

`cmd_exec` and `cmd_exec_always` should not have any quotes stripped from them and should be passed to `exexcl` as is.

`cmd_bindcode` and `cmd_bindsym` will have their bound command processed by `execute_command`, which will strip quotes for everything except `cmd_exec`.

Fixes #2736
Fixes #2738