### PR TITLE
Fix crash when moving a container to a fullscreen workspace

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -108,7 +108,7 @@ static void workspace_focus_fullscreen(struct sway_workspace *workspace) {
 		if (focus_ws == workspace) {
 			struct sway_node *new_focus =
 				seat_get_focus_inactive(seat, &workspace->fullscreen->node);
-			seat_set_focus(seat, new_focus);
+			seat_set_raw_focus(seat, new_focus);
 		}
 	}
 }


### PR DESCRIPTION
Setting normal focus to the fullscreen view causes the old workspace to start destroying. We then set focus to the old workspace which is no longer attached in the tree.

As we are only setting `focus_inactive` on the fullscreen container, the fix uses `seat_set_raw_focus` to avoid all the additional behaviour that comes with it such as destroying the old workspace.

Fixes #2915.