### PR TITLE
swaylock: Add some key bindings to emulate login(1)

### DIFF
--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -165,6 +165,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 		schedule_indicator_clear(state);
 		schedule_password_clear(state);
 		break;
+	case XKB_KEY_c: /* fallthrough */
 	case XKB_KEY_u:
 		if (state->xkb.control) {
 			clear_password_buffer(&state->password);


### PR DESCRIPTION
There are a few key combos that do something in the standard `login` program that don't work with swaylock (sabotaging my muscle memory :wink:). Namely, Ctrl-C restarts login (i.e. clears the password buffer) and Ctrl-D (effectively EOF) submits it.

See the commit messages for more detail.