### PR TITLE
Fix crash when view maps while locked

### DIFF
--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -180,6 +180,10 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	if (config->reloading) {
 		return;
 	}
+	if (!workspace->output) {
+		// Happens when there are no outputs connected
+		return;
+	}
 	struct sway_output *output = workspace->output;
 	struct wlr_box *area = &output->usable_area;
 	wlr_log(WLR_DEBUG, "Usable area for ws: %dx%d@%d,%d",

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -504,7 +504,16 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 	}
 
 	// Use the focused workspace
-	return seat_get_focused_workspace(seat);
+	struct sway_node *node = seat_get_focus_inactive(seat, &root->node);
+	if (node && node->type == N_WORKSPACE) {
+		return node->sway_workspace;
+	} else if (node && node->type == N_CONTAINER) {
+		return node->sway_container->workspace;
+	}
+
+	// If there's no focus_inactive workspace then we must be running without
+	// any outputs connected
+	return root->saved_workspaces->items[0];
 }
 
 static bool should_focus(struct sway_view *view) {


### PR DESCRIPTION
When locked, there is no active workspace so it must find the `focus_inactive` workspace instead.

Additionally, this adds a check for if a view maps while there are no outputs connected and handles it gracefully.

Fixes #2827.