### PR TITLE
Respect border settings when rendering lone tabbed/stacked child

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -781,6 +781,13 @@ static void render_containers_stacked(struct sway_output *output,
 
 static void render_containers(struct sway_output *output,
 		pixman_region32_t *damage, struct parent_data *parent) {
+	if (parent->children->length == 1) {
+		struct sway_container *child = parent->children->items[0];
+		if (child->view) {
+			render_containers_linear(output, damage, parent);
+			return;
+		}
+	}
 	switch (parent->layout) {
 	case L_NONE:
 	case L_HORIZ:

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -242,23 +242,23 @@ void view_autoconfigure(struct sway_view *view) {
 		view->border_bottom = bottom_y != ws->y + ws->height;
 	}
 
-	double x, y, width, height;
-	x = y = width = height = 0;
-	double y_offset = 0;
-
 	// In a tabbed or stacked container, the container's y is the top of the
 	// title area. We have to offset the surface y by the height of the title,
 	// bar, and disable any top border because we'll always have the title bar.
+	double y_offset = 0;
 	enum sway_container_layout layout = container_parent_layout(con);
-	if (layout == L_TABBED && !container_is_floating(con)) {
-		y_offset = container_titlebar_height();
-		view->border_top = false;
-	} else if (layout == L_STACKED && !container_is_floating(con)) {
-		list_t *siblings = container_get_siblings(con);
-		y_offset = container_titlebar_height() * siblings->length;
-		view->border_top = false;
+	list_t *siblings = container_get_siblings(con);
+	if (siblings->length > 1 && !container_is_floating(con)) {
+		if (layout == L_TABBED) {
+			y_offset = container_titlebar_height();
+			view->border_top = false;
+		} else if (layout == L_STACKED) {
+			y_offset = container_titlebar_height() * siblings->length;
+			view->border_top = false;
+		}
 	}
 
+	double x, y, width, height = 0;
 	switch (view->border) {
 	case B_CSD:
 	case B_NONE:


### PR DESCRIPTION
In i3, when a child of a tabbed or stacked container has no siblings, its border settings are respected.

This patch achieves the same effect by rendering a lone tabbed/stacked child as if it's a linear container. This makes the border settings be respected.

Over in `view_autoconfigure`, we compensate for this by only adjusting `y_offset` if there's multiple children.

When the lone child is itself a split container, I'm taking a guess that rendering the tab title (containing the tree representation) is the ideal thing to do here.

Tested with `hide_edge_borders smart`, `hide_edge_borders none`, and with the lone child being a split container.

Fixes #2912.