### PR TITLE
Fix crash when flattening container after moving

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -157,6 +157,11 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 
 	seat_node_destroy(seat_node);
 
+	if (!parent) {
+		// Destroying a container that is no longer in the tree
+		return;
+	}
+
 	// Find new focus_inactive (ie. sibling, or workspace if no siblings left)
 	struct sway_node *next_focus = NULL;
 	while (next_focus == NULL) {


### PR DESCRIPTION
`container_flatten` removes the container from the tree (via `container_replace`) before destroying it. When destroying, the recent changes to `handle_seat_node_destroy` incorrectly assumes that the container has a parent.

This adds a check for destroying a container which is no longer in the tree. If this is the case, focus does not need to be changed.

To test, create layout `H[view T[view]]`, focus the tabbed view and run `move left`.

Fixes #2765