### PR TITLE
cmd_split: flatten when possible

### DIFF
--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -18,6 +18,10 @@ static struct cmd_results *do_split(int layout) {
 		workspace_split(ws, layout);
 	}
 
+	if (con->parent->parent) {
+		container_flatten(con->parent->parent);
+	}
+
 	arrange_workspace(ws);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);


### PR DESCRIPTION
Fixes #3259 

Matches i3 behavior