### PR TITLE
Work around swayidle never triggering on SIGUSR1

### DIFF
--- a/swayidle/main.c
+++ b/swayidle/main.c
@@ -347,7 +347,9 @@ void sway_terminate(int exit_code) {
 
 static void register_zero_idle_timeout(void *item) {
 	struct swayidle_timeout_cmd *cmd = item;
-	register_timeout(cmd, 0);
+	// A zero timeout never actually triggers. Adding a 50ms timeout is most
+	// likely not the correct fix either, but will work
+	register_timeout(cmd, 50);
 }
 
 static int handle_signal(int sig, void *data) {


### PR DESCRIPTION
SIGUSR1 is supposed to trigger swayidle; however, in my experience this never happens.

I suspect there might be some kind of a race condition between setting a 0-timeout timer and the actual signal handling, so here's a PR that kind of papers over the problem by making the timeout 50ms instead. This makes it work for me consistently

Feel free to reject this PR if this workaround is not acceptable, but I'm not sure how to actually fix the timer logic so that 0-timeout timers work.