### PR TITLE
cmd_focus: show scratchpad if hidden

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -269,6 +269,9 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	}
 
 	if (argc == 0 && container) {
+		if (container->scratchpad && !container->workspace) {
+			root_scratchpad_show(container);
+		}
 		seat_set_focus_container(seat, container);
 		seat_consider_warp_to_focus(seat);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);


### PR DESCRIPTION
Fixes #3235 

If a scratchpad container is hidden, it is still focusable using criteria and should be shown. This fixes a segfault when attempting to rebase the cursor since previously the scratchpad container would not be on any output.