### PR TITLE
Add xwayland command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -176,8 +176,9 @@ sway_cmd cmd_title_format;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;
-sway_cmd cmd_ws_auto_back_and_forth;
 sway_cmd cmd_workspace_layout;
+sway_cmd cmd_ws_auto_back_and_forth;
+sway_cmd cmd_xwayland;
 
 sway_cmd bar_cmd_activate_button;
 sway_cmd bar_cmd_binding_mode_indicator;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -393,6 +393,7 @@ struct sway_config {
 	size_t urgent_timeout;
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;
+	bool xwayland;
 
 	// Flags
 	enum focus_follows_mouse_mode focus_follows_mouse;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -71,7 +71,7 @@ struct sway_server server;
 bool server_privileged_prepare(struct sway_server *server);
 bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);
-bool server_start_backend(struct sway_server *server);
+bool server_start(struct sway_server *server);
 void server_run(struct sway_server *server);
 
 void handle_new_output(struct wl_listener *listener, void *data);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -113,6 +113,7 @@ static struct cmd_handler config_handlers[] = {
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },
 	{ "workspace_layout", cmd_workspace_layout },
+	{ "xwayland", cmd_xwayland },
 };
 
 /* Runtime-only commands. Keep alphabetized */

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -1,0 +1,21 @@
+#include "sway/config.h"
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/server.h"
+#include "util.h"
+
+struct cmd_results *cmd_xwayland(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "xwayland", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+#ifdef HAVE_XWAYLAND
+	config->xwayland = parse_boolean(argv[0], config->xwayland);
+#else
+	wlr_log(WLR_INFO, "Ignoring `xwayland` command, "
+		"sway hasn't been built with Xwayland support");
+#endif
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -212,6 +212,7 @@ static void config_defaults(struct sway_config *config) {
 	config->font_height = 17; // height of monospace 10
 	config->urgent_timeout = 500;
 	config->popup_during_fullscreen = POPUP_SMART;
+	config->xwayland = true;
 
 	// floating view
 	config->floating_maximum_width = 0;

--- a/sway/main.c
+++ b/sway/main.c
@@ -382,7 +382,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (!terminate_request) {
-		if (!server_start_backend(&server)) {
+		if (!server_start(&server)) {
 			sway_terminate(EXIT_FAILURE);
 		}
 	}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -94,6 +94,7 @@ sway_sources = files(
 	'commands/workspace.c',
 	'commands/workspace_layout.c',
 	'commands/ws_auto_back_and_forth.c',
+	'commands/xwayland.c',
 
 	'commands/bar/activate_button.c',
 	'commands/bar/binding_mode_indicator.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -84,6 +84,10 @@ The following commands may only be used in the configuration file.
 	It can be disabled by setting the command to a single dash:
 	_swaynag\_command -_
 
+*xwayland* enable|disable
+	Enables or disables Xwayland support, which allows X11 applications to be
+	used.
+
 The following commands cannot be used directly in the configuration file.
 They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 
@@ -421,7 +425,7 @@ The default colors are:
 
 *focus\_follows\_mouse* yes|no|always
 	If set to _yes_, moving your mouse over a window will focus that window. If
-	set to _always_, the window under the cursor will always be focused, even 
+	set to _always_, the window under the cursor will always be focused, even
 	after switching between workspaces.
 
 *focus\_wrapping* yes|no|force


### PR DESCRIPTION
This allows xwayland to be disabled at runtime.

Xwayland needs to be started in `server_start`, after the config has been read.

Closes https://github.com/swaywm/sway/issues/2965