### PR TITLE
cmd_bind{sym,code}: Implement per-device bindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -43,6 +43,7 @@ enum binding_flags {
 struct sway_binding {
 	enum binding_input_type type;
 	int order;
+	char *input;
 	uint32_t flags;
 	list_t *keys; // sorted in ascending order
 	uint32_t modifiers;

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -42,8 +42,9 @@ void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 	bool allow_refocusing);
-void dispatch_cursor_button(struct sway_cursor *cursor, uint32_t time_msec,
-	uint32_t button, enum wlr_button_state state);
+void dispatch_cursor_button(struct sway_cursor *cursor,
+	struct wlr_input_device *device, uint32_t time_msec, uint32_t button,
+	enum wlr_button_state state);
 
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	struct wl_client *client);

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -63,5 +63,6 @@ struct sway_seat *input_manager_current_seat(struct sway_input_manager *input);
 
 struct input_config *input_device_get_config(struct sway_input_device *device);
 
+char *input_device_get_identifier(struct wlr_input_device *device);
 
 #endif

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -80,6 +80,6 @@ static struct cmd_results *press_or_release(struct sway_cursor *cursor,
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);
 		}
 	}
-	dispatch_cursor_button(cursor, 0, button, state);
+	dispatch_cursor_button(cursor, NULL, 0, button, state);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -45,7 +45,7 @@ struct sway_seat *input_manager_get_seat(
 	return seat_create(input, seat_name);
 }
 
-static char *get_device_identifier(struct wlr_input_device *device) {
+char *input_device_get_identifier(struct wlr_input_device *device) {
 	int vendor = device->vendor;
 	int product = device->product;
 	char *name = strdup(device->name);
@@ -278,7 +278,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	device->data = input_device;
 
 	input_device->wlr_device = device;
-	input_device->identifier = get_device_identifier(device);
+	input_device->identifier = input_device_get_identifier(device);
 	wl_list_insert(&input->devices, &input_device->link);
 
 	wlr_log(WLR_DEBUG, "adding device: '%s'",
@@ -375,7 +375,7 @@ void handle_virtual_keyboard(struct wl_listener *listener, void *data) {
 	device->data = input_device;
 
 	input_device->wlr_device = device;
-	input_device->identifier = get_device_identifier(device);
+	input_device->identifier = input_device_get_identifier(device);
 	wl_list_insert(&input_manager->devices, &input_device->link);
 
 	wlr_log(WLR_DEBUG, "adding virtual keyboard: '%s'",

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -257,20 +257,22 @@ runtime.
 
 		for\_window <criteria> move container to output <output>
 
-*bindsym* [--release|--locked] <key combo> <command>
+*bindsym* [--release|--locked] [--input-device=<device>] <key combo> <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
 	With the flag _--release_, the command is executed when the key combo is
 	released. Unless the flag _--locked_ is set, the command will not be run
-	when a screen locking program is active.
+	when a screen locking program is active. If _input-device_ is given, the
+	binding will only be executed for that input device and will be executed
+	instead of any binding that is generic to all devices.
 
 	Example:
 
 		# Execute firefox when alt, shift, and f are pressed together
 		bindsym Mod1+Shift+f exec firefox
 
-	*bindcode* [--release|--locked] <code> <command> is also available for
-	binding with key codes instead of key names.
+	*bindcode* [--release|--locked] [--input-device=<device>] <code> <command>
+	is also available for binding with key codes instead of key names.
 
 *client.<class>* <border> <background> <text> <indicator> <child\_border>
 	Configures the color of window borders and title bars. All 5 colors are


### PR DESCRIPTION
Closes #2378 
Closes #2141 

Implements the syntax `bind{sym,code} --input-device=<identifier> <...>` for both keyboard and mouse bindings.

Since I don't have multiple physical keyboards, I found this easiest to test by launching sway on DRM, on the Wayland backend, and on the X11 backend.

My test config:
```
set $mod Mod4
set $keyboard <keyboard-id>
set $wl_keyboard 0:0:wayland
set $mouse <mouse-id>
set $wl_mouse 0:0:wayland

bindsym $mod+x exec urxvt -e python
bindsym --input-device=$keyboard $mod+x exec urxvt -e bash
bindsym --input-device=$wl_keyboard $mod+x exec urxvt -e zsh

bindsym --whole-window button3 floating toggle
bindsym --input-device=$mouse --whole-window button3 fullscreen toggle
bindsym --input-device=$wl_mouse --whole-window button3 border toggle
```

For the config above:
- `urxvt -e python` and `floating toggle` should get triggered on the X11 backend
- `urxvt -e bash` and `fullscreen toggle` should get triggered on DRM
- `urxvt -e zsh` and `border toggle` should get triggered on the Wayland backend