### PR TITLE
Implement swaynag -B/--button-no-terminal

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -44,6 +44,7 @@ struct swaynag_button {
 	int y;
 	int width;
 	int height;
+	bool terminal;
 };
 
 struct swaynag_details {

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -52,6 +52,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 
 	static struct option opts[] = {
 		{"button", required_argument, NULL, 'b'},
+		{"button-no-terminal", required_argument, NULL, 'B'},
 		{"config", required_argument, NULL, 'c'},
 		{"debug", no_argument, NULL, 'd'},
 		{"edge", required_argument, NULL, 'e'},
@@ -86,7 +87,10 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		"Usage: swaynag [options...]\n"
 		"\n"
 		"  -b, --button <text> <action>  Create a button with text that "
-			"executes action when pressed. Multiple buttons can be defined.\n"
+			"executes action in a terminal when pressed. Multiple buttons can "
+			"be defined.\n"
+		"  -B, --button-no-terminal <text> <action>  Like --button, but does"
+			"not run the action in a terminal.\n"
 		"  -c, --config <path>           Path to config file.\n"
 		"  -d, --debug                   Enable debugging.\n"
 		"  -e, --edge top|bottom         Set the edge to use.\n"
@@ -117,12 +121,13 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 
 	optind = 1;
 	while (1) {
-		int c = getopt_long(argc, argv, "b:c:de:f:hlL:m:o:s:t:v", opts, NULL);
+		int c = getopt_long(argc, argv, "b:B:c:de:f:hlL:m:o:s:t:v", opts, NULL);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 'b': // Button
+		case 'B': // Button (No Terminal)
 			if (swaynag) {
 				if (optind >= argc) {
 					fprintf(stderr, "Missing action for button %s\n", optarg);
@@ -133,6 +138,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 				button->text = strdup(optarg);
 				button->type = SWAYNAG_ACTION_COMMAND;
 				button->action = strdup(argv[optind]);
+				button->terminal = c == 'b';
 				list_add(swaynag->buttons, button);
 			}
 			optind++;

--- a/swaynag/swaynag.1.scd
+++ b/swaynag/swaynag.1.scd
@@ -12,7 +12,14 @@ _swaynag_ [options...]
 
 *-b, --button* <text> <action>
 	Create a button with the text _text_ that executes _action_ when pressed.
-	Multiple buttons can be defined by providing the flag multiple times.
+	If the environment variable `TERMINAL` is set, _action_ will be run inside
+	the terminal. Otherwise, it will fallback to running directly. Multiple
+	buttons can be defined by providing the flag multiple times.
+
+*-B, --button-no-terminal* <text> <action>
+	Create a button with the text _text_ that executes _action_ when pressed.
+	_action_ will be run directly instead of in a terminal. Multiple buttons
+	can be defined by providing the flag multiple times.
 
 *-c, --config* <path>
 	The config file to use. By default, the following paths are checked:

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -49,14 +49,17 @@ static void swaynag_button_execute(struct swaynag *swaynag,
 			if (fork() == 0) {
 				// Child of the child. Will be reparented to the init process
 				char *terminal = getenv("TERMINAL");
-				if (terminal && strlen(terminal)) {
+				if (button->terminal && terminal && strlen(terminal)) {
 					wlr_log(WLR_DEBUG, "Found $TERMINAL: %s", terminal);
 					if (!terminal_execute(terminal, button->action)) {
 						swaynag_destroy(swaynag);
 						exit(EXIT_FAILURE);
 					}
 				} else {
-					wlr_log(WLR_DEBUG, "$TERMINAL not found. Running directly");
+					if (button->terminal) {
+						wlr_log(WLR_DEBUG,
+								"$TERMINAL not found. Running directly");
+					}
 					execl("/bin/sh", "/bin/sh", "-c", button->action, NULL);
 				}
 			}


### PR DESCRIPTION
Related to #3082 

In `i3 4.16`, `i3-nagbar` introduces the flags `-B/--button-no-terminal` to run the action directly instead of inside a terminal. This implements the flags for swaynag for compatibility.

Since swaynag does not use an equivalent to `i3-sensible-terminal`, the flags `-b/--button` only uses a terminal when the environment variable `TERMINAL` is set, otherwise it acts the same as these new flags.