### PR TITLE
Fix #2992

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -66,7 +66,6 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	}
 	struct wlr_output *wlr_output = output->wlr_output;
 	output->enabled = true;
-	apply_output_config(oc, output);
 	list_add(root->outputs, output);
 
 	output->lx = wlr_output->lx;
@@ -97,6 +96,8 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		wl_list_init(&output->layers[i]);
 	}
 	wl_signal_init(&output->events.destroy);
+
+	apply_output_config(oc, output);
 
 	input_manager_configure_xcursor();
 


### PR DESCRIPTION
Move a function call, such that data it depends on is initialized before.

This fixed the crash described in #2992 for me. Previously I was able to reproduce the crash, every time I was using an external monitor.