### PR TITLE
Fix popup damage issues when toplevel and/or popup uses geometry

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -25,9 +25,12 @@ static void popup_get_root_coords(struct sway_view_child *child,
 	struct sway_xdg_popup *popup = (struct sway_xdg_popup *)child;
 	struct wlr_xdg_surface *surface = popup->wlr_xdg_surface;
 
+	int x_offset = -child->view->geometry.x - surface->geometry.x;
+	int y_offset = -child->view->geometry.y - surface->geometry.y;
+
 	wlr_xdg_popup_get_toplevel_coords(surface->popup,
-		-surface->geometry.x + surface->popup->geometry.x,
-		-surface->geometry.y + surface->popup->geometry.y,
+		x_offset + surface->popup->geometry.x,
+		y_offset + surface->popup->geometry.y,
 		root_sx, root_sy);
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -24,9 +24,12 @@ static void popup_get_root_coords(struct sway_view_child *child,
 	struct sway_xdg_popup_v6 *popup = (struct sway_xdg_popup_v6 *)child;
 	struct wlr_xdg_surface_v6 *surface = popup->wlr_xdg_surface_v6;
 
+	int x_offset = -child->view->geometry.x - surface->geometry.x;
+	int y_offset = -child->view->geometry.y - surface->geometry.y;
+
 	wlr_xdg_popup_v6_get_toplevel_coords(surface->popup,
-		-surface->geometry.x + surface->popup->geometry.x,
-		-surface->geometry.y + surface->popup->geometry.y,
+		x_offset + surface->popup->geometry.x,
+		y_offset + surface->popup->geometry.y,
 		root_sx, root_sy);
 }
 


### PR DESCRIPTION
The `wlr_xdg_popup_get_toplevel_coords` function has the following quirks:

* It does not do anything with the coordinates of the passed popup. Instead, we are required to add them ourselves, which we do by passing them to the function as the surface local values.
* It adds the geometry (shadows etc) of the toplevel itself, so the coordinates are surface local rather than content local. For this reason, we have to negate the toplevel's geometry (`child->view->geometry`).
* I may be wrong, but the popup positions appear to be stored in surface local coordinates rather than content local coordinates. The geometry (shadows etc) of the popup itself must be negated (`surface->geometry`).

Fixes #2893.