### PR TITLE
Fix fullscreen command and improve documentation

### DIFF
--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -13,14 +13,14 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "fullscreen",
+		return cmd_results_new(CMD_FAILURE, "fullscreen",
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_node *node = config->handler_context.node;
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 	if (node->type == N_WORKSPACE && workspace->tiling->length == 0) {
-		return cmd_results_new(CMD_INVALID, "fullscreen",
+		return cmd_results_new(CMD_FAILURE, "fullscreen",
 				"Can't fullscreen an empty workspace");
 	}
 	if (node->type == N_WORKSPACE) {

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -130,8 +130,9 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *focus* mode\_toggle
 	Moves focus between the floating and tiled layers.
 
-*fullscreen*
-	Toggles fullscreen for the focused view.
+*fullscreen* [enable|disable|toggle]
+	Makes focused view fullscreen, non-fullscreen, or the opposite of what it
+	is now. If no argument is given, it does the same as _toggle_.
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left all|current
 set|plus|minus <amount>


### PR DESCRIPTION
The first commit fixes a problem that I have when using the following keybinding on an empty workspace

`bindsym Mod4+v fullscreen disable,exec termite -e pulsemixer`.

With this binding I want to open an application but in case that another view is currently in fullscreen mode, it should leave fullscreen mode first. This does not work on an empty Workspace, because `fullscreen disable` returns with error status `CMD_INVALID` and then the following exec command will not be executed (cf. https://github.com/swaywm/sway/blob/master/sway/commands.c#L307).
In i3 this binding works on empty workspaces.

The second commit documents the optional arguments of the fullscreen command, which can be found in i3's documentation too.