### PR TITLE
Reload config using idle event

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -35,7 +35,6 @@ enum binding_flags {
 	BINDING_BORDER=4,    // mouse only; trigger on container border
 	BINDING_CONTENTS=8,  // mouse only; trigger on container contents
 	BINDING_TITLEBAR=16, // mouse only; trigger on container titlebar
-	BINDING_RELOAD=32,   // the binding runs the reload command
 };
 
 /**

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -23,6 +23,8 @@ struct cmd_results *seat_cmd_attach(int argc, char **argv) {
 	new_attachment->identifier = strdup(argv[0]);
 	list_add(new_config->attachments, new_attachment);
 
-	apply_seat_config(new_config);
+	if (!config->validating) {
+		apply_seat_config(new_config);
+	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/seat/fallback.c
+++ b/sway/commands/seat/fallback.c
@@ -27,6 +27,8 @@ struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
 			"Expected 'fallback <true|false>'");
 	}
 
-	apply_seat_config(new_config);
+	if (!config->validating) {
+		apply_seat_config(new_config);
+	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -457,6 +457,12 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	success = success && load_config(path, config,
 			&config->swaynag_config_errors);
 
+	if (validating) {
+		free_config(config);
+		config = old_config;
+		return success;
+	}
+
 	if (is_active) {
 		for (int i = 0; i < config->output_configs->length; i++) {
 			apply_output_config_to_outputs(config->output_configs->items[i]);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -264,29 +264,27 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	}
 
 	// Identify and execute active pressed binding
-	struct sway_binding *next_repeat_binding = NULL;
+	struct sway_binding *binding = NULL;
 	if (event->state == WLR_KEY_PRESSED) {
-		struct sway_binding *binding_pressed = NULL;
 		get_active_binding(&keyboard->state_keycodes,
-				config->current_mode->keycode_bindings, &binding_pressed,
+				config->current_mode->keycode_bindings, &binding,
 				code_modifiers, false, input_inhibited);
 		get_active_binding(&keyboard->state_keysyms_translated,
-				config->current_mode->keysym_bindings, &binding_pressed,
+				config->current_mode->keysym_bindings, &binding,
 				translated_modifiers, false, input_inhibited);
 		get_active_binding(&keyboard->state_keysyms_raw,
-				config->current_mode->keysym_bindings, &binding_pressed,
+				config->current_mode->keysym_bindings, &binding,
 				raw_modifiers, false, input_inhibited);
 
-		if (binding_pressed) {
-			next_repeat_binding = binding_pressed;
-			seat_execute_command(seat, binding_pressed);
+		if (binding) {
+			seat_execute_command(seat, binding);
 			handled = true;
 		}
 	}
 
 	// Set up (or clear) keyboard repeat for a pressed binding
-	if (next_repeat_binding && wlr_device->keyboard->repeat_info.delay > 0) {
-		keyboard->repeat_binding = next_repeat_binding;
+	if (binding && wlr_device->keyboard->repeat_info.delay > 0) {
+		keyboard->repeat_binding = binding;
 		if (wl_event_source_timer_update(keyboard->key_repeat_source,
 				wlr_device->keyboard->repeat_info.delay) < 0) {
 			wlr_log(WLR_DEBUG, "failed to set key repeat timer");

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -278,9 +278,7 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 				raw_modifiers, false, input_inhibited);
 
 		if (binding_pressed) {
-			if ((binding_pressed->flags & BINDING_RELOAD) == 0) {
-				next_repeat_binding = binding_pressed;
-			}
+			next_repeat_binding = binding_pressed;
 			seat_execute_command(seat, binding_pressed);
 			handled = true;
 		}


### PR DESCRIPTION
This patch makes it so when you run `reload`, the actual reloading is deferred to the next time the event loop becomes idle. This avoids several use-after-frees and removes the workarounds we have to avoid them.

When you run `reload`, we validate the config before creating the idle event. This is so the reload command will still return an error if there are validation errors. To allow this, `load_main_config` has been adjusted so it doesn't apply the config if `validating` is true rather than applying it unconditionally.

This also fixes a memory leak in the reload command where if the config failed to load, the `bar_ids` list would not be freed.

To test:

* Change config and reload, verify new config applied
* Hold the binding for reload
* Introduce a validation error and reload your config, eg. by renaming your config file to something else before reloading (it appears that command validation errors are not reported by swaymsg, even in master)