### PR TITLE
swaynag: remove double free of details button

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -416,7 +416,6 @@ void swaynag_destroy(struct swaynag *swaynag) {
 		free(button);
 	}
 	list_free(swaynag->buttons);
-	free(swaynag->details.button_details);
 	free(swaynag->details.message);
 	free(swaynag->details.button_up.text);
 	free(swaynag->details.button_down.text);


### PR DESCRIPTION
Fixes #3300 

If there are no arguments or invalid arguments given, swaynag will free
`swaynag.details.button_details` under the `cleanup` label in main. It
then called `swaynag_destroy`, which would attempt to free it again.

Since `swaynag.details.button_details` is either freed on line 106 of
main (when there is no detailed message) or added to `swaynag.buttons`
on line 103 of main, there is no reason to manually free it in
`swaynag_destroy`.

Although I cannot reproduce a double free on my system, for some reason,
it should have actually resulted in a double free in all code paths.