### PR TITLE
[WIP] Introduce shell_expand

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -4,14 +4,15 @@ lib_sway_common = static_library(
 		'background-image.c',
 		'cairo.c',
 		'ipc-client.c',
+		'list.c',
 		'log.c',
 		'loop.c',
-		'list.c',
 		'pango.c',
 		'readline.c',
+		'shexp.c',
 		'stringop.c',
 		'unicode.c',
-		'util.c'
+		'util.c',
 	),
 	dependencies: [
 		cairo,

--- a/common/shexp.c
+++ b/common/shexp.c
@@ -1,0 +1,51 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdlib.h>
+#include <string.h>
+#include <wordexp.h>
+#include "shexp.h"
+
+static const char escaped_quote[] = "'\"'\"'";
+
+static char *escape(const char *str) {
+	size_t escaped_len = 2; // quotes at the begining and end
+	for (size_t i = 0; str[i] != '\0'; ++i) {
+		if (str[i] == '\'') {
+			escaped_len += strlen(escaped_quote);
+		} else {
+			++escaped_len;
+		}
+	}
+
+	char *escaped = malloc(escaped_len + 1);
+	escaped[0] = '\'';
+	size_t j = 1;
+	for (size_t i = 0; str[i] != '\0'; ++i) {
+		if (str[i] == '\'') {
+			memcpy(&escaped[j], escaped_quote, strlen(escaped_quote));
+			j += strlen(escaped_quote);
+		} else {
+			escaped[j] = str[i];
+			++j;
+		}
+	}
+	escaped[j] = '\'';
+	escaped[j + 1] = '\0';
+
+	return escaped;
+}
+
+bool shell_expand(char **path) {
+	char *escaped_path = escape(*path);
+
+	wordexp_t p;
+	bool ret = false;
+	if (wordexp(escaped_path, &p, WRDE_UNDEF) == 0) {
+		free(*path);
+		*path = strdup(p.we_wordv[0]);
+		wordfree(&p);
+		ret = true;
+	}
+
+	free(escaped_path);
+	return ret;
+}

--- a/include/shexp.h
+++ b/include/shexp.h
@@ -1,0 +1,14 @@
+#ifndef _SWAY_SHEXP_H
+#define _SWAY_SHEXP_H
+
+#include <stdbool.h>
+
+/**
+ * Takes a pointer to a string and reallocates it with the result of its shell
+ * expansion. Undefined environment variables are considered as errors. Returns
+ * true if it succeeds, otherwise returns false, leaving the original string
+ * unchanged.
+ */
+bool shell_expand(char **path);
+
+#endif

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -3,7 +3,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <wordexp.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This performs shell expansion without field splitting. This fixes issues with
filenames containing spaces, like https://github.com/swaywm/sway/issues/654#issuecomment-445982588.

This commit also cleans up complicated logic to join fields and to set
XDG_CONFIG_HOME.