### PR TITLE
cmd_ws_auto_back_and_forth: fix negation

### DIFF
--- a/sway/commands/ws_auto_back_and_forth.c
+++ b/sway/commands/ws_auto_back_and_forth.c
@@ -9,6 +9,6 @@ struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
 		return error;
 	}
 	config->auto_back_and_forth = 
-		!parse_boolean(argv[0], config->auto_back_and_forth);
+		parse_boolean(argv[0], config->auto_back_and_forth);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }


### PR DESCRIPTION
In the conversion to `parse_boolean` for `cmd_ws_auto_back_and_forth` (#3098), the `!` was never removed (was previously using `strcasecmp`) causing the setting to be the opposite of what it should be.