### PR TITLE
Ignore unrelated cursor buttons while doing seat operations

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -754,11 +754,12 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	}
 	struct sway_seat *seat = cursor->seat;
 
-	// Handle ending seat operation
-	if (cursor->seat->operation != OP_NONE &&
-			button == cursor->seat->op_button && state == WLR_BUTTON_RELEASED) {
-		seat_end_mouse_operation(seat);
-		seat_pointer_notify_button(seat, time_msec, button, state);
+	// Handle existing seat operation
+	if (cursor->seat->operation != OP_NONE) {
+		if (button == cursor->seat->op_button && state == WLR_BUTTON_RELEASED) {
+			seat_end_mouse_operation(seat);
+			seat_pointer_notify_button(seat, time_msec, button, state);
+		}
 		return;
 	}
 


### PR DESCRIPTION
* Click and hold a scrollbar
* Drag the cursor onto another surface
* While still holding the original button, press and release another cursor button
* Things get weird

There's two ways to fix this. Either cancel the seat operation and do the other click, or continue the seat operation and ignore the other click. I opted for the latter (ignoring the click) because it's easier to implement, and I suspect a second click during a seat operation is probably unintentional anyway.

Fixes #2756