### PR TITLE
Switch events

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -101,6 +101,7 @@ struct sway_container *container_find_resize_parent(struct sway_container *con,
 sway_cmd cmd_assign;
 sway_cmd cmd_bar;
 sway_cmd cmd_bindcode;
+sway_cmd cmd_bindswitch;
 sway_cmd cmd_bindsym;
 sway_cmd cmd_border;
 sway_cmd cmd_client_noop;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
+#include <wlr/interfaces/wlr_switch.h>
 #include <wlr/types/wlr_box.h>
 #include <xkbcommon/xkbcommon.h>
 #include "../include/config.h"
@@ -29,6 +30,7 @@ enum binding_input_type {
 	BINDING_KEYSYM,
 	BINDING_MOUSECODE,
 	BINDING_MOUSESYM,
+	BINDING_SWITCH
 };
 
 enum binding_flags {
@@ -61,6 +63,16 @@ struct sway_mouse_binding {
 };
 
 /**
+ * A laptop switch binding and an associated command.
+ */
+struct sway_switch_binding {
+	enum wlr_switch_type type;
+	enum wlr_switch_state state;
+	uint32_t flags;
+	char *command;
+};
+
+/**
  * Focus on window activation.
  */
 enum sway_fowa {
@@ -78,6 +90,7 @@ struct sway_mode {
 	list_t *keysym_bindings;
 	list_t *keycode_bindings;
 	list_t *mouse_bindings;
+	list_t *switch_bindings;
 	bool pango;
 };
 
@@ -602,6 +615,8 @@ int sway_binding_cmp_qsort(const void *a, const void *b);
 int sway_binding_cmp_keys(const void *a, const void *b);
 
 void free_sway_binding(struct sway_binding *sb);
+
+void free_switch_binding(struct sway_switch_binding *binding);
 
 void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -27,6 +27,7 @@ struct sway_seat_device {
 	struct sway_seat *sway_seat;
 	struct sway_input_device *input_device;
 	struct sway_keyboard *keyboard;
+	struct sway_switch *switch_device;
 	struct wl_list link; // sway_seat::devices
 };
 

--- a/include/sway/input/switch.h
+++ b/include/sway/input/switch.h
@@ -1,0 +1,19 @@
+#ifndef _SWAY_INPUT_SWITCH_H
+#define _SWAY_INPUT_SWITCH_H
+
+#include "sway/input/seat.h"
+
+struct sway_switch {
+    struct sway_seat_device *seat_device;
+
+    struct wl_listener switch_toggle;
+};
+
+struct sway_switch *sway_switch_create(struct sway_seat *seat,
+        struct sway_seat_device *device);
+
+void sway_switch_configure(struct sway_switch *sway_switch);
+
+void sway_switch_destroy(struct sway_switch *sway_switch);
+
+#endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -47,6 +47,7 @@ static struct cmd_handler handlers[] = {
 	{ "assign", cmd_assign },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },
+	{ "bindswitch", cmd_bindswitch },
 	{ "bindsym", cmd_bindsym },
 	{ "client.background", cmd_client_noop },
 	{ "client.focused", cmd_client_focused },
@@ -386,6 +387,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 				&& handler->handle != cmd_mode
 				&& handler->handle != cmd_bindsym
 				&& handler->handle != cmd_bindcode
+				&& handler->handle != cmd_bindswitch
 				&& handler->handle != cmd_set
 				&& handler->handle != cmd_for_window
 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -12,6 +12,7 @@
 // Must be in order for the bsearch
 static struct cmd_handler mode_handlers[] = {
 	{ "bindcode", cmd_bindcode },
+	{ "bindswitch", cmd_bindswitch },
 	{ "bindsym", cmd_bindsym }
 };
 
@@ -54,6 +55,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		mode->keysym_bindings = create_list();
 		mode->keycode_bindings = create_list();
 		mode->mouse_bindings = create_list();
+		mode->switch_bindings = create_list();
 		mode->pango = pango;
 		list_add(config->modes, mode);
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -56,6 +56,12 @@ static void free_mode(struct sway_mode *mode) {
 		}
 		list_free(mode->mouse_bindings);
 	}
+	if (mode->switch_bindings) {
+		for (int i = 0; i < mode->switch_bindings->length; i++) {
+			free_switch_binding(mode->switch_bindings->items[i]);
+		}
+		list_free(mode->switch_bindings);
+	}
 	free(mode);
 }
 
@@ -195,6 +201,7 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->current_mode->keysym_bindings = create_list())) goto cleanup;
 	if (!(config->current_mode->keycode_bindings = create_list())) goto cleanup;
 	if (!(config->current_mode->mouse_bindings = create_list())) goto cleanup;
+	if (!(config->current_mode->switch_bindings = create_list())) goto cleanup;
 	list_add(config->modes, config->current_mode);
 
 	config->floating_mod = 0;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -155,6 +155,47 @@ static void input_manager_libinput_reset_keyboard(
 				libinput_device, send_events));
 }
 
+static void input_manager_libinput_config_switch(
+		struct sway_input_device *input_device) {
+	struct wlr_input_device *wlr_device = input_device->wlr_device;
+	struct input_config *ic = input_device_get_config(input_device);
+	struct libinput_device *libinput_device;
+
+	if (!ic || !wlr_input_device_is_libinput(wlr_device)) {
+		return;
+	}
+
+	libinput_device = wlr_libinput_get_device_handle(wlr_device);
+	sway_log(SWAY_DEBUG, "input_manager_libinput_config_switch(%s)",
+		ic->identifier);
+
+	if (ic->send_events != INT_MIN) {
+		sway_log(SWAY_DEBUG, "libinput_config_switch(%s) send_events_set_mode(%d)",
+			ic->identifier, ic->send_events);
+		log_libinput_config_status(libinput_device_config_send_events_set_mode(
+				libinput_device, ic->send_events));
+	}
+}
+
+static void input_manager_libinput_reset_switch(
+		struct sway_input_device *input_device) {
+	struct wlr_input_device *wlr_device = input_device->wlr_device;
+	struct libinput_device *libinput_device;
+
+	if (!wlr_input_device_is_libinput(wlr_device)) {
+		return;
+	}
+
+	libinput_device = wlr_libinput_get_device_handle(wlr_device);
+
+	uint32_t send_events =
+		libinput_device_config_send_events_get_default_mode(libinput_device);
+	sway_log(SWAY_DEBUG, "libinput_reset_switch(%s) send_events_set_mode(%d)",
+		input_device->identifier, send_events);
+	log_libinput_config_status(libinput_device_config_send_events_set_mode(
+				libinput_device, send_events));
+}
+
 static void input_manager_libinput_config_touch(
 		struct sway_input_device *input_device) {
 	struct wlr_input_device *wlr_device = input_device->wlr_device;
@@ -471,6 +512,8 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 		input_manager_libinput_config_pointer(input_device);
 	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_KEYBOARD) {
 		input_manager_libinput_config_keyboard(input_device);
+	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_SWITCH) {
+		input_manager_libinput_config_switch(input_device);
 	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_TOUCH) {
 		input_manager_libinput_config_touch(input_device);
 	}
@@ -624,6 +667,8 @@ void input_manager_apply_input_config(struct input_config *input_config) {
 				input_manager_libinput_config_pointer(input_device);
 			} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_KEYBOARD) {
 				input_manager_libinput_config_keyboard(input_device);
+			} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_SWITCH) {
+				input_manager_libinput_config_switch(input_device);
 			} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_TOUCH) {
 				input_manager_libinput_config_touch(input_device);
 			}
@@ -642,6 +687,8 @@ void input_manager_reset_input(struct sway_input_device *input_device) {
 		input_manager_libinput_reset_pointer(input_device);
 	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_KEYBOARD) {
 		input_manager_libinput_reset_keyboard(input_device);
+	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_SWITCH) {
+		input_manager_libinput_reset_switch(input_device);
 	} else if (input_device->wlr_device->type == WLR_INPUT_DEVICE_TOUCH) {
 		input_manager_libinput_reset_touch(input_device);
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -15,6 +15,7 @@
 #include "sway/input/input-manager.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/seat.h"
+#include "sway/input/switch.h"
 #include "sway/ipc-server.h"
 #include "sway/layers.h"
 #include "sway/output.h"
@@ -482,8 +483,8 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 		case WLR_INPUT_DEVICE_TABLET_TOOL:
 			caps |= WL_SEAT_CAPABILITY_POINTER;
 			break;
-		case WLR_INPUT_DEVICE_TABLET_PAD:
 		case WLR_INPUT_DEVICE_SWITCH:
+		case WLR_INPUT_DEVICE_TABLET_PAD:
 			break;
 		}
 	}
@@ -570,6 +571,15 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	}
 }
 
+static void seat_configure_switch(struct sway_seat *seat,
+        struct sway_seat_device *seat_device) {
+	if (!seat_device->switch_device) {
+		sway_switch_create(seat, seat_device);
+	}
+	seat_apply_input_config(seat, seat_device);
+	sway_switch_configure(seat_device->switch_device);
+}
+
 static void seat_configure_touch(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
@@ -611,6 +621,9 @@ void seat_configure_device(struct sway_seat *seat,
 		case WLR_INPUT_DEVICE_KEYBOARD:
 			seat_configure_keyboard(seat, seat_device);
 			break;
+		case WLR_INPUT_DEVICE_SWITCH:
+			seat_configure_switch(seat, seat_device);
+			break;
 		case WLR_INPUT_DEVICE_TOUCH:
 			seat_configure_touch(seat, seat_device);
 			break;
@@ -619,9 +632,6 @@ void seat_configure_device(struct sway_seat *seat,
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
 			sway_log(SWAY_DEBUG, "TODO: configure tablet pad");
-			break;
-		case WLR_INPUT_DEVICE_SWITCH:
-			sway_log(SWAY_DEBUG, "TODO: configure switch device");
 			break;
 	}
 }

--- a/sway/input/switch.c
+++ b/sway/input/switch.c
@@ -1,0 +1,85 @@
+#include "sway/config.h"
+#include "sway/desktop/transaction.h"
+#include "sway/input/switch.h"
+#include <wlr/types/wlr_idle.h>
+#include "log.h"
+
+struct sway_switch *sway_switch_create(struct sway_seat *seat,
+        struct sway_seat_device *device) {
+    struct sway_switch *switch_device =
+        calloc(1, sizeof(struct sway_switch));
+    if (!sway_assert(switch_device, "could not allocate switch")) {
+        return NULL;
+    }
+    device->switch_device = switch_device;
+    switch_device->seat_device = device;
+    wl_list_init(&switch_device->switch_toggle.link);
+    sway_log(SWAY_DEBUG, "Allocated switch for device");
+
+    return switch_device;
+}
+
+static void handle_switch_toggle(struct wl_listener *listener, void *data) {
+    struct sway_switch *sway_switch =
+            wl_container_of(listener, sway_switch, switch_toggle);
+    struct sway_seat* seat = sway_switch->seat_device->sway_seat;
+    struct wlr_seat *wlr_seat = seat->wlr_seat;
+    struct wlr_input_device *wlr_device =
+        sway_switch->seat_device->input_device->wlr_device;
+
+    wlr_idle_notify_activity(server.idle, wlr_seat);
+    bool input_inhibited = seat->exclusive_client != NULL;
+
+    char *device_identifier = input_device_get_identifier(wlr_device);
+
+    struct wlr_event_switch_toggle *event = data;
+    enum wlr_switch_type type = event->switch_type;
+    enum wlr_switch_state state = event->switch_state;
+    sway_log(SWAY_DEBUG, "%s: type %d state %d", device_identifier, type, state);
+
+    list_t *bindings = config->current_mode->switch_bindings;
+    for (int i = 0; i < bindings->length; ++i) {
+        struct sway_switch_binding *binding = bindings->items[i];
+        if (binding->type != type) {
+            continue;
+        }
+        if (binding->state != WLR_SWITCH_STATE_TOGGLE &&
+                binding->state != state) {
+            continue;
+        }
+        bool binding_locked = binding->flags & BINDING_LOCKED;
+        if (!binding_locked && input_inhibited) {
+            continue;
+        }
+
+        struct sway_binding *dummy_binding = calloc(1, sizeof(struct sway_binding));
+        dummy_binding->type = BINDING_SWITCH;
+        dummy_binding->flags = binding->flags;
+        dummy_binding->command = binding->command;
+
+        seat_execute_command(seat, dummy_binding);
+        free(dummy_binding);
+    }
+
+    transaction_commit_dirty();
+
+    free(device_identifier);
+}
+
+void sway_switch_configure(struct sway_switch *sway_switch) {
+    struct wlr_input_device *wlr_device =
+        sway_switch->seat_device->input_device->wlr_device;
+    wl_list_remove(&sway_switch->switch_toggle.link);
+    wl_signal_add(&wlr_device->switch_device->events.toggle,
+            &sway_switch->switch_toggle);
+    sway_switch->switch_toggle.notify = handle_switch_toggle;
+    sway_log(SWAY_DEBUG, "Configured switch for device");
+}
+
+void sway_switch_destroy(struct sway_switch *sway_switch) {
+    if (!sway_switch) {
+        return;
+    }
+    wl_list_remove(&sway_switch->switch_toggle.link);
+    free(sway_switch);
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -91,14 +91,14 @@ static const char *ipc_json_device_type_description(struct sway_input_device *de
 		return "pointer";
 	case WLR_INPUT_DEVICE_KEYBOARD:
 		return "keyboard";
+	case WLR_INPUT_DEVICE_SWITCH:
+		return "switch";
 	case WLR_INPUT_DEVICE_TOUCH:
 		return "touch";
 	case WLR_INPUT_DEVICE_TABLET_TOOL:
 		return "tablet_tool";
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		return "tablet_pad";
-	case WLR_INPUT_DEVICE_SWITCH:
-		return "switch";
 	}
 	return "unknown";
 }

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -30,6 +30,7 @@ sway_sources = files(
 	'input/seatop_resize_tiling.c',
 	'input/cursor.c',
 	'input/keyboard.c',
+	'input/switch.c',
 
 	'config/bar.c',
 	'config/output.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -341,6 +341,28 @@ runtime.
 	*bindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] [--input-device=<device>] [--no-warn] <code> <command>
 	is also available for binding with key/button codes instead of key/button names.
 
+*bindswitch* [--locked] [--no-warn] <switch>:<state> <command>
+	Binds <switch> to execute the sway command _command_ on state changes.
+	Supported switches are _lid_ (laptop lid) and _tablet_ (tablet mode)
+	switches. Valid values for _state_ are _on_, _off_ and _toggle. These
+	switches are on when the device lid is shut and when tablet mode is active
+	respectively. _toggle_ is also supported to run a command both when the
+	switch is toggled on or off.
+
+	Unless the flag _--locked_ is set, the command will not be run
+	when a screen locking program is active. By default, if you
+	overwrite a binding, swaynag will give you a warning. To silence this, use
+	the _--no-warn_ flag.
+
+	Example:
+```
+		# Show the virtual keyboard when tablet mode is entered.
+		bindswitch tablet:on busctl call --user sm.puri.OSK0 /sm/puri/OSK0 sm.puri.OSK0 SetVisible b true
+
+		# Log a message when the laptop lid is opened or closed.
+		bindswitch lid:toggle exec echo "Lid moved"
+```
+
 *client.<class>* <border> <background> <text> <indicator> <child_border>
 	Configures the color of window borders and title bars. All 5 colors are
 	required, with the exception of *client.background*, which requires exactly
@@ -551,9 +573,9 @@ The default colors are:
 	Switches to the specified mode. The default mode _default_.
 
 *mode* [--pango_markup] <mode> <mode-subcommands...>
-	The only two valid _mode-subcommands..._ are *bindsym* and *bindcode*.
-	If _--pango_markup_ is given, then _mode_ will be interpreted as pango
-	markup.
+	The only valid _mode-subcommands..._ are *bindsym*, *bindcode* and
+	*bindswitch*. If _--pango_markup_ is given, then _mode_ will be interpreted
+	as pango markup.
 
 *mouse_warping* output|container|none
 	If _output_ is specified, the mouse will be moved to new outputs as you


### PR DESCRIPTION
~I'm planning to expose this config by adding the `bindswitch` command as follows:~
On second thoughts it might be better to use the existing `bindsym` architecture and match `evdev` switch names, 

eg `bindsym tablet:lid:on exec "Lid opened"`
vs
```
bindswitch lid:on exec echo "Lid opened"
bindswitch lid:off exec echo "Lid closed"
bindswitch lid:toggle exec echo "Lid moved"

bindswitch tablet:on exec echo "Entered tablet mode"
bindswitch tablet:off exec echo "Entered laptop mode"
bindswitch tablet:toggle exec echo "Toggled tablet mode"

bindswitch ThinkPad Extra Buttons:on exec echo "Matched name on"
bindswitch ThinkPad Extra Buttons:on exec echo "Matched name off"
```
As we did for rootston, commands can match on either the switch type (`lid` for `LIBINPUT_SWITCH_LID`, `tablet` for `LIBINPUT_SWITCH_TABLET_MODE`) or name, though I'd imagine that most people would just use the switch type.