### PR TITLE
Implement per side and per direction outer gaps

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -168,6 +168,16 @@ struct output_config {
 };
 
 /**
+ * Stores size of gaps for each side
+ */
+struct side_gaps {
+	int top;
+	int right;
+	int bottom;
+	int left;
+};
+
+/**
  * Stores configuration for a workspace, regardless of whether the workspace
  * exists.
  */
@@ -175,7 +185,7 @@ struct workspace_config {
 	char *workspace;
 	char *output;
 	int gaps_inner;
-	int gaps_outer;
+	struct side_gaps gaps_outer;
 };
 
 struct bar_config {
@@ -398,7 +408,7 @@ struct sway_config {
 
 	bool smart_gaps;
 	int gaps_inner;
-	int gaps_outer;
+	struct side_gaps gaps_outer;
 
 	list_t *config_chain;
 	const char *current_config_path;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -32,9 +32,9 @@ struct sway_workspace {
 	enum sway_container_layout layout;
 	enum sway_container_layout prev_split_layout;
 
-	int current_gaps;
+	struct side_gaps current_gaps;
 	int gaps_inner;
-	int gaps_outer;
+	struct side_gaps gaps_outer;
 
 	struct sway_output *output; // NULL if no outputs are connected
 	list_t *floating;           // struct sway_container

--- a/sway/config.c
+++ b/sway/config.c
@@ -234,7 +234,10 @@ static void config_defaults(struct sway_config *config) {
 
 	config->smart_gaps = false;
 	config->gaps_inner = 0;
-	config->gaps_outer = 0;
+	config->gaps_outer.top = 0;
+	config->gaps_outer.right = 0;
+	config->gaps_outer.bottom = 0;
+	config->gaps_outer.left = 0;
 
 	if (!(config->active_bar_modifiers = create_list())) goto cleanup;
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -133,9 +133,12 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *fullscreen*
 	Toggles fullscreen for the focused view.
 
-*gaps* inner|outer all|current set|plus|minus <amount>
+*gaps* inner|outer|horizontal|vertical|top|right|bottom|left all|current
+set|plus|minus <amount>
 	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
-	_current_ workspace.
+	_current_ workspace. _outer_ gaps can be altered per side with _top_,
+	_right_, _bottom_, and _left_ or per direction with _horizontal_ and
+	_vertical_.
 
 *layout* default|splith|splitv|stacking|tabbed
 	Sets the layout mode of the focused container.
@@ -429,14 +432,16 @@ The default colors are:
 	_focus\_wrapping force_. This is only available for convenience. Please
 	use _focus\_wrapping_ instead when possible.
 
-*gaps* inner|outer <amount>
+*gaps* inner|outer|horizontal|vertical|top|right|bottom|left <amount>
 	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the inner
 	affects spacing around each view and outer affects the spacing around each
 	workspace. Outer gaps are in addition to inner gaps. To reduce or remove
-	outer gaps, outer gaps can be set to a negative value.
+	outer gaps, outer gaps can be set to a negative value. _outer_ gaps can
+	also be specified per side with _top_, _right_, _bottom_, and _left_ or
+	per direction with _horizontal_ and _vertical_.
 
 	This affects new workspaces only, and is used when the workspace doesn't
-	have its own gaps settings (see: workspace <ws> gaps inner|outer <amount>).
+	have its own gaps settings (see: workspace <ws> gaps ...).
 
 *hide\_edge\_borders* none|vertical|horizontal|both|smart|smart\_no\_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_.
@@ -549,7 +554,8 @@ The default colors are:
 *workspace* back\_and\_forth
 	Switches to the previously focused workspace.
 
-*workspace* <name> gaps inner|outer <amount>
+*workspace* <name> gaps inner|outer|horizontal|vertical|top|right|bottom|left
+<amount>
 	Specifies that workspace _name_ should have the given gaps settings when it
 	is created.
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -190,7 +190,8 @@ static bool gaps_to_edge(struct sway_view *view) {
 		}
 		con = con->parent;
 	}
-	return view->container->workspace->current_gaps > 0;
+	struct side_gaps gaps = view->container->workspace->current_gaps;
+	return gaps.top > 0 || gaps.right > 0 || gaps.bottom > 0 || gaps.left > 0;
 }
 
 void view_autoconfigure(struct sway_view *view) {


### PR DESCRIPTION
Closes #3059 

This introduces the following command extensions from `i3-gaps`:
* `gaps horizontal|vertical|top|right|bottom|left <amount>`
* `gaps horizontal|vertical|top|right|bottom|left all|current set|plus|minus <amount>`
* `workspace <ws> gaps horizontal|vertical|top|right|bottom|left <amount>`

`inner` and `outer` are also still available as options for all three of the above commands. `outer` now acts as a shorthand to set/alter all sides.

Additionally, this fixes two bugs with the prevention of invalid gap configurations for workspace configs:
1. If outer gaps were not set and inner gaps were, the outer gaps would be snapped to the negation of the inner gaps due to `INT_MIN` being less than the negation. This took precedence over the default outer gaps.
2. Similarly, if inner gaps were not set and outer gaps were, inner gaps would be set to zero, which would take precedence over the default inner gaps.

Fixing both of the above items also requires checking the gaps again when creating a workspace since the default outer gaps can be smaller than the negation of the workspace specific inner gaps.