### PR TITLE
Remove button from state on release during op

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -825,6 +825,11 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			seat_end_mouse_operation(seat);
 			seat_pointer_notify_button(seat, time_msec, button, state);
 		}
+		if (state == WLR_BUTTON_PRESSED) {
+			state_add_button(cursor, button);
+		} else {
+			state_erase_button(cursor, button);
+		}
 		return;
 	}
 


### PR DESCRIPTION
This fixes a bug in `dispatch_cursor_button` where if there was an
operation occurring, the button would not be removed from the state on
release. This resulted in the button appearing to be permanently pressed
and caused mouse bindings to not match correctly.

This was probably part of the problem for https://github.com/swaywm/sway/issues/2576