### PR TITLE
resize: Determine if anything changed using before/after check

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -95,7 +95,7 @@ struct cmd_results *add_color(const char *name,
 /**
  * TODO: Move this function and its dependent functions to container.c.
  */
-bool container_resize_tiled(struct sway_container *parent, enum wlr_edges edge,
+void container_resize_tiled(struct sway_container *parent, enum wlr_edges edge,
 		int amount);
 
 sway_cmd cmd_assign;


### PR DESCRIPTION
Returning a boolean from `container_resize_tiled` and `resize_tiled` doesn't work in all cases. This patch changes it back to void and does a before/after check to see if the container was resized.

See https://github.com/swaywm/sway/pull/2729#issuecomment-428155420