### PR TITLE
swaylock: fix build with musl libc

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -961,7 +962,7 @@ int main(int argc, char **argv) {
 	}
 
 	state.eventloop = loop_create();
-	loop_add_fd(state.eventloop, wl_display_get_fd(state.display), POLL_IN,
+	loop_add_fd(state.eventloop, wl_display_get_fd(state.display), POLLIN,
 			display_in, NULL);
 
 	state.run_display = true;


### PR DESCRIPTION
To use POLL_IN, signal.h must be included and _XOPEN_SOURCE [must be defined](https://git.musl-libc.org/cgit/musl/tree/include/signal.h#n223).