### PR TITLE
Improve documentation and remove dead code

### DIFF
--- a/completions/fish/swaymsg.fish
+++ b/completions/fish/swaymsg.fish
@@ -16,4 +16,5 @@ complete -c swaymsg -s t -l type -fra 'get_bar_config' --description "Get a JSON
 complete -c swaymsg -s t -l type -fra 'get_version' --description "Get JSON-encoded version information for the running instance of sway."
 complete -c swaymsg -s t -l type -fra 'get_binding_modes' --description "Gets a JSON-encoded list of currently configured binding modes."
 complete -c swaymsg -s t -l type -fra 'get_config' --description "Gets a JSON-encoded copy of the current configuration."
+complete -c swaymsg -s t -l type -fra 'get_seats' --description "Gets a JSON-encoded list of all seats, its properties and all assigned devices."
 complete -c swaymsg -s t -l type -fra 'send_tick' --description "Sends a tick event to all subscribed clients."

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -55,9 +55,6 @@ void seat_destroy(struct sway_seat *seat) {
 	free(seat);
 }
 
-static struct sway_seat_node *seat_node_from_node(
-		struct sway_seat *seat, struct sway_node *node);
-
 static void seat_node_destroy(struct sway_seat_node *seat_node) {
 	wl_list_remove(&seat_node->destroy.link);
 	wl_list_remove(&seat_node->link);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -364,6 +364,7 @@ The default colors are:
 :  #000000
 :  #0c0c0c
 
+
 *debuglog* on|off|toggle
 	Enables, disables or toggles debug logging. _toggle_ cannot be used in the
 	configuration file.

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -50,6 +50,10 @@ _swaymsg_ [options...] [message]
 	Gets a JSON-encoded layout tree of all open windows, containers, outputs,
 	workspaces, and so on.
 
+*get\_seats*
+	Gets a JSON-encoded list of all seats,
+	its properties and all assigned devices.
+
 *get\_marks*
 	Get a JSON-encoded list of marks.
 


### PR DESCRIPTION
This contains three unrelated things:
* Documentation for `swaymsg -t get_seats` (as well as implementation in fish completions)
* Fix in sway.5 manpage (fixes spacing after the Table)
* Deletion of a not needed code fragment in seat.c