### PR TITLE
Added is_fullscreen command to swaymsg

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -21,6 +21,8 @@ enum ipc_command_type {
 	IPC_GET_INPUTS = 100,
 	IPC_GET_SEATS = 101,
 
+	IPC_IS_FULLSCREEN = 102,
+
 	// Events sent from sway to clients. Events have the highest bits set.
 	IPC_EVENT_WORKSPACE = ((1<<31) | 0),
 	IPC_EVENT_OUTPUT = ((1<<31) | 1),

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -836,6 +836,22 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		goto exit_cleanup;
     }
 
+	case IPC_IS_FULLSCREEN:
+	{
+		json_object *json = json_object_new_object();
+		struct sway_container *container = config->handler_context.container;
+		if(container != NULL && container->is_fullscreen) {
+			json_object_object_add(json, "fullscreen", json_object_new_string("true"));
+		}
+		else {
+			json_object_object_add(json, "fullscreen", json_object_new_string("false"));
+		}
+		const char *json_string = json_object_to_json_string(json);
+		client_valid =
+			ipc_send_reply(client, json_string, (uint32_t)strlen(json_string));
+		json_object_put(json); // free
+		goto exit_cleanup;
+	}
 	default:
 		wlr_log(WLR_INFO, "Unknown IPC command type %i", client->current_command);
 		goto exit_cleanup;
@@ -860,7 +876,7 @@ bool ipc_send_reply(struct ipc_client *client, const char *payload, uint32_t pay
 	memcpy(&data32[1], &client->current_command, sizeof(client->current_command));
 
 	while (client->write_buffer_len + ipc_header_size + payload_length >=
-				 client->write_buffer_size) {
+		client->write_buffer_size) {
 		client->write_buffer_size *= 2;
 	}
 

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -389,7 +389,9 @@ int main(int argc, char **argv) {
 		type = IPC_COMMAND;
 	} else if (strcasecmp(cmdtype, "get_workspaces") == 0) {
 		type = IPC_GET_WORKSPACES;
-	} else if (strcasecmp(cmdtype, "get_seats") == 0) {
+	} else if (strcasecmp(cmdtype, "is_fullscreen") == 0) {
+        type = IPC_IS_FULLSCREEN; 
+    } else if (strcasecmp(cmdtype, "get_seats") == 0) {
 		type = IPC_GET_SEATS;
 	} else if (strcasecmp(cmdtype, "get_inputs") == 0) {
 		type = IPC_GET_INPUTS;


### PR DESCRIPTION
I needed to check if the current window were fullscreen or not, suprised by not seeing it in swaymsg API, I added it. 

The main purpose was to lock my screen after timeout only if I wasn't watching a movie or a youtube video (in fullscreen). 

With this patch, we can now customize a little wiki's swayidle command : 

```
exec swayidle \
    timeout 300 'if (swaymsg -t is_fullscreen | grep "false"); then swaylock ;fi' \
    timeout 600 'if (swaymsg -t is_fullscreen | grep "false"); then swaymsg "output * dpms off"' \
       resume 'swaymsg "output * dpms on"' \
    before-sleep 'swaylock'
```

What left todo, is to add in swaymsg's man docs is_fullscreen capabilities. 
I didn't do it since I don't know how this works.