### PR TITLE
cmd_split: add null checks in do_split

### DIFF
--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -18,7 +18,7 @@ static struct cmd_results *do_split(int layout) {
 		workspace_split(ws, layout);
 	}
 
-	if (con->parent->parent) {
+	if (con && con->parent && con->parent->parent) {
 		container_flatten(con->parent->parent);
 	}
 


### PR DESCRIPTION
Fixes #3304

Fixes a crash when running `split` commands with the workspace focused.