### PR TITLE
Apply implicit fallback seat config

### DIFF
--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -102,7 +102,8 @@ void input_manager_verify_fallback_seat(void) {
 		seat = input_manager_get_default_seat();
 		struct seat_config *sc = new_seat_config(seat->wlr_seat->name);
 		sc->fallback = true;
-		store_seat_config(sc);
+		sc = store_seat_config(sc);
+		input_manager_apply_seat_config(sc);
 	}
 }
 


### PR DESCRIPTION
#3348 did not completely fix the issue of input devices being
removed from the implicit fallback on reload. This should handle
the remaining case(s).

The implicit fallback seat config needs to be applied (if created).
Otherwise, the input devices will still be removed from the implicit
default seat on reload when there is any seat config.