### PR TITLE
swaybar: allow null status_command

### DIFF
--- a/config.in
+++ b/config.in
@@ -202,6 +202,11 @@ bindsym $mod+r mode "resize"
 # Read `man 5 sway-bar` for more information about this section.
 bar {
     position top
+
+    # When the status_command prints a new line to stdout, swaybar updates.
+    # The default just shows the current date and time.
+    status_command while date +'%Y-%m-%d %l:%M:%S %p'; do sleep 1; done
+
     colors {
         statusline #ffffff
         background #323232

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -46,14 +46,14 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		return error;
 	}
 
-	if (!config->reading) {
-		if (!find_handler(argv[0], bar_config_handlers,
-					sizeof(bar_config_handlers))) {
-			return cmd_results_new(CMD_FAILURE, "bar",
-					"Can only be used in config file.");
+	if (find_handler(argv[0], bar_config_handlers,
+				sizeof(bar_config_handlers))) {
+		if (config->reading) {
+			return config_subcommand(argv, argc, bar_config_handlers,
+					sizeof(bar_config_handlers));
 		}
-		return config_subcommand(argv, argc, bar_config_handlers,
-				sizeof(bar_config_handlers));
+		return cmd_results_new(CMD_FAILURE, "bar",
+				"Can only be used in config file.");
 	}
 
 	if (argc > 1) {

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -13,8 +13,18 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 				"status_command", "No bar defined.");
 	}
 	free(config->current_bar->status_command);
-	config->current_bar->status_command = join_args(argv, argc);
-	wlr_log(WLR_DEBUG, "Feeding bar with status command: %s",
-			config->current_bar->status_command);
+	config->current_bar->status_command = NULL;
+
+	char *new_command = join_args(argv, argc);
+	if (strcmp(new_command, "-") != 0) {
+		config->current_bar->status_command = new_command;
+		wlr_log(WLR_DEBUG, "Feeding bar with status command: %s",
+				config->current_bar->status_command);
+	}
+
+	if (config->active && !config->validating) {
+		load_swaybars();
+	}
+
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -99,10 +99,6 @@ struct bar_config *default_bar_config(void) {
 	if (!(bar->bindings = create_list())) {
 		goto cleanup;
 	}
-	if (!(bar->status_command =
-			strdup("while date +'%Y-%m-%d %l:%M:%S %p'; do sleep 1; done"))) {
-		goto cleanup;
-	}
 	// set default colors
 	if (!(bar->colors.background = strndup("#000000ff", 9))) {
 		goto cleanup;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -514,8 +514,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 			json_object_new_string(bar->hidden_state));
 	json_object_object_add(json, "position",
 			json_object_new_string(bar->position));
-	json_object_object_add(json, "status_command",
-			json_object_new_string(bar->status_command));
+	json_object_object_add(json, "status_command", bar->status_command ?
+			json_object_new_string(bar->status_command) : NULL);
 	json_object_object_add(json, "font",
 			json_object_new_string((bar->font) ? bar->font : config->font));
 	if (bar->separator_symbol) {

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -17,6 +17,9 @@ Sway allows configuring swaybar in the sway configuration file.
 
 	https://i3wm.org/docs/i3bar-protocol.html
 
+	If running this command via IPC, you can disable a running status command by
+	setting the command to a single dash: _swaybar bar bar-0 status\_command -_
+
 *pango\_markup* enabled|disabled
 	Enables or disables pango markup for status lines. This has no effect on
 	status lines using the i3bar JSON protocol.

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -572,8 +572,8 @@ void bar_run(struct swaybar *bar) {
 		add_event(bar->status->read_fd, POLLIN, status_in, bar);
 	}
 	while (1) {
-		event_loop_poll();
 		wl_display_flush(bar->display);
+		event_loop_poll();
 	}
 }
 


### PR DESCRIPTION
Sway sets a default `status_command` which runs `date` every second. This patch removes this behaviour so the user can have a `NULL` status bar if desired.

I had to swap swaybar's `event_loop_poll` and `wl_display_flush` so that it would map the initial surface.