### PR TITLE
Fix crash when scratchpad contains split containers

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -145,7 +145,7 @@ void root_scratchpad_hide(struct sway_container *con) {
 
 	container_detach(con);
 	arrange_workspace(ws);
-	if (&con->node == focus) {
+	if (&con->node == focus || node_has_ancestor(focus, &con->node)) {
 		seat_set_focus(seat, seat_get_focus_inactive(seat, &ws->node));
 	}
 	list_move_to_end(root->scratchpad, con);


### PR DESCRIPTION
To reproduce:

* Launch two terminals in a workspace
* `focus parent` to select both terminals
* `move scratchpad`
* `scratchpad show` to show the terminals
* `scratchpad show` to hide the terminals
* `scratchpad show` - crash

When hiding the terminals, it should be moving focus to whatever is in the workspace, but this wasn't happening because the focus check didn't consider split containers. So the terminals were hidden in the scratchpad while still having focus. This confused the next invocation of `scratchpad show`, causing it to attempt to hide them instead of show them, and the hide-related code caused a crash when it tried to arrange the workspace which was `NULL`.

This patch corrects the focus check.