### PR TITLE
Fix unused function in swap command

### DIFF
--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -144,19 +144,18 @@ static void container_swap(struct sway_container *con1,
 	}
 }
 
-static bool test_con_id(struct sway_container *container, void *con_id) {
-	return container->node.id == (size_t)con_id;
+static bool test_con_id(struct sway_container *container, void *data) {
+	size_t *con_id = data;
+	return container->node.id == *con_id;
 }
 
-static bool test_id(struct sway_container *container, void *id) {
 #ifdef HAVE_XWAYLAND
-	xcb_window_t *wid = id;
+static bool test_id(struct sway_container *container, void *data) {
+	xcb_window_t *wid = data;
 	return (container->view && container->view->type == SWAY_VIEW_XWAYLAND
 			&& container->view->wlr_xwayland_surface->window_id == *wid);
-#else
-	return false;
-#endif
 }
+#endif
 
 static bool test_mark(struct sway_container *container, void *mark) {
 	if (container->marks->length) {
@@ -187,13 +186,13 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	if (strcasecmp(argv[2], "id") == 0) {
 #ifdef HAVE_XWAYLAND
 		xcb_window_t id = strtol(value, NULL, 0);
-		other = root_find_container(test_id, (void *)&id);
+		other = root_find_container(test_id, &id);
 #endif
 	} else if (strcasecmp(argv[2], "con_id") == 0) {
 		size_t con_id = atoi(value);
-		other = root_find_container(test_con_id, (void *)con_id);
+		other = root_find_container(test_con_id, &con_id);
 	} else if (strcasecmp(argv[2], "mark") == 0) {
-		other = root_find_container(test_mark, (void *)value);
+		other = root_find_container(test_mark, value);
 	} else {
 		free(value);
 		return cmd_results_new(CMD_INVALID, "swap", EXPECTED_SYNTAX);


### PR DESCRIPTION
```
Error: test_id defined but not used. [-Werror=unused-function].
```

Also fixes a `size_t` cast to `void *`.

https://github.com/swaywm/sway/issues/3123#issuecomment-438763220