### PR TITLE
Fix swaylock version string

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -634,13 +634,9 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			}
 			break;
 		case 'v':
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "swaylock version %s (%s, branch \"%s\")\n",
-					SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version unknown\n");
-#endif
-			return 1;
+			fprintf(stdout, "swaylock version " SWAY_VERSION "\n");
+			exit(EXIT_SUCCESS);
+			break;
 		case LO_BS_HL_COLOR:
 			if (state) {
 				state->args.colors.bs_highlight = parse_color(optarg);


### PR DESCRIPTION
The referenced constants were not defined so it always printed "version unknown".

Also it would exit with code 1. It now exits with code 0.