### PR TITLE
Don't commit transaction in output_layout_handle_change

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -19,7 +19,6 @@ struct sway_root *root;
 static void output_layout_handle_change(struct wl_listener *listener,
 		void *data) {
 	arrange_root();
-	transaction_commit_dirty();
 }
 
 struct sway_root *root_create(void) {


### PR DESCRIPTION
Because this is only ever emitted by wlroots in response to a direct function call by us (such as in `apply_output_config`) or in response to an output event such as a mode event, and we already commit transactions in the output event handlers.

This prevents creating a transaction while the tree is in an inconsistent state, which caused a crash.

Probably fixes #3015, but I can't reproduce it.