### PR TITLE
Parse floating criteria

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -339,6 +339,8 @@ static enum criteria_token token_from_name(char *name) {
 		return T_URGENT;
 	} else if (strcmp(name, "workspace") == 0) {
 		return T_WORKSPACE;
+	} else if (strcmp(name, "floating") == 0) {
+		return T_FLOATING;
 	}
 	return T_INVALID;
 }


### PR DESCRIPTION
This makes the criteria parser recognize the "floating" token. From there on the criteria seems to be handled as expected.