### PR TITLE
Allow multiple outputs for workspace output

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -183,7 +183,7 @@ struct side_gaps {
  */
 struct workspace_config {
 	char *workspace;
-	char *output;
+	list_t *outputs;
 	int gaps_inner;
 	struct side_gaps gaps_outer;
 };

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -573,8 +573,12 @@ The default colors are:
 	Specifies that workspace _name_ should have the given gaps settings when it
 	is created.
 
-*workspace* <name> output <output>
-	Specifies that workspace _name_ should be shown on the specified _output_.
+*workspace* <name> output <outputs...>
+	Specifies that workspace _name_ should be shown on the specified _outputs_.
+	Multiple outputs can be listed and the first available will be used. If the
+	workspace gets placed on an output further down the list and an output that
+	is higher on the list becomes available, the workspace will be move to the
+	higher priority output.
 
 *workspace\_auto\_back\_and\_forth* yes|no
 	When _yes_, repeating a workspace switch command will switch back to the

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -31,6 +31,13 @@ static void restore_workspaces(struct sway_output *output) {
 				j--;
 			}
 		}
+
+		if (other->workspaces->length == 0) {
+			char *next = workspace_next_name(other->wlr_output->name);
+			struct sway_workspace *ws = workspace_create(other, next);
+			free(next);
+			ipc_event_workspace(NULL, ws, "init");
+		}
 	}
 
 	// Saved workspaces


### PR DESCRIPTION
Related to #3082 
i3 documentation: https://i3wm.org/docs/userguide.html#workspace_screen
`workspace <workspace> output <outputs>`

`i3 4.16` allows users to list multiple outputs for a workspace and the first available will be used.

Additionally when the workspace is created, the outputs get added to the output priority list in the order specified. This ensures that if a higher output gets connected, the workspace will move to the higher output. This works the same way as if the user had a workspace on an output, disconnected the output, and then later reconnected the output.