### PR TITLE
Allow output identifier in move, focus, and assign

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -194,6 +194,9 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 	}
 	char *identifier = join_args(argv, argc);
 	struct sway_output *output = output_by_name(identifier);
+	if (!output) {
+		output = output_by_identifier(identifier);
+	}
 
 	if (!output) {
 		enum wlr_direction direction;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -64,7 +64,11 @@ static struct sway_output *output_in_direction(const char *direction_string,
 		}
 	}
 
-	return output_by_name(direction_string);
+	struct sway_output *output = output_by_name(direction_string);
+	if (!output) {
+		output = output_by_identifier(direction_string);
+	}
+	return output;
 }
 
 static bool is_parallel(enum sway_container_layout layout,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -460,6 +460,9 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 		struct criteria *criteria = criterias->items[i];
 		if (criteria->type == CT_ASSIGN_OUTPUT) {
 			struct sway_output *output = output_by_name(criteria->target);
+			if (!output) {
+				output = output_by_identifier(criteria->target);
+			}
 			if (output) {
 				ws = output_get_active_workspace(output);
 				break;


### PR DESCRIPTION
This allows output identifiers to be used with the following commands:
- `move container|window|workspace to output`
- `focus output`
- `assign [criteria] output`