### PR TITLE
Add relative output transform

### DIFF
--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -1,6 +1,8 @@
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "log.h"
+#include "sway/output.h"
 
 struct cmd_results *output_cmd_transform(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
@@ -10,30 +12,52 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "output",
 			"Missing transform argument.");
 	}
-
-	struct output_config *output = config->handler_context.output_config;
+	enum wl_output_transform transform;
 	if (strcmp(*argv, "normal") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_NORMAL;
+		transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	} else if (strcmp(*argv, "90") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_90;
+		transform = WL_OUTPUT_TRANSFORM_90;
 	} else if (strcmp(*argv, "180") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_180;
+		transform = WL_OUTPUT_TRANSFORM_180;
 	} else if (strcmp(*argv, "270") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_270;
+		transform = WL_OUTPUT_TRANSFORM_270;
 	} else if (strcmp(*argv, "flipped") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_FLIPPED;
+		transform = WL_OUTPUT_TRANSFORM_FLIPPED;
 	} else if (strcmp(*argv, "flipped-90") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_FLIPPED_90;
+		transform = WL_OUTPUT_TRANSFORM_FLIPPED_90;
 	} else if (strcmp(*argv, "flipped-180") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_FLIPPED_180;
+		transform = WL_OUTPUT_TRANSFORM_FLIPPED_180;
 	} else if (strcmp(*argv, "flipped-270") == 0) {
-		output->transform = WL_OUTPUT_TRANSFORM_FLIPPED_270;
+		transform = WL_OUTPUT_TRANSFORM_FLIPPED_270;
 	} else {
 		return cmd_results_new(CMD_INVALID, "output",
 			"Invalid output transform.");
 	}
-
+	struct output_config *output = config->handler_context.output_config;
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
+	if (argc > 1 &&
+			(strcmp(argv[1], "clockwise") == 0 || strcmp(argv[1], "anticlockwise") == 0)) {
+		if (!sway_assert(output->name != NULL, "Output config name not set")) {
+			return NULL;
+		}
+		if (strcmp(output->name, "*") == 0) {
+			return cmd_results_new(CMD_INVALID, "output",
+				"Cannot apply relative transform to all outputs.");
+		}
+		struct sway_output *s_output = output_by_name(output->name);
+		if (s_output == NULL) {
+			return cmd_results_new(CMD_INVALID, "output",
+				"Cannot apply relative transform to unknown output %s", output->name);
+		}
+		if (strcmp(argv[1], "anticlockwise") == 0) {
+			transform = wlr_output_transform_invert(transform);
+		}
+		struct wlr_output *w_output = s_output->wlr_output;
+		transform = wlr_output_transform_compose(w_output->transform, transform);
+		config->handler_context.leftovers.argv += 1;
+		config->handler_context.leftovers.argc -= 1;
+	}
+	output->transform = transform;
 	return NULL;
 }

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -59,10 +59,13 @@ must be separated by one space. For example:
 	Sets the background of the given output to the specified color. _color_
 	should be specified as _#RRGGBB_. Alpha is not supported.
 
-*output* <name> transform <transform>
+*output* <name> transform <transform> [clockwise|anticlockwise]
 	Sets the background transform to the given value. Can be one of "90", "180",
 	"270" for rotation; or "flipped", "flipped-90", "flipped-180", "flipped-270"
-	to apply a rotation and flip, or "normal" to apply no transform.
+	to apply a rotation and flip, or "normal" to apply no transform. If a single
+	output is chosen and a rotation direction is specified 
+	(_clockwise_ or _anticlockwise_) then the transform is added or 
+	subtracted from the current tranform.
 
 *output* <name> disable|enable
 	Enables or disables the specified output (all outputs are enabled by


### PR DESCRIPTION
This commit enhances the output transform
command with options for a relative transform,
i.e. the provided transform will be applied as
an offset to the current transform. Append
`clockwise` to rotate clockwise from the current
rotation, or `anticlockwise` to rotate in the
opposite direction.

For example, if the output LVDS-1 is rotated 90 degrees
clockwise, the command `output LVDS-1 transform 90 clockwise`
will rotate the display to 180 degrees. All transform
options are supported, including flipped transforms.