### PR TITLE
[DO NOT MERGE] config: allow for inline to end of line comments

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -415,7 +415,13 @@ struct cmd_results *config_command(char *exec) {
 	free(command);
 
 	// Strip quotes and unescape the string
-	for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
+	int i;
+	for (i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
+		if (strcmp(argv[i], "#") == 0) {
+			wlr_log(WLR_DEBUG, "Inline comment detected at argv[%d]."
+					"Ignoring all further arguments.", i);
+			break;
+		}
 		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
 				&& handler->handle != cmd_bindsym
 				&& handler->handle != cmd_bindcode
@@ -427,7 +433,7 @@ struct cmd_results *config_command(char *exec) {
 	}
 
 	// Run command
-	results = handler->handle(argc - 1, argv + 1);
+	results = handler->handle(i - 1, argv + 1);
 
 cleanup:
 	free_argv(argc, argv);


### PR DESCRIPTION
**THIS IS BRANCHED FROM #2979 SO THAT NEEDS TO BE MERGED FIRST**

Closes #3044 

Allows for the following syntax in the config: `command <arguments...> # the rest of this line is a comment`
Example: `input * repeat_delay 200 # milliseconds`

Note: The space before and after the `#` is mandatory otherwise the `#` will be seen as part of an argument (such as colors). If a `#` is needed as it's own argument, then it can be enclosed in quotes. For example, `bar bar-0 separator_symbol "#"`.