### PR TITLE
Revamp seat configs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -536,7 +536,7 @@ struct seat_attachment_config *seat_attachment_config_new(void);
 struct seat_attachment_config *seat_config_get_attachment(
 		struct seat_config *seat_config, char *identifier);
 
-void apply_seat_config(struct seat_config *seat);
+struct seat_config *store_seat_config(struct seat_config *seat);
 
 int output_name_cmp(const void *item, const void *data);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -42,21 +42,6 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 		: NULL;
 }
 
-void apply_seat_config(struct seat_config *seat_config) {
-	int i = list_seq_find(config->seat_configs, seat_name_cmp, seat_config->name);
-	if (i >= 0) {
-		// merge existing config
-		struct seat_config *sc = config->seat_configs->items[i];
-		merge_seat_config(sc, seat_config);
-		free_seat_config(seat_config);
-		seat_config = sc;
-	} else {
-		list_add(config->seat_configs, seat_config);
-	}
-
-	input_manager_apply_seat_config(seat_config);
-}
-
 /* Keep alphabetized */
 static struct cmd_handler handlers[] = {
 	{ "assign", cmd_assign },

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -26,9 +26,16 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 
 	struct cmd_results *res = config_subcommand(argv + 1, argc - 1,
 			seat_handlers, sizeof(seat_handlers));
+	if (res && res->status != CMD_SUCCESS) {
+		free_seat_config(config->handler_context.seat_config);
+		config->handler_context.seat_config = NULL;
+		return res;
+	}
 
-	free_seat_config(config->handler_context.seat_config);
+	struct seat_config *sc =
+		store_seat_config(config->handler_context.seat_config);
+	input_manager_apply_seat_config(sc);
+
 	config->handler_context.seat_config = NULL;
-
-	return res;
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -1,10 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <string.h>
-#include <strings.h>
-#include "sway/input/input-manager.h"
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "log.h"
 #include "stringop.h"
 
 struct cmd_results *seat_cmd_attach(int argc, char **argv) {
@@ -12,19 +9,17 @@ struct cmd_results *seat_cmd_attach(int argc, char **argv) {
 	if ((error = checkarg(argc, "attach", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	struct seat_config *current_seat_config =
-		config->handler_context.seat_config;
-	if (!current_seat_config) {
+	if (!config->handler_context.seat_config) {
 		return cmd_results_new(CMD_FAILURE, "attach", "No seat defined");
 	}
 
-	struct seat_config *new_config = new_seat_config(current_seat_config->name);
-	struct seat_attachment_config *new_attachment = seat_attachment_config_new();
-	new_attachment->identifier = strdup(argv[0]);
-	list_add(new_config->attachments, new_attachment);
-
-	if (!config->validating) {
-		apply_seat_config(new_config);
+	struct seat_attachment_config *attachment = seat_attachment_config_new();
+	if (!attachment) {
+		return cmd_results_new(CMD_FAILURE, "attach",
+				"Failed to allocate seat attachment config");
 	}
+	attachment->identifier = strdup(argv[0]);
+	list_add(config->handler_context.seat_config->attachments, attachment);
+
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/seat/fallback.c
+++ b/sway/commands/seat/fallback.c
@@ -1,27 +1,18 @@
-#include <string.h>
-#include <strings.h>
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "util.h"
 
 struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "fallback", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, "fallback", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	struct seat_config *current_seat_config =
-		config->handler_context.seat_config;
-	if (!current_seat_config) {
+	if (!config->handler_context.seat_config) {
 		return cmd_results_new(CMD_FAILURE, "fallback", "No seat defined");
 	}
-	struct seat_config *new_config =
-		new_seat_config(current_seat_config->name);
-		
-	new_config->fallback = parse_boolean(argv[0], false);
 
-	if (!config->validating) {
-		apply_seat_config(new_config);
-	}
+	config->handler_context.seat_config->fallback =
+		parse_boolean(argv[0], false);
+
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }


### PR DESCRIPTION
This makes seat configs work like output and input configs do. This also
adds support for wildcard seat configs. A seat config is still created
in the main seat command handler, but instead of creating a new one in
the subcommands and destroying the main seat command's instance, the
seat subcommands modify the main one. The seat config is then stored,
where it is merged appropriately. The seat config returned from
`store_seat_config` is then applied. When attempting to apply a wildcard
seat config, a seat specific config is queried for and if found, that is
used. Otherwise, the wildcard config is applied directly.

Additionally, instead of adding input devices to the default seat
directly when there is no seat configs, a seat config for the default
seat is created with only fallback set to true, which is more explicit.
It also fixes an issue where running a seat command at runtime (with no
seat config in the sway config), would result in all input devices being
removed from the default seat and leaving sway in an unusable state.

Also, instead of checking for any seat config, the search is for a seat
config with a fallback option seat. This makes it so if there are only
seat configs with fallback set to -1, the default seat is still created
since there is no explicit notion on what to do regarding fallbacks.
However, if there is even a single fallback 0, then the default seat is
not used as a fallback. This will be needed for seat subcommands like
hide_cursor where the user may only want to set that property without
effecting anything else.

Follow-up PRs:
- Move hide_cursor to be a seat subcommand
- Fix seat cursor to work on the specified seat instead of the current