### PR TITLE
Implement hide_cursor <timeout> command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -133,6 +133,7 @@ sway_cmd cmd_force_display_urgency_hint;
 sway_cmd cmd_force_focus_wrapping;
 sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
+sway_cmd cmd_hide_cursor;
 sway_cmd cmd_hide_edge_borders;
 sway_cmd cmd_include;
 sway_cmd cmd_input;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -436,6 +436,8 @@ struct sway_config {
 	enum edge_border_types hide_edge_borders;
 	enum edge_border_types saved_edge_borders;
 
+	int hide_cursor_timeout;
+
 	// border colors
 	struct {
 		struct border_colors focused;

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -68,6 +68,10 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	struct wl_client *client);
 
+void cursor_set_image_surface(struct sway_cursor *cursor,
+		struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y,
+		struct wl_client *client);
+
 void cursor_warp_to_container(struct sway_cursor *cursor,
 	struct sway_container *container);
 

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -1,6 +1,8 @@
 #ifndef _SWAY_INPUT_CURSOR_H
 #define _SWAY_INPUT_CURSOR_H
+#include <stdbool.h>
 #include <stdint.h>
+#include <wlr/types/wlr_surface.h>
 #include "sway/input/seat.h"
 
 #define SWAY_CURSOR_PRESSED_BUTTONS_CAP 32
@@ -16,6 +18,8 @@ struct sway_cursor {
 
 	const char *image;
 	struct wl_client *image_client;
+	struct wlr_surface *image_surface;
+	int hotspot_x, hotspot_y;
 
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;
@@ -32,6 +36,9 @@ struct sway_cursor {
 	uint32_t tool_buttons;
 
 	struct wl_listener request_set_cursor;
+
+	struct wl_event_source *hide_source;
+	bool hidden;
 
 	// Mouse binding state
 	uint32_t pressed_buttons[SWAY_CURSOR_PRESSED_BUTTONS_CAP];

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -86,6 +86,7 @@ static struct cmd_handler handlers[] = {
 	{ "force_focus_wrapping", cmd_force_focus_wrapping },
 	{ "fullscreen", cmd_fullscreen },
 	{ "gaps", cmd_gaps },
+	{ "hide_cursor", cmd_hide_cursor },
 	{ "hide_edge_borders", cmd_hide_edge_borders },
 	{ "include", cmd_include },
 	{ "input", cmd_input },

--- a/sway/commands/hide_cursor.c
+++ b/sway/commands/hide_cursor.c
@@ -1,0 +1,33 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+#include "stringop.h"
+
+struct cmd_results *cmd_hide_cursor(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "hide_cursor", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	char *end;
+	int timeout = strtol(argv[0], &end, 10);
+	if (*end) {
+		return cmd_results_new(CMD_INVALID, "hide_cursor",
+				"Expected an integer timeout");
+	}
+	if (timeout < 100 && timeout != 0) {
+		timeout = 100;
+	}
+	config->hide_cursor_timeout = timeout;
+
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		wl_event_source_timer_update(seat->cursor->hide_source,
+				config->hide_cursor_timeout);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -257,6 +257,8 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_edge_borders = E_NONE;
 	config->saved_edge_borders = E_NONE;
 
+	config->hide_cursor_timeout = 0;
+
 	// border colors
 	set_color(config->border_colors.focused.border, 0x4C7899);
 	set_color(config->border_colors.focused.background, 0x285577);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -589,6 +589,23 @@ void cursor_rebase(struct sway_cursor *cursor) {
 	cursor_do_rebase(cursor, time_msec, cursor->previous.node, surface, sx, sy);
 }
 
+static int hide_notify(void *data) {
+	struct sway_cursor *cursor = data;
+	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+	cursor->hidden = true;
+	return 1;
+}
+
+static void handle_activity(struct sway_cursor *cursor) {
+	wl_event_source_timer_update(cursor->hide_source,
+			config->hide_cursor_timeout);
+	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
+	if (cursor->hidden) {
+		cursor->hidden = false;
+		cursor_set_image(cursor, NULL, cursor->image_client);
+	}
+}
+
 void cursor_send_pointer_motion(struct sway_cursor *cursor,
 		uint32_t time_msec) {
 	if (time_msec == 0) {
@@ -679,11 +696,11 @@ void cursor_send_pointer_motion(struct sway_cursor *cursor,
 
 static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, motion);
-	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_motion *event = data;
 	wlr_cursor_move(cursor->cursor, event->device,
 		event->delta_x, event->delta_y);
 	cursor_send_pointer_motion(cursor, event->time_msec);
+	handle_activity(cursor);
 	transaction_commit_dirty();
 }
 
@@ -691,10 +708,10 @@ static void handle_cursor_motion_absolute(
 		struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor =
 		wl_container_of(listener, cursor, motion_absolute);
-	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_motion_absolute *event = data;
 	wlr_cursor_warp_absolute(cursor->cursor, event->device, event->x, event->y);
 	cursor_send_pointer_motion(cursor, event->time_msec);
+	handle_activity(cursor);
 	transaction_commit_dirty();
 }
 
@@ -975,10 +992,10 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 static void handle_cursor_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, button);
-	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_button *event = data;
 	dispatch_cursor_button(cursor, event->device,
 			event->time_msec, event->button, event->state);
+	handle_activity(cursor);
 	transaction_commit_dirty();
 }
 
@@ -1040,9 +1057,9 @@ static void dispatch_cursor_axis(struct sway_cursor *cursor,
 
 static void handle_cursor_axis(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, axis);
-	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	struct wlr_event_pointer_axis *event = data;
 	dispatch_cursor_axis(cursor, event);
+	handle_activity(cursor);
 	transaction_commit_dirty();
 }
 
@@ -1233,10 +1250,12 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		return;
 	}
 
-	wlr_cursor_set_surface(cursor->cursor, event->surface, event->hotspot_x,
-		event->hotspot_y);
 	cursor->image = NULL;
 	cursor->image_client = focused_client;
+	cursor->image_surface = event->surface;
+	cursor->hotspot_x = event->hotspot_x;
+	cursor->hotspot_y = event->hotspot_y;
+	cursor_set_image(cursor, NULL, cursor->image_client);
 }
 
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
@@ -1244,9 +1263,16 @@ void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	if (!(cursor->seat->wlr_seat->capabilities & WL_SEAT_CAPABILITY_POINTER)) {
 		return;
 	}
-	if (!image) {
+	if (cursor->hidden) {
+		return;
+	}
+	if (!image && cursor->image_surface) {
+		wlr_cursor_set_surface(cursor->cursor, cursor->image_surface,
+				cursor->hotspot_x, cursor->hotspot_y);
+	} else if (!image) {
 		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	} else if (!cursor->image || strcmp(cursor->image, image) != 0) {
+		cursor->image_surface = NULL;
 		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager, image,
 				cursor->cursor);
 	}
@@ -1258,6 +1284,8 @@ void sway_cursor_destroy(struct sway_cursor *cursor) {
 	if (!cursor) {
 		return;
 	}
+
+	wl_event_source_remove(cursor->hide_source);
 
 	wlr_xcursor_manager_destroy(cursor->xcursor_manager);
 	wlr_cursor_destroy(cursor->cursor);
@@ -1281,6 +1309,9 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 
 	cursor->seat = seat;
 	wlr_cursor_attach_output_layout(wlr_cursor, root->output_layout);
+
+	cursor->hide_source = wl_event_loop_add_timer(server.wl_event_loop,
+			hide_notify, cursor);
 
 	// input events
 	wl_signal_add(&wlr_cursor->events.motion, &cursor->motion);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -602,7 +602,15 @@ static void handle_activity(struct sway_cursor *cursor) {
 	wlr_idle_notify_activity(server.idle, cursor->seat->wlr_seat);
 	if (cursor->hidden) {
 		cursor->hidden = false;
-		cursor_set_image(cursor, NULL, cursor->image_client);
+		if (cursor->image_surface) {
+			cursor_set_image_surface(cursor, cursor->image_surface,
+					cursor->hotspot_x, cursor->hotspot_y,
+					cursor->image_client);
+		} else {
+			const char *image = cursor->image;
+			cursor->image = NULL;
+			cursor_set_image(cursor, image, cursor->image_client);
+		}
 	}
 }
 
@@ -1250,12 +1258,8 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 		return;
 	}
 
-	cursor->image = NULL;
-	cursor->image_client = focused_client;
-	cursor->image_surface = event->surface;
-	cursor->hotspot_x = event->hotspot_x;
-	cursor->hotspot_y = event->hotspot_y;
-	cursor_set_image(cursor, NULL, cursor->image_client);
+	cursor_set_image_surface(cursor, event->surface, event->hotspot_x,
+			event->hotspot_y, focused_client);
 }
 
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
@@ -1263,21 +1267,43 @@ void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	if (!(cursor->seat->wlr_seat->capabilities & WL_SEAT_CAPABILITY_POINTER)) {
 		return;
 	}
+
+	const char *current_image = cursor->image;
+	cursor->image = image;
+	cursor->image_surface = NULL;
+	cursor->hotspot_x = cursor->hotspot_y = 0;
+	cursor->image_client = client;
+
 	if (cursor->hidden) {
 		return;
 	}
-	if (!image && cursor->image_surface) {
-		wlr_cursor_set_surface(cursor->cursor, cursor->image_surface,
-				cursor->hotspot_x, cursor->hotspot_y);
-	} else if (!image) {
+
+	if (!image) {
 		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
-	} else if (!cursor->image || strcmp(cursor->image, image) != 0) {
-		cursor->image_surface = NULL;
+	} else if (!current_image || strcmp(current_image, image) != 0) {
 		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager, image,
 				cursor->cursor);
 	}
-	cursor->image = image;
+}
+
+void cursor_set_image_surface(struct sway_cursor *cursor,
+		struct wlr_surface *surface, int32_t hotspot_x, int32_t hotspot_y,
+		struct wl_client *client) {
+	if (!(cursor->seat->wlr_seat->capabilities & WL_SEAT_CAPABILITY_POINTER)) {
+		return;
+	}
+
+	cursor->image = NULL;
+	cursor->image_surface = surface;
+	cursor->hotspot_x = hotspot_x;
+	cursor->hotspot_y = hotspot_y;
 	cursor->image_client = client;
+
+	if (cursor->hidden) {
+		return;
+	}
+
+	wlr_cursor_set_surface(cursor->cursor, surface, hotspot_x, hotspot_y);
 }
 
 void sway_cursor_destroy(struct sway_cursor *cursor) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -56,6 +56,7 @@ sway_sources = files(
 	'commands/force_focus_wrapping.c',
 	'commands/fullscreen.c',
 	'commands/gaps.c',
+	'commands/hide_cursor.c',
 	'commands/hide_edge_borders.c',
 	'commands/kill.c',
 	'commands/mark.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -470,6 +470,12 @@ The default colors are:
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps ...).
 
+*hide\_cursor* <timeout>
+	Hides the cursor image after the specified _timeout_ (in milliseconds)
+	has elapsed with no activity on that cursor. A timeout of 0 (default)
+	disables hiding the cursor. The minimal timeout is 100 and any value less
+	than that (aside from 0), will be increased to 100.
+
 *hide\_edge\_borders* none|vertical|horizontal|both|smart|smart\_no\_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_.
 


### PR DESCRIPTION
Supersedes #1979 
Related to #1894

Allows the cursor to be hidden after a specified timeout in milliseconds. Unlike #1979, `handle_activity` will only set the cursor image when it was previously hidden. This version will also iterate over the seats and update the timeouts for the associated cursors when the timeout is changed.