### PR TITLE
Fix scratchpad segfault - NULL focused workspace

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -69,13 +69,16 @@ void root_scratchpad_add_container(struct sway_container *con) {
 	list_add(root->scratchpad, con);
 
 	struct sway_seat *seat = input_manager_current_seat();
+	struct sway_node *new_focus = NULL;
 	if (parent) {
 		arrange_container(parent);
-		seat_set_focus(seat, seat_get_focus_inactive(seat, &parent->node));
-	} else {
-		arrange_workspace(workspace);
-		seat_set_focus(seat, seat_get_focus_inactive(seat, &workspace->node));
+		new_focus = seat_get_focus_inactive(seat, &parent->node);
 	}
+	if (!new_focus) {
+		arrange_workspace(workspace);
+		new_focus = seat_get_focus_inactive(seat, &workspace->node);
+	}
+	seat_set_focus(seat, new_focus);
 
 	ipc_event_window(con, "move");
 }


### PR DESCRIPTION
Fixes #3203 

When adding a container to the scratchpad, it was possible for focus to be removed from the seat. This occurred when a single child was moved from it's parent to the scratchpad due to the focus_inactive for the parent being NULL. If the focus_inactive for the parent is NULL, the focus_inactive for the workspace should be focused.