### PR TITLE
swaybar: fix double free

### DIFF
--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -185,7 +185,6 @@ void status_line_free(struct status_line *status) {
 	}
 	free(status->read);
 	free(status->write);
-	free((char*) status->text);
 	free(status->buffer);
 	free(status);
 }


### PR DESCRIPTION
status->text should not be freed here. There are two scenarios:

* status->text has been set to an error by status_error. In this case
  the value shouldn't be freed because it's always a reference to a
  constant.
* status->text has been set to status->buffer because the bar is in
  text protocol mode. In this case it's a double free because the
  buffer is already freed after.