### PR TITLE
Add mouse_warping container

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -325,6 +325,12 @@ enum focus_wrapping_mode {
 	WRAP_FORCE
 };
 
+enum mouse_warping_mode {
+	WARP_NO,
+	WARP_OUTPUT,
+	WARP_CONTAINER
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -366,7 +372,7 @@ struct sway_config {
 	// Flags
 	bool focus_follows_mouse;
 	bool raise_floating;
-	bool mouse_warping;
+	enum mouse_warping_mode mouse_warping;
 	enum focus_wrapping_mode focus_wrapping;
 	bool active;
 	bool failed;

--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -6,13 +6,15 @@ struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "mouse_warping", EXPECTED_EQUAL_TO, 1))) {
 		return error;
+	} else if (strcasecmp(argv[0], "container") == 0) {
+		config->mouse_warping = WARP_CONTAINER;
 	} else if (strcasecmp(argv[0], "output") == 0) {
-		config->mouse_warping = true;
+		config->mouse_warping = WARP_OUTPUT;
 	} else if (strcasecmp(argv[0], "none") == 0) {
-		config->mouse_warping = false;
+		config->mouse_warping = WARP_NO;
 	} else {
 		return cmd_results_new(CMD_FAILURE, "mouse_warping",
-				"Expected 'mouse_warping output|none'");
+				"Expected 'mouse_warping output|container|none'");
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -223,7 +223,7 @@ static void config_defaults(struct sway_config *config) {
 	// Flags
 	config->focus_follows_mouse = true;
 	config->raise_floating = true;
-	config->mouse_warping = true;
+	config->mouse_warping = WARP_OUTPUT;
 	config->focus_wrapping = WRAP_YES;
 	config->validating = false;
 	config->reloading = false;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -772,7 +772,9 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 	}
 
 	if (last_focus) {
-		if (config->mouse_warping && warp && new_output != last_output) {
+		if (config->mouse_warping && warp &&
+				(new_output != last_output ||
+				config->mouse_warping == WARP_CONTAINER)) {
 			double x = 0;
 			double y = 0;
 			if (container) {
@@ -782,9 +784,11 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 				x = new_workspace->x + new_workspace->width / 2.0;
 				y = new_workspace->y + new_workspace->height / 2.0;
 			}
+
 			if (!wlr_output_layout_contains_point(root->output_layout,
 					new_output->wlr_output, seat->cursor->cursor->x,
-					seat->cursor->cursor->y)) {
+					seat->cursor->cursor->y)
+					|| config->mouse_warping == WARP_CONTAINER) {
 				wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
 				cursor_send_pointer_motion(seat->cursor, 0, true);
 			}

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -492,9 +492,10 @@ The default colors are:
 	If _--pango\_markup_ is given, then _mode_ will be interpreted as pango
 	markup.
 
-*mouse\_warping* output|none
+*mouse\_warping* output|container|none
 	If _output_ is specified, the mouse will be moved to new outputs as you
-	move focus between them. Default is _output_.
+	move focus between them. If _container_ is specified, the mouse will be
+	moved to the middle of the container on switch. Default is _output_.
 
 *no\_focus* <criteria>
 	Prevents windows matching <criteria> from being focused automatically when


### PR DESCRIPTION
This option always moves the cursor into the middle of the container if the warp
variable is true in seat_set_focus_warp.

Fixes #2577