### PR TITLE
Fix edge gaps

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -389,7 +389,6 @@ struct sway_config {
 	bool show_marks;
 	bool tiling_drag;
 
-	bool edge_gaps;
 	bool smart_gaps;
 	int gaps_inner;
 	int gaps_outer;

--- a/sway/config.c
+++ b/sway/config.c
@@ -234,7 +234,6 @@ static void config_defaults(struct sway_config *config) {
 	config->show_marks = true;
 	config->tiling_drag = true;
 
-	config->edge_gaps = true;
 	config->smart_gaps = false;
 	config->gaps_inner = 0;
 	config->gaps_outer = 0;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -420,15 +420,11 @@ The default colors are:
 	_focus\_wrapping force_. This is only available for convenience. Please
 	use _focus\_wrapping_ instead when possible.
 
-*gaps* edge\_gaps on|off|toggle
-	When _on_, gaps will be added between windows and workspace edges if the
-	inner gap is nonzero. When _off_, gaps will only be added between views.
-	_toggle_ cannot be used in the configuration file.
-
 *gaps* inner|outer <amount>
 	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the inner
 	affects spacing around each view and outer affects the spacing around each
-	workspace. Outer gaps are in addition to inner gaps.
+	workspace. Outer gaps are in addition to inner gaps. To reduce or remove
+	outer gaps, outer gaps can be set to a negative value.
 
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps inner|outer <amount>).

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -73,10 +73,10 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 	if (name) {
 		struct workspace_config *wsc = workspace_find_config(name);
 		if (wsc) {
-			if (wsc->gaps_outer != -1) {
+			if (wsc->gaps_outer != INT_MIN) {
 				ws->gaps_outer = wsc->gaps_outer;
 			}
-			if (wsc->gaps_inner != -1) {
+			if (wsc->gaps_inner != INT_MIN) {
 				ws->gaps_inner = wsc->gaps_inner;
 			}
 		}
@@ -616,9 +616,6 @@ void workspace_remove_gaps(struct sway_workspace *ws) {
 
 void workspace_add_gaps(struct sway_workspace *ws) {
 	if (ws->current_gaps > 0) {
-		return;
-	}
-	if (!config->edge_gaps) {
 		return;
 	}
 	if (config->smart_gaps) {


### PR DESCRIPTION
Fixes [Issue: Fix or remove edge_gaps](https://github.com/swaywm/sway/issues/2727) by removing them and allowing negative values for `gaps outer` just the way i3 does it.

While this change allows negative values for the outer gaps to essentially negate `gaps inner` it does not allow to set it lower than the negated `gaps inner` value to prevent windows from ending up outside the container.

This pull request may result in issues with the -1 token value in `workspace_config` struct, if you see this going wrong please give me some pointers on how to go about fixing and testing that.