### PR TITLE
Introduce a way to show config warnings in swaynag

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -425,6 +425,8 @@ struct sway_config {
 	list_t *config_chain;
 	const char *current_config_path;
 	const char *current_config;
+	int current_config_line_number;
+	char *current_config_line;
 
 	enum sway_container_border border;
 	enum sway_container_border floating_border;
@@ -488,6 +490,11 @@ bool load_include_configs(const char *path, struct sway_config *config,
  */
 bool read_config(FILE *file, struct sway_config *config,
 		struct swaynag_instance *swaynag);
+
+/**
+ * Adds a warning entry to the swaynag instance used for errors.
+ */
+void config_add_swaynag_warning(char *fmt, ...);
 
 /**
  * Free config struct

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -255,8 +255,12 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 	for (int i = 0; i < mode_bindings->length; ++i) {
 		struct sway_binding *config_binding = mode_bindings->items[i];
 		if (binding_key_compare(binding, config_binding)) {
-			wlr_log(WLR_DEBUG, "overwriting old binding with command '%s'",
-				config_binding->command);
+			wlr_log(WLR_INFO, "Overwriting binding '%s' for device '%s' "
+					"from `%s` to `%s`", argv[0], binding->input,
+					binding->command, config_binding->command);
+			config_add_swaynag_warning("Overwriting binding '%s' for device "
+					"'%s' to `%s` from `%s`", argv[0], binding->input,
+					binding->command, config_binding->command);
 			free_sway_binding(config_binding);
 			mode_bindings->items[i] = binding;
 			overwritten = true;

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -116,11 +116,8 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		if (!can_access) {
 			wlr_log(WLR_ERROR, "Unable to access background file '%s': %s",
 					src, strerror(errno));
-			if (config->reading && !config->validating) {
-				swaynag_log(config->swaynag_command,
-						&config->swaynag_config_errors,
-						"Unable to access background file '%s'", src);
-			}
+			config_add_swaynag_warning("Unable to access background file '%s'",
+					src);
 			free(src);
 		} else {
 			// Escape double quotes in the final path for swaybg


### PR DESCRIPTION
Closes #3138

Adds the function `config_add_swaynag_warning(char *fmt, ...)` so that handlers can add warnings to the swaynag config log in a uniform way. The formatting is identical to errors and include the line number, line, and config path.

This also alters the background file access warning to use the function and introduces a warning for duplicate bindings.