### PR TITLE
Fix sway crash on new keyboard

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -186,7 +186,10 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 	} else {
 		// Setting focus_inactive
 		seat_set_raw_focus(seat, next_focus);
-		seat_set_raw_focus(seat, focus);
+
+		if (focus) {
+			seat_set_raw_focus(seat, focus);
+		}
 	}
 }
 


### PR DESCRIPTION
Sway sometime crashes when attaching a new keyboard.

Following is the backtrace:

```
#0  0x0000000000423051 in seat_node_from_node (seat=0x21665f0, node=0x0) at ../sway/input/seat.c:195
#1  0x0000000000424294 in seat_set_raw_focus (seat=0x21665f0, node=0x0) at ../sway/input/seat.c:635
#2  0x0000000000423038 in handle_seat_node_destroy (listener=0x29f8450, data=0x29f8280) at ../sway/input/seat.c:189
#3  0x0000000000440fd2 in wl_signal_emit (signal=0x29f82b0, data=0x29f8280) at /usr/include/wayland-server-core.h:468
#4  0x0000000000441315 in container_begin_destroy (con=0x29f8280) at ../sway/tree/container.c:90
#5  0x000000000044797a in view_unmap (view=0x29f6fa0) at ../sway/tree/view.c:635
#6  0x000000000044d4f3 in handle_unmap (listener=0x29f7230, data=0x28ae810) at ../sway/desktop/xwayland.c:383
#7  0x00007f8ae971f4b9 in wlr_signal_emit_safe (signal=0x28ae988, data=0x28ae810) at ../util/signal.c:29
#8  0x00007f8ae96d0be6 in xsurface_unmap (surface=0x28ae810) at ../xwayland/xwm.c:763
#9  0x00007f8ae96cf82c in xwayland_surface_destroy (xsurface=0x28ae810) at ../xwayland/xwm.c:301
#10 0x00007f8ae96d22b6 in xwm_destroy (xwm=0x2984410) at ../xwayland/xwm.c:1419
#11 0x00007f8ae96ce18d in xwayland_finish_server (wlr_xwayland=0x2188370) at ../xwayland/xwayland.c:165
#12 0x00007f8ae96ce33f in handle_client_destroy (listener=0x2188388, data=0x2960ef0) at ../xwayland/xwayland.c:224
#13 0x00007f8ae975d7cd in  () at /lib64/libwayland-server.so.0
#14 0x00007f8ae975d9b5 in wl_client_destroy () at /lib64/libwayland-server.so.0
#15 0x00007f8ae975de0d in wl_display_flush_clients () at /lib64/libwayland-server.so.0
#16 0x00007f8ae975de58 in wl_display_run () at /lib64/libwayland-server.so.0
#17 0x0000000000416e2a in server_run (server=0x46ab60 <server>) at ../sway/server.c:187
#18 0x0000000000416528 in main (argc=1, argv=0x7ffc3aece878) at ../sway/main.c:404
```

This pull request fix the crash