### PR TITLE
Fix crash when quitting a QT app on the wayland backend using menu

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -226,7 +226,6 @@ struct sway_view_child {
 	struct wl_listener surface_map;
 	struct wl_listener surface_unmap;
 	struct wl_listener surface_destroy;
-	struct wl_listener view_unmap;
 };
 
 struct sway_xdg_popup_v6 {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -731,13 +731,6 @@ static void view_child_handle_surface_destroy(struct wl_listener *listener,
 	view_child_destroy(child);
 }
 
-static void view_child_handle_view_unmap(struct wl_listener *listener,
-		void *data) {
-	struct sway_view_child *child =
-		wl_container_of(listener, child, view_unmap);
-	view_child_destroy(child);
-}
-
 static void view_init_subsurfaces(struct sway_view *view,
 		struct wlr_surface *surface) {
 	struct wlr_subsurface *subsurface;
@@ -779,9 +772,6 @@ void view_child_init(struct sway_view_child *child,
 	child->surface_map.notify = view_child_handle_surface_map;
 	child->surface_unmap.notify = view_child_handle_surface_unmap;
 
-	wl_signal_add(&view->events.unmap, &child->view_unmap);
-	child->view_unmap.notify = view_child_handle_view_unmap;
-
 	struct sway_output *output = child->view->container->workspace->output;
 	wlr_surface_send_enter(child->surface, output->wlr_output);
 
@@ -791,7 +781,6 @@ void view_child_init(struct sway_view_child *child,
 void view_child_destroy(struct sway_view_child *child) {
 	wl_list_remove(&child->surface_commit.link);
 	wl_list_remove(&child->surface_destroy.link);
-	wl_list_remove(&child->view_unmap.link);
 
 	if (child->impl && child->impl->destroy) {
 		child->impl->destroy(child);


### PR DESCRIPTION
QT unmaps the view before destroying the popup. We destroyed the popup in response to the view unmapping, but then we'd attempt to destroy it a second time which caused a crash.

The patch removes the listener.

I tested it with GTK as well, and can confirm the popup is still being destroyed.

Fixes #2908.