### PR TITLE
FreeBSD fixes

### DIFF
--- a/common/loop.c
+++ b/common/loop.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>

--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,13 @@ if scdoc.found()
 	endforeach
 endif
 
-add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
+# If prefix is '/usr', sysconfdir will be explicitly set to '/etc' by Meson to
+# enforce FHS compliance, so we should look for configs there as well.
+if prefix == '/usr'
+	add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
+else
+	add_project_arguments('-DSYSCONFDIR="/@0@/@1@"'.format(prefix, sysconfdir), language : 'c')
+endif
 
 version = get_option('sway-version')
 if version != ''
@@ -157,9 +163,16 @@ subdir('swaynag')
 subdir('swaylock')
 
 config = configuration_data()
-config.set('sysconfdir', sysconfdir)
 config.set('datadir', join_paths(prefix, datadir))
 config.set('prefix', prefix)
+
+# If prefix is '/usr', sysconfdir will be explicitly set to '/etc' by Meson to
+# enforce FHS compliance, so we should look for configs there as well.
+if prefix == '/usr'
+	config.set('sysconfdir', sysconfdir)
+else
+	config.set('sysconfdir', join_paths(prefix, sysconfdir))
+endif
 
 configure_file(
 	configuration: config,


### PR DESCRIPTION
This PR fixes two issues on FreeBSD:

1. `CLOCK_MONOTONIC` appeared in IEEE Std. 1003.1-200x, it was not part of POSIX.1b (the 1993 version). FreeBSD treats it accordingly, thus `_POSIX_C_SOURCE` needs to be set to `200112L`.
2. PR #2855 basically hardcodes the config file path to /etc, which is a problem on e.g. FreeBSD, where the expected path for config files of non-base software is '/usr/local/etc'. Meson sets `sysconfdir` to '/etc' explicitly *only* when `prefix` is '/usr', so it is still possible to use '/usr/local' as `prefix`, and install the config files under '/usr/local/etc'. This commit allows to do that by setting `sysconfdir` based on whether `prefix` is '/usr', or not.