### PR TITLE
input-manager: consider cursor warping on input_manager_set_focus

### DIFF
--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -431,6 +431,7 @@ void input_manager_set_focus(struct sway_node *node) {
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
 		seat_set_focus(seat, node);
+		seat_consider_warp_to_focus(seat);
 	}
 }
 


### PR DESCRIPTION
input_manager_set_focus is used to set the focus after mapping the view in
view_map. This needs to consider to warp the cursor as well, since for
WARP_CONTAINER, the cursor should warp to the newly created view.

OT:
The only place where `input_manager_set_focus` is used is inside the `view_map`function. We could remove the function and open code it into `view_map`.