### PR TITLE
Check if there is a current container before setting its opacity

### DIFF
--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -21,6 +21,10 @@ struct cmd_results *cmd_opacity(int argc, char **argv) {
 
 	struct sway_container *con = config->handler_context.container;
 
+	if (con == NULL) {
+		return cmd_results_new(CMD_FAILURE, "opacity", "No current container");
+	}
+
 	float opacity = 0.0f;
 
 	if (!parse_opacity(argv[0], &opacity)) {


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/2792

Issuing an opacity command when there is no current container (for example issuing via `exec swaymsg "opacity 0.75"` from the config file) causes sway to crash. Now there is a NULL check which stops this from happening.