### PR TITLE
Adding commands for configuring titlebar borders and padding

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -173,6 +173,8 @@ sway_cmd cmd_swaynag_command;
 sway_cmd cmd_swap;
 sway_cmd cmd_tiling_drag;
 sway_cmd cmd_title_format;
+sway_cmd cmd_titlebar_border_thickness;
+sway_cmd cmd_titlebar_padding;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -391,6 +391,9 @@ struct sway_config {
 	size_t font_height;
 	size_t font_baseline;
 	bool pango_markup;
+	int titlebar_border_thickness;
+	int titlebar_h_padding;
+	int titlebar_v_padding;
 	size_t urgent_timeout;
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -10,12 +10,6 @@
 struct sway_view;
 struct sway_seat;
 
-#define TITLEBAR_BORDER_THICKNESS 1
-
-// Padding includes titlebar border
-#define TITLEBAR_H_PADDING 3
-#define TITLEBAR_V_PADDING 4
-
 enum sway_container_layout {
 	L_NONE,
 	L_HORIZ,

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -103,6 +103,8 @@ static struct cmd_handler handlers[] = {
 	{ "smart_borders", cmd_smart_borders },
 	{ "smart_gaps", cmd_smart_gaps },
 	{ "tiling_drag", cmd_tiling_drag },
+	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
+	{ "titlebar_padding", cmd_titlebar_padding },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/commands/titlebar_border_thickness.c
+++ b/sway/commands/titlebar_border_thickness.c
@@ -1,0 +1,30 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+#include "log.h"
+
+struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "titlebar_border_thickness", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	char *inv;
+	int value = strtol(argv[0], &inv, 10);
+	if (*inv != '\0' || value < 0 || value > config->titlebar_v_padding) {
+		return cmd_results_new(CMD_FAILURE, "titlebar_border_thickness",
+			"Invalid size specified");
+	}
+
+	config->titlebar_border_thickness = value;
+
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		arrange_workspace(output_get_active_workspace(output));
+		output_damage_whole(output);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/titlebar_padding.c
+++ b/sway/commands/titlebar_padding.c
@@ -1,0 +1,42 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+#include "log.h"
+
+struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "titlebar_padding", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	char *inv;
+	int h_value = strtol(argv[0], &inv, 10);
+	if (*inv != '\0' || h_value < 0 || h_value < config->titlebar_border_thickness) {
+		return cmd_results_new(CMD_FAILURE, "titlebar_padding",
+			"Invalid size specified");
+	}
+
+	int v_value;
+	if (argc == 1) {
+		v_value = h_value;
+	} else {
+		v_value = strtol(argv[1], &inv, 10);
+		if (*inv != '\0' || v_value < 0 || v_value < config->titlebar_border_thickness) {
+			return cmd_results_new(CMD_FAILURE, "titlebar_padding",
+				"Invalid size specified");
+		}
+	}
+
+	config->titlebar_v_padding = v_value;
+	config->titlebar_h_padding = h_value;
+
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		arrange_workspace(output_get_active_workspace(output));
+		output_damage_whole(output);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -213,6 +213,10 @@ static void config_defaults(struct sway_config *config) {
 	config->urgent_timeout = 500;
 	config->popup_during_fullscreen = POPUP_SMART;
 
+	config->titlebar_border_thickness = 1;
+	config->titlebar_h_padding = 5;
+	config->titlebar_v_padding = 4;
+
 	// floating view
 	config->floating_maximum_width = 0;
 	config->floating_maximum_height = 0;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -368,6 +368,9 @@ static void render_titlebar(struct sway_output *output,
 		children->items[children->length - 1] == con;
 	double output_x = output->wlr_output->lx;
 	double output_y = output->wlr_output->ly;
+	int titlebar_border_thickness = config->titlebar_border_thickness;
+	int titlebar_h_padding = config->titlebar_h_padding;
+	int titlebar_v_padding = config->titlebar_v_padding;
 
 	// Single pixel bar above title
 	memcpy(&color, colors->border, sizeof(float) * 4);
@@ -375,7 +378,7 @@ static void render_titlebar(struct sway_output *output,
 	box.x = x;
 	box.y = y;
 	box.width = width;
-	box.height = TITLEBAR_BORDER_THICKNESS;
+	box.height = titlebar_border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(output->wlr_output, output_damage, &box, color);
 
@@ -391,36 +394,36 @@ static void render_titlebar(struct sway_output *output,
 		}
 	}
 	box.x = x + left_offset;
-	box.y = y + container_titlebar_height() - TITLEBAR_BORDER_THICKNESS;
+	box.y = y + container_titlebar_height() - titlebar_border_thickness;
 	box.width = width - left_offset - right_offset;
-	box.height = TITLEBAR_BORDER_THICKNESS;
+	box.height = titlebar_border_thickness;
 	scale_box(&box, output_scale);
 	render_rect(output->wlr_output, output_damage, &box, color);
 
 	if (layout == L_TABBED) {
 		// Single pixel left edge
 		box.x = x;
-		box.y = y + TITLEBAR_BORDER_THICKNESS;
-		box.width = TITLEBAR_BORDER_THICKNESS;
+		box.y = y + titlebar_border_thickness;
+		box.width = titlebar_border_thickness;
 		box.height =
-			container_titlebar_height() - TITLEBAR_BORDER_THICKNESS * 2;
+			container_titlebar_height() - titlebar_border_thickness * 2;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, output_damage, &box, color);
 
 		// Single pixel right edge
-		box.x = x + width - TITLEBAR_BORDER_THICKNESS;
-		box.y = y + TITLEBAR_BORDER_THICKNESS;
-		box.width = TITLEBAR_BORDER_THICKNESS;
+		box.x = x + width - titlebar_border_thickness;
+		box.y = y + titlebar_border_thickness;
+		box.width = titlebar_border_thickness;
 		box.height =
-			container_titlebar_height() - TITLEBAR_BORDER_THICKNESS * 2;
+			container_titlebar_height() - titlebar_border_thickness * 2;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, output_damage, &box, color);
 	}
 
-	size_t inner_width = width - TITLEBAR_H_PADDING * 2;
-	int bg_y = y + TITLEBAR_BORDER_THICKNESS;
+	size_t inner_width = width - titlebar_h_padding * 2;
+	int bg_y = y + titlebar_border_thickness;
 	int ob_bg_height = scale_length(
-			(TITLEBAR_V_PADDING - TITLEBAR_BORDER_THICKNESS) * 2 +
+			(titlebar_v_padding - titlebar_border_thickness) * 2 +
 			config->font_height, bg_y, output_scale);
 
 	// Marks
@@ -438,7 +441,7 @@ static void render_titlebar(struct sway_output *output,
 		int ob_padding_below = ceil(ob_padding_total / 2.0);
 
 		// Render texture
-		texture_box.x = round((x - output_x + width - TITLEBAR_H_PADDING)
+		texture_box.x = round((x - output_x + width - titlebar_h_padding)
 				* output_scale) - texture_box.width;
 		texture_box.y = round((bg_y - output_y) * output_scale) +
 			ob_padding_above;
@@ -458,7 +461,7 @@ static void render_titlebar(struct sway_output *output,
 		memcpy(&color, colors->background, sizeof(float) * 4);
 		premultiply_alpha(color, con->alpha);
 		box.x = texture_box.x + round(output_x * output_scale);
-		box.y = round((y + TITLEBAR_BORDER_THICKNESS) * output_scale);
+		box.y = round((y + titlebar_border_thickness) * output_scale);
 		box.width = texture_box.width;
 		box.height = ob_padding_above;
 		render_rect(output->wlr_output, output_damage, &box, color);
@@ -480,14 +483,14 @@ static void render_titlebar(struct sway_output *output,
 		// The title texture might be shorter than the config->font_height,
 		// in which case we need to pad it above and below.
 		int ob_padding_above = round((config->font_baseline -
-					con->title_baseline + TITLEBAR_V_PADDING -
-					TITLEBAR_BORDER_THICKNESS) * output_scale);
+					con->title_baseline + titlebar_v_padding -
+					titlebar_border_thickness) * output_scale);
 		int ob_padding_below = ob_bg_height - ob_padding_above -
 			texture_box.height;
 
 		// Render texture
 		texture_box.x =
-			round((x - output_x + TITLEBAR_H_PADDING) * output_scale);
+			round((x - output_x + titlebar_h_padding) * output_scale);
 		texture_box.y =
 			round((bg_y - output_y) * output_scale) + ob_padding_above;
 
@@ -496,7 +499,7 @@ static void render_titlebar(struct sway_output *output,
 			WL_OUTPUT_TRANSFORM_NORMAL,
 			0.0, output->wlr_output->transform_matrix);
 
-		int inner_x = x - output_x + TITLEBAR_H_PADDING;
+		int inner_x = x - output_x + titlebar_h_padding;
 		int ob_inner_width = scale_length(inner_width, inner_x, output_scale);
 		if (ob_inner_width - marks_ob_width < texture_box.width) {
 			texture_box.width = ob_inner_width - marks_ob_width;
@@ -508,7 +511,7 @@ static void render_titlebar(struct sway_output *output,
 		memcpy(&color, colors->background, sizeof(float) * 4);
 		premultiply_alpha(color, con->alpha);
 		box.x = texture_box.x + round(output_x * output_scale);
-		box.y = round((y + TITLEBAR_BORDER_THICKNESS) * output_scale);
+		box.y = round((y + titlebar_border_thickness) * output_scale);
 		box.width = texture_box.width;
 		box.height = ob_padding_above;
 		render_rect(output->wlr_output, output_damage, &box, color);
@@ -523,28 +526,28 @@ static void render_titlebar(struct sway_output *output,
 	box.width =
 		round(inner_width * output_scale) - title_ob_width - marks_ob_width;
 	if (box.width > 0) {
-		box.x = round((x + TITLEBAR_H_PADDING) * output_scale) + title_ob_width;
+		box.x = round((x + titlebar_h_padding) * output_scale) + title_ob_width;
 		box.y = round(bg_y * output_scale);
 		box.height = ob_bg_height;
 		render_rect(output->wlr_output, output_damage, &box, color);
 	}
 
 	// Padding left of title
-	left_offset = (layout == L_TABBED) * TITLEBAR_BORDER_THICKNESS;
+	left_offset = (layout == L_TABBED) * titlebar_border_thickness;
 	box.x = x + left_offset;
-	box.y = y + TITLEBAR_BORDER_THICKNESS;
-	box.width = TITLEBAR_H_PADDING - left_offset;
-	box.height = (TITLEBAR_V_PADDING - TITLEBAR_BORDER_THICKNESS) * 2 +
+	box.y = y + titlebar_border_thickness;
+	box.width = titlebar_h_padding - left_offset;
+	box.height = (titlebar_v_padding - titlebar_border_thickness) * 2 +
 		config->font_height;
 	scale_box(&box, output_scale);
 	render_rect(output->wlr_output, output_damage, &box, color);
 
 	// Padding right of marks
-	right_offset = (layout == L_TABBED) * TITLEBAR_BORDER_THICKNESS;
-	box.x = x + width - TITLEBAR_H_PADDING;
-	box.y = y + TITLEBAR_BORDER_THICKNESS;
-	box.width = TITLEBAR_H_PADDING - right_offset;
-	box.height = (TITLEBAR_V_PADDING - TITLEBAR_BORDER_THICKNESS) * 2 +
+	right_offset = (layout == L_TABBED) * titlebar_border_thickness;
+	box.x = x + width - titlebar_h_padding;
+	box.y = y + titlebar_border_thickness;
+	box.width = titlebar_h_padding - right_offset;
+	box.height = (titlebar_v_padding - titlebar_border_thickness) * 2 +
 		config->font_height;
 	scale_box(&box, output_scale);
 	render_rect(output->wlr_output, output_damage, &box, color);
@@ -552,17 +555,17 @@ static void render_titlebar(struct sway_output *output,
 	if (connects_sides) {
 		// Left pixel in line with bottom bar
 		box.x = x;
-		box.y = y + container_titlebar_height() - TITLEBAR_BORDER_THICKNESS;
+		box.y = y + container_titlebar_height() - titlebar_border_thickness;
 		box.width = state->border_thickness * state->border_left;
-		box.height = TITLEBAR_BORDER_THICKNESS;
+		box.height = titlebar_border_thickness;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, output_damage, &box, color);
 
 		// Right pixel in line with bottom bar
 		box.x = x + width - state->border_thickness * state->border_right;
-		box.y = y + container_titlebar_height() - TITLEBAR_BORDER_THICKNESS;
+		box.y = y + container_titlebar_height() - titlebar_border_thickness;
 		box.width = state->border_thickness * state->border_right;
-		box.height = TITLEBAR_BORDER_THICKNESS;
+		box.height = titlebar_border_thickness;
 		scale_box(&box, output_scale);
 		render_rect(output->wlr_output, output_damage, &box, color);
 	}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -89,6 +89,8 @@ sway_sources = files(
 	'commands/swap.c',
 	'commands/tiling_drag.c',
 	'commands/title_format.c',
+	'commands/titlebar_border_thickness.c',
+	'commands/titlebar_padding.c',
 	'commands/unmark.c',
 	'commands/urgent.c',
 	'commands/workspace.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -436,6 +436,16 @@ The default colors are:
 *font* <font>
 	Sets font for use in title bars in Pango format.
 
+*titlebar\_border\_thickness* <thickness>
+	Thickness of the titlebar border in pixels
+
+*titlebar\_padding* <horizontal> [<vertical>]
+	Padding of the text in the titlebar. _horizontal_ value affects horizontal 
+	padding of the text while _vertical_ value affects vertical padding (space 
+	above and below text). Padding includes titlebar borders so their value 
+	should be greater than titlebar\_border\_thickness. If _vertical_ value is
+	not specified it is set to the _horizontal_ value. 
+
 *for\_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -594,7 +594,7 @@ void container_update_representation(struct sway_container *con) {
 }
 
 size_t container_titlebar_height(void) {
-	return config->font_height + TITLEBAR_V_PADDING * 2;
+	return config->font_height + config->titlebar_v_padding * 2;
 }
 
 void container_init_floating(struct sway_container *con) {


### PR DESCRIPTION
As talked in issue #3134 titlebar border size and padding are currently hardcoded

This patch proposes two new commands, which permits to adjust the width of titlebars
 - titlebar_border_thickness \<n\>
 - titlebar_padding \<h\> [v]

Example use with swaymsg to just get a 1 px border and minimal space above and below text : 
$ swaymsg titlebar_border_thickness 1
$ swaymsg titlebar_padding 5 1