### PR TITLE
commands/resize: fix grow vars uninitialized

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -511,7 +511,7 @@ static struct cmd_results *resize_set_tiled(struct sway_container *con,
  */
 static struct cmd_results *resize_set_floating(struct sway_container *con,
 		struct resize_amount *width, struct resize_amount *height) {
-	int min_width, max_width, min_height, max_height, grow_width, grow_height;
+	int min_width, max_width, min_height, max_height, grow_width = 0, grow_height = 0;
 	calculate_constraints(&min_width, &max_width, &min_height, &max_height);
 
 	if (width->amount) {


### PR DESCRIPTION
I'm not sure I understand why the PPT/PX codepaths are different and thus why these would be uninitialized. Hopefully zero is a sane default.

This fixes a build error and my packaging treats it as an error. Thanks.