### PR TITLE
Fix fullscreen view rendering crash

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1017,7 +1017,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 		if (fullscreen_con->view) {
 			if (fullscreen_con->view->saved_buffer) {
 				render_saved_view(fullscreen_con->view, output, damage, 1.0f);
-			} else {
+			} else if (fullscreen_con->view->surface) {
 				render_view_toplevels(fullscreen_con->view,
 						output, damage, 1.0f);
 			}


### PR DESCRIPTION
See issue #3359 for reproduction details. When a fullscreen view is
unmapped and there's a preceding transaction waiting, there may be
neither a saved buffer or a surface to render. This change matches
the equivalent code in render_view.