### PR TITLE
Use output identifier for workspace config

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -86,6 +86,8 @@ void output_damage_whole_container(struct sway_output *output,
 
 struct sway_output *output_by_name(const char *name);
 
+struct sway_output *output_by_identifier(const char *identifier);
+
 void output_sort_workspaces(struct sway_output *output);
 
 struct output_config *output_find_config(struct sway_output *output);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -39,6 +39,19 @@ struct sway_output *output_by_name(const char *name) {
 	return NULL;
 }
 
+struct sway_output *output_by_identifier(const char *identifier) {
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		char output_identifier[128];
+		snprintf(output_identifier, sizeof(output_identifier), "%s %s %s", output->wlr_output->make,
+			output->wlr_output->model, output->wlr_output->serial);
+		if (strcasecmp(output_identifier, identifier) == 0) {
+			return output;
+		}
+	}
+	return NULL;
+}
+
 /**
  * Rotate a child's position relative to a parent. The parent size is (pw, ph),
  * the child position is (*sx, *sy) and its size is (sw, sh).

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -35,6 +35,10 @@ struct sway_output *workspace_get_initial_output(const char *name) {
 	struct workspace_config *wsc = workspace_find_config(name);
 	if (wsc && wsc->output) {
 		struct sway_output *output = output_by_name(wsc->output);
+		if (!output) {
+			output = output_by_identifier(wsc->output);
+		}
+		
 		if (output) {
 			return output;
 		}
@@ -143,7 +147,11 @@ void workspace_consider_destroy(struct sway_workspace *ws) {
 static bool workspace_valid_on_output(const char *output_name,
 		const char *ws_name) {
 	struct workspace_config *wsc = workspace_find_config(ws_name);
-	return !wsc || !wsc->output || strcmp(wsc->output, output_name) == 0;
+	char identifier[128];
+	struct sway_output *output = output_by_name(output_name);
+	output_get_identifier(identifier, sizeof(identifier), output);
+		
+	return !wsc || !wsc->output || strcmp(wsc->output, output_name) == 0 || strcasecmp(identifier, output_name) == 0;
 }
 
 static void workspace_name_from_binding(const struct sway_binding * binding,


### PR DESCRIPTION
This adds the ability to address outputs by their identifier when using the workspace command.

A config for this could look something like this:
```
workspace 1 output 'Dell Inc. DELL U2415 08DXD49E5DUL'
```

Closes #2991