### PR TITLE
Terminate swaybg in output_disable

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -179,10 +179,6 @@ void apply_output_config(struct output_config *oc, struct sway_output *output) {
 
 	if (oc && oc->enabled == 0) {
 		if (output->enabled) {
-			if (output->bg_pid != 0) {
-				terminate_swaybg(output->bg_pid);
-				output->bg_pid = 0;
-			}
 			output_disable(output);
 			wlr_output_layout_remove(root->output_layout, wlr_output);
 		}

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -225,6 +225,11 @@ void output_disable(struct sway_output *output) {
 
 	root_for_each_container(untrack_output, output);
 
+	if (output->bg_pid) {
+		terminate_swaybg(output->bg_pid);
+		output->bg_pid = 0;
+	}
+
 	int index = list_find(root->outputs, output);
 	list_del(root->outputs, index);
 


### PR DESCRIPTION
Moves the call to `terminate_swaybg` from inside `apply_output_config` to
`output_disable`. The former was only called when an output was being
disabled. The latter is called when an output is being disabled and when
an output becomes disconnected. Without this, disconnecting an enabled
output would result in a defunct swaybg process.