### PR TITLE
v2: do not create uninitialized sway_keyboard

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -403,6 +403,7 @@ struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,
 	keyboard->key_repeat_source = wl_event_loop_add_timer(server.wl_event_loop,
 			handle_keyboard_repeat, keyboard);
 
+	sway_keyboard_configure(device->keyboard);
 	return keyboard;
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -443,10 +443,12 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 		struct sway_seat_device *seat_device) {
 	if (!seat_device->keyboard) {
 		sway_keyboard_create(seat, seat_device);
+	} else {
+		sway_keyboard_configure(seat_device->keyboard);
 	}
+
 	struct wlr_keyboard *wlr_keyboard =
 		seat_device->input_device->wlr_device->keyboard;
-	sway_keyboard_configure(seat_device->keyboard);
 	wlr_seat_set_keyboard(seat->wlr_seat,
 			seat_device->input_device->wlr_device);
 	struct sway_node *focus = seat_get_focus(seat);


### PR DESCRIPTION
It's not good to create a uninitialized struct, because it might become
a possible error in future. I actually got hit by this while working on
https://github.com/swaywm/sway/pull/3155

v2: just move initialization inside the keyboard creation, leave the rest in place.