### PR TITLE
Only damage popups when popups have damage

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -206,6 +206,7 @@ struct sway_xwayland_unmanaged {
 struct sway_view_child;
 
 struct sway_view_child_impl {
+	void (*get_root_coords)(struct sway_view_child *child, int *sx, int *sy);
 	void (*destroy)(struct sway_view_child *child);
 };
 
@@ -220,6 +221,8 @@ struct sway_view_child {
 
 	struct wl_listener surface_commit;
 	struct wl_listener surface_new_subsurface;
+	struct wl_listener surface_map;
+	struct wl_listener surface_unmap;
 	struct wl_listener surface_destroy;
 	struct wl_listener view_unmap;
 };

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -20,6 +20,19 @@
 
 static const struct sway_view_child_impl popup_impl;
 
+static void popup_get_root_coords(struct sway_view_child *child,
+		int *root_sx, int *root_sy) {
+	struct sway_xdg_popup *popup = (struct sway_xdg_popup *)child;
+	struct wlr_xdg_surface *surface = popup->wlr_xdg_surface;
+	*root_sx = -surface->geometry.x;
+	*root_sy = -surface->geometry.y;
+	while (surface && surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
+		*root_sx += surface->popup->geometry.x;
+		*root_sy += surface->popup->geometry.y;
+		surface = wlr_xdg_surface_from_wlr_surface(surface->popup->parent);
+	}
+}
+
 static void popup_destroy(struct sway_view_child *child) {
 	if (!sway_assert(child->impl == &popup_impl,
 			"Expected an xdg_shell popup")) {
@@ -32,6 +45,7 @@ static void popup_destroy(struct sway_view_child *child) {
 }
 
 static const struct sway_view_child_impl popup_impl = {
+	.get_root_coords = popup_get_root_coords,
 	.destroy = popup_destroy,
 };
 
@@ -84,6 +98,9 @@ static struct sway_xdg_popup *popup_create(
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&xdg_surface->events.destroy, &popup->destroy);
 	popup->destroy.notify = popup_handle_destroy;
+
+	wl_signal_add(&xdg_surface->events.map, &popup->child.surface_map);
+	wl_signal_add(&xdg_surface->events.unmap, &popup->child.surface_unmap);
 
 	popup_unconstrain(popup);
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -24,13 +24,11 @@ static void popup_get_root_coords(struct sway_view_child *child,
 		int *root_sx, int *root_sy) {
 	struct sway_xdg_popup *popup = (struct sway_xdg_popup *)child;
 	struct wlr_xdg_surface *surface = popup->wlr_xdg_surface;
-	*root_sx = -surface->geometry.x;
-	*root_sy = -surface->geometry.y;
-	while (surface && surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
-		*root_sx += surface->popup->geometry.x;
-		*root_sy += surface->popup->geometry.y;
-		surface = wlr_xdg_surface_from_wlr_surface(surface->popup->parent);
-	}
+
+	wlr_xdg_popup_get_toplevel_coords(surface->popup,
+		-surface->geometry.x + surface->popup->geometry.x,
+		-surface->geometry.y + surface->popup->geometry.y,
+		root_sx, root_sy);
 }
 
 static void popup_destroy(struct sway_view_child *child) {

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -23,13 +23,11 @@ static void popup_get_root_coords(struct sway_view_child *child,
 		int *root_sx, int *root_sy) {
 	struct sway_xdg_popup_v6 *popup = (struct sway_xdg_popup_v6 *)child;
 	struct wlr_xdg_surface_v6 *surface = popup->wlr_xdg_surface_v6;
-	*root_sx = -surface->geometry.x;
-	*root_sy = -surface->geometry.y;
-	while (surface && surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP) {
-		*root_sx += surface->popup->geometry.x;
-		*root_sy += surface->popup->geometry.y;
-		surface = surface->popup->parent;
-	}
+
+	wlr_xdg_popup_v6_get_toplevel_coords(surface->popup,
+		-surface->geometry.x + surface->popup->geometry.x,
+		-surface->geometry.y + surface->popup->geometry.y,
+		root_sx, root_sy);
 }
 
 static void popup_destroy(struct sway_view_child *child) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -15,6 +15,7 @@
 #include "log.h"
 #include "sway/criteria.h"
 #include "sway/commands.h"
+#include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/ipc-server.h"
@@ -639,12 +640,18 @@ static void view_subsurface_create(struct sway_view *view,
 	view_child_init(child, NULL, view, subsurface->surface);
 }
 
+static void view_child_damage(struct sway_view_child *child, bool whole) {
+	int sx, sy;
+	child->impl->get_root_coords(child, &sx, &sy);
+	desktop_damage_surface(child->surface,
+			child->view->x + sx, child->view->y + sy, whole);
+}
+
 static void view_child_handle_surface_commit(struct wl_listener *listener,
 		void *data) {
 	struct sway_view_child *child =
 		wl_container_of(listener, child, surface_commit);
-	// TODO: only accumulate damage from the child
-	view_damage_from(child->view);
+	view_child_damage(child, false);
 }
 
 static void view_child_handle_surface_new_subsurface(
@@ -677,6 +684,20 @@ static void view_init_subsurfaces(struct sway_view *view,
 	}
 }
 
+static void view_child_handle_surface_map(struct wl_listener *listener,
+		void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, surface_map);
+	view_child_damage(child, true);
+}
+
+static void view_child_handle_surface_unmap(struct wl_listener *listener,
+		void *data) {
+	struct sway_view_child *child =
+		wl_container_of(listener, child, surface_unmap);
+	view_child_damage(child, true);
+}
+
 void view_child_init(struct sway_view_child *child,
 		const struct sway_view_child_impl *impl, struct sway_view *view,
 		struct wlr_surface *surface) {
@@ -692,6 +713,10 @@ void view_child_init(struct sway_view_child *child,
 		view_child_handle_surface_new_subsurface;
 	wl_signal_add(&surface->events.destroy, &child->surface_destroy);
 	child->surface_destroy.notify = view_child_handle_surface_destroy;
+
+	child->surface_map.notify = view_child_handle_surface_map;
+	child->surface_unmap.notify = view_child_handle_surface_unmap;
+
 	wl_signal_add(&view->events.unmap, &child->view_unmap);
 	child->view_unmap.notify = view_child_handle_view_unmap;
 
@@ -699,15 +724,9 @@ void view_child_init(struct sway_view_child *child,
 	wlr_surface_send_enter(child->surface, output->wlr_output);
 
 	view_init_subsurfaces(child->view, surface);
-
-	// TODO: only damage the whole child
-	container_damage_whole(child->view->container);
 }
 
 void view_child_destroy(struct sway_view_child *child) {
-	// TODO: only damage the whole child
-	container_damage_whole(child->view->container);
-
 	wl_list_remove(&child->surface_commit.link);
 	wl_list_remove(&child->surface_destroy.link);
 	wl_list_remove(&child->view_unmap.link);


### PR DESCRIPTION
The previous behaviour was to damage the entire view, which would recurse into each popup. This patch makes it damage only the popup's surface, and respect the surface damage given by the client.

This adds listeners to the popup's map and unmap events rather than doing the damage in the create and destroy functions. To get the popup's position relative to the view, a new `child_impl` function `get_root_coords` has been introduced, which traverses up the parents.

Fixes #2601