### PR TITLE
Fix mouse warping container

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -46,6 +46,11 @@ void dispatch_cursor_button(struct sway_cursor *cursor, uint32_t time_msec,
 	uint32_t button, enum wlr_button_state state);
 
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
-		struct wl_client *client);
+	struct wl_client *client);
 
+void cursor_warp_to_container(struct sway_cursor *cursor,
+	struct sway_container *container);
+
+void cursor_warp_to_workspace(struct sway_cursor *cursor,
+		struct sway_workspace *workspace);
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -329,7 +329,8 @@ void view_destroy(struct sway_view *view);
 
 void view_begin_destroy(struct sway_view *view);
 
-void view_map(struct sway_view *view, struct wlr_surface *wlr_surface);
+void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
+	bool fullscreen, bool decoration);
 
 void view_unmap(struct sway_view *view);
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -406,26 +406,18 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		view->natural_height = view->wlr_xdg_surface->surface->current.height;
 	}
 
-	view_map(view, view->wlr_xdg_surface->surface);
+	bool csd = false;
 
 	if (!view->xdg_decoration) {
 		struct sway_server_decoration *deco =
-			decoration_from_surface(xdg_surface->surface);
-		bool csd = !deco || deco->wlr_server_decoration->mode ==
+				decoration_from_surface(xdg_surface->surface);
+		csd = !deco || deco->wlr_server_decoration->mode ==
 			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-		view_update_csd_from_client(view, csd);
+
 	}
 
-	if (xdg_surface->toplevel->client_pending.fullscreen) {
-		container_set_fullscreen(view->container, true);
-		arrange_workspace(view->container->workspace);
-	} else {
-		if (view->container->parent) {
-			arrange_container(view->container->parent);
-		} else if (view->container->workspace) {
-			arrange_workspace(view->container->workspace);
-		}
-	}
+	view_map(view, view->wlr_xdg_surface->surface,
+		xdg_surface->toplevel->client_pending.fullscreen, csd);
 
 	transaction_commit_dirty();
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -402,25 +402,14 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		view->natural_width = view->wlr_xdg_surface_v6->surface->current.width;
 		view->natural_height = view->wlr_xdg_surface_v6->surface->current.height;
 	}
-
-	view_map(view, view->wlr_xdg_surface_v6->surface);
-
 	struct sway_server_decoration *deco =
-		decoration_from_surface(xdg_surface->surface);
-	bool csd = !deco || deco->wlr_server_decoration->mode ==
-			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-	view_update_csd_from_client(view, csd);
+			decoration_from_surface(xdg_surface->surface);
+	bool csd = !deco || deco->wlr_server_decoration->mode
+		== WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
 
-	if (xdg_surface->toplevel->client_pending.fullscreen) {
-		container_set_fullscreen(view->container, true);
-		arrange_workspace(view->container->workspace);
-	} else {
-		if (view->container->parent) {
-			arrange_container(view->container->parent);
-		} else if (view->container->workspace) {
-			arrange_workspace(view->container->workspace);
-		}
-	}
+	view_map(view, view->wlr_xdg_surface_v6->surface,
+		xdg_surface->toplevel->client_pending.fullscreen, csd);
+
 	transaction_commit_dirty();
 
 	xdg_shell_v6_view->commit.notify = handle_commit;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -405,18 +405,8 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xwayland_view->commit.notify = handle_commit;
 
 	// Put it back into the tree
-	view_map(view, xsurface->surface);
+	view_map(view, xsurface->surface, xsurface->fullscreen, false);
 
-	if (xsurface->fullscreen) {
-		container_set_fullscreen(view->container, true);
-		arrange_workspace(view->container->workspace);
-	} else {
-		if (view->container->parent) {
-			arrange_container(view->container->parent);
-		} else if (view->container->workspace) {
-			arrange_workspace(view->container->workspace);
-		}
-	}
 	transaction_commit_dirty();
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_idle.h>
+#include <wlr/types/wlr_box.h>
 #include "list.h"
 #include "log.h"
 #include "config.h"
@@ -1271,4 +1272,44 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 	cursor->cursor = wlr_cursor;
 
 	return cursor;
+
+}
+
+/**
+ * Warps the cursor to the middle of the container argument.
+ * Does nothing if the cursor is already inside the container.
+ * If container is NULL, returns without doing anything.
+ */
+void cursor_warp_to_container(struct sway_cursor *cursor,
+		struct sway_container *container) {
+	if (!container) {
+		return;
+	}
+
+	struct wlr_box box;
+	container_get_box(container, &box);
+	if (wlr_box_contains_point(&box, cursor->cursor->x, cursor->cursor->y)) {
+		return;
+	}
+
+	double x = container->x + container->width / 2.0;
+	double y = container->y + container->height / 2.0;
+
+	wlr_cursor_warp(cursor->cursor, NULL, x, y);
+}
+
+/**
+ * Warps the cursor to the middle of the workspace argument.
+ * If workspace is NULL, returns without doing anything.
+ */
+void cursor_warp_to_workspace(struct sway_cursor *cursor,
+		struct sway_workspace *workspace) {
+	if (!workspace) {
+		return;
+	}
+
+	double x = workspace->x + workspace->width / 2.0;
+	double y = workspace->y + workspace->height / 2.0;
+
+	wlr_cursor_warp(cursor->cursor, NULL, x, y);
 }

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -771,27 +771,18 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 		workspace_consider_destroy(last_workspace);
 	}
 
-	if (last_focus) {
-		if (config->mouse_warping && warp &&
-				(new_output != last_output ||
-				config->mouse_warping == WARP_CONTAINER)) {
-			double x = 0;
-			double y = 0;
+	if (last_focus && warp) {
+		if (container && config->mouse_warping == WARP_CONTAINER) {
+			cursor_warp_to_container(seat->cursor, container);
+			cursor_send_pointer_motion(seat->cursor, 0, true);
+		} else if (new_output != last_output &&
+				   config->mouse_warping >= WARP_OUTPUT) {
 			if (container) {
-				x = container->x + container->width / 2.0;
-				y = container->y + container->height / 2.0;
+				cursor_warp_to_container(seat->cursor, container);
 			} else {
-				x = new_workspace->x + new_workspace->width / 2.0;
-				y = new_workspace->y + new_workspace->height / 2.0;
+				cursor_warp_to_workspace(seat->cursor, new_workspace);
 			}
-
-			if (!wlr_output_layout_contains_point(root->output_layout,
-					new_output->wlr_output, seat->cursor->cursor->x,
-					seat->cursor->cursor->y)
-					|| config->mouse_warping == WARP_CONTAINER) {
-				wlr_cursor_warp(seat->cursor->cursor, NULL, x, y);
-				cursor_send_pointer_motion(seat->cursor, 0, true);
-			}
+			cursor_send_pointer_motion(seat->cursor, 0, true);
 		}
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -637,7 +637,16 @@ void view_unmap(struct sway_view *view) {
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &input_manager->seats, link) {
-		cursor_send_pointer_motion(seat->cursor, 0, true);
+		if (config->mouse_warping == WARP_CONTAINER) {
+			struct sway_node *node = seat_get_focus(seat);
+			if (node && node->type == N_CONTAINER) {
+				cursor_warp_to_container(seat->cursor, node->sway_container);
+			} else if (node && node->type == N_WORKSPACE) {
+				cursor_warp_to_workspace(seat->cursor, node->sway_workspace);
+			}
+		} else {
+			cursor_send_pointer_motion(seat->cursor, 0, true);
+		}
 	}
 
 	transaction_commit_dirty();


### PR DESCRIPTION
For the drm backend the pointer would warp to 0,0 on window if `mouse_warping container` was set.
Check that the pointer does not warp to 0,0 and move the arrange functions into `view_map`.
This is actually a decrease in code size, if somebody has a fancier idea than passing `fullscreen` and `decoration` as arguments, I'm all for it. The cursor now correctly warps to the middle of the newly created window.

Edit: codestyle has not been fixed thoroughly, will do that when I can remove the [WIP] comment.