### PR TITLE
Give focus to another swaylock surface when output is disconnected

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -800,9 +800,6 @@ void seat_set_focus_workspace(struct sway_seat *seat,
 
 void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus) {
-	if (seat->focused_layer != NULL) {
-		return;
-	}
 	if (seat->has_focus && unfocus) {
 		struct sway_node *focus = seat_get_focus(seat);
 		seat_send_unfocus(focus, seat);


### PR DESCRIPTION
* Have multiple outputs
* Launch swaylock
* Unplug an output (possibly has to be the last "connected" one)
* The swaylock surface on the remaining output would not respond to key events

This was happening because when the output destroys, focus was not given to the other swaylock surface.

This patch makes focus be transferred to another layer surface owned by the same Wayland client, but only if input was inhibited by the surface being destroyed, and only if it's in the overlay layer. I figure it's best to be overly specific and relax the requirements later if needed.

This patch removes a check in `seat_set_focus_surface` which was preventing focus from being passed from a layer surface to any other surface. I don't know of a use case for this check, but it's possible that this change could produce issues.