### PR TITLE
Fix xwayland wants_floating logic

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -239,7 +239,7 @@ static bool wants_floating(struct sway_view *view) {
 
 	struct wlr_xwayland_surface_size_hints *size_hints = surface->size_hints;
 	if (size_hints != NULL &&
-			size_hints->min_width != 0 && size_hints->min_height != 0 &&
+			size_hints->min_width > 0 && size_hints->min_height > 0 &&
 			(size_hints->max_width == size_hints->min_width ||
 			size_hints->max_height == size_hints->min_height)) {
 		return true;


### PR DESCRIPTION
Requires https://github.com/swaywm/wlroots/pull/1327 to actually fix the floating logic, but won't break anything if this is merged first.

See i3's implementation here: https://github.com/i3/i3/blob/a319860cd10cda17e176218e6dc34145fbb3bd94/src/manage.c#L444-L445

To test:

* Run `emacs`, press Alt + x and type `server-start`, then open a terminal and run `emacsclient -nc`. This window should be tiled.
* Run `echo getpin | pinenetry-gtk-2`. This window should be floating.

Fixes #2844.