### PR TITLE
Fix moving tiled containers to workspaces which only have floating views

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -483,7 +483,8 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 			ws = workspace_create(NULL, ws_name);
 		}
 		free(ws_name);
-		destination = seat_get_focus_inactive(seat, &ws->node);
+		struct sway_container *dst = seat_get_focus_inactive_tiling(seat, ws);
+		destination = dst ? &dst->node : &ws->node;
 	} else if (strcasecmp(argv[1], "output") == 0) {
 		struct sway_output *new_output = output_in_direction(argv[2],
 				old_output, container->x, container->y);


### PR DESCRIPTION
* Make a workspace which only contains floating views
* Switch to another workspace and create a tiled view
* Move the tiled view to the workspace with `move container to workspace N`

The container would be added as a sibling to the floating view, which makes the container floating while having the geometry of a tiled container.

This changes it so it only looks for tiled containers in the workspace with a fallback to the workspace itself.

Probably fixes #2857 but my symptoms are different to the ones reported in that issue. @c-edw Can you please test if this fixes your issue?