### PR TITLE
tree/view.c: fix uninitialized variables warning

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -258,7 +258,7 @@ void view_autoconfigure(struct sway_view *view) {
 		}
 	}
 
-	double x, y, width, height = 0;
+	double x = 0, y = 0, width = 0, height = 0;
 	switch (view->border) {
 	case B_CSD:
 	case B_NONE:


### PR DESCRIPTION
I don't know if it's the project settings or the way the meson infra works in `nixpkgs`, but my package is broken without this change. (my toolchain is treating warnings as errors.) Plus, I figure this can only help.

Thanks.

cc: @RyanDwyer the change came from (https://github.com/colemickens/sway/commit/65328ef60c9468ae44b4b1d6316d604c47293ec3#diff-819010104a02bd78a3801147b06a4d57)