### PR TITLE
Implement support for swaymsg -t SUBSCRIBE [-m]

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -668,7 +668,8 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		// TODO: Check if they're permitted to use these events
 		struct json_object *request = json_tokener_parse(buf);
 		if (request == NULL) {
-			client_valid = ipc_send_reply(client, "{\"success\": false}", 18);
+			const char msg[] = "[{\"success\": false}]";
+			client_valid = ipc_send_reply(client, msg, strlen(msg));
 			wlr_log(WLR_INFO, "Failed to parse subscribe request");
 			goto exit_cleanup;
 		}
@@ -695,8 +696,8 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client->subscribed_events |= event_mask(IPC_EVENT_TICK);
 				is_tick = true;
 			} else {
-				client_valid =
-					ipc_send_reply(client, "{\"success\": false}", 18);
+				const char msg[] = "[{\"success\": false}]";
+				client_valid = ipc_send_reply(client, msg, strlen(msg));
 				json_object_put(request);
 				wlr_log(WLR_INFO, "Unsupported event type in subscribe request");
 				goto exit_cleanup;
@@ -704,10 +705,12 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 
 		json_object_put(request);
-		client_valid = ipc_send_reply(client, "{\"success\": true}", 17);
+		const char msg[] = "[{\"success\": true}]";
+		client_valid = ipc_send_reply(client, msg, strlen(msg));
 		if (is_tick) {
 			client->current_command = IPC_EVENT_TICK;
-			ipc_send_reply(client, "{\"first\": true, \"payload\": \"\"}", 30);
+			const char tickmsg[] = "{\"first\": true, \"payload\": \"\"}";
+			ipc_send_reply(client, tickmsg, strlen(tickmsg));
 		}
 		goto exit_cleanup;
 	}

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -13,6 +13,12 @@ _swaymsg_ [options...] [message]
 *-h, --help*
 	Show help message and quit.
 
+*-m, --monitor*
+	Monitor for responses until killed instead of exiting after the first
+	response. This can only be used with the IPC message type _subscribe_. If
+	there is a malformed response or an invalid event type was requested,
+	swaymsg will stop monitoring and exit.
+
 *-q, --quiet*
 	Sends the IPC message but does not print the response from sway.
 
@@ -71,3 +77,8 @@ _swaymsg_ [options...] [message]
 
 *send\_tick*
 	Sends a tick event to all subscribed clients.
+
+*subscribe*
+	Subscribe to a list of event types. The argument for this type should be
+	provided in the form of a valid JSON array. If any of the types are invalid
+	or if an valid JSON array is not provided, this will result in an failure.


### PR DESCRIPTION
Related to #3082

In `i3 4.16`, `i3-msg` can be used with the message type `subscribe` and has the ability to monitor for responses until killed. This adds support for both to swaymsg.

If the JSON array of event types is malformed or contains an invalid event, sway will send a response with `success` set to `false`. If swaymsg sees this, it will not display the failure and exit.

If the `subscribe` event is successful, swaymsg will wait for the first response and display that instead of the success message. If `-m/--monitor` is given, swaymsg will continue monitor for responses until killed or a malformed response is received.

For the `subscribe` event, the responses will always be printed as JSON. If `-r/--raw` is given, the JSON will not be pretty printed, which may be preferred when monitoring due to there being multiple responses.

Example: `swaymsg -t subscribe -m "['window']"`