### PR TITLE
ipc: move refresh to current_mode

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -136,6 +136,8 @@ static void ipc_json_describe_output(struct sway_output *output,
 			json_object_new_int(mode->width));
 		json_object_object_add(mode_object, "height",
 			json_object_new_int(mode->height));
+		json_object_object_add(mode_object, "refresh",
+			json_object_new_int(mode->refresh));
 		json_object_array_add(modes_array, mode_object);
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -118,8 +118,6 @@ static void ipc_json_describe_output(struct sway_output *output,
 			json_object_new_string(wlr_output->serial));
 	json_object_object_add(object, "scale",
 			json_object_new_double(wlr_output->scale));
-	json_object_object_add(object, "refresh",
-			json_object_new_int(wlr_output->refresh));
 	json_object_object_add(object, "transform",
 		json_object_new_string(
 			ipc_json_get_output_transform(wlr_output->transform)));
@@ -148,6 +146,8 @@ static void ipc_json_describe_output(struct sway_output *output,
 		json_object_new_int(wlr_output->width));
 	json_object_object_add(current_mode_object, "height",
 		json_object_new_int(wlr_output->height));
+	json_object_object_add(current_mode_object, "refresh",
+		json_object_new_int(wlr_output->refresh));
 	json_object_object_add(object, "current_mode", current_mode_object);
 
 	struct sway_node *parent = node_get_parent(&output->node);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -163,28 +163,28 @@ static void pretty_print_seat(json_object *i) {
 }
 
 static void pretty_print_output(json_object *o) {
-	json_object *name, *rect, *focused, *active, *ws;
+	json_object *name, *rect, *focused, *active, *ws, *current_mode;
 	json_object_object_get_ex(o, "name", &name);
 	json_object_object_get_ex(o, "rect", &rect);
 	json_object_object_get_ex(o, "focused", &focused);
 	json_object_object_get_ex(o, "active", &active);
 	json_object_object_get_ex(o, "current_workspace", &ws);
-	json_object *make, *model, *serial, *scale, *refresh, *transform;
+	json_object *make, *model, *serial, *scale, *transform;
 	json_object_object_get_ex(o, "make", &make);
 	json_object_object_get_ex(o, "model", &model);
 	json_object_object_get_ex(o, "serial", &serial);
 	json_object_object_get_ex(o, "scale", &scale);
-	json_object_object_get_ex(o, "refresh", &refresh);
 	json_object_object_get_ex(o, "transform", &transform);
-	json_object *x, *y, *width, *height;
+	json_object *x, *y;
 	json_object_object_get_ex(rect, "x", &x);
 	json_object_object_get_ex(rect, "y", &y);
-	json_object_object_get_ex(rect, "width", &width);
-	json_object_object_get_ex(rect, "height", &height);
 	json_object *modes;
 	json_object_object_get_ex(o, "modes", &modes);
-	json_object *current_mode;
+	json_object *width, *height, *refresh;
 	json_object_object_get_ex(o, "current_mode", &current_mode);
+	json_object_object_get_ex(current_mode, "width", &width);
+	json_object_object_get_ex(current_mode, "height", &height);
+	json_object_object_get_ex(current_mode, "refresh", &refresh);
 
 	if (json_object_get_boolean(active)) {
 		printf(
@@ -199,10 +199,8 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_string(model),
 			json_object_get_string(serial),
 			json_object_get_boolean(focused) ? " (focused)" : "",
-			json_object_get_int(
-				json_object_object_get(current_mode, "width")),
-			json_object_get_int(
-				json_object_object_get(current_mode, "height")),
+			json_object_get_int(width),
+			json_object_get_int(height),
 			(float)json_object_get_int(refresh) / 1000,
 			json_object_get_int(x), json_object_get_int(y),
 			json_object_get_double(scale),


### PR DESCRIPTION
In responding to feedback during #3052, I accidentally removed the `refresh` field from each `mode` entry. This corrects that mistake. Sorry for the churn.

cc: @emersion 