### PR TITLE
reload: reset input configs

### DIFF
--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -37,6 +37,10 @@ void input_manager_configure_xcursor(void);
 
 void input_manager_apply_input_config(struct input_config *input_config);
 
+void input_manager_reset_input(struct sway_input_device *input_device);
+
+void input_manager_reset_all_inputs();
+
 void input_manager_apply_seat_config(struct seat_config *seat_config);
 
 struct sway_seat *input_manager_get_default_seat(void);

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -100,6 +100,9 @@ void seat_add_device(struct sway_seat *seat,
 void seat_configure_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 
+void seat_reset_device(struct sway_seat *seat,
+		struct sway_input_device *input_device);
+
 void seat_remove_device(struct sway_seat *seat,
 		struct sway_input_device *device);
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -387,6 +387,8 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		memcpy(&config->swaynag_config_errors,
 				&old_config->swaynag_config_errors,
 				sizeof(struct swaynag_instance));
+
+		input_manager_reset_all_inputs();
 	}
 
 	config->current_config_path = path;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -405,6 +405,14 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 	}
 }
 
+static void seat_reset_input_config(struct sway_seat *seat,
+		struct sway_seat_device *sway_device) {
+	wlr_log(WLR_DEBUG, "Resetting output mapping for input device %s",
+		sway_device->input_device->identifier);
+	wlr_cursor_map_input_to_output(seat->cursor->cursor,
+		sway_device->input_device->wlr_device, NULL);
+}
+
 static void seat_apply_input_config(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
 	const char *mapped_to_output = NULL;
@@ -518,6 +526,35 @@ void seat_configure_device(struct sway_seat *seat,
 			break;
 		case WLR_INPUT_DEVICE_SWITCH:
 			wlr_log(WLR_DEBUG, "TODO: configure switch device");
+			break;
+	}
+}
+
+void seat_reset_device(struct sway_seat *seat,
+		struct sway_input_device *input_device) {
+	struct sway_seat_device *seat_device = seat_get_device(seat, input_device);
+	if (!seat_device) {
+		return;
+	}
+
+	switch (input_device->wlr_device->type) {
+		case WLR_INPUT_DEVICE_POINTER:
+			seat_reset_input_config(seat, seat_device);
+			break;
+		case WLR_INPUT_DEVICE_KEYBOARD:
+			sway_keyboard_configure(seat_device->keyboard);
+			break;
+		case WLR_INPUT_DEVICE_TOUCH:
+			seat_reset_input_config(seat, seat_device);
+			break;
+		case WLR_INPUT_DEVICE_TABLET_TOOL:
+			seat_reset_input_config(seat, seat_device);
+			break;
+		case WLR_INPUT_DEVICE_TABLET_PAD:
+			wlr_log(WLR_DEBUG, "TODO: reset tablet pad");
+			break;
+		case WLR_INPUT_DEVICE_SWITCH:
+			wlr_log(WLR_DEBUG, "TODO: reset switch device");
 			break;
 	}
 }


### PR DESCRIPTION
This resets all input options to their defaults on reload. This also
fixes some debug log typos in `input_manager_libinput_config_pointer`.

_Note: Without #3386 and/or #3387, reloading may crash due to the
destruction of the keyboard. This can be prevented by adding
`seat seat0 fallback true` to the top of your config while testing this or by
rebasing on top of one or both of the PRs._