### PR TITLE
Fix bar subcommand handler structs and selection

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -531,6 +531,8 @@ void free_sway_binding(struct sway_binding *sb);
 
 void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding);
 
+void load_swaybar(struct bar_config *bar);
+
 void load_swaybars(void);
 
 void terminate_swaybg(pid_t pid);

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -13,6 +13,8 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 	const char *oldname = config->current_bar->id;
 	if (strcmp(name, oldname) == 0) {
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);  // NOP
+	} else if (strcmp(name, "id") == 0) {
+		return cmd_results_new(CMD_INVALID, "id", "id cannot be 'id'");
 	}
 	// check if id is used by a previously defined bar
 	for (int i = 0; i < config->bars->length; ++i) {

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -25,7 +25,7 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 	}
 
 	if (config->active && !config->validating) {
-		load_swaybars();
+		load_swaybar(config->current_bar);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -226,13 +226,17 @@ static void invoke_swaybar(struct bar_config *bar) {
 	close(filedes[1]);
 }
 
+void load_swaybar(struct bar_config *bar) {
+	if (bar->pid != 0) {
+		terminate_swaybar(bar->pid);
+	}
+	wlr_log(WLR_DEBUG, "Invoking swaybar for bar id '%s'", bar->id);
+	invoke_swaybar(bar);
+}
+
 void load_swaybars(void) {
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *bar = config->bars->items[i];
-		if (bar->pid != 0) {
-			terminate_swaybar(bar->pid);
-		}
-		wlr_log(WLR_DEBUG, "Invoking swaybar for bar id '%s'", bar->id);
-		invoke_swaybar(bar);
+		load_swaybar(bar);
 	}
 }


### PR DESCRIPTION
Overview of changes:
- Made it so `mode` and `hidden_state` are valid both in the config and during runtime.
- Made it so `id` and `swaybar_command` are  only valid in the config.
- Moves the config-only subcommand handling to below bar selection/creation.
- Only allows creation of custom id bars during runtime (default id bars in config only)

For a follow-up PR:
Once #2751 is merged, send the IPC `barconfig_update` event for the subcommands in `cmd_bar_handlers` and handle it in swaybar