### PR TITLE
swaymsg: parse success of single object

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -32,6 +32,9 @@ static bool success_object(json_object *result) {
 // Iterate results array and return false if any of them failed
 static bool success(json_object *r, bool fallback) {
 	if (!json_object_is_type(r, json_type_array)) {
+		if (json_object_is_type(r, json_type_object)) {
+			return success_object(r);
+		}
 		return fallback;
 	}
 


### PR DESCRIPTION
Related to #3218

Allows swaymsg to parse the success attribute of a single object response. This is needed for the subscribe event.