### PR TITLE
[WIP] Don't modeset output to default mode when already set to a mode

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -200,7 +200,7 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_log(WLR_DEBUG, "Set %s mode to %dx%d (%f GHz)", oc->name, oc->width,
 			oc->height, oc->refresh_rate);
 		set_mode(wlr_output, oc->width, oc->height, oc->refresh_rate);
-	} else if (!wl_list_empty(&wlr_output->modes)) {
+	} else if (wlr_output->current_mode == NULL && !wl_list_empty(&wlr_output->modes)) {
 		struct wlr_output_mode *mode =
 			wl_container_of(wlr_output->modes.prev, mode, link);
 		wlr_output_set_mode(wlr_output, mode);


### PR DESCRIPTION
When an output already has a mode set then the default mode does not need to be set. This change was triggered by me getting annoyed that my screen would be modeset (giving a flash even when DPMS off) for every background change (I have a periodic background change scripted).

I am not entirely sure if this is the best place to fix this but it does at least fix the issue I encountered where a completely unrelated output command triggers a modeset.