### PR TITLE
Unhide mouse after container warp to focus

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -61,6 +61,8 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 void cursor_rebase(struct sway_cursor *cursor);
 
 void cursor_handle_activity(struct sway_cursor *cursor);
+void cursor_unhide(struct sway_cursor *cursor);
+int cursor_get_timeout(struct sway_cursor *cursor);
 
 /**
  * Like cursor_rebase, but also allows focus to change when the cursor enters a

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1231,4 +1231,8 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	} else {
 		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
 	}
+	if (seat->cursor->hidden){
+		cursor_unhide(seat->cursor);
+		wl_event_source_timer_update(seat->cursor->hide_source, cursor_get_timeout(seat->cursor));
+	}
 }

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -654,6 +654,7 @@ void view_unmap(struct sway_view *view) {
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
+		seat->cursor->image_surface = NULL;
 		seat_consider_warp_to_focus(seat);
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -654,14 +654,7 @@ void view_unmap(struct sway_view *view) {
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
-		if (config->mouse_warping == WARP_CONTAINER) {
-			struct sway_node *node = seat_get_focus(seat);
-			if (node && node->type == N_CONTAINER) {
-				cursor_warp_to_container(seat->cursor, node->sway_container);
-			} else if (node && node->type == N_WORKSPACE) {
-				cursor_warp_to_workspace(seat->cursor, node->sway_workspace);
-			}
-		}
+		seat_consider_warp_to_focus(seat);
 	}
 
 	transaction_commit_dirty();


### PR DESCRIPTION
After @RedSoxFan implemented hide_cursor command, I noticed that the cursor was not shown between window switches, if container warping is enabled. This PR adds this feature, however I am not sure whether this should be configurable and that the code handles all cases correctly.

Please provide feedback if and how this should be configurable (IMO this only makes sense if container warping is enabled) and review the code, thanks!