### PR TITLE
swaybar: fix cursor scale

### DIFF
--- a/include/swaybar/input.h
+++ b/include/swaybar/input.h
@@ -4,6 +4,7 @@
 #include <wayland-client.h>
 #include "list.h"
 
+struct swaybar;
 struct swaybar_output;
 
 struct swaybar_pointer {
@@ -13,6 +14,7 @@ struct swaybar_pointer {
 	struct wl_surface *cursor_surface;
 	struct swaybar_output *current;
 	int x, y;
+	uint32_t serial;
 };
 
 enum x11_button {
@@ -44,6 +46,8 @@ struct swaybar_hotspot {
 };
 
 extern const struct wl_seat_listener seat_listener;
+
+void update_cursor(struct swaybar *bar);
 
 void free_hotspots(struct wl_list *list);
 


### PR DESCRIPTION
Fixes #1750

This fixes a few issues with swaybar's cursor scaling:
1. The cursor scale is now changed when the output scale changes
2. The cursor scale is no longer bound by the max output scale when
swaybar is launched
3. Related to the previous item, the cursor is no longer tiny on low
scale outputs after the max output scale has changed

This also bumps up `wl_compositor` to version 4 to allow usage of `wl_surface_damage_buffer`.

Note: This matches the way swaynag handles cursor scaling so any changes to this PR may also need to be changed for swaynag in a follow-up PR