### PR TITLE
[WIP] Don't schedule unnecessary output frames, and simplify damage functions

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -75,7 +75,7 @@ void output_damage_whole(struct sway_output *output);
 void output_damage_surface(struct sway_output *output, double ox, double oy,
 	struct wlr_surface *surface, bool whole);
 
-void output_damage_from_view(struct sway_output *output,
+void output_damage_view_surfaces(struct sway_output *output,
 	struct sway_view *view);
 
 void output_damage_box(struct sway_output *output, struct wlr_box *box);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -371,7 +371,7 @@ void view_close_popups(struct sway_view *view) {
 void view_damage_from(struct sway_view *view) {
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		output_damage_from_view(output, view);
+		output_damage_view_surfaces(output, view);
 	}
 }
 


### PR DESCRIPTION
The `whole` argument has been removed from `damage_surface_iterator` because it was never used. As this function now only deals with partial damaging, it's been changed to return early if there is no damage and avoids scheduling a frame unnecessarily.

With the removal of the `whole` argument, `output_damage_from_view` just called `output_damage_view` with the same arguments, so I've combined these into the one function and renamed it to `output_damage_view_surfaces`.

Lastly, `output_damage_whole_container_iterator` is now removed as it was never used. `output_damage_whole_container` just damages the container including decorations and doesn't care about surfaces.

Probably closes #2748, but I'd like to see before and after metrics...