### PR TITLE
Check xdg_surface's role before using its toplevel

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -216,7 +216,7 @@ static bool is_transient_for(struct sway_view *child,
 		return false;
 	}
 	struct wlr_xdg_surface *surface = child->wlr_xdg_surface;
-	while (surface) {
+	while (surface && surface->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL) {
 		if (surface->toplevel->parent == ancestor->wlr_xdg_surface) {
 			return true;
 		}

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -213,7 +213,7 @@ static bool is_transient_for(struct sway_view *child,
 		return false;
 	}
 	struct wlr_xdg_surface_v6 *surface = child->wlr_xdg_surface_v6;
-	while (surface) {
+	while (surface && surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
 		if (surface->toplevel->parent == ancestor->wlr_xdg_surface_v6) {
 			return true;
 		}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -341,7 +341,7 @@ static bool surface_is_popup(struct wlr_surface *surface) {
 	if (wlr_surface_is_xdg_surface(surface)) {
 		struct wlr_xdg_surface *xdg_surface =
 			wlr_xdg_surface_from_wlr_surface(surface);
-		while (xdg_surface) {
+		while (xdg_surface && xdg_surface->role != WLR_XDG_SURFACE_ROLE_NONE) {
 			if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
 				return true;
 			}
@@ -353,7 +353,8 @@ static bool surface_is_popup(struct wlr_surface *surface) {
 	if (wlr_surface_is_xdg_surface_v6(surface)) {
 		struct wlr_xdg_surface_v6 *xdg_surface_v6 =
 			wlr_xdg_surface_v6_from_wlr_surface(surface);
-		while (xdg_surface_v6) {
+		while (xdg_surface_v6 &&
+				xdg_surface_v6->role != WLR_XDG_SURFACE_V6_ROLE_NONE) {
 			if (xdg_surface_v6->role == WLR_XDG_SURFACE_V6_ROLE_POPUP) {
 				return true;
 			}


### PR DESCRIPTION
After some debugging I found the reason for the crash in #3311. The problem was
that I ended up with a toplevel child whos parent had unmapped.  So the child's
`xdg_surface->toplevel->parent` pointed to an `xdg_surface` with its role set
to `WLR_XDG_SURFACE_ROLE_NONE` and its `xdg_surface->toplevel` pointer freed.
The function `surface_is_popup` didn't check this case, which led to a segfault
when setting `xdg_surface = xdg_surface->toplevel->parent;`.  I searched for
similar occurrences and found one in the function `is_transient_for`, where I
also added a check (I was able to reproduce a segfault there too).

Despite that this patch fixes my crash, I know too little about how xdg shell
works, to be confident that this is the right fix. I don't know if it is normal
that a child points to its parent, even if the parent has unmapped. So I think
someone with a better understanding of xdg shell should check if this patch is
the right approach.
