### PR TITLE
swaybar: obey height if given

### DIFF
--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -96,7 +96,7 @@ struct bar_config *default_bar_config(void) {
 	bar->pango_markup = false;
 	bar->swaybar_command = NULL;
 	bar->font = NULL;
-	bar->height = -1;
+	bar->height = 0;
 	bar->workspace_buttons = true;
 	bar->wrap_scroll = false;
 	bar->separator_symbol = NULL;

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -69,7 +69,7 @@ Sway allows configuring swaybar in the sway configuration file.
 	use.
 
 *height* <height>
-	Sets the height of the bar. Default height will match the font size.
+	Sets the height of the bar. Default height (0) will match the font size.
 
 *bindsym* [--release] button<n> <command>
 	Executes _command_ when mouse button _n_ has been pressed (or if _released_

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -44,7 +44,8 @@ static uint32_t render_status_line_error(cairo_t *cairo,
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2;
 	uint32_t ideal_surface_height = ideal_height / output->scale;
-	if (output->height < ideal_surface_height) {
+	if (!output->bar->config->height &&
+			output->height < ideal_surface_height) {
 		return ideal_surface_height;
 	}
 	*x -= text_width + margin;
@@ -76,7 +77,8 @@ static uint32_t render_status_line_text(cairo_t *cairo,
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2;
 	uint32_t ideal_surface_height = ideal_height / output->scale;
-	if (output->height < ideal_surface_height) {
+	if (!output->bar->config->height &&
+			output->height < ideal_surface_height) {
 		return ideal_surface_height;
 	}
 
@@ -151,7 +153,8 @@ static uint32_t render_status_block(cairo_t *cairo,
 	double block_width = width;
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2;
 	uint32_t ideal_surface_height = ideal_height / output->scale;
-	if (output->height < ideal_surface_height) {
+	if (!output->bar->config->height &&
+			output->height < ideal_surface_height) {
 		return ideal_surface_height;
 	}
 
@@ -173,7 +176,8 @@ static uint32_t render_status_block(cairo_t *cairo,
 					output->scale, false, "%s", config->sep_symbol);
 			uint32_t _ideal_height = sep_height + ws_vertical_padding * 2;
 			uint32_t _ideal_surface_height = _ideal_height / output->scale;
-			if (output->height < _ideal_surface_height) {
+			if (!output->bar->config->height &&
+					output->height < _ideal_surface_height) {
 				return _ideal_surface_height;
 			}
 			if (sep_width > sep_block_width) {
@@ -328,7 +332,8 @@ static uint32_t render_binding_mode_indicator(cairo_t *cairo,
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2
 		+ border_width * 2;
 	uint32_t ideal_surface_height = ideal_height / output->scale;
-	if (output->height < ideal_surface_height) {
+	if (!output->bar->config->height &&
+			output->height < ideal_surface_height) {
 		return ideal_surface_height;
 	}
 	uint32_t width = text_width + ws_horizontal_padding * 2 + border_width * 2;
@@ -394,7 +399,8 @@ static uint32_t render_workspace_button(cairo_t *cairo,
 	uint32_t ideal_height = ws_vertical_padding * 2 + text_height
 		+ border_width * 2;
 	uint32_t ideal_surface_height = ideal_height / output->scale;
-	if (output->height < ideal_surface_height) {
+	if (!output->bar->config->height &&
+			output->height < ideal_surface_height) {
 		return ideal_surface_height;
 	}
 
@@ -521,7 +527,7 @@ void render_frame(struct swaybar_output *output) {
 	cairo_restore(cairo);
 	uint32_t height = render_to_cairo(cairo, output);
 	int config_height = output->bar->config->height;
-	if (config_height >= 0 && height < (uint32_t)config_height) {
+	if (config_height > 0) {
 		height = config_height;
 	}
 	if (height != output->height || output->width == 0) {


### PR DESCRIPTION
Fixes #3012 

If there is a bar height given, use that as the absolute height rather than as a minimum height. This matches i3-gaps behavior.

Easy test:
1. Use the following minimal config:
```
set $mod Mod4
set $term termite

bindsym $mod+Return exec $$term
bindsym $mod+Shift+e exit

bar bar-0 position top
bar bar-0 height 0
bar bar-0 status_command while date +'%Y-%m-%d %l:%M:%S %p'; do sleep 1; done

bar bar-1 position bottom
bar bar-1 height 25
bar bar-1 status_command while date +'%Y-%m-%d %l:%M:%S %p'; do sleep 1; done
```
2. Execute the command `swaymsg workspace 𒁏` (Unicode character: 0x1204F)
3. Observe `bar-0` (top) increases in height while `bar-1` (bottom) stays the same height