### PR TITLE
Fix wlr_box_intersection args for wlroots 1441

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -108,7 +108,7 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	};
 
 	struct wlr_box intersection;
-	return wlr_box_intersection(&output_box, &rotated_box, &intersection);
+	return wlr_box_intersection(&intersection, &output_box, &rotated_box);
 }
 
 static void output_for_each_surface_iterator(struct wlr_surface *surface,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -261,7 +261,7 @@ static void render_saved_view(struct sway_view *view,
 	};
 
 	struct wlr_box intersection;
-	bool intersects = wlr_box_intersection(&output_box, &box, &intersection);
+	bool intersects = wlr_box_intersection(&intersection, &output_box, &box);
 	if (!intersects) {
 		return;
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -979,7 +979,7 @@ void container_discover_outputs(struct sway_container *con) {
 		output_get_box(output, &output_box);
 		struct wlr_box intersection;
 		bool intersects =
-			wlr_box_intersection(&con_box, &output_box, &intersection);
+			wlr_box_intersection(&intersection, &con_box, &output_box);
 		int index = list_find(con->outputs, output);
 
 		if (intersects && index == -1) {


### PR DESCRIPTION
Fixes #3322 

The fix pushed to master missed wlr_box_intersection. This just fixes those calls so sway renders properly again