### PR TITLE
Remove cursor warping from seat_set_focus

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -52,6 +52,7 @@ struct sway_seat {
 	bool has_focus;
 	struct wl_list focus_stack; // list of containers in focus order
 	struct sway_workspace *workspace;
+	struct sway_node *prev_focus;
 
 	// If the focused layer is set, views cannot receive keyboard focus
 	struct wlr_layer_surface_v1 *focused_layer;
@@ -120,9 +121,6 @@ void seat_set_focus_workspace(struct sway_seat *seat,
  * with the real focus.
  */
 void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node);
-
-void seat_set_focus_warp(struct sway_seat *seat,
-		struct sway_node *node, bool warp);
 
 void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus);

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -61,13 +61,13 @@ static void swap_focus(struct sway_container *con1,
 		enum sway_container_layout layout2 = container_parent_layout(con2);
 		if (focus == con1 && (layout2 == L_TABBED || layout2 == L_STACKED)) {
 			if (workspace_is_visible(ws2)) {
-				seat_set_focus_warp(seat, &con2->node, false);
+				seat_set_focus(seat, &con2->node);
 			}
 			seat_set_focus_container(seat, ws1 != ws2 ? con2 : con1);
 		} else if (focus == con2 && (layout1 == L_TABBED
 					|| layout1 == L_STACKED)) {
 			if (workspace_is_visible(ws1)) {
-				seat_set_focus_warp(seat, &con1->node, false);
+				seat_set_focus(seat, &con1->node);
 			}
 			seat_set_focus_container(seat, ws1 != ws2 ? con1 : con2);
 		} else if (ws1 != ws2) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -597,7 +597,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			struct sway_output *focused_output = node_get_output(focus);
 			struct sway_output *output = node_get_output(node);
 			if (output != focused_output) {
-				seat_set_focus_warp(seat, node, false);
+				seat_set_focus(seat, node);
 			}
 		} else if (node->type == N_CONTAINER && node->sway_container->view) {
 			// Focus node if the following are true:
@@ -607,14 +607,14 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			if (!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
 					node != prev_node &&
 					view_is_visible(node->sway_container->view)) {
-				seat_set_focus_warp(seat, node, false);
+				seat_set_focus(seat, node);
 			} else {
 				struct sway_node *next_focus =
 					seat_get_focus_inactive(seat, &root->node);
 				if (next_focus && next_focus->type == N_CONTAINER &&
 						next_focus->sway_container->view &&
 						view_is_visible(next_focus->sway_container->view)) {
-					seat_set_focus_warp(seat, next_focus, false);
+					seat_set_focus(seat, next_focus);
 				}
 			}
 		}


### PR DESCRIPTION
Because cursor warping was the default behaviour in `seat_set_focus`, there may be cases where we may have been warping the cursor unintentionally. This patch removes cursor warping from `seat_set_focus` and only does it in the `focus` command. This is managed by a static function in `focus.c`.

To know whether to warp or not, we need to know which node had focus previously. To keep track of this easily, `seat->prev_focus` has been introduced and is set to the previous in `seat_set_focus`.