### PR TITLE
xwayland: populate window_properties in json for views

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -30,6 +30,7 @@ enum sway_view_prop {
 	VIEW_PROP_WINDOW_ROLE,
 #ifdef HAVE_XWAYLAND
 	VIEW_PROP_X11_WINDOW_ID,
+	VIEW_PROP_X11_PARENT_ID,
 #endif
 };
 
@@ -256,6 +257,8 @@ const char *view_get_class(struct sway_view *view);
 const char *view_get_instance(struct sway_view *view);
 
 uint32_t view_get_x11_window_id(struct sway_view *view);
+
+uint32_t view_get_x11_parent_id(struct sway_view *view);
 
 const char *view_get_window_role(struct sway_view *view);
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -171,6 +171,11 @@ static uint32_t get_int_prop(struct sway_view *view, enum sway_view_prop prop) {
 	switch (prop) {
 	case VIEW_PROP_X11_WINDOW_ID:
 		return view->wlr_xwayland_surface->window_id;
+	case VIEW_PROP_X11_PARENT_ID:
+		if (view->wlr_xwayland_surface->parent) {
+			return view->wlr_xwayland_surface->parent->window_id;
+		}
+		return 0;
 	case VIEW_PROP_WINDOW_TYPE:
 		return *view->wlr_xwayland_surface->window_type;
 	default:

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -266,6 +266,29 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	if (c->view->type == SWAY_VIEW_XWAYLAND) {
 		json_object_object_add(object, "window",
 				json_object_new_int(view_get_x11_window_id(c->view)));
+
+		json_object *window_props = json_object_new_object();
+
+		json_object_object_add(window_props, "class",
+				class ? json_object_new_string(class) : NULL);
+		const char *instance = view_get_instance(c->view);
+		json_object_object_add(window_props, "instance",
+				instance ? json_object_new_string(instance) : NULL);
+		json_object_object_add(window_props, "title",
+				c->title ? json_object_new_string(c->title) : NULL);
+
+		// the transient_for key is always present in i3's output
+		uint32_t parent_id = view_get_x11_parent_id(c->view);
+		json_object_object_add(window_props, "transient_for",
+				parent_id ? json_object_new_int(parent_id) : NULL);
+
+		const char *role = view_get_window_role(c->view);
+		if (role) {
+			json_object_object_add(window_props, "window_role",
+					json_object_new_string(role));
+		}
+
+		json_object_object_add(object, "window_properties", window_props);
 	}
 #endif
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -116,6 +116,13 @@ uint32_t view_get_x11_window_id(struct sway_view *view) {
 	}
 	return 0;
 }
+
+uint32_t view_get_x11_parent_id(struct sway_view *view) {
+	if (view->impl->get_int_prop) {
+		return view->impl->get_int_prop(view, VIEW_PROP_X11_PARENT_ID);
+	}
+	return 0;
+}
 #endif
 const char *view_get_window_role(struct sway_view *view) {
 	if (view->impl->get_string_prop) {


### PR DESCRIPTION
window_properties is documented to contain a subset of the X11 properties
of a window (its title, class, instance, role, and transient ID). This
commit adds the missing json object from the get_tree output for
xwayland windows only.

This is a follow-up of #2911.

Signed-off-by: Franklin "Snaipe" Mathieu <me@snai.pe>