### PR TITLE
Fix building with clang

### DIFF
--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -181,7 +181,7 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	}
 
 	struct sway_container *current = config->handler_context.container;
-	struct sway_container *other;
+	struct sway_container *other = NULL;
 
 	char *value = join_args(argv + 3, argc - 3);
 	if (strcasecmp(argv[2], "id") == 0) {


### PR DESCRIPTION
The `struct sway_container *other` variable in swap.c was potentially used uninitialized, depending on an "if" statement.