### PR TITLE
reload: apply seat cfgs after reading entire cfg

### DIFF
--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -35,7 +35,9 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 
 	struct seat_config *sc =
 		store_seat_config(config->handler_context.seat_config);
-	input_manager_apply_seat_config(sc);
+	if (!config->reading) {
+		input_manager_apply_seat_config(sc);
+	}
 
 	config->handler_context.seat_config = NULL;
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/config.c
+++ b/sway/config.c
@@ -463,7 +463,11 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		if (config->swaynag_config_errors.pid > 0) {
 			swaynag_show(&config->swaynag_config_errors);
 		}
+
 		input_manager_verify_fallback_seat();
+		for (int i = 0; i < config->seat_configs->length; i++) {
+			input_manager_apply_seat_config(config->seat_configs->items[i]);
+		}
 	}
 
 	if (old_config) {


### PR DESCRIPTION
Wait until all seat configs have been read before applying them on
reload. This prevents unnecessary attachment/detachment of input
devices and therefore creation/destruction of seat devices as
individual lines are read.