### PR TITLE
Introduce seat_set_raw_focus and remove notify argument from seat_set_focus_warp

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -112,8 +112,16 @@ void seat_set_focus_container(struct sway_seat *seat,
 void seat_set_focus_workspace(struct sway_seat *seat,
 		struct sway_workspace *ws);
 
+/**
+ * Manipulate the focus stack without triggering any other behaviour.
+ *
+ * This can be used to set focus_inactive by calling the function a second time
+ * with the real focus.
+ */
+void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node);
+
 void seat_set_focus_warp(struct sway_seat *seat,
-		struct sway_node *node, bool warp, bool notify);
+		struct sway_node *node, bool warp);
 
 void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus);

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -51,6 +51,7 @@ struct sway_seat {
 
 	bool has_focus;
 	struct wl_list focus_stack; // list of containers in focus order
+	struct sway_workspace *workspace;
 
 	// If the focused layer is set, views cannot receive keyboard focus
 	struct wlr_layer_surface_v1 *focused_layer;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -543,7 +543,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	if (new_output_last_ws && new_output_last_ws != new_workspace) {
 		struct sway_node *new_output_last_focus =
 			seat_get_focus_inactive(seat, &new_output_last_ws->node);
-		seat_set_focus_warp(seat, new_output_last_focus, false, false);
+		seat_set_raw_focus(seat, new_output_last_focus);
 	}
 
 	// restore focus
@@ -556,7 +556,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 			focus = seat_get_focus_inactive(seat, &old_ws->node);
 		}
 	}
-	seat_set_focus_warp(seat, focus, true, false);
+	seat_set_focus(seat, focus);
 
 	// clean-up, destroying parents if the container was the last child
 	if (old_parent) {
@@ -593,7 +593,7 @@ static void workspace_move_to_output(struct sway_workspace *workspace,
 		char *ws_name = workspace_next_name(old_output->wlr_output->name);
 		struct sway_workspace *ws = workspace_create(old_output, ws_name);
 		free(ws_name);
-		seat_set_focus_workspace(seat, ws);
+		seat_set_raw_focus(seat, &ws->node);
 	}
 
 	workspace_consider_destroy(new_output_old_ws);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -704,7 +704,7 @@ static struct cmd_results *cmd_move_in_direction(
 	}
 
 	// Hack to re-focus container
-	seat_set_focus_workspace(config->handler_context.seat, new_ws);
+	seat_set_raw_focus(config->handler_context.seat, &new_ws->node);
 	seat_set_focus_container(config->handler_context.seat, container);
 
 	if (old_ws != new_ws) {

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -50,13 +50,13 @@ static void swap_focus(struct sway_container *con1,
 		enum sway_container_layout layout2 = container_parent_layout(con2);
 		if (focus == con1 && (layout2 == L_TABBED || layout2 == L_STACKED)) {
 			if (workspace_is_visible(ws2)) {
-				seat_set_focus_warp(seat, &con2->node, false, true);
+				seat_set_focus_warp(seat, &con2->node, false);
 			}
 			seat_set_focus_container(seat, ws1 != ws2 ? con2 : con1);
 		} else if (focus == con2 && (layout1 == L_TABBED
 					|| layout1 == L_STACKED)) {
 			if (workspace_is_visible(ws1)) {
-				seat_set_focus_warp(seat, &con1->node, false, true);
+				seat_set_focus_warp(seat, &con1->node, false);
 			}
 			seat_set_focus_container(seat, ws1 != ws2 ? con1 : con2);
 		} else if (ws1 != ws2) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -596,7 +596,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			struct sway_output *focused_output = node_get_output(focus);
 			struct sway_output *output = node_get_output(node);
 			if (output != focused_output) {
-				seat_set_focus_warp(seat, node, false, true);
+				seat_set_focus_warp(seat, node, false);
 			}
 		} else if (node->type == N_CONTAINER && node->sway_container->view) {
 			// Focus node if the following are true:
@@ -606,14 +606,14 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			if (!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
 					node != prev_node &&
 					view_is_visible(node->sway_container->view)) {
-				seat_set_focus_warp(seat, node, false, true);
+				seat_set_focus_warp(seat, node, false);
 			} else {
 				struct sway_node *next_focus =
 					seat_get_focus_inactive(seat, &root->node);
 				if (next_focus && next_focus->type == N_CONTAINER &&
 						next_focus->sway_container->view &&
 						view_is_visible(next_focus->sway_container->view)) {
-					seat_set_focus_warp(seat, next_focus, false, true);
+					seat_set_focus_warp(seat, next_focus, false);
 				}
 			}
 		}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -184,8 +184,8 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 		seat_set_focus(seat, next_focus);
 	} else {
 		// Setting focus_inactive
-		seat_set_focus_warp(seat, next_focus, false, false);
-		seat_set_focus_warp(seat, focus, false, false);
+		seat_set_raw_focus(seat, next_focus);
+		seat_set_raw_focus(seat, focus);
 	}
 }
 
@@ -623,8 +623,16 @@ static void container_raise_floating(struct sway_container *con) {
 	}
 }
 
+void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node) {
+	struct sway_seat_node *seat_node = seat_node_from_node(seat, node);
+	wl_list_remove(&seat_node->link);
+	wl_list_insert(&seat->focus_stack, &seat_node->link);
+	node_set_dirty(node);
+	node_set_dirty(node_get_parent(node));
+}
+
 void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
-		bool warp, bool notify) {
+		bool warp) {
 	if (seat->focused_layer) {
 		return;
 	}
@@ -688,32 +696,20 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 	if (container) {
 		struct sway_container *parent = container->parent;
 		while (parent) {
-			struct sway_seat_node *seat_node =
-				seat_node_from_node(seat, &parent->node);
-			wl_list_remove(&seat_node->link);
-			wl_list_insert(&seat->focus_stack, &seat_node->link);
-			node_set_dirty(&parent->node);
+			seat_set_raw_focus(seat, &parent->node);
 			parent = parent->parent;
 		}
 	}
 	if (new_workspace) {
-		struct sway_seat_node *seat_node =
-			seat_node_from_node(seat, &new_workspace->node);
-		wl_list_remove(&seat_node->link);
-		wl_list_insert(&seat->focus_stack, &seat_node->link);
-		node_set_dirty(&new_workspace->node);
+		seat_set_raw_focus(seat, &new_workspace->node);
 	}
 	if (container) {
-		struct sway_seat_node *seat_node =
-			seat_node_from_node(seat, &container->node);
-		wl_list_remove(&seat_node->link);
-		wl_list_insert(&seat->focus_stack, &seat_node->link);
-		node_set_dirty(&container->node);
+		seat_set_raw_focus(seat, &container->node);
 		seat_send_focus(&container->node, seat);
 	}
 
 	// emit ipc events
-	if (notify && new_workspace && last_workspace != new_workspace) {
+	if (new_workspace && last_workspace != new_workspace) {
 		 ipc_event_workspace(last_workspace, new_workspace, "focus");
 	}
 	if (container && container->view) {
@@ -807,17 +803,17 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 }
 
 void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
-	seat_set_focus_warp(seat, node, true, true);
+	seat_set_focus_warp(seat, node, true);
 }
 
 void seat_set_focus_container(struct sway_seat *seat,
 		struct sway_container *con) {
-	seat_set_focus_warp(seat, con ? &con->node : NULL, true, true);
+	seat_set_focus_warp(seat, con ? &con->node : NULL, true);
 }
 
 void seat_set_focus_workspace(struct sway_seat *seat,
 		struct sway_workspace *ws) {
-	seat_set_focus_warp(seat, ws ? &ws->node : NULL, true, true);
+	seat_set_focus_warp(seat, ws ? &ws->node : NULL, true);
 }
 
 void seat_set_focus_surface(struct sway_seat *seat,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -623,6 +623,15 @@ static void container_raise_floating(struct sway_container *con) {
 	}
 }
 
+static void set_workspace(struct sway_seat *seat,
+		struct sway_workspace *new_ws) {
+	if (seat->workspace == new_ws) {
+		return;
+	}
+	ipc_event_workspace(seat->workspace, new_ws, "focus");
+	seat->workspace = new_ws;
+}
+
 void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node) {
 	struct sway_seat_node *seat_node = seat_node_from_node(seat, node);
 	wl_list_remove(&seat_node->link);
@@ -709,9 +718,7 @@ void seat_set_focus_warp(struct sway_seat *seat, struct sway_node *node,
 	}
 
 	// emit ipc events
-	if (new_workspace && last_workspace != new_workspace) {
-		 ipc_event_workspace(last_workspace, new_workspace, "focus");
-	}
+	set_workspace(seat, new_workspace);
 	if (container && container->view) {
 		ipc_event_window(container, "focus");
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1202,8 +1202,8 @@ struct sway_container *container_split(struct sway_container *child,
 	container_add_child(cont, child);
 
 	if (set_focus) {
-		seat_set_focus_container(seat, cont);
-		seat_set_focus_container(seat, child);
+		seat_set_raw_focus(seat, &cont->node);
+		seat_set_raw_focus(seat, &child->node);
 	}
 
 	return cont;


### PR DESCRIPTION
This introduces `seat_set_raw_focus`: a function that manipulates the focus stack without doing any other behaviour whatsoever. There are a few places where this is useful, such as where we set `focus_inactive` followed by another call to set the real focus again. With this change, the `notify` argument to `seat_set_focus_warp` is also removed as these cases now use the raw function instead.

A bonus of this is we are no longer emitting `window::focus` IPC events when setting `focus_inactive`, nor are we sending focus/unfocus events to the surface.

This also fixes the following:

* When running `move workspace to output <name>` and moving the last workspace from the source output, the `workspace::focus` IPC event is no longer emitted for the newly created workspace.
* When splitting the currently focused container, unfocus/focus events will not be sent to the surface when giving `focus_inactive` to the newly created parent, and `window::focus` events will not be emitted.