### PR TITLE
Wrap to fartherest output when running focus output

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -1,4 +1,5 @@
 #define _XOPEN_SOURCE 700
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -137,4 +138,19 @@ bool parse_boolean(const char *boolean, bool current) {
 	}
 	// All other values are false to match i3
 	return false;
+}
+
+enum wlr_direction opposite_direction(enum wlr_direction d) {
+	switch (d) {
+	case WLR_DIRECTION_UP:
+		return WLR_DIRECTION_DOWN;
+	case WLR_DIRECTION_DOWN:
+		return WLR_DIRECTION_UP;
+	case WLR_DIRECTION_RIGHT:
+		return WLR_DIRECTION_LEFT;
+	case WLR_DIRECTION_LEFT:
+		return WLR_DIRECTION_RIGHT;
+	}
+	assert(false);
+	return 0;
 }

--- a/include/util.h
+++ b/include/util.h
@@ -59,4 +59,6 @@ uint32_t parse_color(const char *color);
  */
 bool parse_boolean(const char *boolean, bool current);
 
+enum wlr_direction opposite_direction(enum wlr_direction d);
+
 #endif

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -196,6 +196,17 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 		}
 		struct sway_workspace *ws = seat_get_focused_workspace(seat);
 		output = output_get_in_direction(ws->output, direction);
+
+		if (!output) {
+			int center_lx = ws->output->lx + ws->output->width / 2;
+			int center_ly = ws->output->ly + ws->output->height / 2;
+			struct wlr_output *target = wlr_output_layout_farthest_output(
+					root->output_layout, opposite_direction(direction),
+					ws->output->wlr_output, center_lx, center_ly);
+			if (target) {
+				output = output_from_wlr_output(target);
+			}
+		}
 	}
 
 	free(identifier);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -27,19 +27,6 @@ static const char *expected_syntax =
 	"'move <container|window|workspace> [to] output <name|direction>' or "
 	"'move <container|window> [to] mark <mark>'";
 
-enum wlr_direction opposite_direction(enum wlr_direction d) {
-	switch (d) {
-		case WLR_DIRECTION_UP:
-			return WLR_DIRECTION_DOWN;
-		case WLR_DIRECTION_DOWN:
-			return WLR_DIRECTION_UP;
-		case WLR_DIRECTION_RIGHT:
-			return WLR_DIRECTION_LEFT;
-		default:
-			return WLR_DIRECTION_RIGHT;
-	}
-}
-
 static struct sway_output *output_in_direction(const char *direction_string,
 		struct sway_output *reference, int ref_lx, int ref_ly) {
 	struct {


### PR DESCRIPTION
Also moves the `opposite_direction` function into `util.c` as it's used in two places now.

Fixes #3030.