### PR TITLE
Fix program name in version strings

### DIFF
--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 			bar_id = strdup(optarg);
 			break;
 		case 'v':
-			fprintf(stdout, "sway version " SWAY_VERSION "\n");
+			fprintf(stdout, "swaybar version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'd': // Debug

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -345,7 +345,7 @@ int main(int argc, char **argv) {
 			cmdtype = strdup(optarg);
 			break;
 		case 'v':
-			fprintf(stdout, "sway version " SWAY_VERSION "\n");
+			fprintf(stdout, "swaymsg version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		default:


### PR DESCRIPTION
When running `swaymsg -v`, the version returned is actually the version of swaymsg itself, yet the message displayed was `sway version <version>`. This can create confusion if users update sway and swaymsg but don't restart sway, then use swaymsg to check the version.

This patch changes the wording to be `swaymsg version <version>` instead, and likewise for swaybar.

To get the version of a running sway instance, users should run `swaymsg -t get_version`.