### PR TITLE
Fix the double execution of exec_always commands on config reloads

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -15,7 +15,7 @@
 
 struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (!config->active) return cmd_results_new(CMD_DEFER, NULL, NULL);
+	if (!config->active || config->validating) return cmd_results_new(CMD_DEFER, NULL, NULL);
 	if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -389,7 +389,8 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	config_defaults(config);
 	config->validating = validating;
 	if (is_active) {
-		wlr_log(WLR_DEBUG, "Performing configuration file reload");
+		wlr_log(WLR_DEBUG, "Performing configuration file %s",
+			validating ? "validation" : "reload");
 		config->reloading = true;
 		config->active = true;
 


### PR DESCRIPTION
While at it, fix the reload message.