### PR TITLE
Export XCURSOR_SIZE and XCURSOR_THEME

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -83,6 +83,17 @@ bool server_init(struct sway_server *server) {
 		&server->xdg_shell_surface);
 	server->xdg_shell_surface.notify = handle_xdg_shell_surface;
 
+	// TODO: configurable cursor theme and size
+	int cursor_size = 24;
+	const char *cursor_theme = NULL;
+
+	char cursor_size_fmt[16];
+	snprintf(cursor_size_fmt, sizeof(cursor_size_fmt), "%d", cursor_size);
+	setenv("XCURSOR_SIZE", cursor_size_fmt, 1);
+	if (cursor_theme != NULL) {
+		setenv("XCURSOR_THEME", cursor_theme, 1);
+	}
+
 #ifdef HAVE_XWAYLAND
 	server->xwayland.wlr_xwayland =
 		wlr_xwayland_create(server->wl_display, server->compositor, true);
@@ -93,8 +104,8 @@ bool server_init(struct sway_server *server) {
 		&server->xwayland_ready);
 	server->xwayland_ready.notify = handle_xwayland_ready;
 
-	// TODO: configurable cursor theme and size
-	server->xwayland.xcursor_manager = wlr_xcursor_manager_create(NULL, 24);
+	server->xwayland.xcursor_manager =
+		wlr_xcursor_manager_create(cursor_theme, cursor_size);
 	wlr_xcursor_manager_load(server->xwayland.xcursor_manager, 1);
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(
 		server->xwayland.xcursor_manager, "left_ptr", 1);


### PR DESCRIPTION
These can be used by toolkits (currently Qt, libxcursor, glfw) to
choose a default cursor theme and size.

This backports this rootston commit:
https://github.com/swaywm/wlroots/pull/1294/commits/3a181ab430997aaf03a75cbe3b79b0fc56ec96c3