### PR TITLE
Add option to bindsym/bindcode to suppress warning on override

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -161,6 +161,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 	binding->type = bindcode ? BINDING_KEYCODE : BINDING_KEYSYM;
 
 	bool exclude_titlebar = false;
+	bool warn = true;
 
 	// Handle --release and --locked
 	while (argc > 0) {
@@ -178,6 +179,8 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 					strlen("--input-device=")) == 0) {
 			free(binding->input);
 			binding->input = strdup(argv[0] + strlen("--input-device="));
+		} else if (strcmp("--no-warn", argv[0]) == 0) {
+			warn = false;
 		} else {
 			break;
 		}
@@ -258,9 +261,12 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			wlr_log(WLR_INFO, "Overwriting binding '%s' for device '%s' "
 					"from `%s` to `%s`", argv[0], binding->input,
 					binding->command, config_binding->command);
-			config_add_swaynag_warning("Overwriting binding '%s' for device "
-					"'%s' to `%s` from `%s`", argv[0], binding->input,
-					binding->command, config_binding->command);
+			if (warn) {
+				config_add_swaynag_warning("Overwriting binding"
+					"'%s' for device '%s' to `%s` from `%s`",
+					argv[0], binding->input, binding->command,
+					config_binding->command);
+			}
 			free_sway_binding(config_binding);
 			mode_bindings->items[i] = binding;
 			overwritten = true;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -277,14 +277,16 @@ runtime.
 
 		for\_window <criteria> move container to output <output>
 
-*bindsym* [--release|--locked] [--input-device=<device>] <key combo> <command>
+*bindsym* [--release|--locked] [--input-device=<device>] [--no-warn] <key combo> <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
 	With the flag _--release_, the command is executed when the key combo is
 	released. Unless the flag _--locked_ is set, the command will not be run
 	when a screen locking program is active. If _input-device_ is given, the
 	binding will only be executed for that input device and will be executed
-	instead of any binding that is generic to all devices.
+	instead of any binding that is generic to all devices. By default, if you
+	overwrite a binding, swaynag will give you a warning. To silence this, use
+	the _--no-warn_ flag.
 
 	Example:
 ```
@@ -292,7 +294,7 @@ runtime.
 		bindsym Mod1+Shift+f exec firefox
 ```
 
-	*bindcode* [--release|--locked] [--input-device=<device>] <code> <command>
+	*bindcode* [--release|--locked] [--input-device=<device>] [--no-warn] <code> <command>
 	is also available for binding with key codes instead of key names.
 
 *client.<class>* <border> <background> <text> <indicator> <child\_border>


### PR DESCRIPTION
Recently, bindsym/bindcode was changed to give a warning when you rebind a keystroke.  This patch allows the user to suppress that warning with the --no-warn flag.