### PR TITLE
common/loop.c: add _POSIX_C_SOURCE for clock_gettime and CLOCK_MONOTONIC

### DIFF
--- a/common/loop.c
+++ b/common/loop.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>


### PR DESCRIPTION
I was getting build errors on my system/toolchain due to an implicit declaration for `clock_gettime` and `CLOCK_MONOTONIC`.

Googling indicated that defining `_POSIX_C_SOURCE` should resolve it. I've used the same value that are used in other source files in the sway source.

This seems to resolve the problem.