### PR TITLE
Add focus_follows_mouse always.

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -327,6 +327,12 @@ struct ipc_policy {
 	uint32_t features;
 };
 
+enum focus_follows_mouse_mode {
+	FOLLOWS_NO,
+	FOLLOWS_YES,
+	FOLLOWS_ALWAYS
+};
+
 enum focus_wrapping_mode {
 	WRAP_NO,
 	WRAP_YES,
@@ -378,7 +384,7 @@ struct sway_config {
 	enum sway_popup_during_fullscreen popup_during_fullscreen;
 
 	// Flags
-	bool focus_follows_mouse;
+	enum focus_follows_mouse_mode focus_follows_mouse;
 	enum mouse_warping_mode mouse_warping;
 	enum focus_wrapping_mode focus_wrapping;
 	bool active;

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -7,13 +7,15 @@ struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
 		return error;
-	}
-	if(strcmp(argv[0], "no") == 0) {
+	} else if(strcmp(argv[0], "no") == 0) {
 		config->focus_follows_mouse = FOLLOWS_NO;
 	} else if(strcmp(argv[0], "yes") == 0) {
 		config->focus_follows_mouse = FOLLOWS_YES;
 	} else if(strcmp(argv[0], "always") == 0) {
 		config->focus_follows_mouse = FOLLOWS_ALWAYS;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "focus_follows_mouse",
+				"Expected 'focus_follows_mouse no|yes|always'");
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -8,7 +8,12 @@ struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
 	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	config->focus_follows_mouse =
-		parse_boolean(argv[0], config->focus_follows_mouse);
+	if(strcmp(argv[0], "no") == 0) {
+		config->focus_follows_mouse = FOLLOWS_NO;
+	} else if(strcmp(argv[0], "yes") == 0) {
+		config->focus_follows_mouse = FOLLOWS_YES;
+	} else if(strcmp(argv[0], "always") == 0) {
+		config->focus_follows_mouse = FOLLOWS_ALWAYS;
+	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -220,7 +220,7 @@ static void config_defaults(struct sway_config *config) {
 	config->floating_minimum_height = 50;
 
 	// Flags
-	config->focus_follows_mouse = true;
+	config->focus_follows_mouse = FOLLOWS_YES;
 	config->mouse_warping = WARP_OUTPUT;
 	config->focus_wrapping = WRAP_YES;
 	config->validating = false;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -637,7 +637,8 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	cursor->previous.y = cursor->cursor->y;
 	cursor->previous.node = node;
 
-	if (node && config->focus_follows_mouse) {
+	if (node && (config->focus_follows_mouse == FOLLOWS_YES ||
+		config->focus_follows_mouse == FOLLOWS_ALWAYS)) {
 		struct sway_node *focus = seat_get_focus(seat);
 		if (focus && node->type == N_WORKSPACE) {
 			// Only follow the mouse if it would move to a new output
@@ -652,9 +653,10 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor,
 			// - cursor is over a new view, i.e. entered a new window; and
 			// - the new view is visible, i.e. not hidden in a stack or tab; and
 			// - the seat does not have a keyboard grab
-			if (!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
+			if ((!wlr_seat_keyboard_has_grab(cursor->seat->wlr_seat) &&
 					node != prev_node &&
-					view_is_visible(node->sway_container->view)) {
+					view_is_visible(node->sway_container->view)) ||
+					config->focus_follows_mouse == FOLLOWS_ALWAYS) {
 				seat_set_focus(seat, node);
 			} else {
 				struct sway_node *next_focus =

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -638,7 +638,7 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor,
 	cursor->previous.node = node;
 
 	if (node && (config->focus_follows_mouse == FOLLOWS_YES ||
-		config->focus_follows_mouse == FOLLOWS_ALWAYS)) {
+			config->focus_follows_mouse == FOLLOWS_ALWAYS)) {
 		struct sway_node *focus = seat_get_focus(seat);
 		if (focus && node->type == N_WORKSPACE) {
 			// Only follow the mouse if it would move to a new output


### PR DESCRIPTION
I suggested a feature in #3025 where the focus will always follow the mouse. This can be used by specifying `focus_follows_mouse always` in the config file.