### PR TITLE
Implement bar gaps

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -188,6 +188,7 @@ sway_cmd bar_cmd_bindsym;
 sway_cmd bar_cmd_colors;
 sway_cmd bar_cmd_context_button;
 sway_cmd bar_cmd_font;
+sway_cmd bar_cmd_gaps;
 sway_cmd bar_cmd_mode;
 sway_cmd bar_cmd_modifier;
 sway_cmd bar_cmd_output;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -227,6 +227,7 @@ struct bar_config {
 	bool strip_workspace_name;
 	bool binding_mode_indicator;
 	bool verbose;
+	struct side_gaps gaps;
 	pid_t pid;
 	struct {
 		char *background;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -42,6 +42,12 @@ struct swaybar_config {
 	struct wl_list outputs; // config_output::link
 	bool all_outputs;
 	int height;
+	struct {
+		int top;
+		int right;
+		int bottom;
+		int left;
+	} gaps;
 
 	struct {
 		uint32_t background;

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -14,6 +14,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "colors", bar_cmd_colors },
 	{ "context_button", bar_cmd_context_button },
 	{ "font", bar_cmd_font },
+	{ "gaps", bar_cmd_gaps },
 	{ "height", bar_cmd_height },
 	{ "hidden_state", bar_cmd_hidden_state },
 	{ "icon_theme", bar_cmd_icon_theme },

--- a/sway/commands/bar/gaps.c
+++ b/sway/commands/bar/gaps.c
@@ -1,0 +1,60 @@
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/ipc-server.h"
+#include "log.h"
+
+struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "gaps", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	if ((error = checkarg(argc, "gaps", EXPECTED_AT_MOST, 4))) {
+		return error;
+	}
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "bar gaps", "No bar defined.");
+	}
+
+	int top = 0, right = 0, bottom = 0, left = 0;
+
+	for (int i = 0; i < argc; i++) {
+		char *end;
+		int amount = strtol(argv[i], &end, 10);
+		if (strlen(end) && strcasecmp(end, "px") != 0) {
+			return cmd_results_new(CMD_INVALID, "bar gaps",
+					"Expected 'bar [<bar-id>] gaps <all> | <horizonal> "
+					"<vertical> | <top> <right> <bottom> <left>'");
+		}
+
+		if (i == 0) {
+			top = amount;
+		}
+		if (i == 0 || i == 1) {
+			right = amount;
+		}
+		if (i == 0 || i == 2) {
+			bottom = amount;
+		}
+		if (i == 0 || i == 1 || i == 3) {
+			left = amount;
+		}
+	}
+
+	config->current_bar->gaps.top = top;
+	config->current_bar->gaps.right = right;
+	config->current_bar->gaps.bottom = bottom;
+	config->current_bar->gaps.left = left;
+
+	wlr_log(WLR_DEBUG, "Setting bar gaps to %d %d %d %d on bar: %s",
+			config->current_bar->gaps.top, config->current_bar->gaps.right,
+			config->current_bar->gaps.bottom, config->current_bar->gaps.left,
+			config->current_bar->id);
+
+	if (!config->reading) {
+		ipc_event_barconfig_update(config->current_bar);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -638,6 +638,18 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 			json_object_new_string(bar->status_command) : NULL);
 	json_object_object_add(json, "font",
 			json_object_new_string((bar->font) ? bar->font : config->font));
+
+	json_object *gaps = json_object_new_object();
+	json_object_object_add(gaps, "top",
+			json_object_new_int(bar->gaps.top));
+	json_object_object_add(gaps, "right",
+			json_object_new_int(bar->gaps.right));
+	json_object_object_add(gaps, "bottom",
+			json_object_new_int(bar->gaps.bottom));
+	json_object_object_add(gaps, "left",
+			json_object_new_int(bar->gaps.left));
+	json_object_object_add(json, "gaps", gaps);
+
 	if (bar->separator_symbol) {
 		json_object_object_add(json, "separator_symbol",
 				json_object_new_string(bar->separator_symbol));

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -104,6 +104,7 @@ sway_sources = files(
 	'commands/bar/colors.c',
 	'commands/bar/context_button.c',
 	'commands/bar/font.c',
+	'commands/bar/gaps.c',
 	'commands/bar/height.c',
 	'commands/bar/hidden_state.c',
 	'commands/bar/icon_theme.c',

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -61,6 +61,13 @@ Sway allows configuring swaybar in the sway configuration file.
 *binding\_mode\_indicator* yes|no
 	Enable or disable binding mode indicator. Default is _yes_.
 
+*gaps* <all> | <horizontal> <vertical> | <top> <right> <bottom> <left>
+	Sets the gaps from the edge of the screen for the bar. Gaps can either be
+	set all at once, per direction, or per side. Note that only sides that
+	touch an edge of the screen can have gaps. For the side that does not
+	touch an edge of the screen, per-side outer gaps for workspaces may be of
+	use.
+
 *height* <height>
 	Sets the height of the bar. Default height will match the font size.
 

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -40,6 +40,12 @@ struct swaybar_config *init_config(void) {
 	/* height */
 	config->height = 0;
 
+	/* gaps */
+	config->gaps.top = 0;
+	config->gaps.right = 0;
+	config->gaps.bottom = 0;
+	config->gaps.left = 0;
+
 	/* colors */
 	config->colors.background = 0x000000FF;
 	config->colors.focused_background = 0x000000FF;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -153,7 +153,7 @@ static bool ipc_parse_config(
 		return false;
 	}
 	json_object *markup, *mode, *hidden_state, *position, *status_command;
-	json_object *font, *bar_height, *wrap_scroll, *workspace_buttons;
+	json_object *font, *gaps, *bar_height, *wrap_scroll, *workspace_buttons;
 	json_object *strip_workspace_numbers, *strip_workspace_name;
 	json_object *binding_mode_indicator, *verbose, *colors, *sep_symbol;
 	json_object *outputs, *bindings;
@@ -162,6 +162,7 @@ static bool ipc_parse_config(
 	json_object_object_get_ex(bar_config, "position", &position);
 	json_object_object_get_ex(bar_config, "status_command", &status_command);
 	json_object_object_get_ex(bar_config, "font", &font);
+	json_object_object_get_ex(bar_config, "gaps", &gaps);
 	json_object_object_get_ex(bar_config, "bar_height", &bar_height);
 	json_object_object_get_ex(bar_config, "wrap_scroll", &wrap_scroll);
 	json_object_object_get_ex(bar_config, "workspace_buttons", &workspace_buttons);
@@ -206,6 +207,24 @@ static bool ipc_parse_config(
 	}
 	if (bar_height) {
 		config->height = json_object_get_int(bar_height);
+	}
+	if (gaps) {
+		json_object *top = json_object_object_get(gaps, "top");
+		if (top) {
+			config->gaps.top = json_object_get_int(top);
+		}
+		json_object *right = json_object_object_get(gaps, "right");
+		if (right) {
+			config->gaps.right = json_object_get_int(right);
+		}
+		json_object *bottom = json_object_object_get(gaps, "bottom");
+		if (bottom) {
+			config->gaps.bottom = json_object_get_int(bottom);
+		}
+		json_object *left = json_object_object_get(gaps, "left");
+		if (left) {
+			config->gaps.left = json_object_get_int(left);
+		}
 	}
 	if (markup) {
 		config->pango_markup = json_object_get_boolean(markup);
@@ -445,6 +464,27 @@ static bool handle_barconfig_update(struct swaybar *bar,
 	json_object_object_get_ex(json_config, "mode", &json_mode);
 	config->mode = strdup(json_object_get_string(json_mode));
 	wlr_log(WLR_DEBUG, "Changing bar mode to %s", config->mode);
+
+	json_object *gaps;
+	json_object_object_get_ex(json_config, "gaps", &gaps);
+	if (gaps) {
+		json_object *top = json_object_object_get(gaps, "top");
+		if (top) {
+			config->gaps.top = json_object_get_int(top);
+		}
+		json_object *right = json_object_object_get(gaps, "right");
+		if (right) {
+			config->gaps.right = json_object_get_int(right);
+		}
+		json_object *bottom = json_object_object_get(gaps, "bottom");
+		if (bottom) {
+			config->gaps.bottom = json_object_get_int(bottom);
+		}
+		json_object *left = json_object_object_get(gaps, "left");
+		if (left) {
+			config->gaps.left = json_object_get_int(left);
+		}
+	}
 
 	return determine_bar_visibility(bar, true);
 }

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -506,6 +506,11 @@ void render_frame(struct swaybar_output *output) {
 	if (height != output->height || output->width == 0) {
 		// Reconfigure surface
 		zwlr_layer_surface_v1_set_size(output->layer_surface, 0, height);
+		zwlr_layer_surface_v1_set_margin(output->layer_surface,
+				output->bar->config->gaps.top,
+				output->bar->config->gaps.right,
+				output->bar->config->gaps.bottom,
+				output->bar->config->gaps.left);
 		if (strcmp(output->bar->config->mode, "dock") == 0) {
 			zwlr_layer_surface_v1_set_exclusive_zone(output->layer_surface, height);
 		}


### PR DESCRIPTION
Closes #2904

Adds the bar subcommand `gaps <amount>|<horizontal> <vertical>|<top> <right> <bottom> <left>` to set gaps for swaybar. Due to restrictions on margins for a layer_surface, only the sides that are anchored to an edge of the screen can have gaps. Since there is support for per-side outer gaps for workspaces, those should be able to be used instead for the last side.