### PR TITLE
Handle gap borders

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -160,6 +160,7 @@ sway_cmd cmd_scratchpad;
 sway_cmd cmd_seamless_mouse;
 sway_cmd cmd_set;
 sway_cmd cmd_show_marks;
+sway_cmd cmd_smart_borders;
 sway_cmd cmd_smart_gaps;
 sway_cmd cmd_split;
 sway_cmd cmd_splith;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -253,7 +253,8 @@ enum edge_border_types {
 	E_VERTICAL,     /**< hide vertical edge borders */
 	E_HORIZONTAL,   /**< hide horizontal edge borders */
 	E_BOTH,		/**< hide vertical and horizontal edge borders */
-	E_SMART		/**< hide both if precisely one window is present in workspace */
+	E_SMART, /**< hide both if precisely one window is present in workspace */
+	E_SMART_NO_GAPS, /**< hide both if one window and gaps to edge is zero */
 };
 
 enum command_context {
@@ -383,6 +384,7 @@ struct sway_config {
 	int border_thickness;
 	int floating_border_thickness;
 	enum edge_border_types hide_edge_borders;
+	enum edge_border_types saved_edge_borders;
 
 	// border colors
 	struct {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -110,6 +110,7 @@ static struct cmd_handler handlers[] = {
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },
+	{ "smart_borders", cmd_smart_borders },
 	{ "smart_gaps", cmd_smart_gaps },
 	{ "tiling_drag", cmd_tiling_drag },
 	{ "workspace", cmd_workspace },

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -1,14 +1,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "sway/tree/container.h"
-#include "sway/tree/root.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/view.h"
-
-static void _configure_view(struct sway_container *con, void *data) {
-	if (con->view) {
-		view_autoconfigure(con->view);
-	}
-}
 
 struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -26,13 +19,16 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		config->hide_edge_borders = E_BOTH;
 	} else if (strcmp(argv[0], "smart") == 0) {
 		config->hide_edge_borders = E_SMART;
+	} else if (strcmp(argv[0], "smart_no_gaps") == 0) {
+		config->hide_edge_borders = E_SMART_NO_GAPS;
 	} else {
 		return cmd_results_new(CMD_INVALID, "hide_edge_borders",
 				"Expected 'hide_edge_borders "
-				"<none|vertical|horizontal|both|smart>'");
+				"<none|vertical|horizontal|both|smart|smart_no_gaps>'");
 	}
+	config->saved_edge_borders = config->hide_edge_borders;
 
-	root_for_each_container(_configure_view, NULL);
+	arrange_root();
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/smart_borders.c
+++ b/sway/commands/smart_borders.c
@@ -1,0 +1,25 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "util.h"
+
+struct cmd_results *cmd_smart_borders(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "smart_borders", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	enum edge_border_types saved = config->hide_edge_borders;
+	if (strcmp(argv[0], "no_gaps") == 0) {
+		config->hide_edge_borders = E_SMART_NO_GAPS;
+	} else {
+		config->hide_edge_borders = parse_boolean(argv[0], true) ?
+			E_SMART : config->saved_edge_borders;
+	}
+	config->saved_edge_borders = saved;
+
+	arrange_root();
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -249,6 +249,7 @@ static void config_defaults(struct sway_config *config) {
 	config->border_thickness = 2;
 	config->floating_border_thickness = 2;
 	config->hide_edge_borders = E_NONE;
+	config->saved_edge_borders = E_NONE;
 
 	// border colors
 	set_color(config->border_colors.focused.border, 0x4C7899);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -78,6 +78,7 @@ sway_sources = files(
 	'commands/seat/fallback.c',
 	'commands/set.c',
 	'commands/show_marks.c',
+	'commands/smart_borders.c',
 	'commands/smart_gaps.c',
 	'commands/split.c',
 	'commands/sticky.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -431,7 +431,7 @@ The default colors are:
 	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
 	_current_ workspace.
 
-*hide\_edge\_borders* none|vertical|horizontal|both|smart
+*hide\_edge\_borders* none|vertical|horizontal|both|smart|smart\_no\_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_.
 
 *input* <input\_device> <input-subcommands...>
@@ -455,6 +455,12 @@ The default colors are:
 
 *kill*
 	Kills (closes) the currently focused container and all of its children.
+
+*smart\_borders* on|no\_gaps|off
+	If smart\_borders are _on_, borders will only be enabled if the workspace
+	only has one visible child (identical to _hide\_edge\_borders_ smart). If
+	smart\_borders is set to _no\_gaps_, borders will only be enabled if the
+	workspace only has one visible child and gaps greater than zero.
 
 *smart\_gaps* on|off
 	If smart\_gaps are _on_ gaps will only be enabled if a workspace has more


### PR DESCRIPTION
Fixes `hide_edge_borders smart` when gaps are in use.
Implements `hide_edge_borders smart_no_gaps` and `smart_borders on|no_gaps|off`.

Since `smart_borders on` is equivalent to `hide_edge_borders smart` and `smart_borders no_gaps` is equivalent to `hide_edge_borders smart_no_gaps`, I opted to just save the last value set for `hide_edge_borders` and restore that on `smart_borders off`. This simplifies the conditions for setting the border.