### PR TITLE
Fix crash when view unmaps while no outputs connected

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -89,6 +89,7 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 			}
 		}
 		free(ws_name);
+		ipc_event_workspace(NULL, ws, "init");
 	}
 
 	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -119,6 +119,11 @@ void workspace_begin_destroy(struct sway_workspace *workspace) {
 
 	if (workspace->output) {
 		workspace_detach(workspace);
+	} else {
+		int index = list_find(root->saved_workspaces, workspace);
+		if (index != -1) {
+			list_del(root->saved_workspaces, index);
+		}
 	}
 
 	workspace->node.destroying = true;
@@ -126,10 +131,13 @@ void workspace_begin_destroy(struct sway_workspace *workspace) {
 }
 
 void workspace_consider_destroy(struct sway_workspace *ws) {
-	if (ws->tiling->length == 0 && ws->floating->length == 0
-			&& output_get_active_workspace(ws->output) != ws) {
-		workspace_begin_destroy(ws);
+	if (ws->tiling->length || ws->floating->length) {
+		return;
 	}
+	if (ws->output && output_get_active_workspace(ws->output) == ws) {
+		return;
+	}
+	workspace_begin_destroy(ws);
 }
 
 char *prev_workspace_name = NULL;


### PR DESCRIPTION
When a view unmaps, we call `workspace_consider_destroy`. This function assumed the workspace would always have an output, but this is not the case when hotplugged down to zero. The function now handles this and allows itself to be destroyed when there is no output.

This means that `workspace_begin_destroy` must remove the workspace from the `root->saved_workspaces` list to avoid an eventual dangling pointer, so it does that now.

Lastly, when an output is plugged in again and it has to create a new initial workspace for it, we must emit the `workspace::init` IPC event otherwise swaybar shows no workspaces at all. I guess when you start sway, swaybar is started after the workspace has been created which is why this hasn't been needed earlier.

To test:

* Run sway in a nested session.
* Open a terminal and run `sleep 3 && exit`.
* While sleeping, close the output window from your DRM session.
* Let the sleep finish, watch the debug log, ensure no crash.
* Use IPC to connect to the nested session's socket and run `create_output`.
* See output window, with swaybar and one empty workspace.

Fixes #2841.