### PR TITLE
Rebase the cursor after mapping a view

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -29,6 +29,13 @@ struct sway_view;
 void transaction_commit_dirty(void);
 
 /**
+ * Same as above, but runs the specific callback when the transaction is
+ * applied.
+ */
+void transaction_commit_dirty_with_callback(
+		void (*callback)(void *data), void *data);
+
+/**
  * Notify the transaction system that a view is ready for the new layout.
  *
  * When all views in the transaction are ready, the layout will be applied.

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -9,6 +9,7 @@
 #include "sway/decoration.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
+#include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
@@ -396,6 +397,11 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_view->set_app_id.link);
 }
 
+static void do_rebase(void *data) {
+	struct sway_cursor *cursor = data;
+	cursor_rebase(cursor);
+}
+
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, map);
@@ -422,7 +428,8 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface->surface,
 		xdg_surface->toplevel->client_pending.fullscreen, csd);
 
-	transaction_commit_dirty();
+	struct sway_seat *seat = input_manager_current_seat();
+	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
 
 	xdg_shell_view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -8,6 +8,7 @@
 #include "sway/decoration.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
+#include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
@@ -393,6 +394,11 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_v6_view->set_app_id.link);
 }
 
+static void do_rebase(void *data) {
+	struct sway_cursor *cursor = data;
+	cursor_rebase(cursor);
+}
+
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, map);
@@ -413,7 +419,8 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface_v6->surface,
 		xdg_surface->toplevel->client_pending.fullscreen, csd);
 
-	transaction_commit_dirty();
+	struct sway_seat *seat = input_manager_current_seat();
+	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
 
 	xdg_shell_v6_view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
+#include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
@@ -390,6 +391,11 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xwayland_view->commit.link);
 }
 
+static void do_rebase(void *data) {
+	struct sway_cursor *cursor = data;
+	cursor_rebase(cursor);
+}
+
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, map);
@@ -416,7 +422,8 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	// Put it back into the tree
 	view_map(view, xsurface->surface, xsurface->fullscreen, false);
 
-	transaction_commit_dirty();
+	struct sway_seat *seat = input_manager_current_seat();
+	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
 }
 
 static void handle_request_configure(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
I originally put the rebase at the end of view_map, but at this point the view is still at its native size and will ignore the motion event if it falls outside of its native size. The only way to do this properly is to rebase the cursor later - either after sending the configure, after the view commits with the new size, or after applying the transaction. I chose to do it after applying the transaction for simplicity.

I then attempted to just call `cursor_rebase` after applying every transaction, but this causes crashes when exiting sway (and possibly other places) because `cursor_rebase` assumes the tree is in a valid state.

So my chosen solution introduces `transaction_commit_dirty_with_callback` which allows `handle_map` to register a callback which will run when the transaction is applied.

Fixes #2949.

Might be a fix for #2946, but I can't reproduce that.