### PR TITLE
Rebase the cursor after focusing in a direction

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -294,6 +294,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (next_focus) {
 		seat_set_focus(seat, next_focus);
 		seat_consider_warp_to_focus(seat);
+		cursor_rebase(seat->cursor);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);


### PR DESCRIPTION
Prior to this patch, creating a tabbed container with two views, switching tab and then scrolling without motion would cause the scroll events to be sent to the old focus. To fix this, rebasing the cursor is needed after changing focus.

Fixes #2945.