### PR TITLE
Fix smart gaps

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -256,6 +256,13 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 	int height);
 
 /**
+ * Whether or not the view is the only visible view in its tree. If the view
+ * is tiling, there may be floating views. If the view is floating, there may
+ * be tiling views or views in a different floating container.
+ */
+bool view_is_only_visible(struct sway_view *view);
+
+/**
  * Configure the view's position and size based on the container's position and
  * size, taking borders into consideration.
  */

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -760,6 +760,12 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 
 	seat->has_focus = true;
 
+	if (config->smart_gaps) {
+		// When smart gaps is on, gaps may change when the focus changes so
+		// the workspace needs to be arranged
+		arrange_workspace(new_workspace);
+	}
+
 	update_debug_tree();
 }
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -640,10 +640,16 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 	if (ws->current_gaps > 0) {
 		return;
 	}
-	bool should_apply =
-		config->edge_gaps || (config->smart_gaps && ws->tiling->length > 1);
-	if (!should_apply) {
+	if (!config->edge_gaps) {
 		return;
+	}
+	if (config->smart_gaps) {
+		struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+		struct sway_container *focus =
+			seat_get_focus_inactive_view(seat, &ws->node);
+		if (focus && focus->view && view_is_only_visible(focus->view)) {
+			return;
+		}
 	}
 
 	ws->current_gaps = ws->gaps_outer;


### PR DESCRIPTION
Fixes #2653 

This PR should make it so `smart_gaps` works identical to how it does in `i3-gaps`.

Since `i3-gaps` does not allow for floating containers (only floating views), there is no behaviour to replicate. Currently, each floating container gets treated as a separate group and will apply gaps accordingly.