### PR TITLE
Sway clients: Exit gracefully when compositor is unavailable

### DIFF
--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -586,7 +586,11 @@ bool bar_setup(struct swaybar *bar, const char *socket_path) {
 	}
 
 	bar->display = wl_display_connect(NULL);
-	assert(bar->display);
+	if (!bar->display) {
+		sway_abort("Unable to connect to the compositor. "
+				"If your compositor is running, check or set the "
+				"WAYLAND_DISPLAY environment variable.");
+	}
 
 	struct wl_registry *registry = wl_display_get_registry(bar->display);
 	wl_registry_add_listener(registry, &registry_listener, bar);

--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -222,7 +222,12 @@ int main(int argc, const char **argv) {
 	}
 
 	state.display = wl_display_connect(NULL);
-	assert(state.display);
+	if (!state.display) {
+		wlr_log(WLR_ERROR, "Unable to connect to the compositor. "
+				"If your compositor is running, check or set the "
+				"WAYLAND_DISPLAY environment variable.");
+		return 1;
+	}
 
 	struct wl_registry *registry = wl_display_get_registry(state.display);
 	wl_registry_add_listener(registry, &registry_listener, &state);

--- a/swayidle/main.c
+++ b/swayidle/main.c
@@ -388,7 +388,9 @@ int main(int argc, char *argv[]) {
 
 	state.display = wl_display_connect(NULL);
 	if (state.display == NULL) {
-		wlr_log(WLR_ERROR, "Failed to create display");
+		wlr_log(WLR_ERROR, "Unable to connect to the compositor. "
+				"If your compositor is running, check or set the "
+				"WAYLAND_DISPLAY environment variable.");
 		return -3;
 	}
 

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -908,7 +908,11 @@ int main(int argc, char **argv) {
 	wl_list_init(&state.surfaces);
 	state.xkb.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	state.display = wl_display_connect(NULL);
-	assert(state.display);
+	if (!state.display) {
+		sway_abort("Unable to connect to the compositor. "
+				"If your compositor is running, check or set the "
+				"WAYLAND_DISPLAY environment variable.");
+	}
 
 	struct wl_registry *registry = wl_display_get_registry(state.display);
 	wl_registry_add_listener(registry, &registry_listener, &state);

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -342,7 +342,11 @@ static const struct wl_registry_listener registry_listener = {
 
 void swaynag_setup(struct swaynag *swaynag) {
 	swaynag->display = wl_display_connect(NULL);
-	assert(swaynag->display);
+	if (!swaynag->display) {
+		sway_abort("Unable to connect to the compositor. "
+				"If your compositor is running, check or set the "
+				"WAYLAND_DISPLAY environment variable.");
+	}
 
 	swaynag->scale = 1;
 	wl_list_init(&swaynag->outputs);


### PR DESCRIPTION
The previous behaviour was to show an error and then crash. The new behaviour is to show a more helpful error then exit.