### PR TITLE
move to workspace: fix moving floating container to non-empty workspace

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -216,6 +216,7 @@ static void container_move_to_container(struct sway_container *container,
 		return;
 	}
 	if (container_is_floating(container)) {
+		container_move_to_workspace(container, destination->workspace);
 		return;
 	}
 	struct sway_workspace *old_workspace = container->workspace;


### PR DESCRIPTION
moving a container to a non-empty workspace will find a container to move
to in the destination workspace and call container_move_to_container,
which must not just skip floating containers