### PR TITLE
Fix compilation error on musl

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <ctype.h>


### PR DESCRIPTION
I have the following error when compiling latest sway+wlroots on Void Linux with musl
```
[271/275] Compiling C object 'swaylock/swaylock@@swaylock@exe/main.c.o'.
FAILED: swaylock/swaylock@@swaylock@exe/main.c.o
cc -Iswaylock/swaylock@@swaylock@exe -Iswaylock -I../swaylock -Iinclude -I../include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/elogind -flto -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=c11 -DWL_HIDE_DEPRECATED -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-unused-result -Wundef '-DSYSCONFDIR="//etc"' '-DSWAY_VERSION=" (" __DATE__ ", branch '"'"''"'"')"' -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pthread  -MD -MQ 'swaylock/swaylock@@swaylock@exe/main.c.o' -MF 'swaylock/swaylock@@swaylock@exe/main.c.o.d' -o 'swaylock/swaylock@@swaylock@exe/main.c.o' -c ../swaylock/main.c
../swaylock/main.c: In function 'main':
../swaylock/main.c:964:65: error: 'POLL_IN' undeclared (first use in this function)
  loop_add_fd(state.eventloop, wl_display_get_fd(state.display), POLL_IN,
                                                                 ^~~~~~~
../swaylock/main.c:964:65: note: each undeclared identifier is reported only once for each function it appears in
ninja: build stopped: subcommand failed.
```
Investigating the error, I found that it was introduced when commit 3a310f9 was merged.
That commit removed the `_XOPEN_SOURCE` definition. If you read the signal.h musl implementation [here](https://git.musl-libc.org/cgit/musl/tree/include/signal.h#n223) we can see that the definition is needed if the `POLL_IN` definition is to be included.
```
#if defined(_XOPEN_SOURCE) || defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
...
#define POLL_IN 1
...
```