### PR TITLE
swaylock: Fix caps lock not updating immediately

### DIFF
--- a/swaylock/password.c
+++ b/swaylock/password.c
@@ -146,14 +146,6 @@ void swaylock_handle_key(struct swaylock_state *state,
 		schedule_indicator_clear(state);
 		break;
 	case XKB_KEY_Caps_Lock:
-		/* The state is getting active after this
-		 * so we need to manually toggle it */
-		state->xkb.caps_lock = !state->xkb.caps_lock;
-		state->auth_state = AUTH_STATE_INPUT_NOP;
-		damage_state(state);
-		schedule_indicator_clear(state);
-		schedule_password_clear(state);
-		break;
 	case XKB_KEY_Shift_L:
 	case XKB_KEY_Shift_R:
 	case XKB_KEY_Control_L:

--- a/swaylock/seat.c
+++ b/swaylock/seat.c
@@ -63,8 +63,12 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 	struct swaylock_state *state = data;
 	xkb_state_update_mask(state->xkb.state,
 		mods_depressed, mods_latched, mods_locked, 0, 0, group);
-	state->xkb.caps_lock = xkb_state_mod_name_is_active(state->xkb.state,
+	int caps_lock = xkb_state_mod_name_is_active(state->xkb.state,
 		XKB_MOD_NAME_CAPS, XKB_STATE_MODS_LOCKED);
+	if (caps_lock != state->xkb.caps_lock) {
+		state->xkb.caps_lock = caps_lock;
+		damage_state(state);
+	}
 	state->xkb.control = xkb_state_mod_name_is_active(state->xkb.state,
 		XKB_MOD_NAME_CTRL,
 		XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);


### PR DESCRIPTION
Partially fixes #2788. This change makes it so the lock screen is redrawn whenever the caps lock modifier state changes, rather on relying on the keypress event. This didn't work because caps lock is disabled when the key is released, not pressed, so the caps lock indicator does not go away until the next keypress event.

This doesn't fully implement the suggestions in #2788, but is a more basic fix that just makes it so the caps lock indicator is always accurate. I'd be happy to have a go implementng them if anyone's interested, although it doesn't personally seem to me that they'd be that useful.