### PR TITLE
fix typo in config.in

### DIFF
--- a/config.in
+++ b/config.in
@@ -41,7 +41,7 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 #    before-sleep 'swaylock -c 000000'
 #
 # This will lock your screen after 300 seconds of inactivity, then turn off
-# your displays after another 600 seconds, and turn your screens back on when
+# your displays after another 300 seconds, and turn your screens back on when
 # resumed. It will also lock your screen before your computer goes to sleep.
 
 ### Input configuration


### PR DESCRIPTION
I think there's a typo in config.in and this commit fixes it.
From experimantation I think that the example timeouts given in config.in don't add to another (like currently described in the comment block) but are timeouts on its own.
This typo is misleading and can be dangerous, e.g. I set the second (DPMS) timeout to a lower value than the first one (I thought from the comments they add to each other) and then typed my password into an open shell (I thought the screen locked).

Please tell me if the commit message is too short - but actually it's just a typo I think.

Although I DID NOT CONFIRM in the source code that it's actually two independent timeouts (I don't know where that is.) Please, someone else should do this.