### PR TITLE
Improve mouse button parsing: input scroll_button

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1593,7 +1593,7 @@ uint32_t get_mouse_bindcode(const char *name, char **error) {
 
 uint32_t get_mouse_button(const char *name, char **error) {
 	uint32_t button = get_mouse_bindsym(name, error);
-	if (!button && !error) {
+	if (!button && !*error) {
 		button = get_mouse_bindcode(name, error);
 	}
 	return button;

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -105,10 +105,11 @@ The following commands may only be used in the configuration file.
 *input* <identifier> repeat\_rate <characters per second>
 	Sets the frequency of key repeats once the repeat\_delay has passed.
 
-*input* <identifier> scroll\_button <button\_identifier>
-	Sets button used for scroll\_method on\_button\_down. The button identifier
-	can be obtained from `libinput debug-events`.
-	If set to 0, it disables the scroll\_button on\_button\_down.
+*input* <identifier> scroll\_button disable|button[1-3,8,9]|<event-code-or-name>
+	Sets the button used for scroll\_method on\_button\_down. The button can
+	be given as an event name or code, which can be obtained from `libinput
+	debug-events`, or as a x11 mouse button (button[1-3,8,9]). If set to
+	_disable_, it disables the scroll\_method on\_button\_down.
 
 *input* <identifier> scroll\_factor <floating point value>
 	Changes the scroll factor for the specified input device. Scroll speed will


### PR DESCRIPTION
~**DO NOT MERGE UNTIL AFTER #3341**~

This is the second in a series of follow-up PRs for #3313.

This modifies `input_cmd_scroll_button` to utilize the mouse button
helper `get_mouse_button` when parsing the button. x11 axis buttons are
not supported with this command and `CMD_INVALID` will be returned, but
all other x11 buttons, button event names, and button event codes should
be working

This also fixes a typo in `get_mouse_button` that prevented the call to
`get_mouse_bindcode` from being executed.