### PR TITLE
Fix containers not being resized when entering scratchpad

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -59,13 +59,13 @@ void root_scratchpad_add_container(struct sway_container *con) {
 	if (!sway_assert(!con->scratchpad, "Container is already in scratchpad")) {
 		return;
 	}
-	con->scratchpad = true;
-	list_add(root->scratchpad, con);
 
 	struct sway_container *parent = con->parent;
 	struct sway_workspace *workspace = con->workspace;
 	container_set_floating(con, true);
 	container_detach(con);
+	con->scratchpad = true;
+	list_add(root->scratchpad, con);
 
 	struct sway_seat *seat = input_manager_current_seat();
 	if (parent) {


### PR DESCRIPTION
This fixes a regression introduced by 662466e8db773926bf61b21280194a3540ae26ec (#2929). When adding a container to the scratchpad, setting `container->scratchpad = true` before `container_set_floating` made `container_set_floating` believe that the container was already floating. This fixes it by setting the property afterwards instead.

Test by focusing a tiling view then running `move scratchpad` followed by `scratchpad show`.

Also tested with the config that the original issue was fixing:

    for_window [class="Firefox"] floating enable
    for_window [class="Firefox"] move scratchpad
    for_window [class="Firefox"] resize set 1000 1000
