### PR TITLE
Implement tiling_drag_threshold

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -172,6 +172,7 @@ sway_cmd cmd_swaybg_command;
 sway_cmd cmd_swaynag_command;
 sway_cmd cmd_swap;
 sway_cmd cmd_tiling_drag;
+sway_cmd cmd_tiling_drag_threshold;
 sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -426,7 +426,9 @@ struct sway_config {
 	bool auto_back_and_forth;
 	bool show_marks;
 	enum alignment title_align;
+
 	bool tiling_drag;
+	int tiling_drag_threshold;
 
 	bool smart_gaps;
 	int gaps_inner;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -39,6 +39,7 @@ enum sway_seat_operation {
 	OP_NONE,
 	OP_DOWN,
 	OP_MOVE_FLOATING,
+	OP_MOVE_TILING_THRESHOLD,
 	OP_MOVE_TILING,
 	OP_RESIZE_FLOATING,
 	OP_RESIZE_TILING,
@@ -184,6 +185,9 @@ void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
 		uint32_t button, double sx, double sy);
 
 void seat_begin_move_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button);
+
+void seat_begin_move_tiling_threshold(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
 
 void seat_begin_move_tiling(struct sway_seat *seat,

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -87,6 +87,7 @@ static struct cmd_handler handlers[] = {
 	{ "smart_borders", cmd_smart_borders },
 	{ "smart_gaps", cmd_smart_gaps },
 	{ "tiling_drag", cmd_tiling_drag },
+	{ "tiling_drag_threshold", cmd_tiling_drag_threshold },
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },

--- a/sway/commands/tiling_drag_threshold.c
+++ b/sway/commands/tiling_drag_threshold.c
@@ -1,0 +1,22 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "log.h"
+
+struct cmd_results *cmd_tiling_drag_threshold(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "tiling_drag_threshold", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	char *inv;
+	int value = strtol(argv[0], &inv, 10);
+	if (*inv != '\0' || value < 0) {
+		return cmd_results_new(CMD_INVALID, "tiling_drag_threshold",
+			"Invalid threshold specified");
+	}
+
+	config->tiling_drag_threshold = value;
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -233,6 +233,7 @@ static void config_defaults(struct sway_config *config) {
 	config->show_marks = true;
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
+	config->tiling_drag_threshold = 9;
 
 	config->smart_gaps = false;
 	config->gaps_inner = 0;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1052,6 +1052,17 @@ void seat_begin_move_floating(struct sway_seat *seat,
 	cursor_set_image(seat->cursor, "grab", NULL);
 }
 
+void seat_begin_move_tiling_threshold(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
+	seat->operation = OP_MOVE_TILING_THRESHOLD;
+	seat->op_container = con;
+	seat->op_button = button;
+	seat->op_target_node = NULL;
+	seat->op_target_edge = 0;
+	seat->op_ref_lx = seat->cursor->cursor->x;
+	seat->op_ref_ly = seat->cursor->cursor->y;
+}
+
 void seat_begin_move_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button) {
 	seat->operation = OP_MOVE_TILING;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -89,6 +89,7 @@ sway_sources = files(
 	'commands/swaynag_command.c',
 	'commands/swap.c',
 	'commands/tiling_drag.c',
+	'commands/tiling_drag_threshold.c',
 	'commands/title_align.c',
 	'commands/title_format.c',
 	'commands/titlebar_border_thickness.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -572,6 +572,15 @@ The default colors are:
 	the _floating\_mod_ will also allow the container to be dragged. _toggle_
 	should not be used in the config file.
 
+*tiling\_drag\_threshold* <threshold>
+	Sets the threshold that must be exceeded for an unfocused tiling container
+	to be dragged by its titlebar. This has no effect if _floating\_mod_ is
+	used, if the container is focused, or if _tiling\_drag_ is set to
+	_disable_. Once the threshold has been exceeded once, the drag starts and
+	the cursor can come back inside the threshold without stopping the drag.
+	_threshold_ is multiplied by the scale of the output that the cursor on.
+	The default is 9.
+
 *title\_align* left|center|right
 	Sets the title alignment. If _right_ is selected and _show\_marks_ is set
 	to _yes_, the marks will be shown on the _left_ side instead of the


### PR DESCRIPTION
This is designed to replicate https://github.com/i3/i3/pull/3559 for sway. I was going to wait for that PR to be reviewed and merged, but decided to just do it now. Unlike that PR, this one allows the user to configure the threshold to their liking.

Implements `tiling_drag_threshold <threshold>` to prevent accidental
dragging of tiling containers. If a container (and all of its
descendants) are unfocused and the tile bar is pressed, a threshold
will be used before actually starting the drag. Once the threshold has
been exceeded, the cursor will change to the grab icon and the operation
will switch from `OP_MOVE_TILING_THRESHOLD` to `OP_MOVE_TILING`.