### PR TITLE
[Do not merge] fix focus_follows_mouse=always in case of not moving the mouse

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -68,7 +68,8 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 
 
 struct sway_node *node_at_cursor(struct sway_seat *seat,
-	struct sway_cursor *cursor, double *sx, double *sy);
+	struct sway_workspace *workspace, struct sway_cursor *cursor,
+	struct wlr_surface **surface, double *sx, double *sy);
 
 /**
  * "Rebase" a cursor on top of whatever view is underneath it.

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -66,6 +66,10 @@ struct sway_node *node_at_coords(
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 
+
+struct sway_node *node_at_cursor(struct sway_seat *seat,
+	struct sway_cursor *cursor, double *sx, double *sy);
+
 /**
  * "Rebase" a cursor on top of whatever view is underneath it.
  *

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -155,6 +155,13 @@ struct sway_node *node_at_coords(
 	return &ws->node;
 }
 
+struct sway_node *node_at_cursor(struct sway_seat *seat,
+		struct sway_cursor *cursor,
+		struct wlr_surface **surface, double *sx, double *sy) {
+	return node_at_coords(seat, cursor->cursor->x, cursor->cursor->y, surface,
+		sx, sy);
+}
+
 /**
  * Determine if the edge of the given container is on the edge of the
  * workspace/output.
@@ -278,8 +285,8 @@ void cursor_rebase(struct sway_cursor *cursor) {
 	uint32_t time_msec = get_current_time_msec();
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	cursor->previous.node = node_at_coords(cursor->seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	cursor->previous.node = node_at_cursor(cursor->seat, cursor,
+		&surface, &sx, &sy);
 	cursor_do_rebase(cursor, time_msec, cursor->previous.node, surface, sx, sy);
 }
 
@@ -595,8 +602,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_cursor(seat, cursor, &surface, &sx, &sy);
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
 	bool is_floating = cont && container_is_floating(cont);
@@ -804,8 +810,7 @@ void dispatch_cursor_axis(struct sway_cursor *cursor,
 	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_cursor(seat, cursor, &surface, &sx, &sy);
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
 	enum wlr_edges edge = cont ? find_edge(cont, cursor) : WLR_EDGE_NONE;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -21,6 +21,7 @@
 #include "sway/output.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
+#include "sway/tree/node.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
@@ -776,6 +777,14 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 
 	if (last_workspace != new_workspace && new_output) {
 		node_set_dirty(&new_output->node);
+	}
+
+	// replace node to focus with node under cursor
+	if (config->focus_follows_mouse == FOLLOWS_ALWAYS) {
+		struct wlr_surface *surface = NULL;
+		double sx, sy;
+		node = node_at_cursor(seat, new_workspace, seat->cursor, &surface, &sx, &sy);
+		container = node->type == N_CONTAINER ? node->sway_container : NULL;
 	}
 
 	// find new output's old workspace, which might have to be removed if empty


### PR DESCRIPTION
This patch focuses the correct window when changing workplaces with `focus_follows_mouse always` but when the mouse is not moved.
Until now I had to move the mouse for the focus to change.

I do not know if this works properly with multiseat and if there is a more simple and clean solution.

@c-edw: fyi