### PR TITLE
Fix focusing on non-visible workspace

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -159,14 +159,6 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	if (node->type == N_CONTAINER &&
-			!workspace_is_visible(node->sway_container->workspace)) {
-		// Do not change the focus stack on a non-visible workspace. The focus
-		// will either be set when the workspace becomes visible or the
-		// workspace is now empty and will be destroyed
-		return;
-	}
-
 	// Find new focus_inactive (ie. sibling, or workspace if no siblings left)
 	struct sway_node *next_focus = NULL;
 	while (next_focus == NULL) {
@@ -180,6 +172,12 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 		}
 
 		parent = node_get_parent(parent);
+	}
+
+	if (next_focus->type == N_WORKSPACE &&
+			!workspace_is_visible(next_focus->sway_workspace)) {
+		// Do not change focus to a non-visible workspace
+		return;
 	}
 
 	if (needs_new_focus) {


### PR DESCRIPTION
Fixes #2625 
#3281 should still be fixed and have no regression

My previous attempt (#3288) was not quite right. Changing the focus stack on a non-visible workspace should only be blocked if the focus would be set to the workspace itself.