### PR TITLE
Improvements to the runtime only part of the gaps command

### DIFF
--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -149,16 +149,17 @@ struct cmd_results *cmd_gaps(int argc, char **argv) {
 		return error;
 	}
 
+	bool config_loading = !config->active || config->reloading;
+
 	if (argc == 2) {
 		return gaps_set_defaults(argc, argv);
 	}
-	if (argc == 4) {
-		if (config->active) {
-			return gaps_set_runtime(argc, argv);
-		} else {
-			return cmd_results_new(CMD_INVALID, "gaps",
-					"This syntax can only be used when sway is running");
-		}
+	if (argc == 4 && !config_loading) {
+		return gaps_set_runtime(argc, argv);
+	}
+	if (config_loading) {
+		return cmd_results_new(CMD_INVALID, "gaps",
+				"Expected 'gaps inner|outer <px>'");
 	}
 	return cmd_results_new(CMD_INVALID, "gaps",
 			"Expected 'gaps inner|outer <px>' or "

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -133,6 +133,10 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *fullscreen*
 	Toggles fullscreen for the focused view.
 
+*gaps* inner|outer all|current set|plus|minus <amount>
+	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
+	_current_ workspace.
+
 *layout* default|splith|splitv|stacking|tabbed
 	Sets the layout mode of the focused container.
 
@@ -432,10 +436,6 @@ The default colors are:
 
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps inner|outer <amount>).
-
-*gaps* inner|outer all|current set|plus|minus <amount>
-	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
-	_current_ workspace.
 
 *hide\_edge\_borders* none|vertical|horizontal|both|smart|smart\_no\_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_.


### PR DESCRIPTION
This patch addresses two issues:
1. The command `gaps inner|outer all|current set|plus|minus <amount>` is not valid in the configuration file, hence list it accordingly in the manpage.
 2.  Always raise an error if the mentioned gaps command is found in the config file. Previously there was only an error reported on startup but not on config reload.

By working on this patch I realized that the gaps command is an exception to the other commands: All commands are classified in config file only commands, runtime only commands or commands which are valid in both cases. But the gaps command doesn't conform to this classification and actually consists  of two commands:
- `gaps inner|outer all|current set|plus|minus <amount>` (runtime only)
- `gaps inner|outer <amount>` (runtime and config)

Therefore the gaps command itself has to check if it is run at config load or at runtime. 

Instead of this patch it might be a cleaner solution to split the gaps command into two distinct commands
- `gaps inner|outer all|current set|plus|minus <amount>` (runtime only)
- `default_gaps inner|outer <amount>` (runtime and config)

with the disadvantage, that this syntax would be incompatible to i3-gaps. If we keep the current syntax, I think my patch is necessary.