### PR TITLE
resize set: fix units for floating containers

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -524,7 +524,9 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 			grow_width = width->amount - con->width;
 			con->x -= grow_width / 2;
 			con->width = width->amount;
+			break;
 		case RESIZE_UNIT_INVALID:
+			sway_assert(false, "invalid width unit");
 			break;
 		}
 	}
@@ -542,7 +544,9 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 			grow_height = height->amount - con->height;
 			con->y -= grow_height / 2;
 			con->height = height->amount;
+			break;
 		case RESIZE_UNIT_INVALID:
+			sway_assert(false, "invalid height unit");
 			break;
 		}
 	}

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -512,34 +512,38 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 	calculate_constraints(&min_width, &max_width, &min_height, &max_height);
 
 	if (width->amount) {
-		if (width->unit == RESIZE_UNIT_PPT ||
-				width->unit == RESIZE_UNIT_DEFAULT) {
+		switch (width->unit) {
+		case RESIZE_UNIT_PPT:
 			// Convert to px
 			width->amount = con->workspace->width * width->amount / 100;
 			width->unit = RESIZE_UNIT_PX;
-		}
-		if (width->unit == RESIZE_UNIT_PX) {
+			// Falls through
+		case RESIZE_UNIT_PX:
+		case RESIZE_UNIT_DEFAULT:
 			width->amount = fmax(min_width, fmin(width->amount, max_width));
 			grow_width = width->amount - con->width;
-
 			con->x -= grow_width / 2;
 			con->width = width->amount;
+		case RESIZE_UNIT_INVALID:
+			break;
 		}
 	}
 
 	if (height->amount) {
-		if (height->unit == RESIZE_UNIT_PPT ||
-				height->unit == RESIZE_UNIT_DEFAULT) {
+		switch (height->unit) {
+		case RESIZE_UNIT_PPT:
 			// Convert to px
 			height->amount = con->workspace->height * height->amount / 100;
 			height->unit = RESIZE_UNIT_PX;
-		}
-		if (height->unit == RESIZE_UNIT_PX) {
+			// Falls through
+		case RESIZE_UNIT_PX:
+		case RESIZE_UNIT_DEFAULT:
 			height->amount = fmax(min_height, fmin(height->amount, max_height));
 			grow_height = height->amount - con->height;
-
 			con->y -= grow_height / 2;
 			con->height = height->amount;
+		case RESIZE_UNIT_INVALID:
+			break;
 		}
 	}
 


### PR DESCRIPTION
The behavior of `resize set <width> <height>` for floating containers has changed recently. According to the documentation, floating containers should be resized in px if the units are omitted, but now ppt are used for both tiled and floating containers.