### PR TITLE
Move view border properties to container struct

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -53,16 +53,16 @@ struct sway_container_state {
 	struct sway_container *focused_inactive_child;
 	bool focused;
 
-	// View properties
-	double view_x, view_y;
-	double view_width, view_height;
-
 	enum sway_container_border border;
 	int border_thickness;
 	bool border_top;
 	bool border_bottom;
 	bool border_left;
 	bool border_right;
+
+	// View properties
+	double view_x, view_y;
+	double view_width, view_height;
 };
 
 struct sway_container {
@@ -90,6 +90,18 @@ struct sway_container {
 	double saved_width, saved_height;
 
 	bool is_fullscreen;
+
+	enum sway_container_border border;
+
+	// Used when the view changes to CSD unexpectedly. This will be a non-B_CSD
+	// border which we use to restore when the view returns to SSD.
+	enum sway_container_border saved_border;
+
+	int border_thickness;
+	bool border_top;
+	bool border_bottom;
+	bool border_left;
+	bool border_right;
 
 	// The gaps currently applied to the container.
 	double current_gaps;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -80,23 +80,7 @@ struct sway_view {
 
 	char *title_format;
 
-	// Our border types are B_NONE, B_PIXEL, B_NORMAL and B_CSD. We normally
-	// just assign this to the border property and ignore the other two.
-	// However, when a view using CSD is tiled, we want to render our own
-	// borders as well. So in this case the border property becomes one of the
-	// first three, and using_csd is true.
-	// Lastly, views can change their decoration mode at any time. When an SSD
-	// view becomes CSD without our approval, we save the SSD border type so it
-	// can be restored if/when the view returns from CSD to SSD.
-	enum sway_container_border border;
-	enum sway_container_border saved_border;
 	bool using_csd;
-
-	int border_thickness;
-	bool border_top;
-	bool border_bottom;
-	bool border_left;
-	bool border_right;
 
 	struct timespec urgent;
 	bool allow_request_urgent;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -137,6 +137,12 @@ static void copy_container_state(struct sway_container *container,
 	state->is_fullscreen = container->is_fullscreen;
 	state->parent = container->parent;
 	state->workspace = container->workspace;
+	state->border = container->border;
+	state->border_thickness = container->border_thickness;
+	state->border_top = container->border_top;
+	state->border_left = container->border_left;
+	state->border_right = container->border_right;
+	state->border_bottom = container->border_bottom;
 
 	if (container->view) {
 		struct sway_view *view = container->view;
@@ -144,12 +150,6 @@ static void copy_container_state(struct sway_container *container,
 		state->view_y = view->y;
 		state->view_width = view->width;
 		state->view_height = view->height;
-		state->border = view->border;
-		state->border_thickness = view->border_thickness;
-		state->border_top = view->border_top;
-		state->border_left = view->border_left;
-		state->border_right = view->border_right;
-		state->border_bottom = view->border_bottom;
 	} else {
 		state->children = create_list();
 		list_cat(state->children, container->children);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -187,23 +187,22 @@ static enum wlr_edges find_edge(struct sway_container *cont,
 	if (!cont->view) {
 		return WLR_EDGE_NONE;
 	}
-	struct sway_view *view = cont->view;
-	if (view->border == B_NONE || !view->border_thickness ||
-			view->border == B_CSD) {
+	if (cont->border == B_NONE || !cont->border_thickness ||
+			cont->border == B_CSD) {
 		return WLR_EDGE_NONE;
 	}
 
 	enum wlr_edges edge = 0;
-	if (cursor->cursor->x < cont->x + view->border_thickness) {
+	if (cursor->cursor->x < cont->x + cont->border_thickness) {
 		edge |= WLR_EDGE_LEFT;
 	}
-	if (cursor->cursor->y < cont->y + view->border_thickness) {
+	if (cursor->cursor->y < cont->y + cont->border_thickness) {
 		edge |= WLR_EDGE_TOP;
 	}
-	if (cursor->cursor->x >= cont->x + cont->width - view->border_thickness) {
+	if (cursor->cursor->x >= cont->x + cont->width - cont->border_thickness) {
 		edge |= WLR_EDGE_RIGHT;
 	}
-	if (cursor->cursor->y >= cont->y + cont->height - view->border_thickness) {
+	if (cursor->cursor->y >= cont->y + cont->height - cont->border_thickness) {
 		edge |= WLR_EDGE_BOTTOM;
 	}
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -639,8 +639,8 @@ void container_init_floating(struct sway_container *con) {
 		view->y = ws->y + (ws->height - view->height) / 2;
 
 		// If the view's border is B_NONE then these properties are ignored.
-		view->border_top = view->border_bottom = true;
-		view->border_left = view->border_right = true;
+		con->border_top = con->border_bottom = true;
+		con->border_left = con->border_right = true;
 
 		container_set_geometry_from_floating_view(con);
 	}
@@ -662,7 +662,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		if (container->view) {
 			view_set_tiled(container->view, false);
 			if (container->view->using_csd) {
-				container->view->border = B_CSD;
+				container->border = B_CSD;
 			}
 		}
 		if (old_parent) {
@@ -688,7 +688,7 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		if (container->view) {
 			view_set_tiled(container->view, true);
 			if (container->view->using_csd) {
-				container->view->border = container->view->saved_border;
+				container->border = container->saved_border;
 			}
 		}
 		container->is_sticky = false;
@@ -710,9 +710,9 @@ void container_set_geometry_from_floating_view(struct sway_container *con) {
 	size_t border_width = 0;
 	size_t top = 0;
 
-	if (view->border != B_CSD) {
-		border_width = view->border_thickness * (view->border != B_NONE);
-		top = view->border == B_NORMAL ?
+	if (con->border != B_CSD) {
+		border_width = con->border_thickness * (con->border != B_NONE);
+		top = con->border == B_NORMAL ?
 			container_titlebar_height() : border_width;
 	}
 


### PR DESCRIPTION
This will be needed to implement layout saving and restoring, as we need to be able to configure borders on a placeholder container which has no view.