### PR TITLE
output: initialize layers before usage in apply_config

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -65,6 +65,12 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		return;
 	}
 	struct wlr_output *wlr_output = output->wlr_output;
+	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
+	for (size_t i = 0; i < len; ++i) {
+		wl_list_init(&output->layers[i]);
+	}
+	wl_signal_init(&output->events.destroy);
+
 	output->enabled = true;
 	apply_output_config(oc, output);
 	list_add(root->outputs, output);
@@ -91,12 +97,6 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		free(ws_name);
 		ipc_event_workspace(NULL, ws, "init");
 	}
-
-	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
-	for (size_t i = 0; i < len; ++i) {
-		wl_list_init(&output->layers[i]);
-	}
-	wl_signal_init(&output->events.destroy);
 
 	input_manager_configure_xcursor();
 


### PR DESCRIPTION
The previous pull request #2993 tried to fix this by moving the function which
used the layers after the initilization.
Since this initialization is done unconditionally only depending on the struct
definition, move the layer initialization to the beginning of the function.

Fixes #2992