### PR TITLE
Verify seat fallback settings on reload

### DIFF
--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -44,6 +44,12 @@ struct sway_seat *input_manager_get_default_seat(void);
 struct sway_seat *input_manager_get_seat(const char *seat_name);
 
 /**
+ * If none of the seat configs have a fallback setting (either true or false),
+ * create the default seat (if needed) and set it as the fallback
+ */
+void input_manager_verify_fallback_seat(void);
+
+/**
  * Gets the last seat the user interacted with
  */
 struct sway_seat *input_manager_current_seat(void);

--- a/sway/config.c
+++ b/sway/config.c
@@ -465,6 +465,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		if (config->swaynag_config_errors.pid > 0) {
 			swaynag_show(&config->swaynag_config_errors);
 		}
+		input_manager_verify_fallback_seat();
 	}
 
 	if (old_config) {


### PR DESCRIPTION
Fixes #3347 

This fixes an issue where on reload, all input devices that were added
via an implicit fallback to the default seat would be removed from the
default seat and applications would crash due to the seat having no
capabilities.

On reload, there is a query for a seat config with the fallback setting
set (it can either be true or false). If no such seat config exists, the
default seat is created (if needed) and has the implicit fallback true
applied to its seat config. This is the same procedure that occurs when
a new input is detected.