### PR TITLE
Add "tiling_drag_threshold_on_focused" command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -173,6 +173,7 @@ sway_cmd cmd_swaynag_command;
 sway_cmd cmd_swap;
 sway_cmd cmd_tiling_drag;
 sway_cmd cmd_tiling_drag_threshold;
+sway_cmd cmd_tiling_drag_threshold_on_focused;
 sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -429,6 +429,7 @@ struct sway_config {
 
 	bool tiling_drag;
 	int tiling_drag_threshold;
+	bool tiling_drag_threshold_on_focused;
 
 	bool smart_gaps;
 	int gaps_inner;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -88,6 +88,7 @@ static struct cmd_handler handlers[] = {
 	{ "smart_gaps", cmd_smart_gaps },
 	{ "tiling_drag", cmd_tiling_drag },
 	{ "tiling_drag_threshold", cmd_tiling_drag_threshold },
+	{ "tiling_drag_threshold_on_focused", cmd_tiling_drag_threshold_on_focused },
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },

--- a/sway/commands/tiling_drag_threshold_on_focused.c
+++ b/sway/commands/tiling_drag_threshold_on_focused.c
@@ -1,0 +1,13 @@
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_tiling_drag_threshold_on_focused(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "tiling_drag_threshold_on_focused", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	config->tiling_drag_threshold_on_focused = parse_boolean(argv[0], config->tiling_drag_threshold_on_focused);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -234,6 +234,7 @@ static void config_defaults(struct sway_config *config) {
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
+	config->tiling_drag_threshold_on_focused = false;
 
 	config->smart_gaps = false;
 	config->gaps_inner = 0;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1022,7 +1022,9 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 
 		// If moving a previously unfocused container by it's title bar, use a
 		// threshold for the drag.
-		if (!mod_pressed && !focused && config->tiling_drag_threshold > 0) {
+		if (!mod_pressed &&
+				(!focused || config->tiling_drag_threshold_on_focused) &&
+				config->tiling_drag_threshold > 0) {
 			seat_begin_move_tiling_threshold(seat, cont, button);
 		} else {
 			seat_begin_move_tiling(seat, cont, button);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -90,6 +90,7 @@ sway_sources = files(
 	'commands/swap.c',
 	'commands/tiling_drag.c',
 	'commands/tiling_drag_threshold.c',
+	'commands/tiling_drag_threshold_on_focused.c',
 	'commands/title_align.c',
 	'commands/title_format.c',
 	'commands/titlebar_border_thickness.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -581,6 +581,10 @@ The default colors are:
 	_threshold_ is multiplied by the scale of the output that the cursor on.
 	The default is 9.
 
+*tiling\_drag\_threshold\_on\_focused* yes|no
+	If set to yes, the _tiling\_drag\_threshold_ is also applied to focused
+	containers. The default is _no_.
+
 *title\_align* left|center|right
 	Sets the title alignment. If _right_ is selected and _show\_marks_ is set
 	to _yes_, the marks will be shown on the _left_ side instead of the


### PR DESCRIPTION
Not sure whether this is wanted. But the first time I noticed the new tiling drag feature was that I accidentally dragged the focused window therefore I'd like to have the threshold also apply to focused windows simply to avoid accidentally dragging them.
I'm also happy to rename the command - I just didn't find a better name. This one seems a bit long though.