### PR TITLE
Enable gaps in the default configuration

### DIFF
--- a/config.in
+++ b/config.in
@@ -197,6 +197,14 @@ mode "resize" {
 bindsym $mod+r mode "resize"
 
 #
+# Gaps:
+#
+gaps inner 10
+gaps outer 15
+smart_gaps on
+smart_borders on
+
+#
 # Status Bar:
 #
 # Read `man 5 sway-bar` for more information about this section.


### PR DESCRIPTION
The new gaps feature is so awesome that I believe it should be enabled by default.

This pull request is just a suggestion, the decision is up to you, of course.

Thanks for creating sway! :heart: