### PR TITLE
Handle sigchld instead of blocking on waitpid

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -535,8 +535,6 @@ void load_swaybar(struct bar_config *bar);
 
 void load_swaybars(void);
 
-void terminate_swaybg(pid_t pid);
-
 struct bar_config *default_bar_config(void);
 
 void free_bar_config(struct bar_config *bar);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -23,6 +23,8 @@ struct sway_server {
 	struct wl_event_loop *wl_event_loop;
 	const char *socket;
 
+	struct wl_event_source *sigchld_source;
+
 	struct wlr_backend *backend;
 
 	struct wlr_compositor *compositor;


### PR DESCRIPTION
This stops any potential blocking when killing swaybg (e.g. reloading config). We also forcefully close their wayland connection, in case they're slow to die and we start a new swaybg.

This fixes an issue that was reported by someone on IRC, but doesn't have a github issue.