### PR TITLE
Combine output_by_name and output_by_identifier

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -84,9 +84,7 @@ void output_damage_box(struct sway_output *output, struct wlr_box *box);
 void output_damage_whole_container(struct sway_output *output,
 	struct sway_container *con);
 
-struct sway_output *output_by_name(const char *name);
-
-struct sway_output *output_by_identifier(const char *identifier);
+struct sway_output *output_by_name_or_id(const char *name_or_id);
 
 void output_sort_workspaces(struct sway_output *output);
 

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -193,7 +193,7 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 			"Expected 'focus output <direction|name>'");
 	}
 	char *identifier = join_args(argv, argc);
-	struct sway_output *output = output_by_name(identifier);
+	struct sway_output *output = output_by_name_or_id(identifier);
 
 	if (!output) {
 		enum wlr_direction direction;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -64,7 +64,7 @@ static struct sway_output *output_in_direction(const char *direction_string,
 		}
 	}
 
-	return output_by_name(direction_string);
+	return output_by_name_or_id(direction_string);
 }
 
 static bool is_parallel(enum sway_container_layout layout,

--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -45,7 +45,7 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 			return cmd_results_new(CMD_INVALID, "output",
 				"Cannot apply relative transform to all outputs.");
 		}
-		struct sway_output *s_output = output_by_name(output->name);
+		struct sway_output *s_output = output_by_name_or_id(output->name);
 		if (s_output == NULL) {
 			return cmd_results_new(CMD_INVALID, "output",
 				"Cannot apply relative transform to unknown output %s", output->name);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -29,23 +29,13 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 
-struct sway_output *output_by_name(const char *name) {
+struct sway_output *output_by_name_or_id(const char *name_or_id) {
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		if (strcasecmp(output->wlr_output->name, name) == 0) {
-			return output;
-		}
-	}
-	return NULL;
-}
-
-struct sway_output *output_by_identifier(const char *identifier) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
-		char output_identifier[128];
-		snprintf(output_identifier, sizeof(output_identifier), "%s %s %s", output->wlr_output->make,
-			output->wlr_output->model, output->wlr_output->serial);
-		if (strcasecmp(output_identifier, identifier) == 0) {
+		char identifier[128];
+		output_get_identifier(identifier, sizeof(identifier), output);
+		if (strcasecmp(identifier, name_or_id) == 0
+				|| strcasecmp(output->wlr_output->name, name_or_id) == 0) {
 			return output;
 		}
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -428,7 +428,7 @@ static void seat_apply_input_config(struct sway_seat *seat,
 	if (mapped_to_output != NULL) {
 		wlr_log(WLR_DEBUG, "Mapping input device %s to output %s",
 			sway_device->input_device->identifier, mapped_to_output);
-		struct sway_output *output = output_by_name(mapped_to_output);
+		struct sway_output *output = output_by_name_or_id(mapped_to_output);
 		if (output) {
 			wlr_cursor_map_input_to_output(seat->cursor->cursor,
 				sway_device->input_device->wlr_device, output->wlr_output);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -459,7 +459,7 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 	for (int i = 0; i < criterias->length; ++i) {
 		struct criteria *criteria = criterias->items[i];
 		if (criteria->type == CT_ASSIGN_OUTPUT) {
-			struct sway_output *output = output_by_name(criteria->target);
+			struct sway_output *output = output_by_name_or_id(criteria->target);
 			if (output) {
 				ws = output_get_active_workspace(output);
 				break;


### PR DESCRIPTION
Supersedes #3314

This combines `output_by_name` and `output_by_identifier` into a single
function called `output_by_name_or_id`. This allows for output
identifiers to be used in all commands, simplifies the logic of the
callers, and is more efficient since worst case is a single pass through
the output list.