### PR TITLE
Rework default output configs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -553,8 +553,6 @@ void apply_output_config_to_outputs(struct output_config *oc);
 
 void free_output_config(struct output_config *oc);
 
-void create_default_output_configs(void);
-
 int workspace_output_cmp_workspace(const void *a, const void *b);
 
 int sway_binding_cmp(const void *a, const void *b);

--- a/sway/config.c
+++ b/sway/config.c
@@ -391,8 +391,6 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		memcpy(&config->swaynag_config_errors,
 				&old_config->swaynag_config_errors,
 				sizeof(struct swaynag_instance));
-
-		create_default_output_configs();
 	}
 
 	config->current_config_path = path;


### PR DESCRIPTION
Fixes #3277 
Fixes #3261

Default output configs were generated on reload to reset an output to its default settings. The idea was that anything that was removed from the config or changed at runtime and not in the config should be reset on reload. Originally, they were created using the output name. Recently, they were changed to use the output identifier. It turns out that there are issues of shadowing with that solution as well. This should fix those issues.

Instead of generating the default output configs on reload and storing them in the output config list to merge on top of, they are now only generated when retrieving the output config for an output during a reload. This means that the default output configs are never stored anywhere and just used as a base to merge unaltered user configs on top of during a reload.

Starting with a blank output config, merges get applied in the following order:
1. Default output config (only during a reload)
2. Wildcard config (only if neither output name or output identifier exist)
3. Output name config
4. Output identifier config