### PR TITLE
Fix crash if view has no container

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -341,7 +341,7 @@ void view_update_csd_from_client(struct sway_view *view, bool enabled) {
 	wlr_log(WLR_DEBUG, "View %p updated CSD to %i", view, enabled);
 	if (enabled && view->border != B_CSD) {
 		view->saved_border = view->border;
-		if (container_is_floating(view->container)) {
+		if (view->container && container_is_floating(view->container)) {
 			view->border = B_CSD;
 		}
 	} else if (!enabled && view->border == B_CSD) {


### PR DESCRIPTION
This crashed on me earlier

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000556bc49809a6 in container_is_floating (container=0x0) at ../sway/tree/container.c:738
738		return !container->parent && container->workspace &&
[Current thread is 1 (Thread 0x7f20ebc029c0 (LWP 2610))]
(gdb) bt f
#0  0x0000556bc49809a6 in container_is_floating (container=0x0) at ../sway/tree/container.c:738
#1  0x0000556bc49847a9 in view_update_csd_from_client (view=0x556bc60bf580, enabled=true) at ../sway/tree/view.c:344
#2  0x0000556bc498aa26 in handle_set_decorations (listener=0x556bc60bf7e0, data=0x556bc60c30e0) at ../sway/desktop/xwayland.c:253
        xwayland_view = 0x556bc60bf580
        view = 0x556bc60bf580
        xsurface = 0x556bc60c30e0
        csd = true
#3  0x00007f20f09a4aed in wlr_signal_emit_safe (signal=0x556bc60c32d8, data=0x556bc60c30e0) at ../subprojects/wlroots/util/signal.c:29
        pos = 0x556bc60bf7e0
        l = 0x556bc60bf7e0
        cursor = {link = {prev = 0x556bc60bf7e0, next = 0x7ffc116c9130}, notify = 0x7f20f09a4a37 <handle_noop>}
        end = {link = {prev = 0x7ffc116c9110, next = 0x556bc60c32d8}, notify = 0x7f20f09a4a37 <handle_noop>}
#4  0x00007f20f09567bc in read_surface_motif_hints (xwm=0x556bc5ec5840, xsurface=0x556bc60c30e0, reply=0x556bc6096c00) at ../subprojects/wlroots/xwayland/xwm.c:597
        decorations = 0
        motif_hints = 0x556bc6096c20
#5  0x00007f20f0956ba6 in read_surface_property (xwm=0x556bc5ec5840, xsurface=0x556bc60c30e0, property=253) at ../subprojects/wlroots/xwayland/xwm.c:666
        cookie = {sequence = 8146}
        reply = 0x556bc6096c00
#6  0x00007f20f0957629 in xwm_handle_property_notify (xwm=0x556bc5ec5840, ev=0x556bc6038dc0) at ../subprojects/wlroots/xwayland/xwm.c:906
        xsurface = 0x556bc60c30e0
#7  0x00007f20f0958319 in x11_event_handler (fd=55, mask=1, data=0x556bc5ec5840) at ../subprojects/wlroots/xwayland/xwm.c:1273
        count = 1
        event = 0x556bc6038dc0
        xwm = 0x556bc5ec5840
#8  0x00007f20eff20702 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#9  0x00007f20eff1f2ac in wl_display_run () at /usr/lib/libwayland-server.so.0
#10 0x0000556bc49535b5 in server_run (server=0x556bc49a9ae0 <server>) at ../sway/server.c:174
#11 0x0000556bc4952cca in main (argc=2, argv=0x7ffc116c9618) at ../sway/main.c:384
        verbose = 0
        debug = 1
        validate = 0
        long_options = 
            {{name = 0x556bc49929b4 "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x556bc49929b9 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x556bc49929c0 "validate", has_arg = 0, flag = 0x0, val = 67}, {name = 0x556bc49929c9 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x556bc49929cf "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x556bc49929d7 "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x556bc49929df "get-socketpath", has_arg = 0, flag = 0x0, val = 112}, {name = 0x0, has_arg = 0, flag = 0x0, val = 0}}
        config_path = 0x0
        usage = 0x556bc4992570 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
        c = -1
```