### PR TITLE
Fix overflow in strcpy

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -10,7 +10,7 @@
 #include "log.h"
 #include "stringop.h"
 
-static const char *overflow = "[buffer overflow]";
+static const char overflow[] = "[buffer overflow]";
 static const int max_chars = 16384;
 
 size_t escape_markup_text(const char *src, char *dest) {


### PR DESCRIPTION
Compiling current master:
```
In function ‘strcpy’,
    inlined from ‘get_text_size’ at ../sway-9999/common/pango.c:95:3:
/usr/include/bits/string_fortified.h:90:10: error: ‘__builtin___memcpy_chk’ writing 18 bytes into a region of size 8 overflows the destination [-Werror=stringop-overflow=]
   return __builtin___strcpy_chk (__dest, __src, __bos (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘strcpy’,
    inlined from ‘pango_printf’ at ../sway-9999/common/pango.c:115:3:
/usr/include/bits/string_fortified.h:90:10: error: ‘__builtin___memcpy_chk’ writing 18 bytes into a region of size 8 overflows the destination [-Werror=stringop-overflow=]
   return __builtin___strcpy_chk (__dest, __src, __bos (__dest));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Introduced in #2843 

Cause:
```c
char* overflow = "[buffer overflow]";
sizeof(overflow); /* = sizeof(char*) = 8 (WRONG) */
```
```c
char overflow[] = "[buffer overflow]";
sizeof(overflow); /* = 18 (CORRECT) */
```
Fixes #2863 