### PR TITLE
Fix crashes when running certain commands on an empty workspace

### DIFF
--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -59,7 +59,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	}
 
 	struct sway_container *container = config->handler_context.container;
-	if (!container->view) {
+	if (!container || !container->view) {
 		return cmd_results_new(CMD_INVALID, "border",
 				"Only views can have borders");
 	}

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -19,7 +19,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;
-	if (!container->view) {
+	if (!container || !container->view) {
 		return cmd_results_new(CMD_INVALID, "mark",
 				"Only views can have marks");
 	}

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -12,7 +12,7 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;
-	if (!container->view) {
+	if (!container || !container->view) {
 		return cmd_results_new(CMD_INVALID, "title_format",
 				"Only views can have a title_format");
 	}

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -25,7 +25,7 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 	struct sway_view *view = NULL;
 	if (config->handler_context.using_criteria) {
 		struct sway_container *container = config->handler_context.container;
-		if (!container->view) {
+		if (!container || !container->view) {
 			return cmd_results_new(CMD_INVALID, "unmark",
 					"Only views can have marks");
 		}


### PR DESCRIPTION
This fixes crashes when running the `border`, `mark`, `unmark` and `title_format` commands on an empty workspace.