### PR TITLE
Update workspace.c

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -108,6 +108,9 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 	} else {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, "workspace", NULL);
+		} else if (!root->outputs->length) {
+			return cmd_results_new(CMD_INVALID, "workspace",
+					"Can't run this command while there's no outputs connected.");
 		}
 
 		bool no_auto_back_and_forth = false;

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -38,10 +38,6 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 	if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "workspace",
-				"Can't run this command while there's no outputs connected.");
-	}
 
 	int output_location = -1;
 	int gaps_location = -1;


### PR DESCRIPTION
#2975 added an output requirement to the workspace command. This PR removes this requirement as this broke assigning workspaces to outputs in the config file and using the workspace command in the config file to autostart programs on specific workspaces on startup.
Fixes #2978 