### PR TITLE
Make SYSCONFDIR FHS compliant when "prefix" is set

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,7 @@ if scdoc.found()
 	endforeach
 endif
 
-add_project_arguments('-DSYSCONFDIR="/@0@/@1@"'.format(prefix, sysconfdir), language : 'c')
+add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
 
 version = get_option('sway-version')
 if version != ''

--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,7 @@ subdir('swaynag')
 subdir('swaylock')
 
 config = configuration_data()
-config.set('sysconfdir', join_paths(prefix, sysconfdir))
+config.set('sysconfdir', sysconfdir)
 config.set('datadir', join_paths(prefix, datadir))
 config.set('prefix', prefix)
 


### PR DESCRIPTION
SYSCONFDIR should always point to `/etc` since `/usr/etc` is not FHS compliant.
From [FHS-2.3](http://www.pathname.com/fhs/pub/fhs-2.3.html):

> Note that /usr/etc is still not allowed: programs in /usr should place configuration files in /etc.

This is the default in meson since version 0.44: [Release Notes](http://mesonbuild.com/Release-notes-for-0-44-0.html#prefixdependent-defaults-for-sysconfdir-localstatedir-and-sharedstatedir)
Since meson installs the config file in `/etc/sway/config` in any case (even with `config.set('sysconfdir', join_paths(prefix, sysconfdir))` in `meson.build` with `prefix="/usr"`), setting the project argument `SYSCONFDIR=/usr/etc` makes sway unable to find the global configuration file (it crashes with error "Unable to find a config file!"). This PR fixes the issue.