### PR TITLE
Fix floating click events

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -877,6 +877,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			while (cont->parent) {
 				cont = cont->parent;
 			}
+			seat_set_focus_container(seat, cont);
 			seat_begin_move_floating(seat, cont, button);
 			return;
 		}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1038,7 +1038,7 @@ void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
 	seat->op_moved = false;
 
 	// In case the container was not raised by gaining focus, raise on click
-	if (con && !config->raise_floating) {
+	if (!config->raise_floating) {
 		container_raise_floating(con);
 	}
 }
@@ -1052,6 +1052,12 @@ void seat_begin_move_floating(struct sway_seat *seat,
 	seat->operation = OP_MOVE_FLOATING;
 	seat->op_container = con;
 	seat->op_button = button;
+
+	// In case the container was not raised by gaining focus, raise on click
+	if (!config->raise_floating) {
+		container_raise_floating(con);
+	}
+
 	cursor_set_image(seat->cursor, "grab", NULL);
 }
 
@@ -1085,6 +1091,11 @@ void seat_begin_resize_floating(struct sway_seat *seat,
 	seat->op_ref_con_ly = con->y;
 	seat->op_ref_width = con->width;
 	seat->op_ref_height = con->height;
+	//
+	// In case the container was not raised by gaining focus, raise on click
+	if (!config->raise_floating) {
+		container_raise_floating(con);
+	}
 
 	const char *image = edge == WLR_EDGE_NONE ?
 		"se-resize" : wlr_xcursor_get_resize_name(edge);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -358,7 +358,6 @@ struct sway_container *container_at(struct sway_workspace *workspace,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	struct sway_container *c;
 
-	// Focused view's popups
 	struct sway_seat *seat = input_manager_current_seat(input_manager);
 	struct sway_container *focus = seat_get_focused_container(seat);
 	bool is_floating = focus && container_is_floating_or_child(focus);
@@ -370,14 +369,11 @@ struct sway_container *container_at(struct sway_workspace *workspace,
 		}
 		*surface = NULL;
 	}
-	// Cast a ray to handle floating windows
-	for (int i = workspace->floating->length - 1; i >= 0; --i) {
-		struct sway_container *cn = workspace->floating->items[i];
-		if (cn->view && (c = surface_at_view(cn, lx, ly, surface, sx, sy))) {
-			return c;
-		}
+	// Floating
+	if ((c = floating_container_at(lx, ly, surface ,sx ,sy))) {
+		return c;
 	}
-	// If focused is tiling, focused view's non-popups
+	// Tiling (focused)
 	if (focus && focus->view && !is_floating) {
 		if ((c = surface_at_view(focus, lx, ly, surface, sx, sy))) {
 			return c;


### PR DESCRIPTION
* Set focus to a floating container when clicking its title bar.
* Raise floating when user clicks title bar or decorations (in the `seat_begin` functions).
* In `container_at`, it only returned a floating container if the user had clicked the surface. This makes it use `floating_container_at` instead.

I have tested using `focus_follows_mouse` and `raise_floating` and it seems to work correctly.

Fixes #2801.