### PR TITLE
Keep focus when destroying containers on non-vis ws

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -159,6 +159,14 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 		return;
 	}
 
+	if (node->type == N_CONTAINER &&
+			!workspace_is_visible(node->sway_container->workspace)) {
+		// Do not change the focus stack on a non-visible workspace. The focus
+		// will either be set when the workspace becomes visible or the
+		// workspace is now empty and will be destroyed
+		return;
+	}
+
 	// Find new focus_inactive (ie. sibling, or workspace if no siblings left)
 	struct sway_node *next_focus = NULL;
 	while (next_focus == NULL) {


### PR DESCRIPTION
Fixes #3281

Changing the focus stack when destroying a container's node on a
non-visible workspace (on an non-focused output) incorrectly causes
the non-visible workspace to become visible. If the workspace is empty,
it will not be destroyed since it is now visible. Additionally since
there was no workspace::focus event, swaybar still shows the previous
workspace as focus-inactive. It also makes no sense to change visible
workspaces due to a container on a non-visible workspace being
destroyed.

Since the focus will either be set when switching to the non-visible
workspace or the workspace will be destroyed due to being empty, there
is no need to change the focus stack when destroying a container on a
non-visible workspace.