### PR TITLE
Call wlr_output_enable for disabled new outputs

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -568,6 +568,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	if (!oc || oc->enabled) {
 		output_enable(output, oc);
+	} else {
+		wlr_output_enable(output->wlr_output, false);
 	}
 
 	transaction_commit_dirty();


### PR DESCRIPTION
Fixes #2948

When a new output is detected and it is disabled by the output config, call `wlr_output_enable(output->wlr_output, false)` to DPMS off the output.