### PR TITLE
Minor refactor of input manager

### DIFF
--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -7,12 +7,6 @@
 #include "sway/config.h"
 #include "list.h"
 
-/**
- * The global singleton input manager
- * TODO: make me not a global
- */
-extern struct sway_input_manager *input_manager;
-
 struct sway_input_device {
 	char *identifier;
 	struct wlr_input_device *wlr_device;
@@ -21,7 +15,6 @@ struct sway_input_device {
 };
 
 struct sway_input_manager {
-	struct sway_server *server;
 	struct wl_list devices;
 	struct wl_list seats;
 
@@ -36,30 +29,24 @@ struct sway_input_manager {
 
 struct sway_input_manager *input_manager_create(struct sway_server *server);
 
-bool input_manager_has_focus(struct sway_input_manager *input,
-		struct sway_node *node);
+bool input_manager_has_focus(struct sway_node *node);
 
-void input_manager_set_focus(struct sway_input_manager *input,
-		struct sway_node *node);
+void input_manager_set_focus(struct sway_node *node);
 
-void input_manager_configure_xcursor(struct sway_input_manager *input);
+void input_manager_configure_xcursor(void);
 
-void input_manager_apply_input_config(struct sway_input_manager *input,
-		struct input_config *input_config);
+void input_manager_apply_input_config(struct input_config *input_config);
 
-void input_manager_apply_seat_config(struct sway_input_manager *input,
-		struct seat_config *seat_config);
+void input_manager_apply_seat_config(struct seat_config *seat_config);
 
-struct sway_seat *input_manager_get_default_seat(
-		struct sway_input_manager *input);
+struct sway_seat *input_manager_get_default_seat(void);
 
-struct sway_seat *input_manager_get_seat(struct sway_input_manager *input,
-		const char *seat_name);
+struct sway_seat *input_manager_get_seat(const char *seat_name);
 
 /**
  * Gets the last seat the user interacted with
  */
-struct sway_seat *input_manager_current_seat(struct sway_input_manager *input);
+struct sway_seat *input_manager_current_seat(void);
 
 struct input_config *input_device_get_config(struct sway_input_device *device);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -47,7 +47,6 @@ enum sway_seat_operation {
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct sway_cursor *cursor;
-	struct sway_input_manager *input;
 
 	bool has_focus;
 	struct wl_list focus_stack; // list of containers in focus order
@@ -89,8 +88,7 @@ struct sway_seat {
 	struct wl_list link; // input_manager::seats
 };
 
-struct sway_seat *seat_create(struct sway_input_manager *input,
-		const char *seat_name);
+struct sway_seat *seat_create(const char *seat_name);
 
 void seat_destroy(struct sway_seat *seat);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -68,7 +68,7 @@ void apply_seat_config(struct seat_config *seat_config) {
 		list_add(config->seat_configs, seat_config);
 	}
 
-	input_manager_apply_seat_config(input_manager, seat_config);
+	input_manager_apply_seat_config(seat_config);
 }
 
 /* Keep alphabetized */
@@ -240,7 +240,7 @@ struct cmd_results *execute_command(char *_exec, struct sway_seat *seat,
 
 	if (seat == NULL) {
 		// passing a NULL seat means we just pick the default seat
-		seat = input_manager_get_default_seat(input_manager);
+		seat = input_manager_get_default_seat();
 		if (!sway_assert(seat, "could not find a seat to run the command on")) {
 			return NULL;
 		}

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -94,7 +94,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 
 	arrange_container(view->container);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	if (seat->cursor) {
 		cursor_rebase(seat->cursor);
 	}

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -71,7 +71,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 		struct input_config *ic =
 			store_input_config(config->handler_context.input_config);
 
-		input_manager_apply_input_config(input_manager, ic);
+		input_manager_apply_input_config(ic);
 	} else {
 		free_input_config(config->handler_context.input_config);
 	}

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -103,7 +103,7 @@ static void workspace_focus_fullscreen(struct sway_workspace *workspace) {
 	}
 	struct sway_seat *seat;
 	struct sway_workspace *focus_ws;
-	wl_list_for_each(seat, &input_manager->seats, link) {
+	wl_list_for_each(seat, &server.input->seats, link) {
 		focus_ws = seat_get_focused_workspace(seat);
 		if (focus_ws == workspace) {
 			struct sway_node *new_focus =

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -8,7 +8,7 @@
 #include "sway/tree/workspace.h"
 
 static void scratchpad_toggle_auto(void) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -108,7 +108,7 @@ static void container_swap(struct sway_container *con1,
 		container_set_fullscreen(con2, false);
 	}
 
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 	struct sway_workspace *vis1 =
 		output_get_active_workspace(con1->workspace->output);

--- a/sway/config.c
+++ b/sway/config.c
@@ -151,8 +151,7 @@ static void destroy_removed_seats(struct sway_config *old_config,
 		/* Also destroy seats that aren't present in new config */
 		if (new_config && list_seq_find(new_config->seat_configs,
 				seat_name_cmp, seat_config->name) < 0) {
-			seat = input_manager_get_seat(input_manager,
-				seat_config->name);
+			seat = input_manager_get_seat(seat_config->name);
 			seat_destroy(seat);
 		}
 	}

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -356,7 +356,7 @@ static enum criteria_token token_from_name(char *name) {
  * criteria is only executed once per view.
  */
 static char *get_focused_prop(enum criteria_token token) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 
 	if (!focus || !focus->view) {

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -140,7 +140,7 @@ void update_debug_tree(void) {
 	cairo_t *cairo = cairo_create(surface);
 	PangoContext *pango = pango_cairo_create_context(cairo);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_node *focus = seat_get_focus(seat);
 
 	cairo_set_source_u32(cairo, 0x000000FF);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -211,7 +211,7 @@ void arrange_layers(struct sway_output *output) {
 	}
 
 	struct sway_seat *seat;
-	wl_list_for_each(seat, &input_manager->seats, link) {
+	wl_list_for_each(seat, &server.input->seats, link) {
 		seat_set_focus_layer(seat, topmost ? topmost->layer_surface : NULL);
 	}
 }
@@ -241,7 +241,7 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, sway_layer, output_destroy);
 	// Determine if this layer is being used by an exclusive client. If it is,
 	// try and find another layer owned by this client to pass focus to.
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat();
 	struct wl_client *client =
 		wl_resource_get_client(sway_layer->layer_surface->resource);
 	bool set_focus = seat->exclusive_client == client;
@@ -299,7 +299,7 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 	output_damage_surface(output, sway_layer->geo.x, sway_layer->geo.y,
 		sway_layer->layer_surface->surface, true);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	if (seat->focused_layer == sway_layer->layer_surface) {
 		seat_set_focus_layer(seat, NULL);
 	}
@@ -370,7 +370,7 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	if (!layer_surface->output) {
 		// Assign last active output
 		struct sway_output *output = NULL;
-		struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+		struct sway_seat *seat = input_manager_get_default_seat();
 		if (seat) {
 			struct sway_workspace *ws = seat_get_focused_workspace(seat);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -235,7 +235,7 @@ static void scale_box(struct wlr_box *box, float scale) {
 }
 
 struct sway_workspace *output_get_active_workspace(struct sway_output *output) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_node *focus = seat_get_active_tiling_child(seat, &output->node);
 	if (!focus) {
 		return output->workspaces->items[0];

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -885,7 +885,7 @@ static void render_floating(struct sway_output *soutput,
 static void render_dropzones(struct sway_output *output,
 		pixman_region32_t *damage) {
 	struct sway_seat *seat;
-	wl_list_for_each(seat, &input_manager->seats, link) {
+	wl_list_for_each(seat, &server.input->seats, link) {
 		if (seat->operation == OP_MOVE_TILING && seat->op_target_node
 				&& node_get_output(seat->op_target_node) == output) {
 			float color[4];
@@ -995,7 +995,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 
 	render_dropzones(output, damage);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 	if (focus && focus->view) {
 		render_view_popups(focus->view, output, damage, focus->alpha);

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -110,7 +110,7 @@ static void copy_workspace_state(struct sway_workspace *ws,
 	list_cat(state->floating, ws->floating);
 	list_cat(state->tiling, ws->tiling);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	state->focused = seat_get_focus(seat) == &ws->node;
 
 	// Set focused_inactive_child to the direct tiling child
@@ -153,7 +153,7 @@ static void copy_container_state(struct sway_container *container,
 		list_cat(state->children, container->children);
 	}
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	state->focused = seat_get_focus(seat) == &container->node;
 
 	if (!container->view) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -70,9 +70,8 @@ static void unmanaged_handle_map(struct wl_listener *listener, void *data) {
 	desktop_damage_surface(xsurface->surface, surface->lx, surface->ly, true);
 
 	if (wlr_xwayland_or_surface_wants_focus(xsurface)) {
-		struct sway_seat *seat = input_manager_current_seat(input_manager);
-		struct wlr_xwayland *xwayland =
-			seat->input->server->xwayland.wlr_xwayland;
+		struct sway_seat *seat = input_manager_current_seat();
+		struct wlr_xwayland *xwayland = server.xwayland.wlr_xwayland;
 		wlr_xwayland_set_seat(xwayland, seat->wlr_seat);
 		seat_set_focus_surface(seat, xsurface->surface, false);
 	}
@@ -86,7 +85,7 @@ static void unmanaged_handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&surface->link);
 	wl_list_remove(&surface->commit.link);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	if (seat->wlr_seat->keyboard_state.focused_surface ==
 			xsurface->surface) {
 		// Restore focus
@@ -457,7 +456,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	if (!container_is_floating(view->container)) {
 		return;
 	}
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	seat_begin_move_floating(seat, view->container, seat->last_button);
 }
 
@@ -473,7 +472,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 		return;
 	}
 	struct wlr_xwayland_resize_event *e = data;
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	seat_begin_resize_floating(seat, view->container,
 			seat->last_button, e->edges);
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -680,7 +680,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor,
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, motion);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_motion *event = data;
 	wlr_cursor_move(cursor->cursor, event->device,
 		event->delta_x, event->delta_y);
@@ -692,7 +692,7 @@ static void handle_cursor_motion_absolute(
 		struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, motion_absolute);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_motion_absolute *event = data;
 	wlr_cursor_warp_absolute(cursor->cursor, event->device, event->x, event->y);
 	cursor_send_pointer_motion(cursor, event->time_msec);
@@ -970,7 +970,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, button);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_button *event = data;
 	dispatch_cursor_button(cursor, event->device,
 			event->time_msec, event->button, event->state);
@@ -1019,7 +1019,7 @@ static void dispatch_cursor_axis(struct sway_cursor *cursor,
 
 static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, axis);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_axis *event = data;
 	dispatch_cursor_axis(cursor, event);
 	transaction_commit_dirty();
@@ -1027,7 +1027,7 @@ static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 
 static void handle_touch_down(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, touch_down);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_touch_down *event = data;
 
 	struct sway_seat *seat = cursor->seat;
@@ -1058,7 +1058,7 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 
 static void handle_touch_up(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, touch_up);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_touch_up *event = data;
 	struct wlr_seat *seat = cursor->seat->wlr_seat;
 	// TODO: fall back to cursor simulation if client has not bound to touch
@@ -1068,7 +1068,7 @@ static void handle_touch_up(struct wl_listener *listener, void *data) {
 static void handle_touch_motion(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, touch_motion);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_touch_motion *event = data;
 
 	struct sway_seat *seat = cursor->seat;
@@ -1132,7 +1132,7 @@ static void apply_mapping_from_region(struct wlr_input_device *device,
 
 static void handle_tool_axis(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, tool_axis);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_tablet_tool_axis *event = data;
 	struct sway_input_device *input_device = event->device->data;
 
@@ -1156,7 +1156,7 @@ static void handle_tool_axis(struct wl_listener *listener, void *data) {
 
 static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, tool_tip);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_tablet_tool_tip *event = data;
 	dispatch_cursor_button(cursor, event->device, event->time_msec,
 			BTN_LEFT, event->state == WLR_TABLET_TOOL_TIP_DOWN ?
@@ -1166,7 +1166,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 
 static void handle_tool_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, tool_button);
-	wlr_idle_notify_activity(cursor->seat->input->server->idle, cursor->seat->wlr_seat);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_tablet_tool_button *event = data;
 	// TODO: the user may want to configure which tool buttons are mapped to
 	// which simulated pointer buttons

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -211,7 +211,7 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 	struct wlr_input_device *wlr_device =
 		keyboard->seat_device->input_device->wlr_device;
 	char *device_identifier = input_device_get_identifier(wlr_device);
-	wlr_idle_notify_activity(seat->input->server->idle, wlr_seat);
+	wlr_idle_notify_activity(server.idle, wlr_seat);
 	struct wlr_event_keyboard_key *event = data;
 	bool input_inhibited = seat->exclusive_client != NULL;
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -95,8 +95,7 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 	if (view && seat_is_input_allowed(seat, view->surface)) {
 #ifdef HAVE_XWAYLAND
 		if (view->type == SWAY_VIEW_XWAYLAND) {
-			struct wlr_xwayland *xwayland =
-				seat->input->server->xwayland.wlr_xwayland;
+			struct wlr_xwayland *xwayland = server.xwayland.wlr_xwayland;
 			wlr_xwayland_set_seat(xwayland, seat->wlr_seat);
 		}
 #endif
@@ -328,14 +327,13 @@ static void collect_focus_container_iter(struct sway_container *container,
 	collect_focus_iter(&container->node, data);
 }
 
-struct sway_seat *seat_create(struct sway_input_manager *input,
-		const char *seat_name) {
+struct sway_seat *seat_create(const char *seat_name) {
 	struct sway_seat *seat = calloc(1, sizeof(struct sway_seat));
 	if (!seat) {
 		return NULL;
 	}
 
-	seat->wlr_seat = wlr_seat_create(input->server->wl_display, seat_name);
+	seat->wlr_seat = wlr_seat_create(server.wl_display, seat_name);
 	if (!sway_assert(seat->wlr_seat, "could not allocate seat")) {
 		free(seat);
 		return NULL;
@@ -361,10 +359,9 @@ struct sway_seat *seat_create(struct sway_input_manager *input,
 	wl_signal_add(&seat->wlr_seat->events.new_drag_icon, &seat->new_drag_icon);
 	seat->new_drag_icon.notify = handle_new_drag_icon;
 
-	seat->input = input;
 	wl_list_init(&seat->devices);
 
-	wl_list_insert(&input->seats, &seat->link);
+	wl_list_insert(&server.input->seats, &seat->link);
 
 	return seat;
 }

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -340,7 +340,7 @@ static void focus_inactive_children_iterator(struct sway_node *node,
 }
 
 json_object *ipc_json_describe_node(struct sway_node *node) {
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat();
 	bool focused = seat_get_focus(seat) == node;
 
 	json_object *object = json_object_new_object();

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -547,7 +547,7 @@ static void ipc_get_workspaces_callback(struct sway_workspace *workspace,
 	json_object *workspace_json = ipc_json_describe_node(&workspace->node);
 	// override the default focused indicator because
 	// it's set differently for the get_workspaces reply
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat();
 	struct sway_workspace *focused_ws = seat_get_focused_workspace(seat);
 	bool focused = workspace == focused_ws;
 	json_object_object_del(workspace_json, "focused");
@@ -702,7 +702,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	{
 		json_object *inputs = json_object_new_array();
 		struct sway_input_device *device = NULL;
-		wl_list_for_each(device, &input_manager->devices, link) {
+		wl_list_for_each(device, &server.input->devices, link) {
 			json_object_array_add(inputs, ipc_json_describe_input(device));
 		}
 		const char *json_string = json_object_to_json_string(inputs);
@@ -716,7 +716,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	{
 		json_object *seats = json_object_new_array();
 		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &input_manager->seats, link) {
+		wl_list_for_each(seat, &server.input->seats, link) {
 			json_object_array_add(seats, ipc_json_describe_seat(seat));
 		}
 		const char *json_string = json_object_to_json_string(seats);

--- a/sway/server.c
+++ b/sway/server.c
@@ -153,7 +153,9 @@ bool server_init(struct sway_server *server) {
 	server->dirty_nodes = create_list();
 	server->transactions = create_list();
 
-	input_manager = input_manager_create(server);
+	server->input = input_manager_create(server);
+	input_manager_get_default_seat(); // create seat0
+
 	return true;
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -200,7 +200,7 @@ static struct sway_container *container_at_tabbed(struct sway_node *parent,
 	if (ly < box.y || ly > box.y + box.height) {
 		return NULL;
 	}
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	list_t *children = node_get_children(parent);
 	if (!children->length) {
 		return NULL;
@@ -234,7 +234,7 @@ static struct sway_container *container_at_stacked(struct sway_node *parent,
 	if (ly < box.y || ly > box.y + box.height) {
 		return NULL;
 	}
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	list_t *children = node_get_children(parent);
 
 	// Title bars
@@ -358,7 +358,7 @@ struct sway_container *container_at(struct sway_workspace *workspace,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	struct sway_container *c;
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 	bool is_floating = focus && container_is_floating_or_child(focus);
 	// Focused view's popups
@@ -651,7 +651,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		return;
 	}
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *workspace = container->workspace;
 
 	if (enable) {
@@ -843,7 +843,7 @@ bool container_has_urgent_child(struct sway_container *container) {
 
 void container_end_mouse_operation(struct sway_container *container) {
 	struct sway_seat *seat;
-	wl_list_for_each(seat, &input_manager->seats, link) {
+	wl_list_for_each(seat, &server.input->seats, link) {
 		if (seat->op_container == container) {
 			seat->op_target_node = NULL; // ensure tiling move doesn't apply
 			seat_end_mouse_operation(seat);
@@ -890,7 +890,7 @@ void container_set_fullscreen(struct sway_container *container, bool enable) {
 
 		struct sway_seat *seat;
 		struct sway_workspace *focus_ws;
-		wl_list_for_each(seat, &input_manager->seats, link) {
+		wl_list_for_each(seat, &server.input->seats, link) {
 			focus_ws = seat_get_focused_workspace(seat);
 			if (focus_ws) {
 				if (focus_ws == workspace) {
@@ -1033,7 +1033,7 @@ void container_add_gaps(struct sway_container *c) {
 		struct sway_view *view = c->view;
 		if (!view) {
 			struct sway_seat *seat =
-				input_manager_get_default_seat(input_manager);
+				input_manager_get_default_seat();
 			struct sway_container *focus =
 				seat_get_focus_inactive_view(seat, &c->node);
 			view = focus ? focus->view : NULL;
@@ -1187,7 +1187,7 @@ void container_replace(struct sway_container *container,
 
 struct sway_container *container_split(struct sway_container *child,
 		enum sway_container_layout layout) {
-	struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+	struct sway_seat *seat = input_manager_get_default_seat();
 	bool set_focus = (seat_get_focus(seat) == &child->node);
 
 	struct sway_container *cont = container_create(NULL);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -83,7 +83,7 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		struct sway_workspace *ws = workspace_create(output, ws_name);
 		// Set each seat's focus if not already set
 		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &input_manager->seats, link) {
+		wl_list_for_each(seat, &server.input->seats, link) {
 			if (!seat->has_focus) {
 				seat_set_focus_workspace(seat, ws);
 			}
@@ -97,7 +97,7 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	}
 	wl_signal_init(&output->events.destroy);
 
-	input_manager_configure_xcursor(input_manager);
+	input_manager_configure_xcursor();
 
 	wl_signal_add(&wlr_output->events.mode, &output->mode);
 	wl_signal_add(&wlr_output->events.transform, &output->transform);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -67,7 +67,7 @@ void root_scratchpad_add_container(struct sway_container *con) {
 	container_set_floating(con, true);
 	container_detach(con);
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	if (parent) {
 		arrange_container(parent);
 		seat_set_focus(seat, seat_get_focus_inactive(seat, &parent->node));
@@ -89,7 +89,7 @@ void root_scratchpad_remove_container(struct sway_container *con) {
 }
 
 void root_scratchpad_show(struct sway_container *con) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 
     // If the current con or any of its parents are in fullscreen mode, we
@@ -127,7 +127,7 @@ void root_scratchpad_show(struct sway_container *con) {
 }
 
 void root_scratchpad_hide(struct sway_container *con) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_node *focus = seat_get_focus(seat);
 	struct sway_workspace *ws = con->workspace;
 
@@ -210,7 +210,7 @@ void root_record_workspace_pid(pid_t pid) {
 		wl_list_init(&pid_workspaces);
 	}
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 	if (!ws) {
 		wlr_log(WLR_DEBUG, "Bailing out, no workspace");

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -305,7 +305,7 @@ void view_request_activate(struct sway_view *view) {
 	if (!ws) { // hidden scratchpad container
 		return;
 	}
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 
 	switch (config->focus_on_window_activation) {
 	case FOWA_SMART:
@@ -443,7 +443,7 @@ void view_execute_criteria(struct sway_view *view) {
 }
 
 static struct sway_workspace *select_workspace(struct sway_view *view) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 
 	// Check if there's any `assign` criteria for the view
 	list_t *criterias = criteria_for_view(view,
@@ -517,7 +517,7 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 }
 
 static bool should_focus(struct sway_view *view) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *prev_con = seat_get_focused_container(seat);
 	struct sway_workspace *prev_ws = seat_get_focused_workspace(seat);
 	struct sway_workspace *map_ws = view->container->workspace;
@@ -551,7 +551,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 	view->surface = wlr_surface;
 
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *ws = select_workspace(view);
 	struct sway_node *node = seat_get_focus_inactive(seat, &ws->node);
 	struct sway_container *target_sibling = node->type == N_CONTAINER ?
@@ -616,7 +616,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 
 	if (should_focus(view)) {
-		input_manager_set_focus(input_manager, &view->container->node);
+		input_manager_set_focus(&view->container->node);
 	}
 }
 
@@ -645,7 +645,7 @@ void view_unmap(struct sway_view *view) {
 	}
 
 	struct sway_seat *seat;
-	wl_list_for_each(seat, &input_manager->seats, link) {
+	wl_list_for_each(seat, &server.input->seats, link) {
 		if (config->mouse_warping == WARP_CONTAINER) {
 			struct sway_node *node = seat_get_focus(seat);
 			if (node && node->type == N_CONTAINER) {
@@ -1106,7 +1106,7 @@ bool view_is_visible(struct sway_view *view) {
 		return false;
 	}
 	// Check view isn't in a tabbed or stacked container on an inactive tab
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *con = view->container;
 	while (con) {
 		enum sway_container_layout layout = container_parent_layout(con);
@@ -1138,7 +1138,7 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 		return;
 	}
 	if (enable) {
-		struct sway_seat *seat = input_manager_current_seat(input_manager);
+		struct sway_seat *seat = input_manager_current_seat();
 		if (seat_get_focused_container(seat) == view->container) {
 			return;
 		}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -40,7 +40,7 @@ struct sway_output *workspace_get_initial_output(const char *name) {
 		}
 	}
 	// Otherwise put it on the focused output
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *focus = seat_get_focused_workspace(seat);
 	return focus->output;
 }
@@ -287,7 +287,7 @@ static bool _workspace_by_name(struct sway_workspace *ws, void *data) {
 }
 
 struct sway_workspace *workspace_by_name(const char *name) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *current = seat_get_focused_workspace(seat);
 
 	if (strcmp(name, "prev") == 0) {
@@ -316,7 +316,7 @@ struct sway_workspace *workspace_by_name(const char *name) {
  */
 static struct sway_workspace *workspace_output_prev_next_impl(
 		struct sway_output *output, int dir) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *workspace = seat_get_focused_workspace(seat);
 
 	int index = list_find(output->workspaces, workspace);
@@ -368,7 +368,7 @@ struct sway_workspace *workspace_prev(struct sway_workspace *current) {
 
 bool workspace_switch(struct sway_workspace *workspace,
 		bool no_auto_back_and_forth) {
-	struct sway_seat *seat = input_manager_current_seat(input_manager);
+	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *active_ws = seat_get_focused_workspace(seat);
 
 	if (!no_auto_back_and_forth && config->auto_back_and_forth
@@ -619,7 +619,7 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 		return;
 	}
 	if (config->smart_gaps) {
-		struct sway_seat *seat = input_manager_get_default_seat(input_manager);
+		struct sway_seat *seat = input_manager_get_default_seat();
 		struct sway_container *focus =
 			seat_get_focus_inactive_tiling(seat, ws);
 		if (focus && !focus->view) {


### PR DESCRIPTION
The input manager is a singleton object. Passing the `sway_input_manager` argument to each of its functions is unnecessary, while removing the argument makes it obvious to the caller that it's a singleton. This patch removes the argument and makes the input manager use `server.input` instead.

On a similar note:

* `sway_input_manager.server` is removed in favour of using the `server` global.
* `seat.input` is removed because it can get it from `server.input`.

Due to a circular dependency, creating seat0 is now done directly in `server_init` rather than in `input_manager_create`. This is because creating seats must be done after `server.input` is set.

Lastly, it now stores the default seat name using a constant and removes a second reference to seat0 (in `input_manager_get_default_seat`).