### PR TITLE
Correct "Current mode" in `swaymsg -t get_outputs` for scaled outputs

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -136,12 +136,17 @@ static void ipc_json_describe_output(struct sway_output *output,
 			json_object_new_int(mode->width));
 		json_object_object_add(mode_object, "height",
 			json_object_new_int(mode->height));
-		json_object_object_add(mode_object, "refresh",
-			json_object_new_int(mode->refresh));
 		json_object_array_add(modes_array, mode_object);
 	}
 
 	json_object_object_add(object, "modes", modes_array);
+
+	json_object *current_mode_object = json_object_new_object();
+	json_object_object_add(current_mode_object, "width",
+		json_object_new_int(wlr_output->width));
+	json_object_object_add(current_mode_object, "height",
+		json_object_new_int(wlr_output->height));
+	json_object_object_add(object, "current_mode", current_mode_object);
 
 	struct sway_node *parent = node_get_parent(&output->node);
 	struct wlr_box parent_box = {0, 0, 0, 0};

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -183,13 +183,15 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(rect, "height", &height);
 	json_object *modes;
 	json_object_object_get_ex(o, "modes", &modes);
+	json_object *current_mode;
+	json_object_object_get_ex(o, "current_mode", &current_mode);
 
 	if (json_object_get_boolean(active)) {
 		printf(
 			"Output %s '%s %s %s'%s\n"
 			"  Current mode: %dx%d @ %f Hz\n"
 			"  Position: %d,%d\n"
-			"  Scale factor: %dx\n"
+			"  Scale factor: %f\n"
 			"  Transform: %s\n"
 			"  Workspace: %s\n",
 			json_object_get_string(name),
@@ -197,10 +199,13 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_string(model),
 			json_object_get_string(serial),
 			json_object_get_boolean(focused) ? " (focused)" : "",
-			json_object_get_int(width), json_object_get_int(height),
+			json_object_get_int(
+				json_object_object_get(current_mode, "width")),
+			json_object_get_int(
+				json_object_object_get(current_mode, "height")),
 			(float)json_object_get_int(refresh) / 1000,
 			json_object_get_int(x), json_object_get_int(y),
-			json_object_get_int(scale),
+			json_object_get_double(scale),
 			json_object_get_string(transform),
 			json_object_get_string(ws)
 		);


### PR DESCRIPTION
Fixes #3051.

Fixed output example:

```
Output eDP-1 'Sharp Corporation 0x148B 0x00000000'
  Current mode: 3840x2160 @ 59.997002 Hz
  Position: 3440,0
  Scale factor: 2x
  Transform: normal
  Workspace: 1
  Available modes:
    3840x2160 @ 47.997002 Hz
    3840x2160 @ 59.997002 Hz
```