### PR TITLE
sway-ipc: don't log errno if unneeded and add more descriptive errors

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -655,7 +655,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		struct json_object *request = json_tokener_parse(buf);
 		if (request == NULL) {
 			client_valid = ipc_send_reply(client, "{\"success\": false}", 18);
-			wlr_log_errno(WLR_INFO, "Failed to read request");
+			wlr_log(WLR_INFO, "Failed to parse subscribe request");
 			goto exit_cleanup;
 		}
 
@@ -684,7 +684,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client_valid =
 					ipc_send_reply(client, "{\"success\": false}", 18);
 				json_object_put(request);
-				wlr_log_errno(WLR_INFO, "Failed to parse request");
+				wlr_log(WLR_INFO, "Unsupported event type in subscribe request");
 				goto exit_cleanup;
 			}
 		}


### PR DESCRIPTION
As discussed in #2967.

The error paths in the handling of the SUBSCRIBE message used `wlr_log_errno()`, which appends the textual representation of `errno`.

In the first case, after failing to parse the message with Json-C, "Failed to read request" is printed.
This is misleading, since it was read correctly, it just wasn't valid JSON. Also, Json-C doesn't set `errno`, so either we use `wlr_log()` or also switch on `json_tokener_get_error()` and build a more detailed error message. The latter is not worth the boilerplate IMO.

Secondly, if an unsupported event name is encountered, the message was "Failed to parse request". I changed this to "Unsupported event type in subscribe request". I changed to `wlr_log()` as above.