### PR TITLE
Kbd layout per window

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -277,6 +277,7 @@ sway_cmd seat_cmd_attach;
 sway_cmd seat_cmd_cursor;
 sway_cmd seat_cmd_fallback;
 sway_cmd seat_cmd_hide_cursor;
+sway_cmd seat_cmd_keep_keyboard_layout;
 sway_cmd seat_cmd_pointer_constraint;
 
 sway_cmd cmd_ipc_cmd;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -41,6 +41,12 @@ enum binding_flags {
 	BINDING_CODE=32,     // keyboard only; convert keysyms into keycodes
 };
 
+enum sway_keep_keyboard_layout {
+	KEYBOARD_LAYOUT_UNDEFINED = 0,
+	KEYBOARD_LAYOUT_GLOBAL,
+	KEYBOARD_LAYOUT_PER_WINDOW
+};
+
 /**
  * A key binding and an associated command.
  */
@@ -165,6 +171,7 @@ struct seat_config {
 	list_t *attachments; // list of seat_attachment configs
 	int hide_cursor_timeout;
 	enum seat_config_allow_constrain allow_constrain;
+	enum sway_keep_keyboard_layout keep_keyboard_layout;
 };
 
 enum config_dpms {

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -63,9 +63,15 @@ struct sway_keyboard {
 
 	struct wl_event_source *key_repeat_source;
 	struct sway_binding *repeat_binding;
+	xkb_layout_index_t default_kbd_layout;
 };
 
 struct xkb_keymap *sway_keyboard_compile_keymap(struct input_config *ic);
+
+struct sway_layout_per_kbd {
+	struct wlr_keyboard *kbd;
+	xkb_layout_index_t layout;
+};
 
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,
 		struct sway_seat_device *device);
@@ -73,6 +79,10 @@ struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,
 void sway_keyboard_configure(struct sway_keyboard *keyboard);
 
 void sway_keyboard_destroy(struct sway_keyboard *keyboard);
+
+void sway_keyboard_set_layout(struct wlr_keyboard *kbd, xkb_layout_index_t layout);
+
+xkb_layout_index_t sway_keyboard_get_layout(struct xkb_state *kbd_state);
 
 void sway_keyboard_disarm_key_repeat(struct sway_keyboard *keyboard);
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -111,6 +111,8 @@ struct sway_view {
 	} events;
 
 	struct wl_listener surface_new_subsurface;
+
+	list_t *kbd_layouts; // struct sway_layout_per_kbd *
 };
 
 struct sway_xdg_shell_v6_view {
@@ -309,7 +311,7 @@ void view_for_each_popup(struct sway_view *view,
 
 // view implementation
 
-void view_init(struct sway_view *view, enum sway_view_type type,
+bool view_init(struct sway_view *view, enum sway_view_type type,
 	const struct sway_view_impl *impl);
 
 void view_destroy(struct sway_view *view);

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -12,6 +12,7 @@ static struct cmd_handler seat_handlers[] = {
 	{ "cursor", seat_cmd_cursor },
 	{ "fallback", seat_cmd_fallback },
 	{ "hide_cursor", seat_cmd_hide_cursor },
+	{ "keep_keyboard_layout", seat_cmd_keep_keyboard_layout },
 	{ "pointer_constraint", seat_cmd_pointer_constraint },
 };
 

--- a/sway/commands/seat/keep_keyboard_layout.c
+++ b/sway/commands/seat/keep_keyboard_layout.c
@@ -1,0 +1,29 @@
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/input-manager.h"
+
+struct cmd_results *seat_cmd_keep_keyboard_layout(int argc, char **argv) {
+	const char *STR_LAYOUT_GLOBAL = "global",
+		*STR_LAYOUT_PER_WINDOW = "per_window";
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "keep_keyboard_layout", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	if (!config->handler_context.seat_config) {
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
+	}
+
+	if (!strcmp(argv[0], STR_LAYOUT_GLOBAL)) {
+		config->handler_context.seat_config->keep_keyboard_layout
+			= KEYBOARD_LAYOUT_GLOBAL;
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	} else if (!strcmp(argv[0], STR_LAYOUT_PER_WINDOW)) {
+		config->handler_context.seat_config->keep_keyboard_layout
+			= KEYBOARD_LAYOUT_PER_WINDOW;
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	} else {
+		return cmd_results_new(CMD_FAILURE, "keep_keyboard_layout",
+				"Expected 'keep_keyboard_layout global|per_window");
+	}
+}

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -27,6 +27,7 @@ struct seat_config *new_seat_config(const char* name) {
 	}
 	seat->hide_cursor_timeout = -1;
 	seat->allow_constrain = CONSTRAIN_DEFAULT;
+	seat->keep_keyboard_layout = KEYBOARD_LAYOUT_UNDEFINED;
 
 	return seat;
 }
@@ -114,6 +115,10 @@ static void merge_seat_attachment_config(struct seat_attachment_config *dest,
 void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 	if (source->fallback != -1) {
 		dest->fallback = source->fallback;
+	}
+
+	if (source->keep_keyboard_layout != KEYBOARD_LAYOUT_UNDEFINED) {
+		dest->keep_keyboard_layout = source->keep_keyboard_layout;
 	}
 
 	for (int i = 0; i < source->attachments->length; ++i) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -504,7 +504,11 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	view_init(&xdg_shell_view->view, SWAY_VIEW_XDG_SHELL, &view_impl);
+	if (!view_init(&xdg_shell_view->view, SWAY_VIEW_XDG_SHELL, &view_impl)) {
+		sway_assert(false, "Failed to init view");
+		return;
+	}
+
 	xdg_shell_view->view.wlr_xdg_surface = xdg_surface;
 
 	xdg_shell_view->map.notify = handle_map;

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -492,7 +492,11 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	view_init(&xdg_shell_v6_view->view, SWAY_VIEW_XDG_SHELL_V6, &view_impl);
+	if (!view_init(&xdg_shell_v6_view->view, SWAY_VIEW_XDG_SHELL_V6, &view_impl)) {
+		sway_assert(false, "Failed to init view");
+		return;
+	}
+
 	xdg_shell_v6_view->view.wlr_xdg_surface_v6 = xdg_surface;
 
 	xdg_shell_v6_view->map.notify = handle_map;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -595,7 +595,11 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	view_init(&xwayland_view->view, SWAY_VIEW_XWAYLAND, &view_impl);
+	if (!view_init(&xwayland_view->view, SWAY_VIEW_XWAYLAND, &view_impl)) {
+		sway_assert(false, "Failed to init view");
+		return;
+	}
+
 	xwayland_view->view.wlr_xwayland_surface = xsurface;
 
 	wl_signal_add(&xsurface->events.destroy, &xwayland_view->destroy);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -88,6 +88,7 @@ sway_sources = files(
 	'commands/seat/cursor.c',
 	'commands/seat/fallback.c',
 	'commands/seat/hide_cursor.c',
+	'commands/seat/keep_keyboard_layout.c',
 	'commands/seat/pointer_constraint.c',
 	'commands/set.c',
 	'commands/show_marks.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -201,6 +201,9 @@ correct seat.
 	disables hiding the cursor. The minimal timeout is 100 and any value less
 	than that (aside from 0), will be increased to 100.
 
+*seat* <name> keep_keyboard_layout global|per_window
+	Controls whether to keep keyboard layout per window. Default is _global_.
+
 *seat* <name> pointer_constraint enable|disable|escape
 	Enables or disables the ability for clients to capture the cursor (enabled
 	by default) for the seat. This is primarily useful for video games. The


### PR DESCRIPTION
This is a work-in-progress code to fix https://github.com/swaywm/sway/issues/2361

It does work as it is, but there's one last todo that I wanted to consult about.

If you highlight "todo" in last commit, you'll see that I'm currently storing only one `xkb_layout_index_t` in every window. However I'm wondering, whether this `xkb_layout_index_t` might have a different meaning for different keyboards. In which case I'd need to keep a list of structs `struct curr_kbd_layout { wlr_keyboard *kbd_owner; xkb_layout_index_t layout };`. And then on every keyboard destroy I'd need to walk over all `sway_view`s, and remove the element in list that refers to the keyboard being destroyed.

Is it the preferred way of dealing with it? Or is there something simpler? Like, if `xkb_layout_index_t` is guaranteed to map to the same layout for any keyboard on the system, then the current code already works well.
