### PR TITLE
Meson: Fix SYSCONFDIR definition

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -108,13 +108,7 @@ if scdoc.found()
 	endforeach
 endif
 
-# If prefix is '/usr', sysconfdir will be explicitly set to '/etc' by Meson to
-# enforce FHS compliance, so we should look for configs there as well.
-if prefix == '/usr'
-	add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
-else
-	add_project_arguments('-DSYSCONFDIR="/@0@/@1@"'.format(prefix, sysconfdir), language : 'c')
-endif
+add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
 
 version = get_option('sway-version')
 if version != ''
@@ -159,14 +153,7 @@ subdir('swaylock')
 config = configuration_data()
 config.set('datadir', join_paths(prefix, datadir))
 config.set('prefix', prefix)
-
-# If prefix is '/usr', sysconfdir will be explicitly set to '/etc' by Meson to
-# enforce FHS compliance, so we should look for configs there as well.
-if prefix == '/usr'
-	config.set('sysconfdir', sysconfdir)
-else
-	config.set('sysconfdir', join_paths(prefix, sysconfdir))
-endif
+config.set('sysconfdir', join_paths(prefix, sysconfdir))
 
 configure_file(
 	configuration: config,


### PR DESCRIPTION
```SYSCONFDIR``` was set to the wrong path if ```prefix``` is not ```'/usr'``` and
```sysconfdir``` is an absolute path. Use ```join_paths()``` to fix it.

Also remove the special case for ```prefix``` ```'/usr'```. In that case Meson
already sets ```sysconfdir``` to the absolute path ```'/etc'```, so just using
```join_paths()``` will return the correct value.

    join_paths('/usr/local', 'etc') => '/usr/local/etc'
    join_paths('/usr/local', '/etc') => '/etc'
    join_paths('/usr', '/etc') => '/etc'

This should allow building and installing to '/usr/local' while storing configuration data like pam settings in ```/etc```. (#3096)