### PR TITLE
Improve mouse button parsing: seat cursor buttons

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -74,6 +74,9 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	struct wlr_input_device *device, uint32_t time_msec, uint32_t button,
 	enum wlr_button_state state);
 
+void dispatch_cursor_axis(struct sway_cursor *cursor,
+		struct wlr_event_pointer_axis *event);
+
 void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	struct wl_client *client);
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1082,11 +1082,13 @@ static uint32_t wl_axis_to_button(struct wlr_event_pointer_axis *event) {
 	}
 }
 
-static void dispatch_cursor_axis(struct sway_cursor *cursor,
+void dispatch_cursor_axis(struct sway_cursor *cursor,
 		struct wlr_event_pointer_axis *event) {
 	struct sway_seat *seat = cursor->seat;
-	struct sway_input_device *input_device = event->device->data;
-	struct input_config *ic = input_device_get_config(input_device);
+	struct sway_input_device *input_device =
+		event->device ? event->device->data : NULL;
+	struct input_config *ic =
+		input_device ? input_device_get_config(input_device) : NULL;
 
 	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
@@ -1109,7 +1111,8 @@ static void dispatch_cursor_axis(struct sway_cursor *cursor,
 	// Gather information needed for mouse bindings
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
 	uint32_t modifiers = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
-	struct wlr_input_device *device = input_device->wlr_device;
+	struct wlr_input_device *device =
+		input_device ? input_device->wlr_device : NULL;
 	char *dev_id = device ? input_device_get_identifier(device) : strdup("*");
 	uint32_t button = wl_axis_to_button(event);
 

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -141,6 +141,19 @@ in their own "seat").
 	Attach an input device to this seat by its input identifier. A special
 	value of "\*" will attach all devices to the seat.
 
+*seat* <seat> cursor move|set <x> <y>
+	Move specified seat's cursor relative to current position or wrap to
+	absolute coordinates (with respect to the global coordinate space).
+	Specifying either value as 0 will not update that coordinate.
+
+*seat* <seat> cursor press|release button[1-9]|<event-name-or-code>
+	Simulate pressing (or releasing) the specified mouse button on the
+	specified seat. The button can either be provided as a button event name or
+	event code, which can be obtained from `libinput debug-events`, or as an x11
+	mouse button (button[1-9]). If using button[4-7], which map to axes, an axis
+	event will be simulated, however _press_ and _release_ will be ignored and
+	both will occur.
+
 *seat* <name> fallback true|false
 	Set this seat as the fallback seat. A fallback seat will attach any device
 	not explicitly attached to another seat (similar to a "default" seat).

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -491,15 +491,6 @@ The default colors are:
 *seat* <seat> <seat-subcommands...>
 	For details on seat subcommands, see *sway-input*(5).
 
-*seat* <seat> cursor move|set <x> <y>
-	Move specified seat's cursor relative to current position or wrap to
-	absolute coordinates (with respect to the global coordinate space).
-	Specifying either value as 0 will not update that coordinate.
-
-*seat* <seat> cursor press|release left|right|1|2|3...
-	Simulate pressing (or releasing) the specified mouse button on the
-	specified seat.
-
 *kill*
 	Kills (closes) the currently focused container and all of its children.
 


### PR DESCRIPTION
~**DO NOT MERGE UNTIL AFTER #3341**~

This is the third in a series of follow-up PRs for #3313.

This modifies `seat_cmd_cursor` to utilize `get_mouse_button` when
parsing mouse buttons for the `press` and `release` operations. All x11
buttons, button event names, and button event codes are supported.
For x11 axis buttons, `dispatch_cursor_axis` is used instead of
`dispatch_cursor_button`. However the `press`/`release` state is ignored
and the either axis event is processed. This also removes support for
`left` and `right` in favor of `BTN_LEFT` and `BTN_RIGHT`.

Note: #3342 has a fix for a typo in `get_mouse_button` that prevents the call to
`get_mouse_bindcode` so in order to test bindcodes, rebasing against that PR
is currently necessary