### PR TITLE
Implement bar bindsym

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -239,6 +239,12 @@ struct bar_config {
 	} colors;
 };
 
+struct bar_binding {
+	uint32_t button;
+	bool release;
+	char *command;
+};
+
 struct border_colors {
 	float border[4];
 	float background[4];
@@ -526,6 +532,8 @@ void terminate_swaybg(pid_t pid);
 struct bar_config *default_bar_config(void);
 
 void free_bar_config(struct bar_config *bar);
+
+void free_bar_binding(struct bar_binding *binding);
 
 void free_workspace_config(struct workspace_config *wsc);
 

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-client.h>
+#include "list.h"
 #include "util.h"
 
 struct box_colors {
@@ -17,6 +18,12 @@ struct config_output {
 	size_t index;
 };
 
+struct swaybar_binding {
+	uint32_t button;
+	char *command;
+	bool release;
+};
+
 struct swaybar_config {
 	char *status_command;
 	bool pango_markup;
@@ -29,6 +36,7 @@ struct swaybar_config {
 	bool binding_mode_indicator;
 	bool wrap_scroll;
 	bool workspace_buttons;
+	list_t *bindings;
 	struct wl_list outputs; // config_output::link
 	bool all_outputs;
 	int height;

--- a/include/swaybar/ipc.h
+++ b/include/swaybar/ipc.h
@@ -7,5 +7,6 @@ bool ipc_initialize(struct swaybar *bar, const char *bar_id);
 bool handle_ipc_readable(struct swaybar *bar);
 void ipc_get_workspaces(struct swaybar *bar);
 void ipc_send_workspace_command(struct swaybar *bar, const char *ws);
+void ipc_execute_binding(struct swaybar *bar, struct swaybar_binding *bind);
 
 #endif

--- a/sway/commands/bar/bindsym.c
+++ b/sway/commands/bar/bindsym.c
@@ -33,12 +33,12 @@ struct cmd_results *bar_cmd_bindsym(int argc, char **argv) {
 	binding->button = 0;
 	if (strncasecmp(argv[0], "button", strlen("button")) == 0 &&
 			strlen(argv[0]) == strlen("button0")) {
-		binding->button = argv[0][strlen("button")] - '1' + 1;
+		binding->button = argv[0][strlen("button")] - '0';
 	}
-	if (binding->button == 0) {
+	if (binding->button < 1 || binding->button > 9) {
 		free_bar_binding(binding);
 		return cmd_results_new(CMD_FAILURE, "bar bindsym",
-				"Only button<n> is supported");
+				"Only button<1-9> is supported");
 	}
 
 	binding->command = join_args(argv + 1, argc - 1);

--- a/sway/commands/bar/bindsym.c
+++ b/sway/commands/bar/bindsym.c
@@ -1,5 +1,7 @@
+#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "list.h"
@@ -7,5 +9,61 @@
 #include "stringop.h"
 
 struct cmd_results *bar_cmd_bindsym(int argc, char **argv) {
-	return cmd_results_new(CMD_FAILURE, "bindsym", "TODO"); // TODO
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "bar bindsym", EXPECTED_MORE_THAN, 1))) {
+		return error;
+	}
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "bar bindsym", "No bar defined.");
+	}
+
+	struct bar_binding *binding = calloc(1, sizeof(struct bar_binding));
+	if (!binding) {
+		return cmd_results_new(CMD_FAILURE, "bar bindsym",
+				"Unable to allocate bar binding");
+	}
+
+	binding->release = false;
+	if (strcmp("--release", argv[0]) == 0) {
+		binding->release = true;
+		argv++;
+		argc--;
+	}
+
+	binding->button = 0;
+	if (strncasecmp(argv[0], "button", strlen("button")) == 0 &&
+			strlen(argv[0]) == strlen("button0")) {
+		binding->button = argv[0][strlen("button")] - '1' + 1;
+	}
+	if (binding->button == 0) {
+		free_bar_binding(binding);
+		return cmd_results_new(CMD_FAILURE, "bar bindsym",
+				"Only button<n> is supported");
+	}
+
+	binding->command = join_args(argv + 1, argc - 1);
+
+	list_t *bindings = config->current_bar->bindings;
+	bool overwritten = false;
+	for (int i = 0; i < bindings->length; i++) {
+		struct bar_binding *other = bindings->items[i];
+		if (other->button == binding->button &&
+				other->release == binding->release) {
+			overwritten = true;
+			bindings->items[i] = binding;
+			free_bar_binding(other);
+			wlr_log(WLR_DEBUG, "[bar %s] Updated binding for button%u%s",
+					config->current_bar->id, binding->button,
+					binding->release ? " (release)" : "");
+			break;
+		}
+	}
+	if (!overwritten) {
+		list_add(bindings, binding);
+		wlr_log(WLR_DEBUG, "[bar %s] Added binding for button%u%s",
+				config->current_bar->id, binding->button,
+				binding->release ? " (release)" : "");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -28,6 +28,16 @@ static void terminate_swaybar(pid_t pid) {
 	}
 }
 
+void free_bar_binding(struct bar_binding *binding) {
+	if (!binding) {
+		return;
+	}
+	if (binding->command) {
+		free(binding->command);
+	}
+	free(binding);
+}
+
 void free_bar_config(struct bar_config *bar) {
 	if (!bar) {
 		return;
@@ -39,7 +49,11 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->status_command);
 	free(bar->font);
 	free(bar->separator_symbol);
-	// TODO: Free mouse bindings
+	while (bar->bindings->length) {
+		struct bar_binding *binding = bar->bindings->items[0];
+		list_del(bar->bindings, 0);
+		free_bar_binding(binding);
+	}
 	list_free(bar->bindings);
 	if (bar->outputs) {
 		free_flat_list(bar->outputs);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -32,9 +32,7 @@ void free_bar_binding(struct bar_binding *binding) {
 	if (!binding) {
 		return;
 	}
-	if (binding->command) {
-		free(binding->command);
-	}
+	free(binding->command);
 	free(binding);
 }
 
@@ -49,9 +47,8 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->status_command);
 	free(bar->font);
 	free(bar->separator_symbol);
-	while (bar->bindings->length) {
-		struct bar_binding *binding = bar->bindings->items[0];
-		list_del(bar->bindings, 0);
+	for (int i = 0; i < bar->bindings->length; i++) {
+		struct bar_binding *binding = bar->bindings->items[i];
 		free_bar_binding(binding);
 	}
 	list_free(bar->bindings);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -623,6 +623,22 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 
 	json_object_object_add(json, "colors", colors);
 
+	if (bar->bindings->length > 0) {
+		json_object *bindings = json_object_new_array();
+		for (int i = 0; i < bar->bindings->length; ++i) {
+			struct bar_binding *binding = bar->bindings->items[i];
+			json_object *bind = json_object_new_object();
+			json_object_object_add(bind, "input_code",
+					json_object_new_int(binding->button));
+			json_object_object_add(bind, "command",
+					json_object_new_string(binding->command));
+			json_object_object_add(bind, "release",
+					json_object_new_boolean(binding->release));
+			json_object_array_add(bindings, bind);
+		}
+		json_object_object_add(json, "bindings", bindings);
+	}
+
 	// Add outputs if defined
 	if (bar->outputs && bar->outputs->length > 0) {
 		json_object *outputs = json_object_new_array();

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -60,6 +60,11 @@ Sway allows configuring swaybar in the sway configuration file.
 *height* <height>
 	Sets the height of the bar. Default height will match the font size.
 
+*bindsym* [--release] button<n> <command>
+	Executes _command_ when mouse button _n_ has been pressed (or if _released_
+	is given, when mouse button _n_ has been released). To disable the default
+	behavior for a button, use the command _nop_.
+
 ## TRAY
 
 Swaybar provides a system tray where third-party applications may place icons.

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include "swaybar/config.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "stringop.h"
+#include "list.h"
 
 uint32_t parse_position(const char *position) {
 	uint32_t horiz = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
@@ -34,6 +36,7 @@ struct swaybar_config *init_config(void) {
 	config->binding_mode_indicator = true;
 	config->wrap_scroll = false;
 	config->workspace_buttons = true;
+	config->bindings = create_list();
 	wl_list_init(&config->outputs);
 
 	/* height */
@@ -74,6 +77,13 @@ void free_config(struct swaybar_config *config) {
 	free(config->font);
 	free(config->mode);
 	free(config->sep_symbol);
+	while (config->bindings->length) {
+		struct swaybar_binding *binding = config->bindings->items[0];
+		list_del(config->bindings, 0);
+		free(binding->command);
+		free(binding);
+	}
+	list_free(config->bindings);
 	struct config_output *coutput, *tmp;
 	wl_list_for_each_safe(coutput, tmp, &config->outputs, link) {
 		wl_list_remove(&coutput->link);

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -72,16 +72,22 @@ struct swaybar_config *init_config(void) {
 	return config;
 }
 
+static void free_binding(struct swaybar_binding *binding) {
+	if (!binding) {
+		return;
+	}
+	free(binding->command);
+	free(binding);
+}
+
 void free_config(struct swaybar_config *config) {
 	free(config->status_command);
 	free(config->font);
 	free(config->mode);
 	free(config->sep_symbol);
-	while (config->bindings->length) {
-		struct swaybar_binding *binding = config->bindings->items[0];
-		list_del(config->bindings, 0);
-		free(binding->command);
-		free(binding);
+	for (int i = 0; i < config->bindings->length; i++) {
+		struct swaybar_binding *binding = config->bindings->items[i];
+		free_binding(binding);
 	}
 	list_free(config->bindings);
 	struct config_output *coutput, *tmp;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -338,6 +338,8 @@ static void ipc_get_outputs(struct swaybar *bar) {
 }
 
 void ipc_execute_binding(struct swaybar *bar, struct swaybar_binding *bind) {
+	wlr_log(WLR_DEBUG, "Executing binding for button %u (release=%d): `%s`",
+			bind->button, bind->release, bind->command);
 	uint32_t len = strlen(bind->command);
 	free(ipc_single_command(bar->ipc_socketfd,
 			IPC_COMMAND, bind->command, &len));

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -7,6 +7,7 @@
 #include "swaybar/config.h"
 #include "swaybar/ipc.h"
 #include "ipc-client.h"
+#include "list.h"
 
 void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
 	const char *fmt = "workspace \"%s\"";
@@ -154,6 +155,7 @@ static bool ipc_parse_config(
 	json_object *markup, *mode, *hidden_bar, *position, *status_command;
 	json_object *font, *bar_height, *wrap_scroll, *workspace_buttons, *strip_workspace_numbers;
 	json_object *binding_mode_indicator, *verbose, *colors, *sep_symbol, *outputs;
+	json_object *bindings;
 	json_object_object_get_ex(bar_config, "mode", &mode);
 	json_object_object_get_ex(bar_config, "hidden_bar", &hidden_bar);
 	json_object_object_get_ex(bar_config, "position", &position);
@@ -169,6 +171,7 @@ static bool ipc_parse_config(
 	json_object_object_get_ex(bar_config, "colors", &colors);
 	json_object_object_get_ex(bar_config, "outputs", &outputs);
 	json_object_object_get_ex(bar_config, "pango_markup", &markup);
+	json_object_object_get_ex(bar_config, "bindings", &bindings);
 	if (status_command) {
 		free(config->status_command);
 		config->status_command = strdup(json_object_get_string(status_command));
@@ -201,6 +204,21 @@ static bool ipc_parse_config(
 	}
 	if (markup) {
 		config->pango_markup = json_object_get_boolean(markup);
+	}
+	if (bindings) {
+		int length = json_object_array_length(bindings);
+		for (int i = 0; i < length; ++i) {
+			json_object *bindobj = json_object_array_get_idx(bindings, i);
+			struct swaybar_binding *binding =
+				calloc(1, sizeof(struct swaybar_binding));
+			binding->button = json_object_get_int(
+					json_object_object_get(bindobj, "input_code"));
+			binding->command = strdup(json_object_get_string(
+					json_object_object_get(bindobj, "command")));
+			binding->release = json_object_get_boolean(
+					json_object_object_get(bindobj, "release"));
+			list_add(config->bindings, binding);
+		}
 	}
 
 	struct config_output *output, *tmp;
@@ -317,6 +335,12 @@ static void ipc_get_outputs(struct swaybar *bar) {
 	}
 	json_object_put(outputs);
 	free(res);
+}
+
+void ipc_execute_binding(struct swaybar *bar, struct swaybar_binding *bind) {
+	uint32_t len = strlen(bind->command);
+	free(ipc_single_command(bar->ipc_socketfd,
+			IPC_COMMAND, bind->command, &len));
 }
 
 bool ipc_initialize(struct swaybar *bar, const char *bar_id) {


### PR DESCRIPTION
Implements `bar [<bar-id>] bindsym [--release] button<n> <command>`.

Tests:
- `bar bindsym button1 nop` should prevent switching to a workspace when left clicking on the workspace buttons
-  The following should prevent switching the workspace when scrolling up and down on the workspace buttons
   ```
   bar bindsym button4 nop
   bar bindsym button5 nop
   ```
- `bar bindsym --release button1 layout  toggle all` should
   - _(If on a workspace button)_, switch to the workspace clicked (or the auto_back_and_forth workspace) and change it's layout (this tests makes sure it doesn't override the pressed behaviour)
   - _(If not on a workspace button)_, change the layout of the current workspace

Fixes #1521