### PR TITLE
input events: toggle and ipc get_inputs

### DIFF
--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -1,9 +1,68 @@
+#include <limits.h>
 #include <string.h>
 #include <strings.h>
+#include <wlr/backend/libinput.h>
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 #include "log.h"
+
+static void toggle_send_events_for_device(struct input_config *ic,
+		struct sway_input_device *input_device) {
+	struct wlr_input_device *wlr_device = input_device->wlr_device;
+	if (!wlr_input_device_is_libinput(wlr_device)) {
+		return;
+	}
+	struct libinput_device *libinput_dev
+		= wlr_libinput_get_device_handle(wlr_device);
+
+	enum libinput_config_send_events_mode mode =
+		libinput_device_config_send_events_get_mode(libinput_dev);
+	uint32_t possible =
+		libinput_device_config_send_events_get_modes(libinput_dev);
+
+	switch (mode) {
+	case LIBINPUT_CONFIG_SEND_EVENTS_ENABLED:
+		mode = LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
+		if (possible & mode) {
+			break;
+		}
+		// fall through
+	case LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE:
+		mode = LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
+		if (possible & mode) {
+			break;
+		}
+		// fall through
+	case LIBINPUT_CONFIG_SEND_EVENTS_DISABLED:
+	default:
+		mode = LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
+		break;
+	}
+
+	ic->send_events = mode;
+}
+
+static void toggle_send_events(struct input_config *ic) {
+	struct sway_input_device *input_device = NULL;
+	wl_list_for_each(input_device, &server.input->devices, link) {
+		if (strcmp(input_device->identifier, ic->identifier) == 0) {
+			toggle_send_events_for_device(ic, input_device);
+		}
+	}
+}
+
+static void toggle_wildcard_send_events() {
+	struct sway_input_device *input_device = NULL;
+	wl_list_for_each(input_device, &server.input->devices, link) {
+		struct input_config *ic = new_input_config(input_device->identifier);
+		if (!ic) {
+			break;
+		}
+		toggle_send_events_for_device(ic, input_device);
+		store_input_config(ic);
+	}
+}
 
 struct cmd_results *input_cmd_events(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -23,9 +82,24 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "disabled_on_external_mouse") == 0) {
 		ic->send_events =
 			LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
-	} else {
+	} else if (config->reading) {
 		return cmd_results_new(CMD_INVALID, "events",
 			"Expected 'events <enabled|disabled|disabled_on_external_mouse>'");
+	} else if (strcasecmp(argv[0], "toggle") == 0) {
+		if (strcmp(ic->identifier, "*") == 0) {
+			// Update the device input configs and then reset the wildcard
+			// config send events mode so that is does not override the device
+			// ones. The device ones will be applied when attempting to apply
+			// the wildcard config
+			toggle_wildcard_send_events();
+			ic->send_events = INT_MIN;
+		} else {
+			toggle_send_events(ic);
+		}
+	} else {
+		return cmd_results_new(CMD_INVALID, "events",
+			"Expected 'events <enabled|disabled|disabled_on_external_mouse|"
+			"toggle>'");
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -11,6 +11,7 @@
 #include "sway/output.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 #include <xkbcommon/xkbcommon.h>
@@ -596,6 +597,26 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 				break;
 			}
 		}
+	}
+
+	if (wlr_input_device_is_libinput(device->wlr_device)) {
+		struct libinput_device *libinput_dev;
+		libinput_dev = wlr_libinput_get_device_handle(device->wlr_device);
+
+		const char *events = "unknown";
+		switch (libinput_device_config_send_events_get_mode(libinput_dev)) {
+		case LIBINPUT_CONFIG_SEND_EVENTS_ENABLED:
+			events = "enabled";
+			break;
+		case LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE:
+			events = "disabled_on_external_mouse";
+			break;
+		case LIBINPUT_CONFIG_SEND_EVENTS_DISABLED:
+			events = "disabled";
+			break;
+		}
+		json_object_object_add(object, "libinput_send_events",
+				json_object_new_string(events));
 	}
 
 	return object;

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -82,9 +82,12 @@ The following commands may only be used in the configuration file.
 *input* <identifier> dwt enabled|disabled
 	Enables or disables disable-while-typing for the specified input device.
 
-*input* <identifier> events enabled|disabled|disabled\_on\_external\_mouse
-	Enables or disables send\_events for specified input device. (Disabling
-	send\_events disables the input device)
+*input* <identifier> events enabled|disabled|disabled\_on\_external\_mouse|toggle
+	Enables or disables send\_events for specified input device. Disabling
+	send\_events disables the input device. The _toggle_ option cannot be used
+	in the config. The order is enabled, disabled\_on\_external\_mouse,
+	disabled, (loop back to enabled). Any mode which is not supported by the
+	device will be skipped during the toggle.
 
 *input* <identifier> left\_handed enabled|disabled
 	Enables or disables left handed mode for specified input device.

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -113,7 +113,7 @@ static const char *pretty_type_name(const char *name) {
 }
 
 static void pretty_print_input(json_object *i) {
-	json_object *id, *name, *type, *product, *vendor, *kbdlayout;
+	json_object *id, *name, *type, *product, *vendor, *kbdlayout, *events;
 	json_object_object_get_ex(i, "identifier", &id);
 	json_object_object_get_ex(i, "name", &name);
 	json_object_object_get_ex(i, "type", &type);
@@ -137,6 +137,10 @@ static void pretty_print_input(json_object *i) {
 	if (json_object_object_get_ex(i, "xkb_active_layout_name", &kbdlayout)) {
 		printf("  Active Keyboard Layout: %s\n",
 			json_object_get_string(kbdlayout));
+	}
+
+	if (json_object_object_get_ex(i, "libinput_send_events", &events)) {
+		printf("  Libinput Send Events: %s\n", json_object_get_string(events));
 	}
 
 	printf("\n");


### PR DESCRIPTION
Closes #2157 

Implements toggling input events during runtime. This will not attempt
to toggle to a mode that is not supported by the device. When toggling
the wildcard input, the device specific input configs are altered. Each
device will cycle one supported mode.

This also adds `libinput_send_events` to the IPC output for `get_inputs`
to allow for custom scripting of mode changes/toggling.