### PR TITLE
binding: match single-key bindings if no multi-key binding matched

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -24,6 +24,7 @@ struct sway_shortcut_state {
 	uint32_t last_keycode;
 	uint32_t last_raw_modifiers;
 	size_t npressed;
+	uint32_t current_key;
 };
 
 struct sway_keyboard {


### PR DESCRIPTION
This makes bindings more snappy when the user is typing faster than
his keycaps are releasing.

Signed-off-by: Franklin "Snaipe" Mathieu <me@snai.pe>