### PR TITLE
Fix crash when resizing container hidden in the scratchpad

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -94,7 +94,7 @@ static void calculate_constraints(int *min_width, int *max_width,
 		*min_height = config->floating_minimum_height;
 	}
 
-	if (config->floating_maximum_width == -1) { // no maximum
+	if (config->floating_maximum_width == -1 || !con->workspace) { // no max
 		*max_width = INT_MAX;
 	} else if (config->floating_maximum_width == 0) { // automatic
 		*max_width = con->workspace->width;
@@ -102,7 +102,7 @@ static void calculate_constraints(int *min_width, int *max_width,
 		*max_width = config->floating_maximum_width;
 	}
 
-	if (config->floating_maximum_height == -1) { // no maximum
+	if (config->floating_maximum_height == -1 || !con->workspace) { // no max
 		*max_height = INT_MAX;
 	} else if (config->floating_maximum_height == 0) { // automatic
 		*max_height = con->workspace->height;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -727,8 +727,14 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 }
 
 bool container_is_floating(struct sway_container *container) {
-	return !container->parent && container->workspace &&
-		list_find(container->workspace->floating, container) != -1;
+	if (!container->parent && container->workspace &&
+			list_find(container->workspace->floating, container) != -1) {
+		return true;
+	}
+	if (container->scratchpad) {
+		return true;
+	}
+	return false;
 }
 
 void container_get_box(struct sway_container *container, struct wlr_box *box) {


### PR DESCRIPTION
Firstly, the container was wrongly identifying as a tiling container because it had no workspace.

Secondly, when calculating the maximum possible size we can't use the workspace if it's not there, so we'll allow unlimited size in this case.

We should probably use the `config->floating_maximum_{width,height}`, but I feel the resize constraints needs to be refactored anyway and I just want to fix the crash for now.

Fixes #2928.