### PR TITLE
list: double list capacity when resizing instead of incrementing

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -17,7 +17,7 @@ list_t *create_list(void) {
 
 static void list_resize(list_t *list) {
 	if (list->length == list->capacity) {
-		list->capacity += 10;
+		list->capacity *= 2;
 		list->items = realloc(list->items, sizeof(void*) * list->capacity);
 	}
 }


### PR DESCRIPTION
This is the industry standard since it allows insertion to be amortized
O(1) time.