### PR TITLE
Handle destroyed subsurfaces

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -203,6 +203,12 @@ struct sway_view_child {
 	struct wl_listener surface_destroy;
 };
 
+struct sway_subsurface {
+	struct sway_view_child child;
+
+	struct wl_listener destroy;
+};
+
 struct sway_xdg_popup_v6 {
 	struct sway_view_child child;
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -713,9 +713,6 @@ static void subsurface_handle_destroy(struct wl_listener *listener,
 	struct sway_subsurface *subsurface =
 		wl_container_of(listener, subsurface, destroy);
 	struct sway_view_child *child = &subsurface->child;
-	if (child->view->container != NULL) {
-		view_child_damage(child, true);
-	}
 	view_child_destroy(child);
 }
 
@@ -812,6 +809,10 @@ void view_child_init(struct sway_view_child *child,
 }
 
 void view_child_destroy(struct sway_view_child *child) {
+	if (child->view->container != NULL) {
+		view_child_damage(child, true);
+	}
+
 	wl_list_remove(&child->surface_commit.link);
 	wl_list_remove(&child->surface_destroy.link);
 


### PR DESCRIPTION
Damage subsurfaces when they are destroyed. Since subsurfaces don't have an
unmap event we need to do that on destroy.

We also don't want to keep a sway_view_child when the wlr_subsurface has been
destroyed.

Fixes https://github.com/swaywm/sway/issues/3197