### PR TITLE
Fix pixel leaks when using fractional scaling

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -223,11 +223,15 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 	}
 }
 
+static int scale_length(int length, int offset, float scale) {
+	return round((offset + length) * scale) - round(offset * scale);
+}
+
 static void scale_box(struct wlr_box *box, float scale) {
-	box->x *= scale;
-	box->y *= scale;
-	box->width *= scale;
-	box->height *= scale;
+	box->width = scale_length(box->width, box->x, scale);
+	box->height = scale_length(box->height, box->y, scale);
+	box->x = round(box->x * scale);
+	box->y = round(box->y * scale);
 }
 
 struct sway_workspace *output_get_active_workspace(struct sway_output *output) {


### PR DESCRIPTION
The basic idea here is to apply rounding after scaling. It's not as simple as this, though, and I've detailed it in the comments for a function.

In order to fix some pixel leaks in the title bar, I found it easier to change how we place rectangles to fill the area. Instead of placing two rectangles across the full width above and below the title and having shorter rectangles in the inner area, it's now pieced together in vertical chunks. This method involves drawing two less rectangles per container.

I've done some pretty thorough testing, including:

* Testing with scale 1, scale 2, scale 1.4
* Testing with semi-transparent containers to make sure we're not rendering over the same pixels twice
* Testing with output positions that are not 0,0
* Testing with containers in different parts of the screen (to clarify: some pixel gaps would appear in one spot for one container but not for another container due to its position within the output and rounding).
* Testing with tabbed and stacking layouts
* Testing with marks
* Testing with titles that are truncated due to overflowing the title bar width
* Testing with titles that are truncated due to overflowing into the mark texture

Fixes #2813