### PR TITLE
Deny several commands when there's no outputs connected

### DIFF
--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -15,6 +15,10 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "floating",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 	if (!container && workspace->tiling->length == 0) {

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -224,6 +224,10 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (config->reading || !config->active) {
 		return cmd_results_new(CMD_DEFER, NULL, NULL);
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "focus",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_node *node = config->handler_context.node;
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -12,6 +12,10 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	if ((error = checkarg(argc, "fullscreen", EXPECTED_AT_MOST, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "fullscreen",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_node *node = config->handler_context.node;
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;

--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -88,6 +88,10 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	if (error) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "gaps",
+				"Can't run this command while there's no outputs connected.");
+	}
 
 	struct gaps_data data;
 

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -14,6 +14,10 @@ static void close_container_iterator(struct sway_container *con, void *data) {
 }
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "kill",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -99,6 +99,10 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	if ((error = checkarg(argc, "layout", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "layout",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -844,6 +844,10 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 	if ((error = checkarg(argc, "move", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "move",
+				"Can't run this command while there's no outputs connected.");
+	}
 
 	if (strcasecmp(argv[0], "left") == 0) {
 		return cmd_move_in_direction(MOVE_LEFT, argc, argv);

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -20,6 +20,10 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	if ((error = checkarg(argc, "rename", EXPECTED_AT_LEAST, 3))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "rename",
+				"Can't run this command while there's no outputs connected.");
+	}
 	if (strcasecmp(argv[0], "workspace") != 0) {
 		return cmd_results_new(CMD_INVALID, "rename", expected_syntax);
 	}

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -671,6 +671,10 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 }
 
 struct cmd_results *cmd_resize(int argc, char **argv) {
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "resize",
+				"Can't run this command while there's no outputs connected.");
+	}
 	struct sway_container *current = config->handler_context.container;
 	if (!current) {
 		return cmd_results_new(CMD_INVALID, "resize", "Cannot resize nothing");

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -87,6 +87,10 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "scratchpad",
 				"Expected 'scratchpad show'");
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "scratchpad",
+				"Can't run this command while there's no outputs connected.");
+	}
 	if (!root->scratchpad->length) {
 		return cmd_results_new(CMD_INVALID, "scratchpad",
 				"Scratchpad is empty");

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -28,6 +28,10 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 	if ((error = checkarg(argc, "split", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "split",
+				"Can't run this command while there's no outputs connected.");
+	}
 	if (strcasecmp(argv[0], "v") == 0 || strcasecmp(argv[0], "vertical") == 0) {
 		return do_split(L_VERT);
 	} else if (strcasecmp(argv[0], "h") == 0 ||

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -171,6 +171,10 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	if ((error = checkarg(argc, "swap", EXPECTED_AT_LEAST, 4))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "swap",
+				"Can't run this command while there's no outputs connected.");
+	}
 
 	if (strcasecmp(argv[0], "container") || strcasecmp(argv[1], "with")) {
 		return cmd_results_new(CMD_INVALID, "swap", EXPECTED_SYNTAX);

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -38,6 +38,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 	if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_INVALID, "workspace",
+				"Can't run this command while there's no outputs connected.");
+	}
 
 	int output_location = -1;
 	int gaps_location = -1;


### PR DESCRIPTION
Fixes #2972.

I probably haven't found them all, but these are the ones that are likely to be bound to shortcuts and which will cause crashes.