### PR TITLE
Improve mouse button parsing: helpers and bind{code/sym}

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -27,7 +27,8 @@ struct sway_variable {
 enum binding_input_type {
 	BINDING_KEYCODE,
 	BINDING_KEYSYM,
-	BINDING_MOUSE,
+	BINDING_MOUSECODE,
+	BINDING_MOUSESYM,
 };
 
 enum binding_flags {

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -86,4 +86,12 @@ void cursor_warp_to_container(struct sway_cursor *cursor,
 
 void cursor_warp_to_workspace(struct sway_cursor *cursor,
 		struct sway_workspace *workspace);
+
+uint32_t get_mouse_bindsym(const char *name, char **error);
+
+uint32_t get_mouse_bindcode(const char *name, char **error);
+
+// Considers both bindsym and bindcode
+uint32_t get_mouse_button(const char *name, char **error);
+
 #endif

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -445,8 +445,12 @@ void ipc_event_binding(struct sway_binding *binding) {
 	json_object_object_add(json_binding, "input_code", json_object_new_int(input_code));
 	json_object_object_add(json_binding, "symbols", symbols);
 	json_object_object_add(json_binding, "symbol", symbol);
-	json_object_object_add(json_binding, "input_type", binding->type == BINDING_MOUSE ?
-			json_object_new_string("mouse") : json_object_new_string("keyboard"));
+
+	bool mouse = binding->type == BINDING_MOUSECODE ||
+		binding->type == BINDING_MOUSESYM;
+	json_object_object_add(json_binding, "input_type", mouse
+			? json_object_new_string("mouse")
+			: json_object_new_string("keyboard"));
 
 	json_object *json = json_object_new_object();
 	json_object_object_add(json, "change", json_object_new_string("run"));

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -302,7 +302,7 @@ runtime.
 ```
 
 	*bindcode* [--release|--locked] [--input-device=<device>] [--no-warn] <code> <command>
-	is also available for binding with key codes instead of key names.
+	is also available for binding with key/button codes instead of key/button names.
 
 *client.<class>* <border> <background> <text> <indicator> <child\_border>
 	Configures the color of window borders and title bars. All 5 colors are


### PR DESCRIPTION
This is the first of five follow-up PRs to #3313. This extracts the parsing of
mouse buttons into helpers and then uses them for `bindcode` and `bindsym`.
The next four PRs are for `input scroll_button`, `seat cursor`, `bar bindsym`,
and `bar tray_bindsym`.

The following helper functions have been added to aid with parsing mouse
buttons from a string:

1. `get_mouse_bindsym`: attempts to parse the string as an x11 button
(button[1-9]) or as an event name (ex BTN_LEFT or BTN_SIDE)
2. `get_mouse_bindcode`: attempts to parse the string as an event code
and validates that the event code is a button (starts with `BTN_`).
3. `get_mouse_button`: this is a conveniency function for callers that
do not care whether a bindsym or bindcode are used and attempts to parse
the string as a bindsym and then bindcode.

This modifies `bindcode` and `bindsym` to use `get_mouse_bindcode` and
`get_mouse_bindsym`, respectively, to parse mouse buttons. Additionally,
the `BINDING_MOUSE` type has been split into `BINDING_MOUSECODE` and
`BINDING_MOUSESYM` to match keys and allow for mouse bindcodes to be
used. Between the two commands, all button syms and codes should be
supported, including x11 axis buttons.