### PR TITLE
cmd_swaynag_command: fix typo in variable

### DIFF
--- a/sway/commands/swaynag_command.c
+++ b/sway/commands/swaynag_command.c
@@ -14,7 +14,7 @@ struct cmd_results *cmd_swaynag_command(int argc, char **argv) {
 
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {
-		config->swaybg_command = new_command;
+		config->swaynag_command = new_command;
 		wlr_log(WLR_DEBUG, "Using custom swaynag command: %s",
 				config->swaynag_command);
 	} else {


### PR DESCRIPTION
The custom `swaynag_command` was being stored as `config->swaybg_command` instead of `config->swaynag_command`.