### PR TITLE
Fix criteria execution in view_map

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -605,7 +605,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	view_update_title(view, false);
 	container_update_representation(view->container);
-	view_execute_criteria(view);
 
 	if (decoration) {
 		view_update_csd_from_client(view, decoration);
@@ -621,6 +620,8 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 			arrange_workspace(view->container->workspace);
 		}
 	}
+
+	view_execute_criteria(view);
 
 	if (should_focus(view)) {
 		input_manager_set_focus(&view->container->node);


### PR DESCRIPTION
This patch moves view_execute_criteria(view) at the end of the function.
Previously, if a view requested to be started in fullscreen, this was
done after execution of criteria and hence it was impossible to disable
fullscreen via criteria.

Fixes #3285 

I don't use telegram but I was able to reproduce the problem in #3285 with mpv by adding
```
for_window [app_id="^mpv$"] fullscreen disable
```
to my config and starting mpv with `mpv --fullscreen <file>`. Before this patch mpv remained in fullscreen.