### PR TITLE
Simplify FreeBSD build

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -1,10 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <libevdev/libevdev.h>
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-names.h>
 #include <string.h>

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -1,9 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 
 #include <strings.h>
 #include <wlr/types/wlr_cursor.h>

--- a/sway/config.c
+++ b/sway/config.c
@@ -13,11 +13,7 @@
 #include <limits.h>
 #include <dirent.h>
 #include <strings.h>
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <wlr/types/wlr_output.h>
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1,11 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <math.h>
 #include <libevdev/libevdev.h>
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <float.h>
 #include <limits.h>
 #include <wlr/types/wlr_cursor.h>

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1,11 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <errno.h>
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <strings.h>
 #include <time.h>
 #include <wlr/types/wlr_cursor.h>

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -1,10 +1,6 @@
 // See https://i3wm.org/docs/ipc.html for protocol information
 #define _POSIX_C_SOURCE 200112L
-#ifdef __linux__
 #include <linux/input-event-codes.h>
-#elif __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#endif
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -1,9 +1,5 @@
 #include <assert.h>
-#ifdef __FreeBSD__
-#include <dev/evdev/input-event-codes.h>
-#else
 #include <linux/input-event-codes.h>
-#endif
 #include <stdlib.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>


### PR DESCRIPTION
Same as swaywm/wlroots#1454. libevdev already depends on `<linux/input.h>` from `evdev-proto` package on both FreeBSD and DragonFly.