### PR TITLE
Consider cursor warp when switching workspaces

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -203,4 +203,6 @@ void seat_end_mouse_operation(struct sway_seat *seat);
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,
 		uint32_t button, enum wlr_button_state state);
 
+void seat_consider_warp_to_focus(struct sway_seat *seat);
+
 #endif

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -34,24 +34,6 @@ static bool parse_movement_direction(const char *name,
 	return true;
 }
 
-static void consider_warp_to_focus(struct sway_seat *seat) {
-	struct sway_node *focus = seat_get_focus(seat);
-	if (config->mouse_warping == WARP_NO || !focus || !seat->prev_focus) {
-		return;
-	}
-	if (config->mouse_warping == WARP_OUTPUT &&
-			node_get_output(focus) == node_get_output(seat->prev_focus)) {
-		return;
-	}
-
-	if (focus->type == N_CONTAINER) {
-		cursor_warp_to_container(seat->cursor, focus->sway_container);
-	} else {
-		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
-	}
-	cursor_send_pointer_motion(seat->cursor, 0, false);
-}
-
 /**
  * Get node in the direction of newly entered output.
  */
@@ -199,7 +181,7 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 	}
 	if (new_focus) {
 		seat_set_focus_container(seat, new_focus);
-		consider_warp_to_focus(seat);
+		seat_consider_warp_to_focus(seat);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "focus",
 				"Failed to find a %s container in workspace",
@@ -232,7 +214,7 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 	free(identifier);
 	if (output) {
 		seat_set_focus(seat, seat_get_focus_inactive(seat, &output->node));
-		consider_warp_to_focus(seat);
+		seat_consider_warp_to_focus(seat);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
@@ -253,7 +235,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 
 	if (argc == 0 && container) {
 		seat_set_focus_container(seat, container);
-		consider_warp_to_focus(seat);
+		seat_consider_warp_to_focus(seat);
 		cursor_send_pointer_motion(seat->cursor, 0, true);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
@@ -283,7 +265,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		struct sway_node *focus = seat_get_active_tiling_child(seat, node);
 		if (focus) {
 			seat_set_focus(seat, focus);
-			consider_warp_to_focus(seat);
+			seat_consider_warp_to_focus(seat);
 		}
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
@@ -303,7 +285,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		struct sway_node *node =
 			get_node_in_output_direction(new_output, direction);
 		seat_set_focus(seat, node);
-		consider_warp_to_focus(seat);
+		seat_consider_warp_to_focus(seat);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
@@ -311,7 +293,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		node_get_in_direction(container, seat, direction);
 	if (next_focus) {
 		seat_set_focus(seat, next_focus);
-		consider_warp_to_focus(seat);
+		seat_consider_warp_to_focus(seat);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -157,6 +157,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			free(name);
 		}
 		workspace_switch(ws, no_auto_back_and_forth);
+		seat_consider_warp_to_focus(config->handler_context.seat);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1187,3 +1187,21 @@ void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,
 	seat->last_button_serial = wlr_seat_pointer_notify_button(seat->wlr_seat,
 			time_msec, button, state);
 }
+
+void seat_consider_warp_to_focus(struct sway_seat *seat) {
+	struct sway_node *focus = seat_get_focus(seat);
+	if (config->mouse_warping == WARP_NO || !focus || !seat->prev_focus) {
+		return;
+	}
+	if (config->mouse_warping == WARP_OUTPUT &&
+			node_get_output(focus) == node_get_output(seat->prev_focus)) {
+		return;
+	}
+
+	if (focus->type == N_CONTAINER) {
+		cursor_warp_to_container(seat->cursor, focus->sway_container);
+	} else {
+		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
+	}
+	cursor_send_pointer_motion(seat->cursor, 0, false);
+}


### PR DESCRIPTION
Fixes a regression introduced in 24a90e5d86441fc345356eb3767e5a6880dcedbd.

`consider_warp_to_focus` has been renamed to `seat_consider_warp_to_focus`, moved to `seat.c` and made public. It is now called when switching workspaces via `workspace <ws>`.