### PR TITLE
swaylock: Support keyboard and pointer disconnects and reconnects

### DIFF
--- a/include/swaylock/swaylock.h
+++ b/include/swaylock/swaylock.h
@@ -58,6 +58,8 @@ struct swaylock_state {
 	struct wl_compositor *compositor;
 	struct zwlr_layer_shell_v1 *layer_shell;
 	struct zwlr_input_inhibit_manager_v1 *input_inhibit_manager;
+	struct wl_pointer *pointer;
+	struct wl_keyboard *keyboard;
 	struct wl_shm *shm;
 	struct wl_list surfaces;
 	struct wl_list images;

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -277,7 +277,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 				&wl_shm_interface, 1);
 	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
 		struct wl_seat *seat = wl_registry_bind(
-				registry, name, &wl_seat_interface, 1);
+				registry, name, &wl_seat_interface, 3);
 		wl_seat_add_listener(seat, &seat_listener, state);
 	} else if (strcmp(interface, zwlr_layer_shell_v1_interface.name) == 0) {
 		state->layer_shell = wl_registry_bind(

--- a/swaylock/seat.c
+++ b/swaylock/seat.c
@@ -145,13 +145,21 @@ static const struct wl_pointer_listener pointer_listener = {
 static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 		enum wl_seat_capability caps) {
 	struct swaylock_state *state = data;
+	if (state->pointer) {
+		wl_pointer_release(state->pointer);
+		state->pointer = NULL;
+	}
+	if (state->keyboard) {
+		wl_keyboard_release(state->keyboard);
+		state->keyboard = NULL;
+	}
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
-		struct wl_pointer *pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+		state->pointer = wl_seat_get_pointer(wl_seat);
+		wl_pointer_add_listener(state->pointer, &pointer_listener, NULL);
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
-		struct wl_keyboard *keyboard = wl_seat_get_keyboard(wl_seat);
-		wl_keyboard_add_listener(keyboard, &keyboard_listener, state);
+		state->keyboard = wl_seat_get_keyboard(wl_seat);
+		wl_keyboard_add_listener(state->keyboard, &keyboard_listener, state);
 	}
 }
 


### PR DESCRIPTION
* Lock the screen with swaylock
* Do something that triggers the seat to update its capabilities (unplug/replug the keyboard, switch TTYs, sleep/suspend...)
* Keys you then type into swaylock would be handled multiple times

This stores the keyboard and pointer in the swaylock state so they can be released when new capabilities are given.

I had to bump the seat version up to 3 because `wl_pointer_remove` isn't supported on anything earlier.