### PR TITLE
swaybar: disallow left and right position and print error on default

### DIFF
--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -12,7 +12,7 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 	if (!config->current_bar) {
 		return cmd_results_new(CMD_FAILURE, "position", "No bar defined.");
 	}
-	char *valid[] = { "top", "bottom", "left", "right" };
+	char *valid[] = { "top", "bottom" };
 	for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
 		if (strcasecmp(valid[i], argv[0]) == 0) {
 			wlr_log(WLR_DEBUG, "Setting bar position '%s' for bar: %s",

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -1,6 +1,7 @@
 #define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <string.h>
+#include <wlr/util/log.h>
 #include "swaybar/config.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "stringop.h"
@@ -9,17 +10,12 @@
 uint32_t parse_position(const char *position) {
 	uint32_t horiz = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
 		ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
-	uint32_t vert = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
-		ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
 	if (strcmp("top", position) == 0) {
 		return ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | horiz;
 	} else if (strcmp("bottom", position) == 0) {
 		return ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM | horiz;
-	} else if (strcmp("left", position) == 0) {
-		return ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | vert;
-	} else if (strcmp("right", position) == 0) {
-		return ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | vert;
 	} else {
+		wlr_log(WLR_ERROR, "Invalid position: %s, defaulting to bottom", position);
 		return ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM | horiz;
 	}
 }


### PR DESCRIPTION
The positions "left" and "right" are not allowed by the man page, remove them
from the allowed positions. Also print an error to stderr if we default to the
bottom position.

Fixes #2878