### PR TITLE
cursor: fix uninitialized pointer in cursor_rebase

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -585,7 +585,7 @@ static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 
 void cursor_rebase(struct sway_cursor *cursor) {
 	uint32_t time_msec = get_current_time_msec();
-	struct wlr_surface *surface;
+	struct wlr_surface *surface = NULL;
 	double sx, sy;
 	cursor->previous.node = node_at_coords(cursor->seat,
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);


### PR DESCRIPTION
The missing initialization of the pointer `struct wlr_surface *surface`  can lead to the following problem: If the next function call
```
cursor->previous.node = node_at_coords(cursor->seat,
			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
```
doesn't set `surface`, then the following function call
```
cursor_do_rebase(cursor, time_msec, cursor->previous.node, surface, sx, sy);
```
uses this uninitialized pointer (which is possibly not `NULL`). By looking at the definition of this function
```
static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 		struct sway_node *node, struct wlr_surface *surface,
 		double sx, double sy) {
 	// Handle cursor image
 	if (surface) {
 		// Reset cursor if switching between clients
 		struct wl_client *client = wl_resource_get_client(surface->resource);
                ...
```
one can see that this could lead to a segfault in `wl_resource_get_client(surface->resource)`.
This patch fixes the problem by initializing the pointer to `NULL`

I think the described problem could be the cause of the **2nd** crash @emersion mentioned in #3015.
