### PR TITLE
Add swaylock grace timer

### DIFF
--- a/include/swaylock/swaylock.h
+++ b/include/swaylock/swaylock.h
@@ -70,6 +70,7 @@ struct swaylock_state {
 	struct swaylock_xkb xkb;
 	enum auth_state auth_state;
 	bool run_display;
+	bool within_grace;
 	struct zxdg_output_manager_v1 *zxdg_output_manager;
 };
 

--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -80,6 +80,10 @@ static void handle_preverify_timeout(void *data) {
 
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
+	if (state->within_grace) {
+		state->run_display = false;
+		return;
+	}
 	switch (keysym) {
 	case XKB_KEY_KP_Enter: /* fallthrough */
 	case XKB_KEY_Return:

--- a/swaylock/swaylock.1.scd
+++ b/swaylock/swaylock.1.scd
@@ -29,6 +29,9 @@ Locks your Wayland session.
 
 	Note: this is the default bahavior of i3lock.
 
+*-g, --grace*
+	Set a grace time (in seconds) before the display is actually locked.
+
 *-h, --help*
 	Show help message and quit.
 

--- a/swaylock/swaylock.1.scd
+++ b/swaylock/swaylock.1.scd
@@ -27,7 +27,7 @@ Locks your Wayland session.
 *-f, --daemonize*
 	Detach from the controlling terminal after locking.
 
-	Note: this is the default bahavior of i3lock.
+	Note: this is the default behavior of i3lock.
 
 *-g, --grace*
 	Set a grace time (in seconds) before the display is actually locked.


### PR DESCRIPTION
This adds a small feature to allow for a moment of grace before swaylock actually activates. This allows the user to hit a key to cancel the lock, if they're quick. 

Most useful when swaylock is used from swayidle, as sometimes the lock screen can trigger when you don't want it to.

Also includes a tiny typo fix.