### PR TITLE
Move view {x,y,width,height} into container struct

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -41,8 +41,8 @@ enum wlr_direction;
 struct sway_container_state {
 	// Container properties
 	enum sway_container_layout layout;
-	double con_x, con_y;
-	double con_width, con_height;
+	double x, y;
+	double width, height;
 
 	bool is_fullscreen;
 
@@ -60,9 +60,8 @@ struct sway_container_state {
 	bool border_left;
 	bool border_right;
 
-	// View properties
-	double view_x, view_y;
-	double view_width, view_height;
+	double content_x, content_y;
+	double content_width, content_height;
 };
 
 struct sway_container {
@@ -88,6 +87,9 @@ struct sway_container {
 	double width, height;
 	double saved_x, saved_y;
 	double saved_width, saved_height;
+
+	double content_x, content_y;
+	int content_width, content_height;
 
 	bool is_fullscreen;
 
@@ -210,7 +212,7 @@ void container_init_floating(struct sway_container *container);
 
 void container_set_floating(struct sway_container *container, bool enable);
 
-void container_set_geometry_from_floating_view(struct sway_container *con);
+void container_set_geometry_from_content(struct sway_container *con);
 
 /**
  * Determine if the given container is itself floating.

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -67,10 +67,6 @@ struct sway_view {
 
 	pid_t pid;
 
-	// Geometry of the view itself (excludes borders) in layout coordinates
-	double x, y;
-	int width, height;
-
 	double saved_x, saved_y;
 	int saved_width, saved_height;
 

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -93,7 +93,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	}
 
 	if (container_is_floating(container)) {
-		container_set_geometry_from_floating_view(container);
+		container_set_geometry_from_content(container);
 	}
 
 	arrange_container(container);

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -404,13 +404,10 @@ static struct cmd_results *resize_adjust_floating(enum resize_axis axis,
 	con->width += grow_width;
 	con->height += grow_height;
 
-	if (con->view) {
-		struct sway_view *view = con->view;
-		view->x += grow_x;
-		view->y += grow_y;
-		view->width += grow_width;
-		view->height += grow_height;
-	}
+	con->content_x += grow_x;
+	con->content_y += grow_y;
+	con->content_width += grow_width;
+	con->content_height += grow_height;
 
 	arrange_container(con);
 
@@ -546,13 +543,10 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 		}
 	}
 
-	if (con->view) {
-		struct sway_view *view = con->view;
-		view->x -= grow_width / 2;
-		view->y -= grow_height / 2;
-		view->width += grow_width;
-		view->height += grow_height;
-	}
+	con->content_x -= grow_width / 2;
+	con->content_y -= grow_height / 2;
+	con->content_width += grow_width;
+	con->content_height += grow_height;
 
 	arrange_container(con);
 

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -28,8 +28,8 @@ void desktop_damage_box(struct wlr_box *box) {
 void desktop_damage_view(struct sway_view *view) {
 	desktop_damage_whole_container(view->container);
 	struct wlr_box box = {
-		.x = view->container->current.view_x - view->geometry.x,
-		.y = view->container->current.view_y - view->geometry.y,
+		.x = view->container->current.content_x - view->geometry.x,
+		.y = view->container->current.content_y - view->geometry.y,
 		.width = view->surface->current.width,
 		.height = view->surface->current.height,
 	};

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -160,12 +160,12 @@ void output_view_for_each_surface(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.view_x - output->wlr_output->lx
+		.ox = view->container->current.content_x - output->wlr_output->lx
 			- view->geometry.x,
-		.oy = view->container->current.view_y - output->wlr_output->ly
+		.oy = view->container->current.content_y - output->wlr_output->ly
 			- view->geometry.y,
-		.width = view->container->current.view_width,
-		.height = view->container->current.view_height,
+		.width = view->container->current.content_width,
+		.height = view->container->current.content_height,
 		.rotation = 0, // TODO
 	};
 
@@ -179,12 +179,12 @@ void output_view_for_each_popup(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.view_x - output->wlr_output->lx
+		.ox = view->container->current.content_x - output->wlr_output->lx
 			- view->geometry.x,
-		.oy = view->container->current.view_y - output->wlr_output->ly
+		.oy = view->container->current.content_y - output->wlr_output->ly
 			- view->geometry.y,
-		.width = view->container->current.view_width,
-		.height = view->container->current.view_height,
+		.width = view->container->current.content_width,
+		.height = view->container->current.content_height,
 		.rotation = 0, // TODO
 	};
 
@@ -473,10 +473,10 @@ void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	// Pad the box by 1px, because the width is a double and might be a fraction
 	struct wlr_box box = {
-		.x = con->current.con_x - output->wlr_output->lx - 1,
-		.y = con->current.con_y - output->wlr_output->ly - 1,
-		.width = con->current.con_width + 2,
-		.height = con->current.con_height + 2,
+		.x = con->current.x - output->wlr_output->lx - 1,
+		.y = con->current.y - output->wlr_output->ly - 1,
+		.width = con->current.width + 2,
+		.height = con->current.height + 2,
 	};
 	scale_box(&box, output->wlr_output->scale);
 	wlr_output_damage_add_box(output->damage, &box);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -211,9 +211,9 @@ static void render_view_toplevels(struct sway_view *view,
 		.alpha = alpha,
 	};
 	// Render all toplevels without descending into popups
-	double ox = view->container->current.view_x -
+	double ox = view->container->current.content_x -
 		output->wlr_output->lx - view->geometry.x;
-	double oy = view->container->current.view_y -
+	double oy = view->container->current.content_y -
 		output->wlr_output->ly - view->geometry.y;
 	output_surface_for_each_surface(output, view->surface, ox, oy,
 			render_surface_iterator, &data);
@@ -247,9 +247,9 @@ static void render_saved_view(struct sway_view *view,
 		return;
 	}
 	struct wlr_box box = {
-		.x = view->container->current.view_x - output->wlr_output->lx -
+		.x = view->container->current.content_x - output->wlr_output->lx -
 			view->saved_geometry.x,
-		.y = view->container->current.view_y - output->wlr_output->ly -
+		.y = view->container->current.content_y - output->wlr_output->ly -
 			view->saved_geometry.y,
 		.width = view->saved_buffer_width,
 		.height = view->saved_buffer_height,
@@ -300,10 +300,10 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 	if (state->border_left) {
 		memcpy(&color, colors->child_border, sizeof(float) * 4);
 		premultiply_alpha(color, con->alpha);
-		box.x = state->con_x;
-		box.y = state->view_y;
+		box.x = state->x;
+		box.y = state->content_y;
 		box.width = state->border_thickness;
-		box.height = state->view_height;
+		box.height = state->content_height;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, damage, &box, color);
 	}
@@ -319,10 +319,10 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
 		}
 		premultiply_alpha(color, con->alpha);
-		box.x = state->view_x + state->view_width;
-		box.y = state->view_y;
+		box.x = state->content_x + state->content_width;
+		box.y = state->content_y;
 		box.width = state->border_thickness;
-		box.height = state->view_height;
+		box.height = state->content_height;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, damage, &box, color);
 	}
@@ -334,9 +334,9 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
 		}
 		premultiply_alpha(color, con->alpha);
-		box.x = state->con_x;
-		box.y = state->view_y + state->view_height;
-		box.width = state->con_width;
+		box.x = state->x;
+		box.y = state->content_y + state->content_height;
+		box.width = state->width;
 		box.height = state->border_thickness;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, damage, &box, color);
@@ -585,9 +585,9 @@ static void render_top_border(struct sway_output *output,
 	// Child border - top edge
 	memcpy(&color, colors->child_border, sizeof(float) * 4);
 	premultiply_alpha(color, con->alpha);
-	box.x = state->con_x;
-	box.y = state->con_y;
-	box.width = state->con_width;
+	box.x = state->x;
+	box.y = state->y;
+	box.width = state->width;
 	box.height = state->border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(output->wlr_output, output_damage, &box, color);
@@ -641,8 +641,8 @@ static void render_containers_linear(struct sway_output *output,
 			}
 
 			if (state->border == B_NORMAL) {
-				render_titlebar(output, damage, child, state->con_x,
-						state->con_y, state->con_width, colors,
+				render_titlebar(output, damage, child, state->x,
+						state->y, state->width, colors,
 						title_texture, marks_texture);
 			} else if (state->border == B_PIXEL) {
 				render_top_border(output, damage, child, colors);
@@ -696,7 +696,7 @@ static void render_containers_tabbed(struct sway_output *output,
 			marks_texture = child->marks_unfocused;
 		}
 
-		int x = cstate->con_x + tab_width * i;
+		int x = cstate->x + tab_width * i;
 
 		// Make last tab use the remaining width of the parent
 		if (i == parent->children->length - 1) {
@@ -801,10 +801,10 @@ static void render_container(struct sway_output *output,
 	struct parent_data data = {
 		.layout = con->current.layout,
 		.box = {
-			.x = con->current.con_x,
-			.y = con->current.con_y,
-			.width = con->current.con_width,
-			.height = con->current.con_height,
+			.x = con->current.x,
+			.y = con->current.y,
+			.width = con->current.width,
+			.height = con->current.height,
 		},
 		.children = con->current.children,
 		.focused = focused,
@@ -853,8 +853,8 @@ static void render_floating_container(struct sway_output *soutput,
 		}
 
 		if (con->current.border == B_NORMAL) {
-			render_titlebar(soutput, damage, con, con->current.con_x,
-					con->current.con_y, con->current.con_width, colors,
+			render_titlebar(soutput, damage, con, con->current.x,
+					con->current.y, con->current.width, colors,
 					title_texture, marks_texture);
 		} else if (con->current.border == B_PIXEL) {
 			render_top_border(soutput, damage, con, colors);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -75,8 +75,8 @@ static void popup_unconstrain(struct sway_xdg_popup *popup) {
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->lx - view->x,
-		.y = output->ly - view->y,
+		.x = output->lx - view->container->content_x,
+		.y = output->ly - view->container->content_y,
 		.width = output->width,
 		.height = output->height,
 	};
@@ -286,9 +286,11 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	} else {
 		struct wlr_box new_geo;
 		wlr_xdg_surface_get_geometry(xdg_surface, &new_geo);
+		struct sway_container *con = view->container;
 
-		if ((new_geo.width != view->width || new_geo.height != view->height) &&
-				container_is_floating(view->container)) {
+		if ((new_geo.width != con->content_width ||
+					new_geo.height != con->content_height) &&
+				container_is_floating(con)) {
 			// A floating view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -74,8 +74,8 @@ static void popup_unconstrain(struct sway_xdg_popup_v6 *popup) {
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->lx - view->x,
-		.y = output->ly - view->y,
+		.x = output->lx - view->container->content_x,
+		.y = output->ly - view->container->content_y,
 		.width = output->width,
 		.height = output->height,
 	};
@@ -283,9 +283,11 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	} else {
 		struct wlr_box new_geo;
 		wlr_xdg_surface_v6_get_geometry(xdg_surface_v6, &new_geo);
+		struct sway_container *con = view->container;
 
-		if ((new_geo.width != view->width || new_geo.height != view->height) &&
-				container_is_floating(view->container)) {
+		if ((new_geo.width != con->content_width ||
+					new_geo.height != con->content_height) &&
+				container_is_floating(con)) {
 			// A floating view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -332,9 +332,11 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	} else {
 		struct wlr_box new_geo;
 		get_geometry(view, &new_geo);
+		struct sway_container *con = view->container;
 
-		if ((new_geo.width != view->width || new_geo.height != view->height) &&
-				container_is_floating(view->container)) {
+		if ((new_geo.width != con->content_width ||
+					new_geo.height != con->content_height) &&
+				container_is_floating(con)) {
 			// A floating view has unexpectedly sent a new size
 			// eg. The Firefox "Save As" dialog when downloading a file
 			desktop_damage_view(view);
@@ -432,13 +434,13 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		return;
 	}
 	if (container_is_floating(view->container)) {
-		configure(view, view->container->current.view_x,
-				view->container->current.view_y, ev->width, ev->height);
+		configure(view, view->container->current.content_x,
+				view->container->current.content_y, ev->width, ev->height);
 	} else {
-		configure(view, view->container->current.view_x,
-				view->container->current.view_y,
-				view->container->current.view_width,
-				view->container->current.view_height);
+		configure(view, view->container->current.content_x,
+				view->container->current.content_y,
+				view->container->current.content_width,
+				view->container->current.content_height);
 	}
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -348,7 +348,7 @@ static void handle_move_tiling_motion(struct sway_seat *seat,
 	}
 
 	// Find the closest edge
-	size_t thickness = fmin(con->view->width, con->view->height) * 0.3;
+	size_t thickness = fmin(con->content_width, con->content_height) * 0.3;
 	size_t closest_dist = INT_MAX;
 	size_t dist;
 	seat->op_target_edge = WLR_EDGE_NONE;
@@ -374,10 +374,10 @@ static void handle_move_tiling_motion(struct sway_seat *seat,
 	}
 
 	seat->op_target_node = node;
-	seat->op_drop_box.x = con->view->x;
-	seat->op_drop_box.y = con->view->y;
-	seat->op_drop_box.width = con->view->width;
-	seat->op_drop_box.height = con->view->height;
+	seat->op_drop_box.x = con->content_x;
+	seat->op_drop_box.y = con->content_y;
+	seat->op_drop_box.width = con->content_width;
+	seat->op_drop_box.height = con->content_height;
 	resize_box(&seat->op_drop_box, seat->op_target_edge, thickness);
 	desktop_damage_box(&seat->op_drop_box);
 }
@@ -498,13 +498,10 @@ static void handle_resize_floating_motion(struct sway_seat *seat,
 	con->width += relative_grow_width;
 	con->height += relative_grow_height;
 
-	if (con->view) {
-		struct sway_view *view = con->view;
-		view->x += relative_grow_x;
-		view->y += relative_grow_y;
-		view->width += relative_grow_width;
-		view->height += relative_grow_height;
-	}
+	con->content_x += relative_grow_x;
+	con->content_y += relative_grow_y;
+	con->content_width += relative_grow_width;
+	con->content_height += relative_grow_height;
 
 	arrange_container(con);
 }

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -246,10 +246,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "marks", marks);
 
 	struct wlr_box window_box = {
-		c->view->x - c->x,
+		c->content_x - c->x,
 		(c->current.border == B_PIXEL) ? c->current.border_thickness : 0,
-		c->view->width,
-		c->view->height
+		c->content_width,
+		c->content_height
 	};
 
 	json_object_object_add(object, "window_rect", ipc_json_create_rect(&window_box));
@@ -258,7 +258,7 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 	if (c->current.border == B_NORMAL) {
 		deco_box.width = c->width;
-		deco_box.height = c->view->y - c->y;
+		deco_box.height = c->content_y - c->y;
 	}
 
 	json_object_object_add(object, "deco_rect", ipc_json_create_rect(&deco_box));

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -196,22 +196,22 @@ static bool gaps_to_edge(struct sway_view *view) {
 }
 
 void view_autoconfigure(struct sway_view *view) {
-	if (!view->container->workspace) {
+	struct sway_container *con = view->container;
+	if (!con->workspace) {
 		// Hidden in the scratchpad
 		return;
 	}
-	struct sway_output *output = view->container->workspace->output;
+	struct sway_output *output = con->workspace->output;
 
-	if (view->container->is_fullscreen) {
-		view->x = output->lx;
-		view->y = output->ly;
-		view->width = output->width;
-		view->height = output->height;
+	if (con->is_fullscreen) {
+		con->content_x = output->lx;
+		con->content_y = output->ly;
+		con->content_width = output->width;
+		con->content_height = output->height;
 		return;
 	}
 
 	struct sway_workspace *ws = view->container->workspace;
-	struct sway_container *con = view->container;
 
 	bool smart = config->hide_edge_borders == E_SMART ||
 		config->hide_edge_borders == E_SMART_NO_GAPS;
@@ -289,10 +289,10 @@ void view_autoconfigure(struct sway_view *view) {
 		break;
 	}
 
-	view->x = x;
-	view->y = y;
-	view->width = width;
-	view->height = height;
+	con->content_x = x;
+	con->content_y = y;
+	con->content_width = width;
+	con->content_height = height;
 }
 
 void view_set_activated(struct sway_view *view, bool activated) {
@@ -667,11 +667,11 @@ void view_update_size(struct sway_view *view, int width, int height) {
 				"Expected a floating container")) {
 		return;
 	}
-	view->width = width;
-	view->height = height;
-	view->container->current.view_width = width;
-	view->container->current.view_height = height;
-	container_set_geometry_from_floating_view(view->container);
+	view->container->content_width = width;
+	view->container->content_height = height;
+	view->container->current.content_width = width;
+	view->container->current.content_height = height;
+	container_set_geometry_from_content(view->container);
 }
 
 static void subsurface_get_root_coords(struct sway_view_child *child,
@@ -707,7 +707,8 @@ static void view_child_damage(struct sway_view_child *child, bool whole) {
 	int sx, sy;
 	child->impl->get_root_coords(child, &sx, &sy);
 	desktop_damage_surface(child->surface,
-			child->view->x + sx, child->view->y + sy, whole);
+			child->view->container->content_x + sx,
+			child->view->container->content_y + sy, whole);
 }
 
 static void view_child_handle_surface_commit(struct wl_listener *listener,


### PR DESCRIPTION
This renames/moves the following properties:

* `sway_view.{x,y,width,height}` -> `sway_container.content_{x,y,width,height}`
    * This is required to support placeholder containers as they don't have a view.
* `sway_container_state.view_{x,y,width,height}` -> `sway_container_state.content_{x,y,width,height}`
    * To remain consistent with the above.
* `sway_container_state.con_{x,y,width,height}` -> `sway_container_state.{x,y,width,height}`
    * The `con` prefix was there to give it contrast from the view properties, and is no longer useful.

The function `container_set_geometry_from_floating_view` has also been renamed to `container_set_geometry_from_content`.