### PR TITLE
Refactor seat operations to use an interface

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -50,6 +50,12 @@ struct sway_cursor {
 	size_t pressed_button_count;
 };
 
+struct sway_node;
+
+struct sway_node *node_at_coords(
+		struct sway_seat *seat, double lx, double ly,
+		struct wlr_surface **surface, double *sx, double *sy);
+
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -6,6 +6,17 @@
 #include <wlr/util/edges.h>
 #include "sway/input/input-manager.h"
 
+struct sway_seat;
+
+struct sway_seatop_impl {
+	void (*motion)(struct sway_seat *seat, uint32_t time_msec);
+	void (*finish)(struct sway_seat *seat);
+	void (*abort)(struct sway_seat *seat);
+	void (*unref)(struct sway_seat *seat, struct sway_container *con);
+	void (*render)(struct sway_seat *seat, struct sway_output *output,
+			pixman_region32_t *damage);
+};
+
 struct sway_seat_device {
 	struct sway_seat *sway_seat;
 	struct sway_input_device *input_device;
@@ -35,16 +46,6 @@ struct sway_drag_icon {
 	struct wl_listener destroy;
 };
 
-enum sway_seat_operation {
-	OP_NONE,
-	OP_DOWN,
-	OP_MOVE_FLOATING,
-	OP_MOVE_TILING_THRESHOLD,
-	OP_MOVE_TILING,
-	OP_RESIZE_FLOATING,
-	OP_RESIZE_TILING,
-};
-
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct sway_cursor *cursor;
@@ -64,19 +65,10 @@ struct sway_seat {
 	int32_t touch_id;
 	double touch_x, touch_y;
 
-	// Operations (drag and resize)
-	enum sway_seat_operation operation;
-	struct sway_container *op_container;
-	struct sway_node *op_target_node; // target for tiling move
-	enum wlr_edges op_target_edge;
-	struct wlr_box op_drop_box;
-	enum wlr_edges op_resize_edge;
-	uint32_t op_button;
-	bool op_resize_preserve_ratio;
-	double op_ref_lx, op_ref_ly;         // cursor's x/y at start of op
-	double op_ref_width, op_ref_height;  // container's size at start of op
-	double op_ref_con_lx, op_ref_con_ly; // container's x/y at start of op
-	bool op_moved;                       // if the mouse moved during a down op
+	// Seat operations (drag and resize)
+	const struct sway_seatop_impl *seatop_impl;
+	void *seatop_data;
+	uint32_t seatop_button;
 
 	uint32_t last_button;
 	uint32_t last_button_serial;
@@ -181,32 +173,59 @@ bool seat_is_input_allowed(struct sway_seat *seat, struct wlr_surface *surface);
 
 void drag_icon_update_position(struct sway_drag_icon *icon);
 
-void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button, double sx, double sy);
+void seatop_begin_down(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, int sx, int sy);
 
-void seat_begin_move_floating(struct sway_seat *seat,
+void seatop_begin_move_floating(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
 
-void seat_begin_move_tiling_threshold(struct sway_seat *seat,
+void seatop_begin_move_tiling_threshold(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
 
-void seat_begin_move_tiling(struct sway_seat *seat,
+void seatop_begin_move_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
 
-void seat_begin_resize_floating(struct sway_seat *seat,
+void seatop_begin_resize_floating(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge);
 
-void seat_begin_resize_tiling(struct sway_seat *seat,
+void seatop_begin_resize_tiling(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button, enum wlr_edges edge);
 
 struct sway_container *seat_get_focus_inactive_floating(struct sway_seat *seat,
 		struct sway_workspace *workspace);
 
-void seat_end_mouse_operation(struct sway_seat *seat);
-
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,
 		uint32_t button, enum wlr_button_state state);
 
 void seat_consider_warp_to_focus(struct sway_seat *seat);
+
+bool seat_doing_seatop(struct sway_seat *seat);
+
+void seatop_motion(struct sway_seat *seat, uint32_t time_msec);
+
+/**
+ * End a seatop and apply the affects.
+ */
+void seatop_finish(struct sway_seat *seat);
+
+/**
+ * End a seatop without applying the affects.
+ */
+void seatop_abort(struct sway_seat *seat);
+
+/**
+ * Instructs the seatop implementation to drop any references to the given
+ * container (eg. because the container is destroying).
+ * The seatop may choose to abort itself in response to this.
+ */
+void seatop_unref(struct sway_seat *seat, struct sway_container *con);
+
+/**
+ * Instructs a seatop to render anything that it needs to render
+ * (eg. dropzone for move-tiling)
+ */
+void seatop_render(struct sway_seat *seat, struct sway_output *output,
+		pixman_region32_t *damage);
+
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -146,4 +146,12 @@ enum sway_container_layout output_get_default_layout(
 
 void output_add_listeners(struct sway_output *output);
 
+void render_rect(struct wlr_output *wlr_output,
+		pixman_region32_t *output_damage, const struct wlr_box *_box,
+		float color[static 4]);
+
+void premultiply_alpha(float color[4], float opacity);
+
+void scale_box(struct wlr_box *box, float scale);
+
 #endif

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -333,4 +333,6 @@ void container_add_mark(struct sway_container *container, char *mark);
 
 void container_update_marks_textures(struct sway_container *container);
 
+void container_raise_floating(struct sway_container *con);
+
 #endif

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -300,7 +300,7 @@ static int scale_length(int length, int offset, float scale) {
 	return round((offset + length) * scale) - round(offset * scale);
 }
 
-static void scale_box(struct wlr_box *box, float scale) {
+void scale_box(struct wlr_box *box, float scale) {
 	box->width = scale_length(box->width, box->x, scale);
 	box->height = scale_length(box->height, box->y, scale);
 	box->x = round(box->x * scale);

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -299,7 +299,7 @@ static void transaction_apply(struct sway_transaction *transaction) {
 	if (root->outputs->length) {
 		struct sway_seat *seat;
 		wl_list_for_each(seat, &server.input->seats, link) {
-			if (seat->operation == OP_NONE) {
+			if (!seat_doing_seatop(seat)) {
 				cursor_rebase(seat->cursor);
 			}
 		}

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -360,7 +360,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move_floating(seat, view->container, seat->last_button);
+		seatop_begin_move_floating(seat, view->container, seat->last_button);
 	}
 }
 
@@ -374,7 +374,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize_floating(seat, view->container,
+		seatop_begin_resize_floating(seat, view->container,
 				seat->last_button, e->edges);
 	}
 }

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -357,7 +357,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_v6_move_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_move_floating(seat, view->container, seat->last_button);
+		seatop_begin_move_floating(seat, view->container, seat->last_button);
 	}
 }
 
@@ -371,7 +371,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_toplevel_v6_resize_event *e = data;
 	struct sway_seat *seat = e->seat->seat->data;
 	if (e->serial == seat->last_button_serial) {
-		seat_begin_resize_floating(seat, view->container,
+		seatop_begin_resize_floating(seat, view->container,
 				seat->last_button, e->edges);
 	}
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -470,7 +470,7 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 		return;
 	}
 	struct sway_seat *seat = input_manager_current_seat();
-	seat_begin_move_floating(seat, view->container, seat->last_button);
+	seatop_begin_move_floating(seat, view->container, seat->last_button);
 }
 
 static void handle_request_resize(struct wl_listener *listener, void *data) {
@@ -486,7 +486,7 @@ static void handle_request_resize(struct wl_listener *listener, void *data) {
 	}
 	struct wlr_xwayland_resize_event *e = data;
 	struct sway_seat *seat = input_manager_current_seat();
-	seat_begin_resize_floating(seat, view->container,
+	seatop_begin_resize_floating(seat, view->container,
 			seat->last_button, e->edges);
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -308,7 +308,7 @@ static void handle_new_drag_icon(struct wl_listener *listener, void *data) {
 	wl_list_insert(&root->drag_icons, &icon->link);
 
 	drag_icon_update_position(icon);
-	seat_end_mouse_operation(seat);
+	seatop_abort(seat);
 }
 
 static void collect_focus_iter(struct sway_node *node, void *data) {
@@ -623,18 +623,6 @@ static int handle_urgent_timeout(void *data) {
 	struct sway_view *view = data;
 	view_set_urgent(view, false);
 	return 0;
-}
-
-static void container_raise_floating(struct sway_container *con) {
-	// Bring container to front by putting it at the end of the floating list.
-	struct sway_container *floater = con;
-	while (floater->parent) {
-		floater = floater->parent;
-	}
-	if (container_is_floating(floater)) {
-		list_move_to_end(floater->workspace->floating, floater);
-		node_set_dirty(&floater->workspace->node);
-	}
 }
 
 static void set_workspace(struct sway_seat *seat,
@@ -1025,187 +1013,6 @@ struct seat_config *seat_get_config_by_name(const char *name) {
 	return NULL;
 }
 
-void seat_begin_down(struct sway_seat *seat, struct sway_container *con,
-		uint32_t button, double sx, double sy) {
-	seat->operation = OP_DOWN;
-	seat->op_container = con;
-	seat->op_button = button;
-	seat->op_ref_lx = seat->cursor->cursor->x;
-	seat->op_ref_ly = seat->cursor->cursor->y;
-	seat->op_ref_con_lx = sx;
-	seat->op_ref_con_ly = sy;
-	seat->op_moved = false;
-
-	container_raise_floating(con);
-}
-
-void seat_begin_move_floating(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button) {
-	if (!seat->cursor) {
-		wlr_log(WLR_DEBUG, "Ignoring move request due to no cursor device");
-		return;
-	}
-	seat->operation = OP_MOVE_FLOATING;
-	seat->op_container = con;
-	seat->op_button = button;
-
-	container_raise_floating(con);
-
-	cursor_set_image(seat->cursor, "grab", NULL);
-}
-
-void seat_begin_move_tiling_threshold(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button) {
-	seat->operation = OP_MOVE_TILING_THRESHOLD;
-	seat->op_container = con;
-	seat->op_button = button;
-	seat->op_target_node = NULL;
-	seat->op_target_edge = 0;
-	seat->op_ref_lx = seat->cursor->cursor->x;
-	seat->op_ref_ly = seat->cursor->cursor->y;
-}
-
-void seat_begin_move_tiling(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button) {
-	seat->operation = OP_MOVE_TILING;
-	seat->op_container = con;
-	seat->op_button = button;
-	seat->op_target_node = NULL;
-	seat->op_target_edge = 0;
-	cursor_set_image(seat->cursor, "grab", NULL);
-}
-
-void seat_begin_resize_floating(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
-	if (!seat->cursor) {
-		wlr_log(WLR_DEBUG, "Ignoring resize request due to no cursor device");
-		return;
-	}
-	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
-	seat->operation = OP_RESIZE_FLOATING;
-	seat->op_container = con;
-	seat->op_resize_preserve_ratio = keyboard &&
-		(wlr_keyboard_get_modifiers(keyboard) & WLR_MODIFIER_SHIFT);
-	seat->op_resize_edge = edge == WLR_EDGE_NONE ?
-		WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT : edge;
-	seat->op_button = button;
-	seat->op_ref_lx = seat->cursor->cursor->x;
-	seat->op_ref_ly = seat->cursor->cursor->y;
-	seat->op_ref_con_lx = con->x;
-	seat->op_ref_con_ly = con->y;
-	seat->op_ref_width = con->width;
-	seat->op_ref_height = con->height;
-
-	container_raise_floating(con);
-
-	const char *image = edge == WLR_EDGE_NONE ?
-		"se-resize" : wlr_xcursor_get_resize_name(edge);
-	cursor_set_image(seat->cursor, image, NULL);
-}
-
-void seat_begin_resize_tiling(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
-	seat->operation = OP_RESIZE_TILING;
-	seat->op_container = con;
-	seat->op_resize_edge = edge;
-	seat->op_button = button;
-	seat->op_ref_lx = seat->cursor->cursor->x;
-	seat->op_ref_ly = seat->cursor->cursor->y;
-	seat->op_ref_con_lx = con->x;
-	seat->op_ref_con_ly = con->y;
-	seat->op_ref_width = con->width;
-	seat->op_ref_height = con->height;
-}
-
-static bool is_parallel(enum sway_container_layout layout,
-		enum wlr_edges edge) {
-	bool layout_is_horiz = layout == L_HORIZ || layout == L_TABBED;
-	bool edge_is_horiz = edge == WLR_EDGE_LEFT || edge == WLR_EDGE_RIGHT;
-	return layout_is_horiz == edge_is_horiz;
-}
-
-static void seat_end_move_tiling(struct sway_seat *seat) {
-	struct sway_container *con = seat->op_container;
-	struct sway_container *old_parent = con->parent;
-	struct sway_workspace *old_ws = con->workspace;
-	struct sway_node *target_node = seat->op_target_node;
-	struct sway_workspace *new_ws = target_node->type == N_WORKSPACE ?
-		target_node->sway_workspace : target_node->sway_container->workspace;
-	enum wlr_edges edge = seat->op_target_edge;
-	int after = edge != WLR_EDGE_TOP && edge != WLR_EDGE_LEFT;
-
-	container_detach(con);
-
-	// Moving container into empty workspace
-	if (target_node->type == N_WORKSPACE && edge == WLR_EDGE_NONE) {
-		workspace_add_tiling(new_ws, con);
-	} else if (target_node->type == N_CONTAINER) {
-		// Moving container before/after another
-		struct sway_container *target = target_node->sway_container;
-		enum sway_container_layout layout = container_parent_layout(target);
-		if (edge && !is_parallel(layout, edge)) {
-			enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
-				edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
-			container_split(target, new_layout);
-		}
-		container_add_sibling(target, con, after);
-	} else {
-		// Target is a workspace which requires splitting
-		enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
-			edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
-		workspace_split(new_ws, new_layout);
-		workspace_insert_tiling(new_ws, con, after);
-	}
-
-	if (old_parent) {
-		container_reap_empty(old_parent);
-	}
-
-	// This is a bit dirty, but we'll set the dimensions to that of a sibling.
-	// I don't think there's any other way to make it consistent without
-	// changing how we auto-size containers.
-	list_t *siblings = container_get_siblings(con);
-	if (siblings->length > 1) {
-		int index = list_find(siblings, con);
-		struct sway_container *sibling = index == 0 ?
-			siblings->items[1] : siblings->items[index - 1];
-		con->width = sibling->width;
-		con->height = sibling->height;
-	}
-
-	arrange_workspace(old_ws);
-	if (new_ws != old_ws) {
-		arrange_workspace(new_ws);
-	}
-}
-
-void seat_end_mouse_operation(struct sway_seat *seat) {
-	enum sway_seat_operation operation = seat->operation;
-	if (seat->operation == OP_MOVE_FLOATING) {
-		// We "move" the container to its own location so it discovers its
-		// output again.
-		struct sway_container *con = seat->op_container;
-		container_floating_move_to(con, con->x, con->y);
-	} else if (seat->operation == OP_MOVE_TILING && seat->op_target_node) {
-		seat_end_move_tiling(seat);
-	}
-	seat->operation = OP_NONE;
-	seat->op_container = NULL;
-	if (operation == OP_DOWN) {
-		// Set the cursor's previous coords to the x/y at the start of the
-		// operation, so the container change will be detected if using
-		// focus_follows_mouse and the cursor moved off the original container
-		// during the operation.
-		seat->cursor->previous.x = seat->op_ref_lx;
-		seat->cursor->previous.y = seat->op_ref_ly;
-		if (seat->op_moved) {
-			cursor_send_pointer_motion(seat->cursor, 0);
-		}
-	} else {
-		cursor_set_image(seat->cursor, "left_ptr", NULL);
-	}
-}
-
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,
 		uint32_t button, enum wlr_button_state state) {
 	seat->last_button = button;
@@ -1236,5 +1043,46 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	if (seat->cursor->hidden){
 		cursor_unhide(seat->cursor);
 		wl_event_source_timer_update(seat->cursor->hide_source, cursor_get_timeout(seat->cursor));
+	}
+}
+
+bool seat_doing_seatop(struct sway_seat *seat) {
+	return seat->seatop_impl != NULL;
+}
+
+void seatop_unref(struct sway_seat *seat, struct sway_container *con) {
+	if (seat->seatop_impl && seat->seatop_impl->unref) {
+		seat->seatop_impl->unref(seat, con);
+	}
+}
+
+void seatop_motion(struct sway_seat *seat, uint32_t time_msec) {
+	if (seat->seatop_impl && seat->seatop_impl->motion) {
+		seat->seatop_impl->motion(seat, time_msec);
+	}
+}
+
+void seatop_finish(struct sway_seat *seat) {
+	if (seat->seatop_impl && seat->seatop_impl->finish) {
+		seat->seatop_impl->finish(seat);
+	}
+	free(seat->seatop_data);
+	seat->seatop_data = NULL;
+	seat->seatop_impl = NULL;
+}
+
+void seatop_abort(struct sway_seat *seat) {
+	if (seat->seatop_impl && seat->seatop_impl->abort) {
+		seat->seatop_impl->abort(seat);
+	}
+	free(seat->seatop_data);
+	seat->seatop_data = NULL;
+	seat->seatop_impl = NULL;
+}
+
+void seatop_render(struct sway_seat *seat, struct sway_output *output,
+		pixman_region32_t *damage) {
+	if (seat->seatop_impl && seat->seatop_impl->render) {
+		seat->seatop_impl->render(seat, output, damage);
 	}
 }

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -1,0 +1,77 @@
+#define _POSIX_C_SOURCE 200809L
+#include <wlr/types/wlr_cursor.h>
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+#include "sway/tree/view.h"
+
+struct seatop_down_event {
+	struct sway_container *con;
+	double ref_lx, ref_ly;         // cursor's x/y at start of op
+	double ref_con_lx, ref_con_ly; // container's x/y at start of op
+	bool moved;
+};
+
+static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
+	struct seatop_down_event *e = seat->seatop_data;
+	struct sway_container *con = e->con;
+	if (seat_is_input_allowed(seat, con->view->surface)) {
+		double moved_x = seat->cursor->cursor->x - e->ref_lx;
+		double moved_y = seat->cursor->cursor->y - e->ref_ly;
+		double sx = e->ref_con_lx + moved_x;
+		double sy = e->ref_con_ly + moved_y;
+		wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
+	}
+	e->moved = true;
+}
+
+static void handle_finish(struct sway_seat *seat) {
+	struct seatop_down_event *e = seat->seatop_data;
+	// Set the cursor's previous coords to the x/y at the start of the
+	// operation, so the container change will be detected if using
+	// focus_follows_mouse and the cursor moved off the original container
+	// during the operation.
+	seat->cursor->previous.x = e->ref_lx;
+	seat->cursor->previous.y = e->ref_ly;
+	if (e->moved) {
+		cursor_send_pointer_motion(seat->cursor, 0);
+	}
+}
+
+static void handle_abort(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
+	struct seatop_down_event *e = seat->seatop_data;
+	if (e->con == con) {
+		seatop_abort(seat);
+	}
+}
+
+static const struct sway_seatop_impl seatop_impl = {
+	.motion = handle_motion,
+	.finish = handle_finish,
+	.abort = handle_abort,
+	.unref = handle_unref,
+};
+
+void seatop_begin_down(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, int sx, int sy) {
+	seatop_abort(seat);
+
+	struct seatop_down_event *e =
+		calloc(1, sizeof(struct seatop_down_event));
+	if (!e) {
+		return;
+	}
+	e->con = con;
+	e->ref_lx = seat->cursor->cursor->x;
+	e->ref_ly = seat->cursor->cursor->y;
+	e->ref_con_lx = sx;
+	e->ref_con_ly = sy;
+	e->moved = false;
+
+	seat->seatop_impl = &seatop_impl;
+	seat->seatop_data = e;
+	seat->seatop_button = button;
+}

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -1,0 +1,65 @@
+#define _POSIX_C_SOURCE 200809L
+#include <wlr/types/wlr_cursor.h>
+#include "sway/desktop.h"
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+
+struct seatop_move_floating_event {
+	struct sway_container *con;
+};
+
+static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
+	struct seatop_move_floating_event *e = seat->seatop_data;
+	desktop_damage_whole_container(e->con);
+	container_floating_translate(e->con,
+			seat->cursor->cursor->x - seat->cursor->previous.x,
+			seat->cursor->cursor->y - seat->cursor->previous.y);
+	desktop_damage_whole_container(e->con);
+}
+
+static void handle_finish(struct sway_seat *seat) {
+	struct seatop_move_floating_event *e = seat->seatop_data;
+
+	// We "move" the container to its own location
+	// so it discovers its output again.
+	container_floating_move_to(e->con, e->con->x, e->con->y);
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_abort(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
+	struct seatop_move_floating_event *e = seat->seatop_data;
+	if (e->con == con) {
+		seatop_abort(seat);
+	}
+}
+
+static const struct sway_seatop_impl seatop_impl = {
+	.motion = handle_motion,
+	.finish = handle_finish,
+	.abort = handle_abort,
+	.unref = handle_unref,
+};
+
+void seatop_begin_move_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
+	seatop_abort(seat);
+
+	struct seatop_move_floating_event *e =
+		calloc(1, sizeof(struct seatop_move_floating_event));
+	if (!e) {
+		return;
+	}
+	e->con = con;
+
+	seat->seatop_impl = &seatop_impl;
+	seat->seatop_data = e;
+	seat->seatop_button = button;
+
+	container_raise_floating(con);
+
+	cursor_set_image(seat->cursor, "grab", NULL);
+}

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -1,0 +1,335 @@
+#define _POSIX_C_SOURCE 200809L
+#include <limits.h>
+#include <wlr/types/wlr_cursor.h>
+#include <wlr/util/edges.h>
+#include "sway/desktop.h"
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/node.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
+
+// Thickness of the dropzone when dragging to the edge of a layout container
+#define DROP_LAYOUT_BORDER 30
+
+struct seatop_move_tiling_event {
+	struct sway_container *con;
+	struct sway_node *target_node;
+	enum wlr_edges target_edge;
+	struct wlr_box drop_box;
+	double ref_lx, ref_ly; // cursor's x/y at start of op
+	bool threshold_reached;
+};
+
+static void handle_render(struct sway_seat *seat,
+		struct sway_output *output, pixman_region32_t *damage) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	if (!e->threshold_reached) {
+		return;
+	}
+	if (e->target_node && node_get_output(e->target_node) == output) {
+		float color[4];
+		memcpy(&color, config->border_colors.focused.indicator,
+				sizeof(float) * 4);
+		premultiply_alpha(color, 0.5);
+		struct wlr_box box;
+		memcpy(&box, &e->drop_box, sizeof(struct wlr_box));
+		scale_box(&box, output->wlr_output->scale);
+		render_rect(output->wlr_output, damage, &box, color);
+	}
+}
+
+static void handle_motion_prethreshold(struct sway_seat *seat) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	double cx = seat->cursor->cursor->x;
+	double cy = seat->cursor->cursor->y;
+	double sx = e->ref_lx;
+	double sy = e->ref_ly;
+
+	// Get the scaled threshold for the output. Even if the operation goes
+	// across multiple outputs of varying scales, just use the scale for the
+	// output that the cursor is currently on for simplicity.
+	struct wlr_output *wlr_output = wlr_output_layout_output_at(
+			root->output_layout, cx, cy);
+	double output_scale = wlr_output ? wlr_output->scale : 1;
+	double threshold = config->tiling_drag_threshold * output_scale;
+	threshold *= threshold;
+
+	// If the threshold has been exceeded, start the actual drag
+	if ((cx - sx) * (cx - sx) + (cy - sy) * (cy - sy) > threshold) {
+		e->threshold_reached = true;
+		cursor_set_image(seat->cursor, "grab", NULL);
+	}
+}
+
+static void resize_box(struct wlr_box *box, enum wlr_edges edge,
+		int thickness) {
+	switch (edge) {
+	case WLR_EDGE_TOP:
+		box->height = thickness;
+		break;
+	case WLR_EDGE_LEFT:
+		box->width = thickness;
+		break;
+	case WLR_EDGE_RIGHT:
+		box->x = box->x + box->width - thickness;
+		box->width = thickness;
+		break;
+	case WLR_EDGE_BOTTOM:
+		box->y = box->y + box->height - thickness;
+		box->height = thickness;
+		break;
+	case WLR_EDGE_NONE:
+		box->x += thickness;
+		box->y += thickness;
+		box->width -= thickness * 2;
+		box->height -= thickness * 2;
+		break;
+	}
+}
+
+static void handle_motion_postthreshold(struct sway_seat *seat) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+	struct sway_cursor *cursor = seat->cursor;
+	struct sway_node *node = node_at_coords(seat,
+			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	// Damage the old location
+	desktop_damage_box(&e->drop_box);
+
+	if (!node) {
+		// Eg. hovered over a layer surface such as swaybar
+		e->target_node = NULL;
+		e->target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	if (node->type == N_WORKSPACE) {
+		// Emtpy workspace
+		e->target_node = node;
+		e->target_edge = WLR_EDGE_NONE;
+		workspace_get_box(node->sway_workspace, &e->drop_box);
+		desktop_damage_box(&e->drop_box);
+		return;
+	}
+
+	// Deny moving within own workspace if this is the only child
+	struct sway_container *con = node->sway_container;
+	if (workspace_num_tiling_views(e->con->workspace) == 1 &&
+			con->workspace == e->con->workspace) {
+		e->target_node = NULL;
+		e->target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	// Traverse the ancestors, trying to find a layout container perpendicular
+	// to the edge. Eg. close to the top or bottom of a horiz layout.
+	while (con) {
+		enum wlr_edges edge = WLR_EDGE_NONE;
+		enum sway_container_layout layout = container_parent_layout(con);
+		struct wlr_box parent;
+		con->parent ? container_get_box(con->parent, &parent) :
+			workspace_get_box(con->workspace, &parent);
+		if (layout == L_HORIZ || layout == L_TABBED) {
+			if (cursor->cursor->y < parent.y + DROP_LAYOUT_BORDER) {
+				edge = WLR_EDGE_TOP;
+			} else if (cursor->cursor->y > parent.y + parent.height
+					- DROP_LAYOUT_BORDER) {
+				edge = WLR_EDGE_BOTTOM;
+			}
+		} else if (layout == L_VERT || layout == L_STACKED) {
+			if (cursor->cursor->x < parent.x + DROP_LAYOUT_BORDER) {
+				edge = WLR_EDGE_LEFT;
+			} else if (cursor->cursor->x > parent.x + parent.width
+					- DROP_LAYOUT_BORDER) {
+				edge = WLR_EDGE_RIGHT;
+			}
+		}
+		if (edge) {
+			e->target_node = node_get_parent(&con->node);
+			e->target_edge = edge;
+			node_get_box(e->target_node, &e->drop_box);
+			resize_box(&e->drop_box, edge, DROP_LAYOUT_BORDER);
+			desktop_damage_box(&e->drop_box);
+			return;
+		}
+		con = con->parent;
+	}
+
+	// Use the hovered view - but we must be over the actual surface
+	con = node->sway_container;
+	if (!con->view->surface || node == &e->con->node) {
+		e->target_node = NULL;
+		e->target_edge = WLR_EDGE_NONE;
+		return;
+	}
+
+	// Find the closest edge
+	size_t thickness = fmin(con->content_width, con->content_height) * 0.3;
+	size_t closest_dist = INT_MAX;
+	size_t dist;
+	e->target_edge = WLR_EDGE_NONE;
+	if ((dist = cursor->cursor->y - con->y) < closest_dist) {
+		closest_dist = dist;
+		e->target_edge = WLR_EDGE_TOP;
+	}
+	if ((dist = cursor->cursor->x - con->x) < closest_dist) {
+		closest_dist = dist;
+		e->target_edge = WLR_EDGE_LEFT;
+	}
+	if ((dist = con->x + con->width - cursor->cursor->x) < closest_dist) {
+		closest_dist = dist;
+		e->target_edge = WLR_EDGE_RIGHT;
+	}
+	if ((dist = con->y + con->height - cursor->cursor->y) < closest_dist) {
+		closest_dist = dist;
+		e->target_edge = WLR_EDGE_BOTTOM;
+	}
+
+	if (closest_dist > thickness) {
+		e->target_edge = WLR_EDGE_NONE;
+	}
+
+	e->target_node = node;
+	e->drop_box.x = con->content_x;
+	e->drop_box.y = con->content_y;
+	e->drop_box.width = con->content_width;
+	e->drop_box.height = con->content_height;
+	resize_box(&e->drop_box, e->target_edge, thickness);
+	desktop_damage_box(&e->drop_box);
+}
+
+static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	if (e->threshold_reached) {
+		handle_motion_postthreshold(seat);
+	} else {
+		handle_motion_prethreshold(seat);
+	}
+}
+
+static void handle_abort(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static bool is_parallel(enum sway_container_layout layout,
+		enum wlr_edges edge) {
+	bool layout_is_horiz = layout == L_HORIZ || layout == L_TABBED;
+	bool edge_is_horiz = edge == WLR_EDGE_LEFT || edge == WLR_EDGE_RIGHT;
+	return layout_is_horiz == edge_is_horiz;
+}
+
+static void handle_finish(struct sway_seat *seat) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+
+	if (!e->target_node) {
+		handle_abort(seat);
+		return;
+	}
+
+	struct sway_container *con = e->con;
+	struct sway_container *old_parent = con->parent;
+	struct sway_workspace *old_ws = con->workspace;
+	struct sway_node *target_node = e->target_node;
+	struct sway_workspace *new_ws = target_node->type == N_WORKSPACE ?
+		target_node->sway_workspace : target_node->sway_container->workspace;
+	enum wlr_edges edge = e->target_edge;
+	int after = edge != WLR_EDGE_TOP && edge != WLR_EDGE_LEFT;
+
+	container_detach(con);
+
+	// Moving container into empty workspace
+	if (target_node->type == N_WORKSPACE && edge == WLR_EDGE_NONE) {
+		workspace_add_tiling(new_ws, con);
+	} else if (target_node->type == N_CONTAINER) {
+		// Moving container before/after another
+		struct sway_container *target = target_node->sway_container;
+		enum sway_container_layout layout = container_parent_layout(target);
+		if (edge && !is_parallel(layout, edge)) {
+			enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
+				edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
+			container_split(target, new_layout);
+		}
+		container_add_sibling(target, con, after);
+	} else {
+		// Target is a workspace which requires splitting
+		enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
+			edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
+		workspace_split(new_ws, new_layout);
+		workspace_insert_tiling(new_ws, con, after);
+	}
+
+	if (old_parent) {
+		container_reap_empty(old_parent);
+	}
+
+	// This is a bit dirty, but we'll set the dimensions to that of a sibling.
+	// I don't think there's any other way to make it consistent without
+	// changing how we auto-size containers.
+	list_t *siblings = container_get_siblings(con);
+	if (siblings->length > 1) {
+		int index = list_find(siblings, con);
+		struct sway_container *sibling = index == 0 ?
+			siblings->items[1] : siblings->items[index - 1];
+		con->width = sibling->width;
+		con->height = sibling->height;
+	}
+
+	arrange_workspace(old_ws);
+	if (new_ws != old_ws) {
+		arrange_workspace(new_ws);
+	}
+
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	if (e->target_node == &con->node) { // Drop target
+		e->target_node = NULL;
+	}
+	if (e->con == con) { // The container being moved
+		seatop_abort(seat);
+	}
+}
+
+static const struct sway_seatop_impl seatop_impl = {
+	.motion = handle_motion,
+	.finish = handle_finish,
+	.abort = handle_abort,
+	.unref = handle_unref,
+	.render = handle_render,
+};
+
+void seatop_begin_move_tiling_threshold(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
+	seatop_abort(seat);
+
+	struct seatop_move_tiling_event *e =
+		calloc(1, sizeof(struct seatop_move_tiling_event));
+	if (!e) {
+		return;
+	}
+	e->con = con;
+	e->ref_lx = seat->cursor->cursor->x;
+	e->ref_ly = seat->cursor->cursor->y;
+
+	seat->seatop_impl = &seatop_impl;
+	seat->seatop_data = e;
+	seat->seatop_button = button;
+
+	container_raise_floating(con);
+}
+
+void seatop_begin_move_tiling(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button) {
+	seatop_begin_move_tiling_threshold(seat, con, button);
+	struct seatop_move_tiling_event *e = seat->seatop_data;
+	if (e) {
+		e->threshold_reached = true;
+		cursor_set_image(seat->cursor, "grab", NULL);
+	}
+}

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -1,0 +1,199 @@
+#define _POSIX_C_SOURCE 200809L
+#include <limits.h>
+#include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_xcursor_manager.h>
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
+
+struct seatop_resize_floating_event {
+	struct sway_container *con;
+	enum wlr_edges edge;
+	bool preserve_ratio;
+	double ref_lx, ref_ly;         // cursor's x/y at start of op
+	double ref_width, ref_height;  // container's size at start of op
+	double ref_con_lx, ref_con_ly; // container's x/y at start of op
+};
+
+static void calculate_floating_constraints(struct sway_container *con,
+		int *min_width, int *max_width, int *min_height, int *max_height) {
+	if (config->floating_minimum_width == -1) { // no minimum
+		*min_width = 0;
+	} else if (config->floating_minimum_width == 0) { // automatic
+		*min_width = 75;
+	} else {
+		*min_width = config->floating_minimum_width;
+	}
+
+	if (config->floating_minimum_height == -1) { // no minimum
+		*min_height = 0;
+	} else if (config->floating_minimum_height == 0) { // automatic
+		*min_height = 50;
+	} else {
+		*min_height = config->floating_minimum_height;
+	}
+
+	if (config->floating_maximum_width == -1) { // no maximum
+		*max_width = INT_MAX;
+	} else if (config->floating_maximum_width == 0) { // automatic
+		*max_width = con->workspace->width;
+	} else {
+		*max_width = config->floating_maximum_width;
+	}
+
+	if (config->floating_maximum_height == -1) { // no maximum
+		*max_height = INT_MAX;
+	} else if (config->floating_maximum_height == 0) { // automatic
+		*max_height = con->workspace->height;
+	} else {
+		*max_height = config->floating_maximum_height;
+	}
+}
+
+static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
+	struct seatop_resize_floating_event *e = seat->seatop_data;
+	struct sway_container *con = e->con;
+	enum wlr_edges edge = e->edge;
+	struct sway_cursor *cursor = seat->cursor;
+
+	// The amount the mouse has moved since the start of the resize operation
+	// Positive is down/right
+	double mouse_move_x = cursor->cursor->x - e->ref_lx;
+	double mouse_move_y = cursor->cursor->y - e->ref_ly;
+
+	if (edge == WLR_EDGE_TOP || edge == WLR_EDGE_BOTTOM) {
+		mouse_move_x = 0;
+	}
+	if (edge == WLR_EDGE_LEFT || edge == WLR_EDGE_RIGHT) {
+		mouse_move_y = 0;
+	}
+
+	double grow_width = edge & WLR_EDGE_LEFT ? -mouse_move_x : mouse_move_x;
+	double grow_height = edge & WLR_EDGE_TOP ? -mouse_move_y : mouse_move_y;
+
+	if (e->preserve_ratio) {
+		double x_multiplier = grow_width / e->ref_width;
+		double y_multiplier = grow_height / e->ref_height;
+		double max_multiplier = fmax(x_multiplier, y_multiplier);
+		grow_width = e->ref_width * max_multiplier;
+		grow_height = e->ref_height * max_multiplier;
+	}
+
+	// Determine new width/height, and accommodate for floating min/max values
+	double width = e->ref_width + grow_width;
+	double height = e->ref_height + grow_height;
+	int min_width, max_width, min_height, max_height;
+	calculate_floating_constraints(con, &min_width, &max_width,
+			&min_height, &max_height);
+	width = fmax(min_width, fmin(width, max_width));
+	height = fmax(min_height, fmin(height, max_height));
+
+	// Apply the view's min/max size
+	if (con->view) {
+		double view_min_width, view_max_width, view_min_height, view_max_height;
+		view_get_constraints(con->view, &view_min_width, &view_max_width,
+				&view_min_height, &view_max_height);
+		width = fmax(view_min_width, fmin(width, view_max_width));
+		height = fmax(view_min_height, fmin(height, view_max_height));
+	}
+
+	// Recalculate these, in case we hit a min/max limit
+	grow_width = width - e->ref_width;
+	grow_height = height - e->ref_height;
+
+	// Determine grow x/y values - these are relative to the container's x/y at
+	// the start of the resize operation.
+	double grow_x = 0, grow_y = 0;
+	if (edge & WLR_EDGE_LEFT) {
+		grow_x = -grow_width;
+	} else if (edge & WLR_EDGE_RIGHT) {
+		grow_x = 0;
+	} else {
+		grow_x = -grow_width / 2;
+	}
+	if (edge & WLR_EDGE_TOP) {
+		grow_y = -grow_height;
+	} else if (edge & WLR_EDGE_BOTTOM) {
+		grow_y = 0;
+	} else {
+		grow_y = -grow_height / 2;
+	}
+
+	// Determine the amounts we need to bump everything relative to the current
+	// size.
+	int relative_grow_width = width - con->width;
+	int relative_grow_height = height - con->height;
+	int relative_grow_x = (e->ref_con_lx + grow_x) - con->x;
+	int relative_grow_y = (e->ref_con_ly + grow_y) - con->y;
+
+	// Actually resize stuff
+	con->x += relative_grow_x;
+	con->y += relative_grow_y;
+	con->width += relative_grow_width;
+	con->height += relative_grow_height;
+
+	con->content_x += relative_grow_x;
+	con->content_y += relative_grow_y;
+	con->content_width += relative_grow_width;
+	con->content_height += relative_grow_height;
+
+	arrange_container(con);
+}
+
+static void handle_finish(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_abort(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
+	struct seatop_resize_floating_event *e = seat->seatop_data;
+	if (e->con == con) {
+		seatop_abort(seat);
+	}
+}
+
+static const struct sway_seatop_impl seatop_impl = {
+	.motion = handle_motion,
+	.finish = handle_finish,
+	.abort = handle_abort,
+	.unref = handle_unref,
+};
+
+void seatop_begin_resize_floating(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
+	seatop_abort(seat);
+
+	struct seatop_resize_floating_event *e =
+		calloc(1, sizeof(struct seatop_resize_floating_event));
+	if (!e) {
+		return;
+	}
+	e->con = con;
+
+	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
+	e->preserve_ratio = keyboard &&
+		(wlr_keyboard_get_modifiers(keyboard) & WLR_MODIFIER_SHIFT);
+
+	e->edge = edge == WLR_EDGE_NONE ? WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT : edge;
+	e->ref_lx = seat->cursor->cursor->x;
+	e->ref_ly = seat->cursor->cursor->y;
+	e->ref_con_lx = con->x;
+	e->ref_con_ly = con->y;
+	e->ref_width = con->width;
+	e->ref_height = con->height;
+
+	seat->seatop_impl = &seatop_impl;
+	seat->seatop_data = e;
+	seat->seatop_button = button;
+
+	container_raise_floating(con);
+
+	const char *image = edge == WLR_EDGE_NONE ?
+		"se-resize" : wlr_xcursor_get_resize_name(edge);
+	cursor_set_image(seat->cursor, image, NULL);
+}

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -1,0 +1,92 @@
+#define _POSIX_C_SOURCE 200809L
+#include <wlr/types/wlr_cursor.h>
+#include "sway/commands.h"
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+
+struct seatop_resize_tiling_event {
+	struct sway_container *con;
+	enum wlr_edges edge;
+	double ref_lx, ref_ly;         // cursor's x/y at start of op
+	double ref_width, ref_height;  // container's size at start of op
+	double ref_con_lx, ref_con_ly; // container's x/y at start of op
+};
+
+static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
+	struct seatop_resize_tiling_event *e = seat->seatop_data;
+	int amount_x = 0;
+	int amount_y = 0;
+	int moved_x = seat->cursor->cursor->x - e->ref_lx;
+	int moved_y = seat->cursor->cursor->y - e->ref_ly;
+	enum wlr_edges edge_x = WLR_EDGE_NONE;
+	enum wlr_edges edge_y = WLR_EDGE_NONE;
+	struct sway_container *con = e->con;
+
+	if (e->edge & WLR_EDGE_TOP) {
+		amount_y = (e->ref_height - moved_y) - con->height;
+		edge_y = WLR_EDGE_TOP;
+	} else if (e->edge & WLR_EDGE_BOTTOM) {
+		amount_y = (e->ref_height + moved_y) - con->height;
+		edge_y = WLR_EDGE_BOTTOM;
+	}
+	if (e->edge & WLR_EDGE_LEFT) {
+		amount_x = (e->ref_width - moved_x) - con->width;
+		edge_x = WLR_EDGE_LEFT;
+	} else if (e->edge & WLR_EDGE_RIGHT) {
+		amount_x = (e->ref_width + moved_x) - con->width;
+		edge_x = WLR_EDGE_RIGHT;
+	}
+
+	if (amount_x != 0) {
+		container_resize_tiled(e->con, edge_x, amount_x);
+	}
+	if (amount_y != 0) {
+		container_resize_tiled(e->con, edge_y, amount_y);
+	}
+}
+
+static void handle_finish(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_abort(struct sway_seat *seat) {
+	cursor_set_image(seat->cursor, "left_ptr", NULL);
+}
+
+static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
+	struct seatop_resize_tiling_event *e = seat->seatop_data;
+	if (e->con == con) {
+		seatop_abort(seat);
+	}
+}
+
+static const struct sway_seatop_impl seatop_impl = {
+	.motion = handle_motion,
+	.finish = handle_finish,
+	.abort = handle_abort,
+	.unref = handle_unref,
+};
+
+void seatop_begin_resize_tiling(struct sway_seat *seat,
+		struct sway_container *con, uint32_t button, enum wlr_edges edge) {
+	seatop_abort(seat);
+
+	struct seatop_resize_tiling_event *e =
+		calloc(1, sizeof(struct seatop_resize_tiling_event));
+	if (!e) {
+		return;
+	}
+	e->con = con;
+	e->edge = edge;
+
+	e->ref_lx = seat->cursor->cursor->x;
+	e->ref_ly = seat->cursor->cursor->y;
+	e->ref_con_lx = con->x;
+	e->ref_con_ly = con->y;
+	e->ref_width = con->width;
+	e->ref_height = con->height;
+
+	seat->seatop_impl = &seatop_impl;
+	seat->seatop_data = e;
+	seat->seatop_button = button;
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -23,6 +23,11 @@ sway_sources = files(
 
 	'input/input-manager.c',
 	'input/seat.c',
+	'input/seatop_down.c',
+	'input/seatop_move_floating.c',
+	'input/seatop_move_tiling.c',
+	'input/seatop_resize_floating.c',
+	'input/seatop_resize_tiling.c',
 	'input/cursor.c',
 	'input/keyboard.c',
 


### PR DESCRIPTION
This splits each seat operation (drag/move tiling/floating etc) into a separate file and introduces a `struct sway_seatop_impl` to abstract the operation. This removes a heap of code from cursor.c and seat.c, and removes a bunch of multi-purpose properties from the seat struct.

The `move_tiling_threshold` operation has been merged into `move_tiling`.

The main logic for each operation is untouched aside from variable renames.

The following previously-static functions have been made public:
* `node_at_coords`
* `container_raise_floating`
* `render_rect`
* `premultiply_alpha`
* `scale_box`

Everything seems to work correctly, but I've only tested it hastily. Please test thoroughly.