### PR TITLE
cmd_bind: pass the seat to execute_command

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -312,8 +312,7 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
 void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) {
 	wlr_log(WLR_DEBUG, "running command for binding: %s", binding->command);
 
-	config->handler_context.seat = seat;
-	list_t *res_list = execute_command(binding->command, NULL, NULL);
+	list_t *res_list = execute_command(binding->command, seat, NULL);
 	bool success = true;
 	for (int i = 0; i < res_list->length; ++i) {
 		struct cmd_results *results = res_list->items[i];


### PR DESCRIPTION
I think this fixes at least part of #2918. I'm not sure if it completely fixes it

`seat_execute_command` was incorrectly setting
`config->handler_context.seat` before calling `execute_command`. Since
`execute_command` was being called with a `NULL` seat argument,
`execute_command` was setting `config->handler_context.seat` to the
default seat. This resulted in all bindings being executed on the
default seat and causing undesired behavior for devices on other seats.