### PR TITLE
Fix undesirable height change of floating views

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -243,10 +243,10 @@ void view_autoconfigure(struct sway_view *view) {
 	// title area. We have to offset the surface y by the height of the title,
 	// bar, and disable any top border because we'll always have the title bar.
 	enum sway_container_layout layout = container_parent_layout(con);
-	if (layout == L_TABBED) {
+	if (layout == L_TABBED && !container_is_floating(con)) {
 		y_offset = container_titlebar_height();
 		view->border_top = false;
-	} else if (layout == L_STACKED) {
+	} else if (layout == L_STACKED && !container_is_floating(con)) {
 		list_t *siblings = container_get_siblings(con);
 		y_offset = container_titlebar_height() * siblings->length;
 		view->border_top = false;


### PR DESCRIPTION
In view_autoconfigure the height of the view is adjusted if the parent
container has a tabbed/stacked layout. Previously this height change
would also be applied to floating views, although it is not needed for
them.

To reproduce the problem:
1.  Open a floating window with a Sway titlebar (SSD).
2.  Change the workspace layout from split to tabbed/stacked.
3. In case of a tabbed workspace layout the height of the floating window
    is reduced by the height of the titlebar.
4. In case of a stacked workspace layout the height of the floating window
    is reduced by  (height of titlebar) * (number of floating windows on this
    workspace). If there are more than one floating windows on the same
    workspace, there is a visible gap between the titlebar and the content of
    the floating window.