### PR TITLE
Do not strip quotes for cmd_mode

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -420,6 +420,7 @@ struct cmd_results *config_command(char *exec) {
 	// Strip quotes and unescape the string
 	for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
 		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
+				&& handler->handle != cmd_mode
 				&& handler->handle != cmd_bindsym
 				&& handler->handle != cmd_bindcode
 				&& handler->handle != cmd_set


### PR DESCRIPTION
Fixes #3146

Like with cmd_bindsym and cmd_bindcode, the quotes should not be stripped for cmd_mode. cmd_mode performs its own stripping for the mode name and the only valid subcommands are cmd_bindsym and cmd_bindcode.