### PR TITLE
Rebase the cursor after applying transactions

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -29,13 +29,6 @@ struct sway_view;
 void transaction_commit_dirty(void);
 
 /**
- * Same as above, but runs the specific callback when the transaction is
- * applied.
- */
-void transaction_commit_dirty_with_callback(
-		void (*callback)(void *data), void *data);
-
-/**
  * Notify the transaction system that a view is ready for the new layout.
  *
  * When all views in the transaction are ready, the layout will be applied.

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -94,10 +94,5 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 
 	arrange_container(view->container);
 
-	struct sway_seat *seat = input_manager_current_seat();
-	if (seat->cursor) {
-		cursor_rebase(seat->cursor);
-	}
-
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -236,7 +236,6 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (argc == 0 && container) {
 		seat_set_focus_container(seat, container);
 		seat_consider_warp_to_focus(seat);
-		cursor_rebase(seat->cursor);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 
@@ -294,7 +293,6 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (next_focus) {
 		seat_set_focus(seat, next_focus);
 		seat_consider_warp_to_focus(seat);
-		cursor_rebase(seat->cursor);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -397,11 +397,6 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_view->set_app_id.link);
 }
 
-static void do_rebase(void *data) {
-	struct sway_cursor *cursor = data;
-	cursor_rebase(cursor);
-}
-
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, map);
@@ -428,8 +423,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface->surface,
 		xdg_surface->toplevel->client_pending.fullscreen, csd);
 
-	struct sway_seat *seat = input_manager_current_seat();
-	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
+	transaction_commit_dirty();
 
 	xdg_shell_view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit,

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -394,11 +394,6 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_v6_view->set_app_id.link);
 }
 
-static void do_rebase(void *data) {
-	struct sway_cursor *cursor = data;
-	cursor_rebase(cursor);
-}
-
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_v6_view *xdg_shell_v6_view =
 		wl_container_of(listener, xdg_shell_v6_view, map);
@@ -419,8 +414,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	view_map(view, view->wlr_xdg_surface_v6->surface,
 		xdg_surface->toplevel->client_pending.fullscreen, csd);
 
-	struct sway_seat *seat = input_manager_current_seat();
-	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
+	transaction_commit_dirty();
 
 	xdg_shell_v6_view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -391,11 +391,6 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xwayland_view->commit.link);
 }
 
-static void do_rebase(void *data) {
-	struct sway_cursor *cursor = data;
-	cursor_rebase(cursor);
-}
-
 static void handle_map(struct wl_listener *listener, void *data) {
 	struct sway_xwayland_view *xwayland_view =
 		wl_container_of(listener, xwayland_view, map);
@@ -422,8 +417,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	// Put it back into the tree
 	view_map(view, xsurface->surface, xsurface->fullscreen, false);
 
-	struct sway_seat *seat = input_manager_current_seat();
-	transaction_commit_dirty_with_callback(do_rebase, seat->cursor);
+	transaction_commit_dirty();
 }
 
 static void handle_request_configure(struct wl_listener *listener, void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1196,5 +1196,4 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	} else {
 		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
 	}
-	cursor_rebase(seat->cursor);
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -661,7 +661,6 @@ void view_unmap(struct sway_view *view) {
 				cursor_warp_to_workspace(seat->cursor, node->sway_workspace);
 			}
 		}
-		cursor_rebase(seat->cursor);
 	}
 
 	transaction_commit_dirty();

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -404,7 +404,6 @@ bool workspace_switch(struct sway_workspace *workspace,
 	}
 	seat_set_focus(seat, next);
 	arrange_workspace(workspace);
-	cursor_rebase(seat->cursor);
 	return true;
 }
 


### PR DESCRIPTION
This approaches cursor rebasing from a different angle. Rather than littering the codebase with `cursor_rebase` calls and using transaction callbacks, this just runs `cursor_rebase` after applying every transaction - but only if there's outputs connected, because otherwise it causes a crash during shutdown.

There is one known case where we still need to call `cursor_rebase` directly, and that's when running `seat seat0 cursor move ...`. This command doesn't set anything as dirty so no transaction occurs.