### PR TITLE
gaps: remove duplicate inner gaps

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -104,7 +104,12 @@ struct sway_container {
 	bool border_right;
 
 	// The gaps currently applied to the container.
-	double current_gaps;
+	struct {
+		int top;
+		int right;
+		int bottom;
+		int left;
+	} current_gaps;
 
 	struct sway_workspace *workspace; // NULL when hidden in the scratchpad
 	struct sway_container *parent;    // NULL if container in root of workspace

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1009,19 +1009,25 @@ void container_discover_outputs(struct sway_container *con) {
 }
 
 void container_remove_gaps(struct sway_container *c) {
-	if (c->current_gaps == 0) {
+	if (c->current_gaps.top == 0 && c->current_gaps.right == 0 &&
+			c->current_gaps.bottom == 0 && c->current_gaps.left == 0) {
 		return;
 	}
 
-	c->width += c->current_gaps * 2;
-	c->height += c->current_gaps * 2;
-	c->x -= c->current_gaps;
-	c->y -= c->current_gaps;
-	c->current_gaps = 0;
+	c->width += c->current_gaps.left + c->current_gaps.right;
+	c->height += c->current_gaps.top + c->current_gaps.bottom;
+	c->x -= c->current_gaps.left;
+	c->y -= c->current_gaps.top;
+
+	c->current_gaps.top = 0;
+	c->current_gaps.right = 0;
+	c->current_gaps.bottom = 0;
+	c->current_gaps.left = 0;
 }
 
 void container_add_gaps(struct sway_container *c) {
-	if (c->current_gaps > 0) {
+	if (c->current_gaps.top > 0 || c->current_gaps.right > 0 ||
+			c->current_gaps.bottom > 0 || c->current_gaps.left > 0) {
 		return;
 	}
 	// Linear containers don't have gaps because it'd create double gaps
@@ -1054,11 +1060,15 @@ void container_add_gaps(struct sway_container *c) {
 
 	struct sway_workspace *ws = c->workspace;
 
-	c->current_gaps = ws->gaps_inner;
-	c->x += c->current_gaps;
-	c->y += c->current_gaps;
-	c->width -= 2 * c->current_gaps;
-	c->height -= 2 * c->current_gaps;
+	c->current_gaps.top = c->y == ws->y ? ws->gaps_inner : 0;
+	c->current_gaps.right = ws->gaps_inner;
+	c->current_gaps.bottom = ws->gaps_inner;
+	c->current_gaps.left = c->x == ws->x ? ws->gaps_inner : 0;
+
+	c->x += c->current_gaps.left;
+	c->y += c->current_gaps.top;
+	c->width -= c->current_gaps.left + c->current_gaps.right;
+	c->height -= c->current_gaps.top + c->current_gaps.bottom;
 }
 
 enum sway_container_layout container_parent_layout(struct sway_container *con) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -185,7 +185,8 @@ bool view_is_only_visible(struct sway_view *view) {
 static bool gaps_to_edge(struct sway_view *view) {
 	struct sway_container *con = view->container;
 	while (con) {
-		if (con->current_gaps > 0) {
+		if (con->current_gaps.top > 0 || con->current_gaps.right > 0 ||
+				con->current_gaps.bottom > 0 || con->current_gaps.left > 0) {
 			return true;
 		}
 		con = con->parent;
@@ -222,15 +223,15 @@ void view_autoconfigure(struct sway_view *view) {
 	if (config->hide_edge_borders == E_BOTH
 			|| config->hide_edge_borders == E_VERTICAL
 			|| (smart && !other_views && no_gaps)) {
-		con->border_left = con->x - con->current_gaps != ws->x;
-		int right_x = con->x + con->width + con->current_gaps;
+		con->border_left = con->x - con->current_gaps.left != ws->x;
+		int right_x = con->x + con->width + con->current_gaps.right;
 		con->border_right = right_x != ws->x + ws->width;
 	}
 	if (config->hide_edge_borders == E_BOTH
 			|| config->hide_edge_borders == E_HORIZONTAL
 			|| (smart && !other_views && no_gaps)) {
-		con->border_top = con->y - con->current_gaps != ws->y;
-		int bottom_y = con->y + con->height + con->current_gaps;
+		con->border_top = con->y - con->current_gaps.top != ws->y;
+		int bottom_y = con->y + con->height + con->current_gaps.bottom;
 		con->border_bottom = bottom_y != ws->y + ws->height;
 	}
 


### PR DESCRIPTION
Removes duplicate inner gaps between two containers. See https://github.com/swaywm/sway/issues/307#issuecomment-165437419.

Instead of dividing the gaps by two between two containers as suggested, I decided to do the following:
1) Inner gaps are always added to the right and bottom sides
2) Inner gaps are only added to the top side when the container's y location matches the workspace's y location without inner gaps applied
3) Inner gaps are only added to the left side when the container's x location matches the workspace's x location without inner gaps applied

I think this solution is better since the inner gaps are guaranteed to be integer values instead of having to deal with half pixel values when dividing an odd inner gap by two.