### PR TITLE
seat_cmd_cursor: work on seat name provided

### DIFF
--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -17,18 +17,8 @@ static const char *expected_syntax = "Expected 'cursor <move> <x> <y>' or "
 					"'cursor <set> <x> <y>' or "
 					"'curor <press|release> <left|right|1|2|3...>'";
 
-struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "cursor", EXPECTED_AT_LEAST, 2))) {
-		return error;
-	}
-	struct sway_seat *seat = config->handler_context.seat;
-	if (!seat) {
-		return cmd_results_new(CMD_FAILURE, "cursor", "No seat defined");
-	}
-
-	struct sway_cursor *cursor = seat->cursor;
-
+static struct cmd_results *handle_command(struct sway_cursor *cursor,
+		int argc, char **argv) {
 	if (strcasecmp(argv[0], "move") == 0) {
 		if (argc < 3) {
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);
@@ -50,12 +40,47 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 		if (argc < 2) {
 			return cmd_results_new(CMD_INVALID, "cursor", expected_syntax);
 		}
+		struct cmd_results *error = NULL;
 		if ((error = press_or_release(cursor, argv[0], argv[1]))) {
 			return error;
 		}
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
+struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "cursor", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+	struct seat_config *sc = config->handler_context.seat_config;
+	if (!sc) {
+		return cmd_results_new(CMD_FAILURE, "cursor", "No seat defined");
+	}
+
+	if (config->reading || !config->active) {
+		return cmd_results_new(CMD_DEFER, NULL, NULL);
+	}
+
+	if (strcmp(sc->name, "*") != 0) {
+		struct sway_seat *seat = input_manager_get_seat(sc->name);
+		if (!seat) {
+			return cmd_results_new(CMD_FAILURE, "cursor",
+					"Failed to get seat");
+		}
+		error = handle_command(seat->cursor, argc, argv);
+	} else {
+		struct sway_seat *seat = NULL;
+		wl_list_for_each(seat, &server.input->seats, link) {
+			error = handle_command(seat->cursor, argc, argv);
+			if ((error && error->status != CMD_SUCCESS)) {
+				break;
+			}
+		}
+	}
+
+	return error ? error : cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
 static struct cmd_results *press_or_release(struct sway_cursor *cursor,


### PR DESCRIPTION
~**DO NOT MERGE UNTIL AFTER #3334**~

Instead of simulating events on the current seat, this makes it so
seat_cmd_cursor respects the seat name provided by
`seat <name> cursor <args>`. It also adds support for simulating
events on all seats when the wildcard is given.

This also defers the command when reading the config, which allows the
user to set the initial position of the cursor when the command is
included in the config file.