### PR TITLE
ipc: make json for view match i3's output more closely

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -229,10 +229,6 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "app_id",
 			app_id ? json_object_new_string(app_id) : NULL);
 
-	const char *class = view_get_class(c->view);
-	json_object_object_add(object, "class",
-			class ? json_object_new_string(class) : NULL);
-
 	json_object *marks = json_object_new_array();
 	list_t *view_marks = c->view->marks;
 	for (int i = 0; i < view_marks->length; ++i) {
@@ -269,6 +265,7 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 		json_object *window_props = json_object_new_object();
 
+		const char *class = view_get_class(c->view);
 		json_object_object_add(window_props, "class",
 				class ? json_object_new_string(class) : NULL);
 		const char *instance = view_get_instance(c->view);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -266,13 +266,16 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 		json_object *window_props = json_object_new_object();
 
 		const char *class = view_get_class(c->view);
-		json_object_object_add(window_props, "class",
-				class ? json_object_new_string(class) : NULL);
+		if (class) {
+			json_object_object_add(window_props, "class", json_object_new_string(class));
+		}
 		const char *instance = view_get_instance(c->view);
-		json_object_object_add(window_props, "instance",
-				instance ? json_object_new_string(instance) : NULL);
-		json_object_object_add(window_props, "title",
-				c->title ? json_object_new_string(c->title) : NULL);
+		if (instance) {
+			json_object_object_add(window_props, "instance", json_object_new_string(instance));
+		}
+		if (c->title) {
+			json_object_object_add(window_props, "title", json_object_new_string(c->title));
+		}
 
 		// the transient_for key is always present in i3's output
 		uint32_t parent_id = view_get_x11_parent_id(c->view);
@@ -281,8 +284,7 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 		const char *role = view_get_window_role(c->view);
 		if (role) {
-			json_object_object_add(window_props, "window_role",
-					json_object_new_string(role));
+			json_object_object_add(window_props, "window_role", json_object_new_string(role));
 		}
 
 		json_object_object_add(object, "window_properties", window_props);


### PR DESCRIPTION
It turns out that i3 does not have a `class` key in the json description
of a view, but provides it through `window_properties.class`. Since
`window_properties` has been added by 8fc9328, we can remove `class`
altogether.

In addition, all of the entries in `window_properties`, save for `transient_for`, are apparently omitted when null.