### PR TITLE
config: remove peeked + expanded line log entries

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -584,13 +584,11 @@ static int detect_brace_on_following_line(FILE *file, char *line,
 		char *peeked = NULL;
 		long position = 0;
 		do {
-			wlr_log(WLR_DEBUG, "Peeking line %d", line_number + lines + 1);
 			free(peeked);
 			peeked = peek_line(file, lines, &position);
 			if (peeked) {
 				peeked = strip_whitespace(peeked);
 			}
-			wlr_log(WLR_DEBUG, "Peeked line: `%s`", peeked);
 			lines++;
 		} while (peeked && strlen(peeked) == 0);
 
@@ -695,7 +693,6 @@ bool read_config(FILE *file, struct sway_config *config,
 			free(line);
 			return false;
 		}
-		wlr_log(WLR_DEBUG, "Expanded line: %s", expanded);
 		struct cmd_results *res;
 		if (block && strcmp(block, "<commands>") == 0) {
 			// Special case


### PR DESCRIPTION
The peeked and expanded line log entries were useful during the switch to generic code blocks and subcommands. However, it has been a while since those were introduced and the log entries are no longer helpful. Instead of keeping them as clutter in the log, they can just be removed.