### PR TITLE
Add scroll factor input command.

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -3,6 +3,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <float.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -138,6 +139,17 @@ bool parse_boolean(const char *boolean, bool current) {
 	}
 	// All other values are false to match i3
 	return false;
+}
+
+float parse_float(const char *value) {
+	errno = 0;
+	char *end;
+	float flt = strtof(value, &end);
+	if (*end || errno) {
+		wlr_log(WLR_DEBUG, "Invalid float value '%s', defaulting to NAN", value);
+		return NAN;
+	}
+	return flt;
 }
 
 enum wlr_direction opposite_direction(enum wlr_direction d) {

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -229,6 +229,7 @@ sway_cmd input_cmd_map_to_output;
 sway_cmd input_cmd_middle_emulation;
 sway_cmd input_cmd_natural_scroll;
 sway_cmd input_cmd_pointer_accel;
+sway_cmd input_cmd_scroll_factor;
 sway_cmd input_cmd_repeat_delay;
 sway_cmd input_cmd_repeat_rate;
 sway_cmd input_cmd_scroll_button;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -100,6 +100,7 @@ struct input_config {
 	int middle_emulation;
 	int natural_scroll;
 	float pointer_accel;
+	float scroll_factor;
 	int repeat_delay;
 	int repeat_rate;
 	int scroll_button;

--- a/include/util.h
+++ b/include/util.h
@@ -59,6 +59,12 @@ uint32_t parse_color(const char *color);
  */
 bool parse_boolean(const char *boolean, bool current);
 
+/**
+ * Given a string that represents a floating point value, return a float.
+ * Returns NAN on error.
+ */
+float parse_float(const char *value);
+
 enum wlr_direction opposite_direction(enum wlr_direction d);
 
 #endif

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -22,6 +22,7 @@ static struct cmd_handler input_handlers[] = {
 	{ "repeat_delay", input_cmd_repeat_delay },
 	{ "repeat_rate", input_cmd_repeat_rate },
 	{ "scroll_button", input_cmd_scroll_button },
+	{ "scroll_factor", input_cmd_scroll_factor },
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
 	{ "tap_button_map", input_cmd_tap_button_map },

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -1,8 +1,10 @@
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "util.h"
 
 struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -15,8 +17,11 @@ struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 			"pointer_accel", "No input device defined.");
 	}
 
-	float pointer_accel = atof(argv[0]);
-	if (pointer_accel < -1 || pointer_accel > 1) {
+	float pointer_accel = parse_float(argv[0]);
+	if (isnan(pointer_accel)) {
+		return cmd_results_new(CMD_INVALID, "pointer_accel",
+			"Invalid pointer accel; expected float.");
+	} if (pointer_accel < -1 || pointer_accel > 1) {
 		return cmd_results_new(CMD_INVALID, "pointer_accel",
 			"Input out of range [-1, 1]");
 	}

--- a/sway/commands/input/scroll_factor.c
+++ b/sway/commands/input/scroll_factor.c
@@ -1,0 +1,32 @@
+#include <errno.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_scroll_factor(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "scroll_factor", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE,
+			"scroll_factor", "No input device defined.");
+	}
+
+	float scroll_factor = parse_float(argv[0]);
+	if (isnan(scroll_factor)) {
+		return cmd_results_new(CMD_INVALID, "scroll_factor",
+			"Invalid scroll factor; expected float.");
+	} else if (scroll_factor < 0) {
+		return cmd_results_new(CMD_INVALID, "scroll_factor",
+			"Scroll factor cannot be negative.");
+	}
+	ic->scroll_factor = scroll_factor;
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -29,6 +29,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->natural_scroll = INT_MIN;
 	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
+	input->scroll_factor = FLT_MIN;
 	input->scroll_button = INT_MIN;
 	input->scroll_method = INT_MIN;
 	input->left_handed = INT_MIN;
@@ -67,6 +68,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->pointer_accel != FLT_MIN) {
 		dst->pointer_accel = src->pointer_accel;
+	}
+	if (src->scroll_factor != FLT_MIN) {
+		dst->scroll_factor = src->scroll_factor;
 	}
 	if (src->repeat_delay != INT_MIN) {
 		dst->repeat_delay = src->repeat_delay;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -135,6 +135,7 @@ sway_sources = files(
 	'commands/input/repeat_delay.c',
 	'commands/input/repeat_rate.c',
 	'commands/input/scroll_button.c',
+	'commands/input/scroll_factor.c',
 	'commands/input/scroll_method.c',
 	'commands/input/tap.c',
 	'commands/input/tap_button_map.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -105,13 +105,17 @@ The following commands may only be used in the configuration file.
 *input* <identifier> repeat\_rate <characters per second>
 	Sets the frequency of key repeats once the repeat\_delay has passed.
 
-*input* <identifier> scroll\_method none|two\_finger|edge|on\_button\_down
-	Changes the scroll method for the specified input device.
-
 *input* <identifier> scroll\_button <button\_identifier>
 	Sets button used for scroll\_method on\_button\_down. The button identifier
 	can be obtained from `libinput debug-events`.
 	If set to 0, it disables the scroll\_button on\_button\_down.
+
+*input* <identifier> scroll\_factor <floating point value>
+	Changes the scroll factor for the specified input device. Scroll speed will
+	be scaled by the given value, which must be non-negative.
+
+*input* <identifier> scroll\_method none|two\_finger|edge|on\_button\_down
+	Changes the scroll method for the specified input device.
 
 *input* <identifier> tap enabled|disabled
 	Enables or disables tap for specified input device.


### PR DESCRIPTION
This commit adds a `scroll_factor` input command whose value is used as a multiplier for axis event deltas received from a device. Put simply, this means that scrolling speed can now be adjusted, a configuration feature that libinput itself lacks. At least on my laptop's touchpad, such a change is sorely needed.

For example, adding `scroll_factor 0.5` under a device's `input` section will make scrolling half as fast.

Fixes #3004.