### PR TITLE
Undocument SWAY_CURSOR_THEME and SWAY_CURSOR_SIZE

### DIFF
--- a/sway/sway.1.scd
+++ b/sway/sway.1.scd
@@ -71,18 +71,14 @@ with *i3-msg*(1) or even with *i3*(1).
 
 The following environment variables have an effect on sway:
 
-_SWAY\_CURSOR\_THEME_
-	Specifies the name of the cursor theme to use.
-
-_SWAY\_CURSOR\_SIZE_
-	Specifies the size of the cursor to use.
-
 _SWAYSOCK_
 	Specifies the path to the sway IPC socket.
 
 _XKB\_DEFAULT\_RULES_, _XKB\_DEFAULT\_MODEL_, _XKB\_DEFAULT\_LAYOUT_,
 _XKB\_DEFAULT\_VARIANT_, _XKB\_DEFAULT\_OPTIONS_
-	Configures the xkb keyboard settings. See *xkeyboard-config*(7).
+	Configures the xkb keyboard settings. See *xkeyboard-config*(7). The
+	preferred way to configure the keyboard is via the configuration file, see
+	*sway-input*(5).
 
 # AUTHORS
 


### PR DESCRIPTION
These are not yet implemented, and will be exposed as a configuration command
rather than env variables when implemented.

This also adds a reference to sway-input(5) in xkb env configuration. Maybe we
should just un-document these instead.