### PR TITLE
Implement layout-independent keysym bindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -577,7 +577,8 @@ void merge_input_config(struct input_config *dst, struct input_config *src);
 
 struct input_config *store_input_config(struct input_config *ic);
 
-struct xkb_rule_names input_config_get_rule_names(struct input_config *ic);
+void input_config_fill_rule_names(struct input_config *ic,
+		struct xkb_rule_names *rules);
 
 void free_input_config(struct input_config *ic);
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -408,14 +408,6 @@ enum alignment {
 };
 
 /**
- * The keysym to keycode translation.
- */
-struct keysym_translation_data {
-	struct xkb_keymap *xkb_keymap;
-	struct xkb_state *xkb_state;
-};
-
-/**
  * The configuration struct. The result of loading a config file.
  */
 struct sway_config {
@@ -518,7 +510,7 @@ struct sway_config {
 	list_t *ipc_policies;
 
 	// The keysym to keycode translation
-	struct keysym_translation_data keysym_translation;
+	struct xkb_state *keysym_translation_state;
 
 	// Context for command handlers
 	struct {

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -577,6 +577,8 @@ void merge_input_config(struct input_config *dst, struct input_config *src);
 
 struct input_config *store_input_config(struct input_config *ic);
 
+struct xkb_rule_names input_config_get_rule_names(struct input_config *ic);
+
 void free_input_config(struct input_config *ic);
 
 int seat_name_cmp(const void *item, const void *data);
@@ -655,7 +657,7 @@ void config_update_font_height(bool recalculate);
  */
 bool translate_binding(struct sway_binding *binding);
 
-void translate_keysyms(const char *layout);
+void translate_keysyms(struct input_config *input_config);
 
 void binding_add_translated(struct sway_binding *binding, list_t *bindings);
 

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -24,6 +24,7 @@ void free_sway_binding(struct sway_binding *binding) {
 	}
 
 	list_free_items_and_destroy(binding->keys);
+	list_free_items_and_destroy(binding->syms);
 	free(binding->input);
 	free(binding->command);
 	free(binding);
@@ -249,31 +250,41 @@ static struct cmd_results *switch_binding_remove(
 			switchcombo);
 }
 
-static struct cmd_results *binding_add(struct sway_binding *binding,
-		list_t *mode_bindings, const char *bindtype,
-		const char *keycombo, bool warn) {
-	// overwrite the binding if it already exists
-	bool overwritten = false;
+/**
+ * Insert or update the binding.
+ * Return the binding which has been replaced or NULL.
+ */
+static struct sway_binding *binding_upsert(struct sway_binding *binding,
+		list_t *mode_bindings) {
 	for (int i = 0; i < mode_bindings->length; ++i) {
 		struct sway_binding *config_binding = mode_bindings->items[i];
 		if (binding_key_compare(binding, config_binding)) {
-			sway_log(SWAY_INFO, "Overwriting binding '%s' for device '%s' "
-					"to `%s` from `%s`", keycombo, binding->input,
-					binding->command, config_binding->command);
-			if (warn) {
-				config_add_swaynag_warning("Overwriting binding"
-						"'%s' for device '%s' to `%s` from `%s`",
-						keycombo, binding->input, binding->command,
-						config_binding->command);
-			}
-			free_sway_binding(config_binding);
 			mode_bindings->items[i] = binding;
-			overwritten = true;
+			return config_binding;
 		}
 	}
 
-	if (!overwritten) {
-		list_add(mode_bindings, binding);
+	list_add(mode_bindings, binding);
+	return NULL;
+}
+
+static struct cmd_results *binding_add(struct sway_binding *binding,
+		list_t *mode_bindings, const char *bindtype,
+		const char *keycombo, bool warn) {
+	struct sway_binding *config_binding = binding_upsert(binding, mode_bindings);
+
+	if (config_binding) {
+		sway_log(SWAY_INFO, "Overwriting binding '%s' for device '%s' "
+				"to `%s` from `%s`", keycombo, binding->input,
+				binding->command, config_binding->command);
+		if (warn) {
+			config_add_swaynag_warning("Overwriting binding"
+					"'%s' for device '%s' to `%s` from `%s`",
+					keycombo, binding->input, binding->command,
+					config_binding->command);
+		}
+		free_sway_binding(config_binding);
+	} else {
 		sway_log(SWAY_DEBUG, "%s - Bound %s to command `%s` for device '%s'",
 				bindtype, keycombo, binding->command, binding->input);
 	}
@@ -329,7 +340,6 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 	bool exclude_titlebar = false;
 	bool warn = true;
 
-	// Handle --release and --locked
 	while (argc > 0) {
 		if (strcmp("--release", argv[0]) == 0) {
 			binding->flags |= BINDING_RELEASE;
@@ -339,6 +349,10 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			binding->flags |= BINDING_BORDER | BINDING_CONTENTS | BINDING_TITLEBAR;
 		} else if (strcmp("--border", argv[0]) == 0) {
 			binding->flags |= BINDING_BORDER;
+		} else if (strcmp("--to-code", argv[0]) == 0) {
+			if (!bindcode) {
+				binding->flags |= BINDING_CODE;
+			}
 		} else if (strcmp("--exclude-titlebar", argv[0]) == 0) {
 			exclude_titlebar = true;
 		} else if (strncmp("--input-device=", argv[0],
@@ -409,6 +423,12 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 
 	// sort ascending
 	list_qsort(binding->keys, key_qsort_cmp);
+
+	// translate keysyms into keycodes
+	if (!translate_binding(binding)) {
+		sway_log(SWAY_INFO,
+				"Unable to translate bindsym into bindcode: %s", argv[0]);
+	}
 
 	list_t *mode_bindings;
 	if (binding->type == BINDING_KEYCODE) {
@@ -564,5 +584,116 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	list_free(res_list);
 	if (success) {
 		ipc_event_binding(binding);
+	}
+}
+
+/**
+ * The last found keycode associated with the keysym
+ * and the total count of matches.
+ */
+struct keycode_matches {
+	xkb_keysym_t keysym;
+	xkb_keycode_t keycode;
+	int count;
+};
+
+/**
+ * Iterate through keycodes in the keymap to find ones matching
+ * the specified keysym.
+ */
+static void find_keycode(struct xkb_keymap *keymap,
+		xkb_keycode_t keycode, void *data) {
+	xkb_keysym_t keysym = xkb_state_key_get_one_sym(
+			config->keysym_translation.xkb_state, keycode);
+
+	if (keysym == XKB_KEY_NoSymbol) {
+		return;
+	}
+
+	struct keycode_matches *matches = data;
+	if (matches->keysym == keysym) {
+		matches->keycode = keycode;
+		matches->count++;
+	}
+}
+
+/**
+ * Return the keycode for the specified keysym.
+ */
+static struct keycode_matches get_keycode_for_keysym(xkb_keysym_t keysym) {
+	struct keycode_matches matches = {
+		.keysym = keysym,
+		.keycode = XKB_KEYCODE_INVALID,
+		.count = 0,
+	};
+
+	xkb_keymap_key_for_each(config->keysym_translation.xkb_keymap,
+			find_keycode, &matches);
+	return matches;
+}
+
+bool translate_binding(struct sway_binding *binding) {
+	if ((binding->flags & BINDING_CODE) == 0) {
+		return true;
+	}
+
+	switch (binding->type) {
+	// a bindsym to translate
+	case BINDING_KEYSYM:
+		binding->syms = binding->keys;
+		binding->keys = create_list();
+		break;
+	// a bindsym to re-translate
+	case BINDING_KEYCODE:
+		list_free_items_and_destroy(binding->keys);
+		binding->keys = create_list();
+		break;
+	default:
+		return true;
+	}
+
+	for (int i = 0; i < binding->syms->length; ++i) {
+		xkb_keysym_t *keysym = binding->syms->items[i];
+		struct keycode_matches matches = get_keycode_for_keysym(*keysym);
+
+		if (matches.count != 1) {
+			sway_log(SWAY_INFO, "Unable to convert keysym %d into"
+					" a single keycode (found %d matches)",
+					*keysym, matches.count);
+			goto error;
+		}
+
+		xkb_keycode_t *keycode = malloc(sizeof(xkb_keycode_t));
+		if (!keycode) {
+			sway_log(SWAY_ERROR, "Unable to allocate memory for a keycode");
+			goto error;
+		}
+
+		*keycode = matches.keycode;
+		list_add(binding->keys, keycode);
+	}
+
+	list_qsort(binding->keys, key_qsort_cmp);
+	binding->type = BINDING_KEYCODE;
+	return true;
+
+error:
+	list_free_items_and_destroy(binding->keys);
+	binding->type = BINDING_KEYSYM;
+	binding->keys = binding->syms;
+	binding->syms = NULL;
+	return false;
+}
+
+void binding_add_translated(struct sway_binding *binding,
+		list_t *mode_bindings) {
+	struct sway_binding *config_binding =
+		binding_upsert(binding, mode_bindings);
+
+	if (config_binding) {
+		sway_log(SWAY_INFO, "Overwriting binding for device '%s' "
+				"to `%s` from `%s`", binding->input,
+				binding->command, config_binding->command);
+		free_sway_binding(config_binding);
 	}
 }

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -604,7 +604,7 @@ struct keycode_matches {
 static void find_keycode(struct xkb_keymap *keymap,
 		xkb_keycode_t keycode, void *data) {
 	xkb_keysym_t keysym = xkb_state_key_get_one_sym(
-			config->keysym_translation.xkb_state, keycode);
+			config->keysym_translation_state, keycode);
 
 	if (keysym == XKB_KEY_NoSymbol) {
 		return;
@@ -627,7 +627,8 @@ static struct keycode_matches get_keycode_for_keysym(xkb_keysym_t keysym) {
 		.count = 0,
 	};
 
-	xkb_keymap_key_for_each(config->keysym_translation.xkb_keymap,
+	xkb_keymap_key_for_each(
+			xkb_state_get_keymap(config->keysym_translation_state),
 			find_keycode, &matches);
 	return matches;
 }

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -43,24 +43,17 @@ static struct cmd_handler input_config_handlers[] = {
  * Re-translate keysyms if a change in the input config could affect them.
  */
 static void retranslate_keysyms(struct input_config *input_config) {
-	bool matched = false;
 	for (int i = 0; i < config->input_configs->length; ++i) {
 		struct input_config *ic = config->input_configs->items[i];
-		matched |= ic->identifier == input_config->identifier;
-
-		// the first configured xkb_layout
 		if (ic->xkb_layout) {
-			if (matched) {
+			// this is the first config with xkb_layout
+			if (ic->identifier == input_config->identifier) {
 				translate_keysyms(ic->xkb_layout);
 			}
 
-			// nothing has changed
 			return;
 		}
 	}
-
-	// no xkb_layout has been set, restore the default
-	translate_keysyms(getenv("XKB_DEFAULT_LAYOUT"));
 }
 
 struct cmd_results *cmd_input(int argc, char **argv) {

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -48,7 +48,7 @@ static void retranslate_keysyms(struct input_config *input_config) {
 		if (ic->xkb_layout) {
 			// this is the first config with xkb_layout
 			if (ic->identifier == input_config->identifier) {
-				translate_keysyms(ic->xkb_layout);
+				translate_keysyms(ic);
 			}
 
 			return;

--- a/sway/config.c
+++ b/sway/config.c
@@ -340,7 +340,7 @@ static void config_defaults(struct sway_config *config) {
 
 	// The keysym to keycode translation
 	config->keysym_translation_state =
-		keysym_translation_state_create(getenv("XKB_DEFAULT_LAYOUT"));
+		keysym_translation_state_create(NULL);
 
 	return;
 cleanup:

--- a/sway/config.c
+++ b/sway/config.c
@@ -968,13 +968,12 @@ static void translate_binding_list(list_t *bindings, list_t *bindsyms,
 		struct sway_binding *binding = bindings->items[i];
 		translate_binding(binding);
 
-		list_t *bindings;
 		switch (binding->type) {
 		case BINDING_KEYSYM:
-			bindings = bindsyms;
+			binding_add_translated(binding, bindsyms);
 			break;
 		case BINDING_KEYCODE:
-			bindings = bindcodes;
+			binding_add_translated(binding, bindcodes);
 			break;
 		default:
 			sway_assert(false, "unexpected translated binding type: %d",
@@ -982,7 +981,6 @@ static void translate_binding_list(list_t *bindings, list_t *bindsyms,
 			break;
 		}
 
-		binding_add_translated(binding, bindings);
 	}
 }
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -337,7 +337,7 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->ipc_policies = create_list())) goto cleanup;
 
 	// The keysym to keycode translation
-	struct xkb_rule_names rules = {};
+	struct xkb_rule_names rules = {0};
 	config->keysym_translation_state =
 		keysym_translation_state_create(rules);
 
@@ -989,7 +989,8 @@ static void translate_binding_list(list_t *bindings, list_t *bindsyms,
 void translate_keysyms(struct input_config *input_config) {
 	keysym_translation_state_destroy(config->keysym_translation_state);
 
-	struct xkb_rule_names rules = input_config_get_rule_names(input_config);
+	struct xkb_rule_names rules = {0};
+	input_config_fill_rule_names(input_config, &rules);
 	config->keysym_translation_state =
 		keysym_translation_state_create(rules);
 

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -212,6 +212,18 @@ struct input_config *store_input_config(struct input_config *ic) {
 	return ic;
 }
 
+struct xkb_rule_names input_config_get_rule_names(struct input_config *ic) {
+	struct xkb_rule_names rules = {
+		.layout = ic->xkb_layout,
+		.model = ic->xkb_model,
+		.options = ic->xkb_options,
+		.rules = ic->xkb_rules,
+		.variant = ic->xkb_variant,
+	};
+
+	return rules;
+}
+
 void free_input_config(struct input_config *ic) {
 	if (!ic) {
 		return;

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -212,16 +212,13 @@ struct input_config *store_input_config(struct input_config *ic) {
 	return ic;
 }
 
-struct xkb_rule_names input_config_get_rule_names(struct input_config *ic) {
-	struct xkb_rule_names rules = {
-		.layout = ic->xkb_layout,
-		.model = ic->xkb_model,
-		.options = ic->xkb_options,
-		.rules = ic->xkb_rules,
-		.variant = ic->xkb_variant,
-	};
-
-	return rules;
+void input_config_fill_rule_names(struct input_config *ic,
+		struct xkb_rule_names *rules) {
+	rules->layout = ic->xkb_layout;
+	rules->model = ic->xkb_model;
+	rules->options = ic->xkb_options;
+	rules->rules = ic->xkb_rules;
+	rules->variant = ic->xkb_variant;
 }
 
 void free_input_config(struct input_config *ic) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -475,11 +475,9 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 	struct wlr_input_device *wlr_device =
 		keyboard->seat_device->input_device->wlr_device;
 
-	struct xkb_rule_names rules;
+	struct xkb_rule_names rules = {0};
 	if (input_config) {
-		rules = input_config_get_rule_names(input_config);
-	} else {
-		memset(&rules, 0, sizeof(rules));
+		input_config_fill_rule_names(input_config, &rules);
 	}
 
 	if (!rules.layout) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -470,39 +470,31 @@ struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,
 }
 
 void sway_keyboard_configure(struct sway_keyboard *keyboard) {
-	struct xkb_rule_names rules;
-	memset(&rules, 0, sizeof(rules));
 	struct input_config *input_config =
 		input_device_get_config(keyboard->seat_device->input_device);
 	struct wlr_input_device *wlr_device =
 		keyboard->seat_device->input_device->wlr_device;
 
-	if (input_config && input_config->xkb_layout) {
-		rules.layout = input_config->xkb_layout;
+	struct xkb_rule_names rules;
+	if (input_config) {
+		rules = input_config_get_rule_names(input_config);
 	} else {
+		memset(&rules, 0, sizeof(rules));
+	}
+
+	if (!rules.layout) {
 		rules.layout = getenv("XKB_DEFAULT_LAYOUT");
 	}
-	if (input_config && input_config->xkb_model) {
-		rules.model = input_config->xkb_model;
-	} else {
+	if (!rules.model) {
 		rules.model = getenv("XKB_DEFAULT_MODEL");
 	}
-
-	if (input_config && input_config->xkb_options) {
-		rules.options = input_config->xkb_options;
-	} else {
+	if (!rules.options) {
 		rules.options = getenv("XKB_DEFAULT_OPTIONS");
 	}
-
-	if (input_config && input_config->xkb_rules) {
-		rules.rules = input_config->xkb_rules;
-	} else {
+	if (!rules.rules) {
 		rules.rules = getenv("XKB_DEFAULT_RULES");
 	}
-
-	if (input_config && input_config->xkb_variant) {
-		rules.variant = input_config->xkb_variant;
-	} else {
+	if (!rules.variant) {
 		rules.variant = getenv("XKB_DEFAULT_VARIANT");
 	}
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -327,7 +327,7 @@ runtime.
 
 		for_window <criteria> move container to output <output>
 
-*bindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] [--input-device=<device>] [--no-warn] <key combo> <command>
+*bindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] [--to-code] [--input-device=<device>] [--no-warn] <key combo> <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
 	With the flag _--release_, the command is executed when the key combo is
@@ -337,6 +337,10 @@ runtime.
 	instead of any binding that is generic to all devices. By default, if you
 	overwrite a binding, swaynag will give you a warning. To silence this, use
 	the _--no-warn_ flag.
+
+	Bindings to keysyms are layout-dependent. This can be changed with the
+	_--to-code_ flag. In this case, the keysyms will be translated into the
+	corresponding keycodes in the first configured layout.
 
 	Mouse bindings operate on the container under the cursor instead of the
 	container that has focus. Mouse buttons can either be specified in the form


### PR DESCRIPTION
Fixes #2999.

The idea is to have an instance of default xkb_keymap and try to resolve bindsyms into bindcodes while binding.

If the conversion is successful, we just treat the binding as a bindcode. If the conversion has failed, we do not change the binding, so it will be processed as a normal bindsym.

In my configuration, all of the 80 bindsyms have been converted into bindcodes. I have tested the following and it worked in any keyboard layout:
* Default bindings
* Bindings with function keys
* Uppercase keysyms
* Special ones like XF86AudioRaiseVolume, XF86AudioMute, XF86MonBrightnessUp

I also checked a keysym with no simple keycode translation (the question mark, keysym `question`) and it worked as a keysym binding, however this kind of bindings still depends on the current keyboard layout.

This makes shortcut behavior more consistent with that of i3 and other programs (e.g. terminal emulators).