### PR TITLE
Remove 'input' field of IPC command return json

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -75,7 +75,7 @@ struct cmd_results *config_commands_command(char *exec);
 /**
  * Allocates a cmd_results object.
  */
-struct cmd_results *cmd_results_new(enum cmd_status status, const char* input, const char *error, ...);
+struct cmd_results *cmd_results_new(enum cmd_status status, const char *error, ...);
 /**
  * Frees a cmd_results object.
  */
@@ -87,8 +87,7 @@ void free_cmd_results(struct cmd_results *results);
  */
 char *cmd_results_to_json(list_t *res_list);
 
-struct cmd_results *add_color(const char *name,
-		char *buffer, const char *color);
+struct cmd_results *add_color(char *buffer, const char *color);
 
 /**
  * TODO: Move this function and its dependent functions to container.c.

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -31,7 +31,6 @@ enum cmd_status {
  */
 struct cmd_results {
 	enum cmd_status status;
-	char *input;
 	/**
 	 * Human friendly error message, or NULL on success
 	 */
@@ -63,7 +62,7 @@ list_t *execute_command(char *command,  struct sway_seat *seat,
  *
  * Do not use this under normal conditions.
  */
-struct cmd_results *config_command(char *command);
+struct cmd_results *config_command(char *command, char **new_block);
 /**
  * Parse and handle a sub command
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -36,7 +36,7 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 		}
 	}
 	return error_name ?
-		cmd_results_new(CMD_INVALID, name, "Invalid %s command "
+		cmd_results_new(CMD_INVALID, "Invalid %s command "
 				"(expected %s%d argument%s, got %d)",
 				name, error_name, val, val != 1 ? "s" : "", argc)
 		: NULL;
@@ -228,8 +228,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			char *error = NULL;
 			struct criteria *criteria = criteria_parse(head, &error);
 			if (!criteria) {
-				list_add(res_list, cmd_results_new(CMD_INVALID, head,
-					"%s", error));
+				list_add(res_list, cmd_results_new(CMD_INVALID,	"%s", error));
 				free(error);
 				goto cleanup;
 			}
@@ -265,8 +264,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			}
 			struct cmd_handler *handler = find_handler(argv[0], NULL, 0);
 			if (!handler) {
-				list_add(res_list, cmd_results_new(CMD_INVALID, cmd,
-							"Unknown/invalid command"));
+				list_add(res_list, cmd_results_new(CMD_INVALID,
+						"Unknown/invalid command '%s'", argv[0]));
 				free_argv(argc, argv);
 				goto cleanup;
 			}
@@ -323,20 +322,20 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 
 	// Check for empty lines
 	if (!argc) {
-		results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		results = cmd_results_new(CMD_SUCCESS, NULL);
 		goto cleanup;
 	}
 
 	// Check for the start of a block
 	if (argc > 1 && strcmp(argv[argc - 1], "{") == 0) {
 		*new_block = join_args(argv, argc - 1);
-		results = cmd_results_new(CMD_BLOCK, NULL, NULL);
+		results = cmd_results_new(CMD_BLOCK, NULL);
 		goto cleanup;
 	}
 
 	// Check for the end of a block
 	if (strcmp(argv[argc - 1], "}") == 0) {
-		results = cmd_results_new(CMD_BLOCK_END, NULL, NULL);
+		results = cmd_results_new(CMD_BLOCK_END, NULL);
 		goto cleanup;
 	}
 
@@ -348,7 +347,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 		argv = split_args(temp, &argc);
 		free(temp);
 		if (!argc) {
-			results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			results = cmd_results_new(CMD_SUCCESS, NULL);
 			goto cleanup;
 		}
 	}
@@ -357,11 +356,10 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 	wlr_log(WLR_INFO, "Config command: %s", exec);
 	struct cmd_handler *handler = find_handler(argv[0], NULL, 0);
 	if (!handler || !handler->handle) {
-		char *input = argv[0] ? argv[0] : "(empty)";
-		char *error = handler
-			? "This command is shimmed, but unimplemented"
-			: "Unknown/invalid command";
-		results = cmd_results_new(CMD_INVALID, input, error);
+		const char *error = handler
+			? "Command '%s' is shimmed, but unimplemented"
+			: "Unknown/invalid command '%s'";
+		results = cmd_results_new(CMD_INVALID, error, argv[0]);
 		goto cleanup;
 	}
 
@@ -410,14 +408,14 @@ struct cmd_results *config_subcommand(char **argv, int argc,
 	struct cmd_handler *handler = find_handler(argv[0], handlers,
 			handlers_size);
 	if (!handler) {
-		char *input = argv[0] ? argv[0] : "(empty)";
-		return cmd_results_new(CMD_INVALID, input, "Unknown/invalid command");
+		return cmd_results_new(CMD_INVALID,
+				"Unknown/invalid command '%s'", argv[0]);
 	}
 	if (handler->handle) {
 		return handler->handle(argc - 1, argv + 1);
 	}
-	return cmd_results_new(CMD_INVALID, argv[0],
-			"This command is shimmed, but unimplemented");
+	return cmd_results_new(CMD_INVALID,
+			"The command '%s' is shimmed, but unimplemented", argv[0]);
 }
 
 struct cmd_results *config_commands_command(char *exec) {
@@ -425,7 +423,7 @@ struct cmd_results *config_commands_command(char *exec) {
 	int argc;
 	char **argv = split_args(exec, &argc);
 	if (!argc) {
-		results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		results = cmd_results_new(CMD_SUCCESS, NULL);
 		goto cleanup;
 	}
 
@@ -433,13 +431,14 @@ struct cmd_results *config_commands_command(char *exec) {
 	char *cmd = argv[0];
 
 	if (strcmp(cmd, "}") == 0) {
-		results = cmd_results_new(CMD_BLOCK_END, NULL, NULL);
+		results = cmd_results_new(CMD_BLOCK_END, NULL);
 		goto cleanup;
 	}
 
 	struct cmd_handler *handler = find_handler(cmd, NULL, 0);
 	if (!handler && strcmp(cmd, "*") != 0) {
-		results = cmd_results_new(CMD_INVALID, cmd, "Unknown/invalid command");
+		results = cmd_results_new(CMD_INVALID,
+			"Unknown/invalid command '%s'", cmd);
 		goto cleanup;
 	}
 
@@ -464,7 +463,7 @@ struct cmd_results *config_commands_command(char *exec) {
 			}
 		}
 		if (j == sizeof(context_names) / sizeof(context_names[0])) {
-			results = cmd_results_new(CMD_INVALID, cmd,
+			results = cmd_results_new(CMD_INVALID,
 					"Invalid command context %s", argv[i]);
 			goto cleanup;
 		}
@@ -482,7 +481,7 @@ struct cmd_results *config_commands_command(char *exec) {
 	if (!policy) {
 		policy = alloc_command_policy(cmd);
 		if (!sway_assert(policy, "Unable to allocate security policy")) {
-			results = cmd_results_new(CMD_INVALID, cmd,
+			results = cmd_results_new(CMD_INVALID,
 					"Unable to allocate memory");
 			goto cleanup;
 		}
@@ -493,7 +492,7 @@ struct cmd_results *config_commands_command(char *exec) {
 	wlr_log(WLR_INFO, "Set command policy for %s to %d",
 			policy->command, policy->context);
 
-	results = cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	results = cmd_results_new(CMD_SUCCESS, NULL);
 
 cleanup:
 	free_argv(argc, argv);
@@ -501,14 +500,13 @@ cleanup:
 }
 
 struct cmd_results *cmd_results_new(enum cmd_status status,
-		const char *input, const char *format, ...) {
+		const char *format, ...) {
 	struct cmd_results *results = malloc(sizeof(struct cmd_results));
 	if (!results) {
 		wlr_log(WLR_ERROR, "Unable to allocate command results");
 		return NULL;
 	}
 	results->status = status;
-	// NOTE: `input` argument is unused, remove
 	if (format) {
 		char *error = malloc(256);
 		va_list args;
@@ -557,20 +555,19 @@ char *cmd_results_to_json(list_t *res_list) {
  *
  * return error object, or NULL if color is valid.
  */
-struct cmd_results *add_color(const char *name,
-		char *buffer, const char *color) {
+struct cmd_results *add_color(char *buffer, const char *color) {
 	int len = strlen(color);
 	if (len != 7 && len != 9) {
-		return cmd_results_new(CMD_INVALID, name,
+		return cmd_results_new(CMD_INVALID,
 				"Invalid color definition %s", color);
 	}
 	if (color[0] != '#') {
-		return cmd_results_new(CMD_INVALID, name,
+		return cmd_results_new(CMD_INVALID,
 				"Invalid color definition %s", color);
 	}
 	for (int i = 1; i < len; ++i) {
 		if (!isxdigit(color[i])) {
-			return cmd_results_new(CMD_INVALID, name,
+			return cmd_results_new(CMD_INVALID,
 					"Invalid color definition %s", color);
 		}
 	}

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -17,7 +17,7 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, "assign", err_str);
+		error = cmd_results_new(CMD_INVALID, err_str);
 		free(err_str);
 		return error;
 	}
@@ -27,7 +27,7 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	if (strncmp(*argv, "→", strlen("→")) == 0) {
 		if (argc < 2) {
 			free(criteria);
-			return cmd_results_new(CMD_INVALID, "assign", "Missing workspace");
+			return cmd_results_new(CMD_INVALID, "Missing workspace");
 		}
 		--argc;
 		++argv;
@@ -44,7 +44,7 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 			--argc; ++argv;
 			if (argv[0][0] < '0' || argv[0][0] > '9') {
 				free(criteria);
-				return cmd_results_new(CMD_INVALID, "assign",
+				return cmd_results_new(CMD_INVALID,
 						"Invalid workspace number '%s'", argv[0]);
 			}
 			criteria->type = CT_ASSIGN_WORKSPACE_NUMBER;
@@ -59,5 +59,5 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	wlr_log(WLR_DEBUG, "assign: '%s' -> '%s' added", criteria->raw,
 			criteria->target);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -69,7 +69,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 			wlr_log(WLR_DEBUG, "Creating bar: %s", argv[0]);
 			bar = default_bar_config();
 			if (!bar) {
-				return cmd_results_new(CMD_FAILURE, "bar",
+				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate bar state");
 			}
 
@@ -83,7 +83,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		// Create new bar with default values
 		struct bar_config *bar = default_bar_config();
 		if (!bar) {
-			return cmd_results_new(CMD_FAILURE, "bar",
+			return cmd_results_new(CMD_FAILURE,
 					"Unable to allocate bar state");
 		}
 
@@ -93,8 +93,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		if (bar->id) {
 			snprintf(bar->id, len, "bar-%d", config->bars->length - 1);
 		} else {
-			return cmd_results_new(CMD_FAILURE,
-					"bar", "Unable to allocate bar ID");
+			return cmd_results_new(CMD_FAILURE, "Unable to allocate bar ID");
 		}
 
 		// Set current bar
@@ -117,7 +116,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 				}
 			}
 		}
-		return cmd_results_new(CMD_INVALID, "bar",
+		return cmd_results_new(CMD_INVALID,
 				"Can only be used in the config file.");
 	}
 

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -16,13 +16,12 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, command, "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	struct bar_binding *binding = calloc(1, sizeof(struct bar_binding));
 	if (!binding) {
-		return cmd_results_new(CMD_FAILURE, command,
-				"Unable to allocate bar binding");
+		return cmd_results_new(CMD_FAILURE, "Unable to allocate bar binding");
 	}
 
 	binding->release = false;
@@ -40,13 +39,12 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 	}
 	if (message) {
 		free_bar_binding(binding);
-		error = cmd_results_new(CMD_INVALID, command, message);
+		error = cmd_results_new(CMD_INVALID, message);
 		free(message);
 		return error;
 	} else if (!binding->button) {
 		free_bar_binding(binding);
-		return cmd_results_new(CMD_INVALID, command,
-				"Unknown button %s", argv[0]);
+		return cmd_results_new(CMD_INVALID, "Unknown button %s", argv[0]);
 	}
 
 	const char *name = libevdev_event_code_get_name(EV_KEY, binding->button);
@@ -94,7 +92,7 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 				binding->release ? " - release" : "");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *bar_cmd_bindcode(int argc, char **argv) {

--- a/sway/commands/bar/binding_mode_indicator.c
+++ b/sway/commands/bar/binding_mode_indicator.c
@@ -11,8 +11,7 @@ struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"binding_mode_indicator", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	config->current_bar->binding_mode_indicator = 
 		parse_boolean(argv[0], config->current_bar->binding_mode_indicator);
@@ -23,5 +22,5 @@ struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Disabling binding mode indicator on bar: %s",
 				config->current_bar->id);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -25,11 +25,11 @@ static struct cmd_results *parse_single_color(char **color,
 	if (!*color && !(*color = malloc(10))) {
 		return NULL;
 	}
-	error = add_color(cmd_name, *color, argv[0]);
+	error = add_color(*color, argv[0]);
 	if (error) {
 		return error;
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *parse_three_colors(char ***colors,
@@ -37,18 +37,18 @@ static struct cmd_results *parse_three_colors(char ***colors,
 	struct cmd_results *error = NULL;
 	if (argc != 3) {
 		return cmd_results_new(CMD_INVALID,
-				cmd_name, "Requires exactly three color values");
+				"Command '%s' requires exactly three color values", cmd_name);
 	}
 	for (size_t i = 0; i < 3; i++) {
 		if (!*colors[i] && !(*(colors[i]) = malloc(10))) {
 			return NULL;
 		}
-		error = add_color(cmd_name, *(colors[i]), argv[i]);
+		error = add_color(*(colors[i]), argv[i]);
 		if (error) {
 			return error;
 		}
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *bar_cmd_colors(int argc, char **argv) {

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -10,12 +10,12 @@ struct cmd_results *bar_cmd_font(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "font", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	char *font = join_args(argv, argc);
 	free(config->current_bar->font);
 	config->current_bar->font = font;
 	wlr_log(WLR_DEBUG, "Settings font '%s' for bar: %s",
 			config->current_bar->font, config->current_bar->id);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/gaps.c
+++ b/sway/commands/bar/gaps.c
@@ -14,7 +14,7 @@ struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "bar gaps", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	int top = 0, right = 0, bottom = 0, left = 0;
@@ -23,7 +23,7 @@ struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
 		char *end;
 		int amount = strtol(argv[i], &end, 10);
 		if (strlen(end) && strcasecmp(end, "px") != 0) {
-			return cmd_results_new(CMD_INVALID, "bar gaps",
+			return cmd_results_new(CMD_INVALID,
 					"Expected 'bar [<bar-id>] gaps <all> | <horizonal> "
 					"<vertical> | <top> <right> <bottom> <left>'");
 		}
@@ -56,5 +56,5 @@ struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
 		ipc_event_barconfig_update(config->current_bar);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/height.c
+++ b/sway/commands/bar/height.c
@@ -10,11 +10,11 @@ struct cmd_results *bar_cmd_height(int argc, char **argv) {
 	}
 	int height = atoi(argv[0]);
 	if (height < 0) {
-		return cmd_results_new(CMD_INVALID, "height",
+		return cmd_results_new(CMD_INVALID,
 				"Invalid height value: %s", argv[0]);
 	}
 	config->current_bar->height = height;
 	wlr_log(WLR_DEBUG, "Setting bar height to %d on bar: %s",
 			height, config->current_bar->id);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/hidden_state.c
+++ b/sway/commands/bar/hidden_state.c
@@ -20,8 +20,7 @@ static struct cmd_results *bar_set_hidden_state(struct bar_config *bar,
 	} else if (strcasecmp("show", hidden_state) == 0) {
 		bar->hidden_state = strdup("show");
 	} else {
-		return cmd_results_new(CMD_INVALID, "hidden_state",
-				"Invalid value %s", hidden_state);
+		return cmd_results_new(CMD_INVALID, "Invalid value %s",	hidden_state);
 	}
 	if (strcmp(old_state, bar->hidden_state) != 0) {
 		if (!config->reading) {
@@ -44,7 +43,7 @@ struct cmd_results *bar_cmd_hidden_state(int argc, char **argv) {
 		return error;
 	}
 	if (config->reading && argc > 1) {
-		return cmd_results_new(CMD_INVALID, "hidden_state",
+		return cmd_results_new(CMD_INVALID,
 				"Unexpected value %s in config mode", argv[1]);
 	}
 
@@ -65,5 +64,5 @@ struct cmd_results *bar_cmd_hidden_state(int argc, char **argv) {
 			}
 		}
 	}
-	return error ? error : cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return error ? error : cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/icon_theme.c
+++ b/sway/commands/bar/icon_theme.c
@@ -13,16 +13,16 @@ struct cmd_results *bar_cmd_icon_theme(int argc, char **argv) {
 	}
 
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "tray_padding", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	wlr_log(WLR_DEBUG, "[Bar %s] Setting icon theme to %s",
 			config->current_bar->id, argv[0]);
 	free(config->current_bar->icon_theme);
 	config->current_bar->icon_theme = strdup(argv[0]);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 #else
-	return cmd_results_new(CMD_INVALID, "icon_theme",
+	return cmd_results_new(CMD_INVALID,
 			"Sway has been compiled without tray support");
 #endif
 }

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -12,15 +12,15 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 	const char *name = argv[0];
 	const char *oldname = config->current_bar->id;
 	if (strcmp(name, oldname) == 0) {
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);  // NOP
+		return cmd_results_new(CMD_SUCCESS, NULL);  // NOP
 	} else if (strcmp(name, "id") == 0) {
-		return cmd_results_new(CMD_INVALID, "id", "id cannot be 'id'");
+		return cmd_results_new(CMD_INVALID, "id cannot be 'id'");
 	}
 	// check if id is used by a previously defined bar
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *find = config->bars->items[i];
 		if (strcmp(name, find->id) == 0 && config->current_bar != find) {
-			return cmd_results_new(CMD_FAILURE, "id",
+			return cmd_results_new(CMD_FAILURE,
 					"Id '%s' already defined for another bar. Id unchanged (%s).",
 					name, oldname);
 		}
@@ -31,5 +31,5 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 	// free old bar id
 	free(config->current_bar->id);
 	config->current_bar->id = strdup(name);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -21,7 +21,7 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 	} else if (strcasecmp("invisible", mode) == 0) {
 		bar->mode = strdup("invisible");
 	} else {
-		return cmd_results_new(CMD_INVALID, "mode", "Invalid value %s", mode);
+		return cmd_results_new(CMD_INVALID, "Invalid value %s", mode);
 	}
 
 	if (strcmp(old_mode, bar->mode) != 0) {
@@ -46,7 +46,7 @@ struct cmd_results *bar_cmd_mode(int argc, char **argv) {
 	}
 	if (config->reading && argc > 1) {
 		return cmd_results_new(CMD_INVALID,
-				"mode", "Unexpected value %s in config mode", argv[1]);
+				"Unexpected value %s in config mode", argv[1]);
 	}
 
 	const char *mode = argv[0];
@@ -66,5 +66,5 @@ struct cmd_results *bar_cmd_mode(int argc, char **argv) {
 			}
 		}
 	}
-	return error ? error : cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return error ? error : cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -11,7 +11,7 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	}
 
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "modifier", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	uint32_t mod = 0;
@@ -21,8 +21,8 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 		if ((tmp_mod = get_modifier_mask_by_name(split->items[i])) > 0) {
 			mod |= tmp_mod;
 		} else {
-			error = cmd_results_new(CMD_INVALID, "modifier",
-				"Unknown modifier '%s'", split->items[i]);
+			error = cmd_results_new(CMD_INVALID,
+				"Unknown modifier '%s'", (char *)split->items[i]);
 			list_free_items_and_destroy(split);
 			return error;
 		}
@@ -31,5 +31,5 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	config->current_bar->modifier = mod;
 	wlr_log(WLR_DEBUG,
 			"Show/Hide the bar when pressing '%s' in hide mode.", argv[0]);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/output.c
+++ b/sway/commands/bar/output.c
@@ -11,7 +11,7 @@ struct cmd_results *bar_cmd_output(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "output", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	const char *output = argv[0];
@@ -45,5 +45,5 @@ struct cmd_results *bar_cmd_output(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Adding bar: '%s' to output '%s'",
 				config->current_bar->id, output);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/pango_markup.c
+++ b/sway/commands/bar/pango_markup.c
@@ -10,7 +10,7 @@ struct cmd_results *bar_cmd_pango_markup(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "pango_markup", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	config->current_bar->pango_markup 
 		= parse_boolean(argv[0], config->current_bar->pango_markup);
@@ -21,5 +21,5 @@ struct cmd_results *bar_cmd_pango_markup(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Disabling pango markup for bar: %s",
 				config->current_bar->id);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -10,7 +10,7 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "position", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	char *valid[] = { "top", "bottom" };
 	for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
@@ -19,9 +19,8 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 					argv[0], config->current_bar->id);
 			free(config->current_bar->position);
 			config->current_bar->position = strdup(argv[0]);
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			return cmd_results_new(CMD_SUCCESS, NULL);
 		}
 	}
-	return cmd_results_new(CMD_INVALID,
-			"position", "Invalid value %s", argv[0]);
+	return cmd_results_new(CMD_INVALID, "Invalid value %s", argv[0]);
 }

--- a/sway/commands/bar/separator_symbol.c
+++ b/sway/commands/bar/separator_symbol.c
@@ -9,12 +9,11 @@ struct cmd_results *bar_cmd_separator_symbol(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"separator_symbol", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	free(config->current_bar->separator_symbol);
 	config->current_bar->separator_symbol = strdup(argv[0]);
 	wlr_log(WLR_DEBUG, "Settings separator_symbol '%s' for bar: %s",
 			config->current_bar->separator_symbol, config->current_bar->id);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -9,8 +9,7 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"status_command", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	free(config->current_bar->status_command);
 	config->current_bar->status_command = NULL;
@@ -28,5 +27,5 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 		load_swaybar(config->current_bar);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/status_edge_padding.c
+++ b/sway/commands/bar/status_edge_padding.c
@@ -11,11 +11,11 @@ struct cmd_results *bar_cmd_status_edge_padding(int argc, char **argv) {
 	char *end;
 	int padding = strtol(argv[0], &end, 10);
 	if (strlen(end) || padding < 0) {
-		return cmd_results_new(CMD_INVALID, "status_edge_padding",
+		return cmd_results_new(CMD_INVALID,
 				"Padding must be a positive integer");
 	}
 	config->current_bar->status_edge_padding = padding;
 	wlr_log(WLR_DEBUG, "Status edge padding on bar %s: %d",
 			config->current_bar->id, config->current_bar->status_edge_padding);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/status_padding.c
+++ b/sway/commands/bar/status_padding.c
@@ -11,11 +11,11 @@ struct cmd_results *bar_cmd_status_padding(int argc, char **argv) {
 	char *end;
 	int padding = strtol(argv[0], &end, 10);
 	if (strlen(end) || padding < 0) {
-		return cmd_results_new(CMD_INVALID, "status_padding",
+		return cmd_results_new(CMD_INVALID,
 				"Padding must be a positive integer");
 	}
 	config->current_bar->status_padding = padding;
 	wlr_log(WLR_DEBUG, "Status padding on bar %s: %d",
 			config->current_bar->id, config->current_bar->status_padding);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/strip_workspace_name.c
+++ b/sway/commands/bar/strip_workspace_name.c
@@ -11,8 +11,7 @@ struct cmd_results *bar_cmd_strip_workspace_name(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"strip_workspace_name", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	config->current_bar->strip_workspace_name =
@@ -28,5 +27,5 @@ struct cmd_results *bar_cmd_strip_workspace_name(int argc, char **argv) {
 				config->current_bar->id);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/strip_workspace_numbers.c
+++ b/sway/commands/bar/strip_workspace_numbers.c
@@ -11,8 +11,7 @@ struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"strip_workspace_numbers", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	
 	config->current_bar->strip_workspace_numbers =
@@ -28,5 +27,5 @@ struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv) {
 				config->current_bar->id);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/swaybar_command.c
+++ b/sway/commands/bar/swaybar_command.c
@@ -9,12 +9,11 @@ struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"swaybar_command", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	free(config->current_bar->swaybar_command);
 	config->current_bar->swaybar_command = join_args(argv, argc);
 	wlr_log(WLR_DEBUG, "Using custom swaybar command: %s",
 			config->current_bar->swaybar_command);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/tray_bindsym.c
+++ b/sway/commands/bar/tray_bindsym.c
@@ -12,7 +12,7 @@ struct cmd_results *bar_cmd_tray_bindsym(int argc, char **argv) {
 	}
 
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "tray_bindsym", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	int button = 0;
@@ -21,7 +21,7 @@ struct cmd_results *bar_cmd_tray_bindsym(int argc, char **argv) {
 		button = argv[0][strlen("button")] - '0';
 	}
 	if (button < 1 || button > 9) {
-		return cmd_results_new(CMD_FAILURE, "tray_bindsym",
+		return cmd_results_new(CMD_FAILURE,
 				"[Bar %s] Only buttons 1 to 9 are supported",
 				config->current_bar->id);
 	}
@@ -42,14 +42,14 @@ struct cmd_results *bar_cmd_tray_bindsym(int argc, char **argv) {
 			wlr_log(WLR_DEBUG, "[Bar %s] Binding button %d to %s",
 					config->current_bar->id, button, commands[i]);
 			config->current_bar->tray_bindings[button] = commands[i];
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			return cmd_results_new(CMD_SUCCESS, NULL);
 		}
 	}
 
-	return cmd_results_new(CMD_INVALID, "tray_bindsym",
+	return cmd_results_new(CMD_INVALID,
 			"[Bar %s] Invalid command %s", config->current_bar->id, argv[1]);
 #else
-	return cmd_results_new(CMD_INVALID, "tray_bindsym",
+	return cmd_results_new(CMD_INVALID,
 			"Sway has been compiled without tray support");
 #endif
 }

--- a/sway/commands/bar/tray_output.c
+++ b/sway/commands/bar/tray_output.c
@@ -14,7 +14,7 @@ struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
 	}
 
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "tray_output", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
 	list_t *outputs = config->current_bar->tray_outputs;
@@ -34,9 +34,9 @@ struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
 	}
 	list_add(outputs, strdup(argv[0]));
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 #else
-	return cmd_results_new(CMD_INVALID, "tray_output",
+	return cmd_results_new(CMD_INVALID,
 			"Sway has been compiled without tray support");
 #endif
 }

--- a/sway/commands/bar/tray_padding.c
+++ b/sway/commands/bar/tray_padding.c
@@ -16,27 +16,27 @@ struct cmd_results *bar_cmd_tray_padding(int argc, char **argv) {
 	}
 
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "tray_padding", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	struct bar_config *bar = config->current_bar;
 
 	char *end;
 	int padding = strtol(argv[0], &end, 10);
 	if (padding < 0 || (*end != '\0' && strcasecmp(end, "px") != 0)) {
-		return cmd_results_new(CMD_INVALID, "tray_padding",
+		return cmd_results_new(CMD_INVALID,
 				"[Bar %s] Invalid tray padding value: %s", bar->id, argv[0]);
 	}
 
 	if (argc == 2 && strcasecmp(argv[1], "px") != 0) {
-		return cmd_results_new(CMD_INVALID, "tray_padding",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'tray_padding <px> [px]'");
 	}
 
 	wlr_log(WLR_DEBUG, "[Bar %s] Setting tray padding to %d", bar->id, padding);
 	config->current_bar->tray_padding = padding;
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 #else
-	return cmd_results_new(CMD_INVALID, "tray_padding",
+	return cmd_results_new(CMD_INVALID,
 			"Sway has been compiled without tray support");
 #endif
 }

--- a/sway/commands/bar/workspace_buttons.c
+++ b/sway/commands/bar/workspace_buttons.c
@@ -10,8 +10,7 @@ struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE,
-				"workspace_buttons", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	config->current_bar->workspace_buttons = 
 		parse_boolean(argv[0], config->current_bar->workspace_buttons);
@@ -22,5 +21,5 @@ struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Disabling workspace buttons on bar: %s",
 				config->current_bar->id);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/wrap_scroll.c
+++ b/sway/commands/bar/wrap_scroll.c
@@ -10,7 +10,7 @@ struct cmd_results *bar_cmd_wrap_scroll(int argc, char **argv) {
 		return error;
 	}
 	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "wrap_scroll", "No bar defined.");
+		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 	config->current_bar->wrap_scroll = 
 			parse_boolean(argv[0], config->current_bar->wrap_scroll);
@@ -21,5 +21,5 @@ struct cmd_results *bar_cmd_wrap_scroll(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Disabling wrap scroll on bar: %s",
 				config->current_bar->id);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -92,11 +92,11 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 		if (!button) {
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, "bindcode", message);
+					cmd_results_new(CMD_INVALID, message);
 				free(message);
 				return error;
 			} else {
-				return cmd_results_new(CMD_INVALID, "bindcode",
+				return cmd_results_new(CMD_INVALID,
 						"Unknown button code %s", name);
 			}
 		}
@@ -108,12 +108,11 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 		if (!button) {
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, "bindsym", message);
+					cmd_results_new(CMD_INVALID, message);
 				free(message);
 				return error;
 			} else if (!button) {
-				return cmd_results_new(CMD_INVALID, "bindsym",
-						"Unknown button %s", name);
+				return cmd_results_new(CMD_INVALID, "Unknown button %s", name);
 			}
 		}
 		*key_val = button;
@@ -133,10 +132,10 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 		xkb_keycode_t keycode = strtol(name, NULL, 10);
 		if (!xkb_keycode_is_legal_ext(keycode)) {
 			if (first_key) {
-				return cmd_results_new(CMD_INVALID, "bindcode",
+				return cmd_results_new(CMD_INVALID,
 						"Invalid keycode or button code '%s'", name);
 			} else {
-				return cmd_results_new(CMD_INVALID, "bindcode",
+				return cmd_results_new(CMD_INVALID,
 						"Invalid keycode '%s'", name);
 			}
 		}
@@ -148,7 +147,7 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 			uint32_t button = get_mouse_bindsym(name, &message);
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, "bindsym", message);
+					cmd_results_new(CMD_INVALID, message);
 				free(message);
 				return error;
 			} else if (button) {
@@ -162,11 +161,10 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 				XKB_KEYSYM_CASE_INSENSITIVE);
 		if (!keysym) {
 			if (first_key) {
-				return cmd_results_new(CMD_INVALID, "bindsym",
+				return cmd_results_new(CMD_INVALID,
 						"Unknown key or button '%s'", name);
 			} else {
-				return cmd_results_new(CMD_INVALID, "bindsym",
-					"Unknown key '%s'", name);
+				return cmd_results_new(CMD_INVALID, "Unknown key '%s'", name);
 			}
 		}
 		*key_val = keysym;
@@ -185,8 +183,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 
 	struct sway_binding *binding = calloc(1, sizeof(struct sway_binding));
 	if (!binding) {
-		return cmd_results_new(CMD_FAILURE, bindtype,
-				"Unable to allocate binding");
+		return cmd_results_new(CMD_FAILURE, "Unable to allocate binding");
 	}
 	binding->input = strdup("*");
 	binding->keys = create_list();
@@ -229,7 +226,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 
 	if (argc < 2) {
 		free_sway_binding(binding);
-		return cmd_results_new(CMD_FAILURE, bindtype,
+		return cmd_results_new(CMD_FAILURE,
 			"Invalid %s command "
 			"(expected at least 2 non-option arguments, got %d)", bindtype, argc);
 	}
@@ -259,7 +256,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 		if (!key) {
 			free_sway_binding(binding);
 			list_free_items_and_destroy(split);
-			return cmd_results_new(CMD_FAILURE, bindtype,
+			return cmd_results_new(CMD_FAILURE,
 					"Unable to allocate binding key");
 		}
 		*key = key_val;
@@ -315,7 +312,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 
 	wlr_log(WLR_DEBUG, "%s - Bound %s to command `%s` for device '%s'",
 		bindtype, argv[0], binding->command, binding->input);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_bindsym(int argc, char **argv) {

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -64,8 +64,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 
 	struct sway_container *container = config->handler_context.container;
 	if (!container || !container->view) {
-		return cmd_results_new(CMD_INVALID, "border",
-				"Only views can have borders");
+		return cmd_results_new(CMD_INVALID, "Only views can have borders");
 	}
 	struct sway_view *view = container->view;
 
@@ -77,14 +76,14 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 		set_border(container, B_PIXEL);
 	} else if (strcmp(argv[0], "csd") == 0) {
 		if (!view || !view->xdg_decoration) {
-			return cmd_results_new(CMD_INVALID, "border",
+			return cmd_results_new(CMD_INVALID,
 					"This window doesn't support client side decorations");
 		}
 		set_border(container, B_CSD);
 	} else if (strcmp(argv[0], "toggle") == 0) {
 		border_toggle(container);
 	} else {
-		return cmd_results_new(CMD_INVALID, "border",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'border <none|normal|pixel|csd|toggle>' "
 				"or 'border pixel <px>'");
 	}
@@ -98,5 +97,5 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 
 	arrange_container(container);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/client.c
+++ b/sway/commands/client.c
@@ -61,27 +61,27 @@ static struct cmd_results *handle_command(int argc, char **argv,
 	}
 
 	if (!parse_color_float(argv[0], class->border)) {
-		return cmd_results_new(CMD_INVALID, cmd_name,
+		return cmd_results_new(CMD_INVALID,
 				"Unable to parse border color '%s'", argv[0]);
 	}
 
 	if (!parse_color_float(argv[1], class->background)) {
-		return cmd_results_new(CMD_INVALID, cmd_name,
+		return cmd_results_new(CMD_INVALID,
 				"Unable to parse background color '%s'", argv[1]);
 	}
 
 	if (!parse_color_float(argv[2], class->text)) {
-		return cmd_results_new(CMD_INVALID, cmd_name,
+		return cmd_results_new(CMD_INVALID,
 				"Unable to parse text color '%s'", argv[2]);
 	}
 
 	if (!parse_color_float(argv[3], class->indicator)) {
-		return cmd_results_new(CMD_INVALID, cmd_name,
+		return cmd_results_new(CMD_INVALID,
 				"Unable to parse indicator color '%s'", argv[3]);
 	}
 
 	if (!parse_color_float(argv[4], class->child_border)) {
-		return cmd_results_new(CMD_INVALID, cmd_name,
+		return cmd_results_new(CMD_INVALID,
 				"Unable to parse child border color '%s'", argv[4]);
 	}
 
@@ -94,7 +94,7 @@ static struct cmd_results *handle_command(int argc, char **argv,
 		}
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_client_focused(int argc, char **argv) {
@@ -115,5 +115,5 @@ struct cmd_results *cmd_client_urgent(int argc, char **argv) {
 
 struct cmd_results *cmd_client_noop(int argc, char **argv) {
 	wlr_log(WLR_INFO, "Warning: %s is ignored by sway", argv[-1]);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/create_output.c
+++ b/sway/commands/create_output.c
@@ -37,9 +37,9 @@ struct cmd_results *cmd_create_output(int argc, char **argv) {
 	wlr_multi_for_each_backend(server.backend, create_output, &done);
 
 	if (!done) {
-		return cmd_results_new(CMD_INVALID, "create_output",
+		return cmd_results_new(CMD_INVALID,
 				"Can only create outputs for Wayland or X11 backends");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/default_border.c
+++ b/sway/commands/default_border.c
@@ -16,12 +16,12 @@ struct cmd_results *cmd_default_border(int argc, char **argv) {
 	} else if (strcmp(argv[0], "pixel") == 0) {
 		config->border = B_PIXEL;
 	} else {
-		return cmd_results_new(CMD_INVALID, "default_border",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'default_border <none|normal|pixel>' or 'default_border <normal|pixel> <px>'");
 	}
 	if (argc == 2) {
 		config->border_thickness = atoi(argv[1]);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/default_floating_border.c
+++ b/sway/commands/default_floating_border.c
@@ -17,7 +17,7 @@ struct cmd_results *cmd_default_floating_border(int argc, char **argv) {
 	} else if (strcmp(argv[0], "pixel") == 0) {
 		config->floating_border = B_PIXEL;
 	} else {
-		return cmd_results_new(CMD_INVALID, "default_floating_border",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'default_floating_border <none|normal|pixel>' "
 				"or 'default_floating_border <normal|pixel> <px>'");
 	}
@@ -25,5 +25,5 @@ struct cmd_results *cmd_default_floating_border(int argc, char **argv) {
 		config->floating_border_thickness = atoi(argv[1]);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/default_orientation.c
+++ b/sway/commands/default_orientation.c
@@ -14,8 +14,8 @@ struct cmd_results *cmd_default_orientation(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "auto") == 0) {
 		// Do nothing
 	} else {
-		return cmd_results_new(CMD_INVALID, "default_orientation",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'orientation <horizontal|vertical|auto>'");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -5,12 +5,12 @@
 #include "stringop.h"
 
 struct cmd_results *cmd_exec(int argc, char **argv) {
-	if (!config->active) return cmd_results_new(CMD_DEFER, "exec", NULL);
+	if (!config->active) return cmd_results_new(CMD_DEFER, NULL);
 	if (config->reloading) {
 		char *args = join_args(argv, argc);
 		wlr_log(WLR_DEBUG, "Ignoring 'exec %s' due to reload", args);
 		free(args);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 	return cmd_exec_always(argc, argv);
 }

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -15,7 +15,9 @@
 
 struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (!config->active || config->validating) return cmd_results_new(CMD_DEFER, NULL, NULL);
+	if (!config->active || config->validating) {
+		return cmd_results_new(CMD_DEFER, NULL);
+	}
 	if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
@@ -71,7 +73,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	} else if (pid < 0) {
 		close(fd[0]);
 		close(fd[1]);
-		return cmd_results_new(CMD_FAILURE, argv[-1], "fork() failed");
+		return cmd_results_new(CMD_FAILURE, "fork() failed");
 	}
 	close(fd[1]); // close write
 	ssize_t s = 0;
@@ -85,9 +87,8 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 		wlr_log(WLR_DEBUG, "Child process created with pid %d", child);
 		root_record_workspace_pid(child);
 	} else {
-		return cmd_results_new(CMD_FAILURE, argv[-1],
-			"Second fork() failed");
+		return cmd_results_new(CMD_FAILURE, "Second fork() failed");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/exit.c
+++ b/sway/commands/exit.c
@@ -10,5 +10,5 @@ struct cmd_results *cmd_exit(int argc, char **argv) {
 		return error;
 	}
 	sway_terminate(0);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -17,14 +17,13 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "floating",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 	if (!container && workspace->tiling->length == 0) {
-		return cmd_results_new(CMD_INVALID, "floating",
-				"Can't float an empty workspace");
+		return cmd_results_new(CMD_INVALID, "Can't float an empty workspace");
 	}
 	if (!container) {
 		// Wrap the workspace's children in a container so we can float it
@@ -48,5 +47,5 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 
 	arrange_workspace(container->workspace);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/floating_minmax_size.c
+++ b/sway/commands/floating_minmax_size.c
@@ -8,10 +8,10 @@
 #include "sway/commands.h"
 #include "log.h"
 
-static const char* min_usage =
+static const char min_usage[] =
 	"Expected 'floating_minimum_size <width> x <height>'";
 
-static const char* max_usage =
+static const char max_usage[] =
 	"Expected 'floating_maximum_size <width> x <height>'";
 
 static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
@@ -39,7 +39,7 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	*config_width = width;
 	*config_height = height;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_floating_minimum_size(int argc, char **argv) {

--- a/sway/commands/floating_modifier.c
+++ b/sway/commands/floating_modifier.c
@@ -11,8 +11,7 @@ struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 
 	uint32_t mod = get_modifier_mask_by_name(argv[0]);
 	if (!mod) {
-		return cmd_results_new(CMD_INVALID, "floating_modifier",
-				"Invalid modifier");
+		return cmd_results_new(CMD_INVALID, "Invalid modifier");
 	}
 
 	if (argc == 1 || strcasecmp(argv[1], "normal") == 0) {
@@ -20,11 +19,11 @@ struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 	} else if (strcasecmp(argv[1], "inverse") == 0) {
 		config->floating_mod_inverse = true;
 	} else {
-		return cmd_results_new(CMD_INVALID, "floating_modifier",
+		return cmd_results_new(CMD_INVALID,
 				"Usage: floating_modifier <mod> [inverse|normal]");
 	}
 
 	config->floating_mod = mod;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -179,17 +179,17 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 		seat_set_focus_container(seat, new_focus);
 		seat_consider_warp_to_focus(seat);
 	} else {
-		return cmd_results_new(CMD_FAILURE, "focus",
+		return cmd_results_new(CMD_FAILURE,
 				"Failed to find a %s container in workspace",
 				floating ? "floating" : "tiling");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *focus_output(struct sway_seat *seat,
 		int argc, char **argv) {
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "focus",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'focus output <direction|name>'");
 	}
 	char *identifier = join_args(argv, argc);
@@ -199,7 +199,7 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 		enum wlr_direction direction;
 		if (!parse_direction(identifier, &direction)) {
 			free(identifier);
-			return cmd_results_new(CMD_INVALID, "focus",
+			return cmd_results_new(CMD_INVALID,
 				"There is no output with that name");
 		}
 		struct sway_workspace *ws = seat_get_focused_workspace(seat);
@@ -223,21 +223,21 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 		seat_consider_warp_to_focus(seat);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *focus_parent(void) {
 	struct sway_seat *seat = config->handler_context.seat;
 	struct sway_container *con = config->handler_context.container;
 	if (!con || con->is_fullscreen) {
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 	struct sway_node *parent = node_get_parent(&con->node);
 	if (parent) {
 		seat_set_focus(seat, parent);
 		seat_consider_warp_to_focus(seat);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *focus_child(void) {
@@ -248,15 +248,15 @@ static struct cmd_results *focus_child(void) {
 		seat_set_focus(seat, focus);
 		seat_consider_warp_to_focus(seat);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_focus(int argc, char **argv) {
 	if (config->reading || !config->active) {
-		return cmd_results_new(CMD_DEFER, NULL, NULL);
+		return cmd_results_new(CMD_DEFER, NULL);
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "focus",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_node *node = config->handler_context.node;
@@ -264,7 +264,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	struct sway_workspace *workspace = config->handler_context.workspace;
 	struct sway_seat *seat = config->handler_context.seat;
 	if (node->type < N_WORKSPACE) {
-		return cmd_results_new(CMD_FAILURE, "focus",
+		return cmd_results_new(CMD_FAILURE,
 			"Command 'focus' cannot be used above the workspace level");
 	}
 
@@ -274,7 +274,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		}
 		seat_set_focus_container(seat, container);
 		seat_consider_warp_to_focus(seat);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	if (strcmp(argv[0], "floating") == 0) {
@@ -300,7 +300,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 
 	enum wlr_direction direction = 0;
 	if (!parse_direction(argv[0], &direction)) {
-		return cmd_results_new(CMD_INVALID, "focus",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'focus <direction|parent|child|mode_toggle|floating|tiling>' "
 			"or 'focus output <direction|name>'");
 	}
@@ -310,14 +310,14 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		struct sway_output *new_output =
 			output_get_in_direction(workspace->output, direction);
 		if (!new_output) {
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			return cmd_results_new(CMD_SUCCESS, NULL);
 		}
 
 		struct sway_node *node =
 			get_node_in_output_direction(new_output, direction);
 		seat_set_focus(seat, node);
 		seat_consider_warp_to_focus(seat);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	struct sway_node *next_focus =
@@ -327,5 +327,5 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		seat_consider_warp_to_focus(seat);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -14,8 +14,8 @@ struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
 	} else if(strcmp(argv[0], "always") == 0) {
 		config->focus_follows_mouse = FOLLOWS_ALWAYS;
 	} else {
-		return cmd_results_new(CMD_FAILURE, "focus_follows_mouse",
+		return cmd_results_new(CMD_FAILURE,
 				"Expected 'focus_follows_mouse no|yes|always'");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/focus_on_window_activation.c
+++ b/sway/commands/focus_on_window_activation.c
@@ -16,10 +16,10 @@ struct cmd_results *cmd_focus_on_window_activation(int argc, char **argv) {
 	} else if (strcmp(argv[0], "none") == 0) {
 		config->focus_on_window_activation = FOWA_NONE;
 	} else {
-		return cmd_results_new(CMD_INVALID, "focus_on_window_activation",
+		return cmd_results_new(CMD_INVALID,
 				"Expected "
 				"'focus_on_window_activation smart|urgent|focus|none'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/focus_wrapping.c
+++ b/sway/commands/focus_wrapping.c
@@ -17,5 +17,5 @@ struct cmd_results *cmd_focus_wrapping(int argc, char **argv) {
 		config->focus_wrapping = WRAP_NO;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/font.c
+++ b/sway/commands/font.c
@@ -23,5 +23,5 @@ struct cmd_results *cmd_font(int argc, char **argv) {
 
 	free(font);
 	config_update_font_height(true);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -14,7 +14,7 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, "for_window", err_str);
+		error = cmd_results_new(CMD_INVALID, err_str);
 		free(err_str);
 		return error;
 	}
@@ -25,5 +25,5 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 	list_add(config->criteria, criteria);
 	wlr_log(WLR_DEBUG, "for_window: '%s' -> '%s' added", criteria->raw, criteria->cmdlist);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/force_display_urgency_hint.c
+++ b/sway/commands/force_display_urgency_hint.c
@@ -12,12 +12,12 @@ struct cmd_results *cmd_force_display_urgency_hint(int argc, char **argv) {
 	int timeout = (int)strtol(argv[0], &err, 10);
 	if (*err) {
 		if (strcmp(err, "ms") != 0) {
-			return cmd_results_new(CMD_INVALID, "force_display_urgency_hint",
+			return cmd_results_new(CMD_INVALID,
 					"Expected 'force_display_urgency_hint <timeout> ms'");
 		}
 	}
 
 	config->urgent_timeout = timeout > 0 ? timeout : 0;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/force_focus_wrapping.c
+++ b/sway/commands/force_focus_wrapping.c
@@ -16,5 +16,5 @@ struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
 		config->focus_wrapping = WRAP_YES;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -13,14 +13,14 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_FAILURE, "fullscreen",
+		return cmd_results_new(CMD_FAILURE,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_node *node = config->handler_context.node;
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 	if (node->type == N_WORKSPACE && workspace->tiling->length == 0) {
-		return cmd_results_new(CMD_FAILURE, "fullscreen",
+		return cmd_results_new(CMD_FAILURE,
 				"Can't fullscreen an empty workspace");
 	}
 	if (node->type == N_WORKSPACE) {
@@ -38,5 +38,5 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	container_set_fullscreen(container, enable);
 	arrange_workspace(workspace);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -43,7 +43,7 @@ static void prevent_invalid_outer_gaps(void) {
 }
 
 // gaps inner|outer|horizontal|vertical|top|right|bottom|left <px>
-static const char *expected_defaults =
+static const char expected_defaults[] =
 	"'gaps inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
 static struct cmd_results *gaps_set_defaults(int argc, char **argv) {
 	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_EQUAL_TO, 2);
@@ -54,8 +54,7 @@ static struct cmd_results *gaps_set_defaults(int argc, char **argv) {
 	char *end;
 	int amount = strtol(argv[1], &end, 10);
 	if (strlen(end) && strcasecmp(end, "px") != 0) {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_defaults);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_defaults);
 	}
 
 	bool valid = false;
@@ -85,12 +84,11 @@ static struct cmd_results *gaps_set_defaults(int argc, char **argv) {
 		}
 	}
 	if (!valid) {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_defaults);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_defaults);
 	}
 
 	prevent_invalid_outer_gaps();
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static void apply_gaps_op(int *prop, enum gaps_op op, int amount) {
@@ -136,7 +134,7 @@ static void configure_gaps(struct sway_workspace *ws, void *_data) {
 
 // gaps inner|outer|horizontal|vertical|top|right|bottom|left current|all
 // set|plus|minus <px>
-static const char *expected_runtime = "'gaps inner|outer|horizontal|vertical|"
+static const char expected_runtime[] = "'gaps inner|outer|horizontal|vertical|"
 	"top|right|bottom|left current|all set|plus|minus <px>'";
 static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_EQUAL_TO, 4);
@@ -144,7 +142,7 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "gaps",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 
@@ -164,8 +162,7 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	}
 	if (!data.inner && !data.outer.top && !data.outer.right &&
 			!data.outer.bottom && !data.outer.left) {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_runtime);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_runtime);
 	}
 
 	bool all;
@@ -174,8 +171,7 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	} else if (strcasecmp(argv[1], "all") == 0) {
 		all = true;
 	} else {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_runtime);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_runtime);
 	}
 
 	if (strcasecmp(argv[2], "set") == 0) {
@@ -185,15 +181,13 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	} else if (strcasecmp(argv[2], "minus") == 0) {
 		data.operation = GAPS_OP_SUBTRACT;
 	} else {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_runtime);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_runtime);
 	}
 
 	char *end;
 	data.amount = strtol(argv[3], &end, 10);
 	if (strlen(end) && strcasecmp(end, "px") != 0) {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_runtime);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_runtime);
 	}
 
 	if (all) {
@@ -202,7 +196,7 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 		configure_gaps(config->handler_context.workspace, &data);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 // gaps inner|outer|<dir>|<side> <px> - sets defaults for workspaces
@@ -224,9 +218,8 @@ struct cmd_results *cmd_gaps(int argc, char **argv) {
 		return gaps_set_runtime(argc, argv);
 	}
 	if (config_loading) {
-		return cmd_results_new(CMD_INVALID, "gaps",
-				"Expected %s", expected_defaults);
+		return cmd_results_new(CMD_INVALID, "Expected %s", expected_defaults);
 	}
-	return cmd_results_new(CMD_INVALID, "gaps",
-			"Expected %s or %s", expected_runtime, expected_defaults);
+	return cmd_results_new(CMD_INVALID, "Expected %s or %s",
+			expected_runtime, expected_defaults);
 }

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -22,13 +22,12 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	} else if (strcmp(argv[0], "smart_no_gaps") == 0) {
 		config->hide_edge_borders = E_SMART_NO_GAPS;
 	} else {
-		return cmd_results_new(CMD_INVALID, "hide_edge_borders",
-				"Expected 'hide_edge_borders "
+		return cmd_results_new(CMD_INVALID, "Expected 'hide_edge_borders "
 				"<none|vertical|horizontal|both|smart|smart_no_gaps>'");
 	}
 	config->saved_edge_borders = config->hide_edge_borders;
 
 	arrange_root();
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/include.c
+++ b/sway/commands/include.c
@@ -9,9 +9,9 @@ struct cmd_results *cmd_include(int argc, char **argv) {
 
 	if (!load_include_configs(argv[0], config,
 				&config->swaynag_config_errors)) {
-		return cmd_results_new(CMD_INVALID, "include",
+		return cmd_results_new(CMD_INVALID,
 				"Failed to include sub configuration file: %s", argv[0]);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -49,7 +49,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 
 	config->handler_context.input_config = new_input_config(argv[0]);
 	if (!config->handler_context.input_config) {
-		return cmd_results_new(CMD_FAILURE, NULL, "Couldn't allocate config");
+		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}
 
 	struct cmd_results *res;
@@ -60,7 +60,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			res = config_subcommand(argv + 1, argc - 1,
 				input_config_handlers, sizeof(input_config_handlers));
 		} else {
-			res = cmd_results_new(CMD_FAILURE, "input",
+			res = cmd_results_new(CMD_FAILURE,
 				"Can only be used in config file.");
 		}
 	} else {

--- a/sway/commands/input/accel_profile.c
+++ b/sway/commands/input/accel_profile.c
@@ -11,8 +11,7 @@ struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "accel_profile",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcasecmp(argv[0], "adaptive") == 0) {
@@ -20,9 +19,9 @@ struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "flat") == 0) {
 		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
 	} else {
-		return cmd_results_new(CMD_INVALID, "accel_profile",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'accel_profile <adaptive|flat>'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/click_method.c
+++ b/sway/commands/input/click_method.c
@@ -12,8 +12,7 @@ struct cmd_results *input_cmd_click_method(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "click_method",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcasecmp(argv[0], "none") == 0) {
@@ -23,9 +22,9 @@ struct cmd_results *input_cmd_click_method(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "clickfinger") == 0) {
 		ic->click_method = LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER;
 	} else {
-		return cmd_results_new(CMD_INVALID, "click_method",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'click_method <none|button_areas|clickfinger'>");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/drag.c
+++ b/sway/commands/input/drag.c
@@ -12,8 +12,7 @@ struct cmd_results *input_cmd_drag(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"drag", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (parse_boolean(argv[0], true)) {
@@ -22,5 +21,5 @@ struct cmd_results *input_cmd_drag(int argc, char **argv) {
 		ic->drag = LIBINPUT_CONFIG_DRAG_DISABLED;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/drag_lock.c
+++ b/sway/commands/input/drag_lock.c
@@ -12,8 +12,7 @@ struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"drag_lock", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (parse_boolean(argv[0], true)) {
@@ -22,5 +21,5 @@ struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
 		ic->drag_lock = LIBINPUT_CONFIG_DRAG_LOCK_DISABLED;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/dwt.c
+++ b/sway/commands/input/dwt.c
@@ -12,7 +12,7 @@ struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "dwt", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (parse_boolean(argv[0], true)) {
@@ -21,5 +21,5 @@ struct cmd_results *input_cmd_dwt(int argc, char **argv) {
 		ic->dwt = LIBINPUT_CONFIG_DWT_DISABLED;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -71,8 +71,7 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "events",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcasecmp(argv[0], "enabled") == 0) {
@@ -83,7 +82,7 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 		ic->send_events =
 			LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
 	} else if (config->reading) {
-		return cmd_results_new(CMD_INVALID, "events",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'events <enabled|disabled|disabled_on_external_mouse>'");
 	} else if (strcasecmp(argv[0], "toggle") == 0) {
 		if (strcmp(ic->identifier, "*") == 0) {
@@ -97,10 +96,10 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 			toggle_send_events(ic);
 		}
 	} else {
-		return cmd_results_new(CMD_INVALID, "events",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'events <enabled|disabled|disabled_on_external_mouse|"
 			"toggle>'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -12,11 +12,10 @@ struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "left_handed",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->left_handed = parse_boolean(argv[0], true);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/map_from_region.c
+++ b/sway/commands/input/map_from_region.c
@@ -40,8 +40,7 @@ struct cmd_results *input_cmd_map_from_region(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "map_from_region",
-			"No input device defined");
+		return cmd_results_new(CMD_FAILURE, "No input device defined");
 	}
 
 	ic->mapped_from_region =
@@ -52,30 +51,27 @@ struct cmd_results *input_cmd_map_from_region(int argc, char **argv) {
 			&ic->mapped_from_region->y1, &mm1)) {
 		free(ic->mapped_from_region);
 		ic->mapped_from_region = NULL;
-		return cmd_results_new(CMD_FAILURE, "map_from_region",
-			"Invalid top-left coordinates");
+		return cmd_results_new(CMD_FAILURE, "Invalid top-left coordinates");
 	}
 	if (!parse_coords(argv[1], &ic->mapped_from_region->x2,
 			&ic->mapped_from_region->y2, &mm2)) {
 		free(ic->mapped_from_region);
 		ic->mapped_from_region = NULL;
-		return cmd_results_new(CMD_FAILURE, "map_from_region",
-			"Invalid bottom-right coordinates");
+		return cmd_results_new(CMD_FAILURE, "Invalid bottom-right coordinates");
 	}
 	if (ic->mapped_from_region->x1 > ic->mapped_from_region->x2 ||
 			ic->mapped_from_region->y1 > ic->mapped_from_region->y2) {
 		free(ic->mapped_from_region);
 		ic->mapped_from_region = NULL;
-		return cmd_results_new(CMD_FAILURE, "map_from_region",
-			"Invalid rectangle");
+		return cmd_results_new(CMD_FAILURE, "Invalid rectangle");
 	}
 	if (mm1 != mm2) {
 		free(ic->mapped_from_region);
 		ic->mapped_from_region = NULL;
-		return cmd_results_new(CMD_FAILURE, "map_from_region",
+		return cmd_results_new(CMD_FAILURE,
 			"Both coordinates must be in the same unit");
 	}
 	ic->mapped_from_region->mm = mm1;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/map_to_output.c
+++ b/sway/commands/input/map_to_output.c
@@ -13,11 +13,10 @@ struct cmd_results *input_cmd_map_to_output(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "map_to_output",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->mapped_to_output = strdup(argv[0]);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/middle_emulation.c
+++ b/sway/commands/input/middle_emulation.c
@@ -12,8 +12,7 @@ struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "middle_emulation",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (parse_boolean(argv[0], true)) {
@@ -22,5 +21,5 @@ struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
 		ic->middle_emulation = LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/natural_scroll.c
+++ b/sway/commands/input/natural_scroll.c
@@ -12,11 +12,10 @@ struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "natural_scoll",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->natural_scroll = parse_boolean(argv[0], true);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -13,19 +13,17 @@ struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"pointer_accel", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	float pointer_accel = parse_float(argv[0]);
 	if (isnan(pointer_accel)) {
-		return cmd_results_new(CMD_INVALID, "pointer_accel",
+		return cmd_results_new(CMD_INVALID,
 			"Invalid pointer accel; expected float.");
 	} if (pointer_accel < -1 || pointer_accel > 1) {
-		return cmd_results_new(CMD_INVALID, "pointer_accel",
-			"Input out of range [-1, 1]");
+		return cmd_results_new(CMD_INVALID, "Input out of range [-1, 1]");
 	}
 	ic->pointer_accel = pointer_accel;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/repeat_delay.c
+++ b/sway/commands/input/repeat_delay.c
@@ -11,16 +11,14 @@ struct cmd_results *input_cmd_repeat_delay(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"repeat_delay", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	int repeat_delay = atoi(argv[0]);
 	if (repeat_delay < 0) {
-		return cmd_results_new(CMD_INVALID, "repeat_delay",
-			"Repeat delay cannot be negative");
+		return cmd_results_new(CMD_INVALID, "Repeat delay cannot be negative");
 	}
 	ic->repeat_delay = repeat_delay;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/repeat_rate.c
+++ b/sway/commands/input/repeat_rate.c
@@ -11,16 +11,14 @@ struct cmd_results *input_cmd_repeat_rate(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"repeat_rate", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	int repeat_rate = atoi(argv[0]);
 	if (repeat_rate < 0) {
-		return cmd_results_new(CMD_INVALID, "repeat_rate",
-			"Repeat rate cannot be negative");
+		return cmd_results_new(CMD_INVALID, "Repeat rate cannot be negative");
 	}
 	ic->repeat_rate = repeat_rate;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -10,30 +10,28 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "scroll_button",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcmp(*argv, "disable") == 0) {
 		ic->scroll_button = 0;
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	char *message = NULL;
 	uint32_t button = get_mouse_button(*argv, &message);
 	if (message) {
-		error = cmd_results_new(CMD_INVALID, "scroll_button", message);
+		error = cmd_results_new(CMD_INVALID, message);
 		free(message);
 		return error;
 	} else if (button == SWAY_SCROLL_UP || button == SWAY_SCROLL_DOWN
 			|| button == SWAY_SCROLL_LEFT || button == SWAY_SCROLL_RIGHT) {
-		return cmd_results_new(CMD_INVALID, "scroll_button",
+		return cmd_results_new(CMD_INVALID,
 				"X11 axis buttons are not supported for scroll_button");
 	} else if (!button) {
-		return cmd_results_new(CMD_INVALID, "scroll_button",
-				"Unknown button %s", *argv);
+		return cmd_results_new(CMD_INVALID, "Unknown button %s", *argv);
 	}
 	ic->scroll_button = button;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/scroll_factor.c
+++ b/sway/commands/input/scroll_factor.c
@@ -14,19 +14,18 @@ struct cmd_results *input_cmd_scroll_factor(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE,
-			"scroll_factor", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	float scroll_factor = parse_float(argv[0]);
 	if (isnan(scroll_factor)) {
-		return cmd_results_new(CMD_INVALID, "scroll_factor",
+		return cmd_results_new(CMD_INVALID,
 			"Invalid scroll factor; expected float.");
 	} else if (scroll_factor < 0) {
-		return cmd_results_new(CMD_INVALID, "scroll_factor",
+		return cmd_results_new(CMD_INVALID,
 			"Scroll factor cannot be negative.");
 	}
 	ic->scroll_factor = scroll_factor;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/scroll_method.c
+++ b/sway/commands/input/scroll_method.c
@@ -11,8 +11,7 @@ struct cmd_results *input_cmd_scroll_method(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "scroll_method",
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcasecmp(argv[0], "none") == 0) {
@@ -24,9 +23,9 @@ struct cmd_results *input_cmd_scroll_method(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "on_button_down") == 0) {
 		ic->scroll_method = LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
 	} else {
-		return cmd_results_new(CMD_INVALID, "scroll_method",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'scroll_method <none|two_finger|edge|on_button_down>'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -13,7 +13,7 @@ struct cmd_results *input_cmd_tap(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "tap", "No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (parse_boolean(argv[0], true)) {
@@ -22,5 +22,5 @@ struct cmd_results *input_cmd_tap(int argc, char **argv) {
 		ic->tap = LIBINPUT_CONFIG_TAP_DISABLED;
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/tap_button_map.c
+++ b/sway/commands/input/tap_button_map.c
@@ -11,8 +11,7 @@ struct cmd_results *input_cmd_tap_button_map(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "tap_button_map",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	if (strcasecmp(argv[0], "lrm") == 0) {
@@ -20,9 +19,9 @@ struct cmd_results *input_cmd_tap_button_map(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "lmr") == 0) {
 		ic->tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LMR;
 	} else {
-		return cmd_results_new(CMD_INVALID, "tap_button_map",
+		return cmd_results_new(CMD_INVALID,
 			"Expected 'tap_button_map <lrm|lmr>'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_capslock.c
+++ b/sway/commands/input/xkb_capslock.c
@@ -12,11 +12,10 @@ struct cmd_results *input_cmd_xkb_capslock(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_capslock", 
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_capslock = parse_boolean(argv[0], false);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -11,13 +11,12 @@ struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_layout",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_layout = strdup(argv[0]);
 
 	wlr_log(WLR_DEBUG, "set-xkb_layout for config: %s layout: %s",
 			ic->identifier, ic->xkb_layout);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -11,13 +11,12 @@ struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_model",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_model = strdup(argv[0]);
 
 	wlr_log(WLR_DEBUG, "set-xkb_model for config: %s model: %s",
 			ic->identifier, ic->xkb_model);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_numlock.c
+++ b/sway/commands/input/xkb_numlock.c
@@ -12,11 +12,10 @@ struct cmd_results *input_cmd_xkb_numlock(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_numlock", 
-			"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_numlock = parse_boolean(argv[0], false);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -11,13 +11,12 @@ struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_options",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_options = strdup(argv[0]);
 
 	wlr_log(WLR_DEBUG, "set-xkb_options for config: %s options: %s",
 			ic->identifier, ic->xkb_options);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -11,13 +11,12 @@ struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_rules",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_rules = strdup(argv[0]);
 
 	wlr_log(WLR_DEBUG, "set-xkb_rules for config: %s rules: %s",
 			ic->identifier, ic->xkb_rules);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -11,13 +11,12 @@ struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
 	}
 	struct input_config *ic = config->handler_context.input_config;
 	if (!ic) {
-		return cmd_results_new(CMD_FAILURE, "xkb_variant",
-				"No input device defined.");
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
 	ic->xkb_variant = strdup(argv[0]);
 
 	wlr_log(WLR_DEBUG, "set-xkb_variant for config: %s variant: %s",
 			ic->identifier, ic->xkb_variant);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -15,7 +15,7 @@ static void close_container_iterator(struct sway_container *con, void *data) {
 
 struct cmd_results *cmd_kill(int argc, char **argv) {
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "kill",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_container *con = config->handler_context.container;
@@ -28,5 +28,5 @@ struct cmd_results *cmd_kill(int argc, char **argv) {
 		workspace_for_each_container(ws, close_container_iterator, NULL);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -20,7 +20,7 @@ static enum sway_container_layout parse_layout_string(char *s) {
 	return L_NONE;
 }
 
-static const char* expected_syntax =
+static const char expected_syntax[] =
 	"Expected 'layout default|tabbed|stacking|splitv|splith' or "
 	"'layout toggle [split|all]' or "
 	"'layout toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...'";
@@ -100,14 +100,14 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "layout",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_container *container = config->handler_context.container;
 	struct sway_workspace *workspace = config->handler_context.workspace;
 
 	if (container && container_is_floating(container)) {
-		return cmd_results_new(CMD_FAILURE, "layout",
+		return cmd_results_new(CMD_FAILURE,
 				"Unable to change layout of floating windows");
 	}
 
@@ -133,7 +133,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 				workspace->layout, workspace->prev_split_layout);
 	}
 	if (new_layout == L_NONE) {
-		return cmd_results_new(CMD_INVALID, "layout", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 	if (new_layout != old_layout) {
 		if (container) {
@@ -152,5 +152,5 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		arrange_workspace(workspace);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -20,8 +20,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	}
 	struct sway_container *container = config->handler_context.container;
 	if (!container) {
-		return cmd_results_new(CMD_INVALID, "mark",
-				"Only containers can have marks");
+		return cmd_results_new(CMD_INVALID, "Only containers can have marks");
 	}
 
 	bool add = false, toggle = false;
@@ -33,7 +32,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 		} else if (strcmp(*argv, "--toggle") == 0) {
 			toggle = true;
 		} else {
-			return cmd_results_new(CMD_INVALID, "mark",
+			return cmd_results_new(CMD_INVALID,
 					"Unrecognized argument '%s'", *argv);
 		}
 		++argv;
@@ -41,7 +40,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	}
 
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "mark",
+		return cmd_results_new(CMD_INVALID,
 				"Expected '[--add|--replace] [--toggle] <identifier>'");
 	}
 
@@ -65,5 +64,5 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 		view_execute_criteria(container->view);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -22,16 +22,14 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 	}
 
 	if (argc > 1 && !config->reading) {
-		return cmd_results_new(CMD_FAILURE,
-				"mode", "Can only be used in config file.");
+		return cmd_results_new(CMD_FAILURE, "Can only be used in config file");
 	}
 
 	bool pango = strcmp(*argv, "--pango_markup") == 0;
 	if (pango) {
 		argc--; argv++;
 		if (argc == 0) {
-			return cmd_results_new(CMD_FAILURE, "mode",
-					"Mode name is missing");
+			return cmd_results_new(CMD_FAILURE, "Mode name is missing");
 		}
 	}
 
@@ -50,8 +48,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 	if (!mode && argc > 1) {
 		mode = calloc(1, sizeof(struct sway_mode));
 		if (!mode) {
-			return cmd_results_new(CMD_FAILURE,
-					"mode", "Unable to allocate mode");
+			return cmd_results_new(CMD_FAILURE, "Unable to allocate mode");
 		}
 		mode->name = strdup(mode_name);
 		mode->keysym_bindings = create_list();
@@ -61,8 +58,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		list_add(config->modes, mode);
 	}
 	if (!mode) {
-		error = cmd_results_new(CMD_INVALID,
-				"mode", "Unknown mode `%s'", mode_name);
+		error = cmd_results_new(CMD_INVALID, "Unknown mode `%s'", mode_name);
 		return error;
 	}
 	if ((config->reading && argc > 1) || (!config->reading && argc == 1)) {
@@ -75,7 +71,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		// trigger IPC mode event
 		ipc_event_mode(config->current_mode->name,
 				config->current_mode->pango);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	// Create binding

--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -13,9 +13,9 @@ struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "none") == 0) {
 		config->mouse_warping = WARP_NO;
 	} else {
-		return cmd_results_new(CMD_FAILURE, "mouse_warping",
+		return cmd_results_new(CMD_FAILURE,
 				"Expected 'mouse_warping output|container|none'");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -21,7 +21,7 @@
 #include "log.h"
 #include "util.h"
 
-static const char *expected_syntax =
+static const char expected_syntax[] =
 	"Expected 'move <left|right|up|down> <[px] px>' or "
 	"'move [--no-auto-back-and-forth] <container|window> [to] workspace <name>' or "
 	"'move <container|window|workspace> [to] output <name|direction>' or "
@@ -378,7 +378,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	struct sway_container *container = config->handler_context.container;
 	if (node->type == N_WORKSPACE) {
 		if (workspace->tiling->length == 0) {
-			return cmd_results_new(CMD_FAILURE, "move",
+			return cmd_results_new(CMD_FAILURE,
 					"Can't move an empty workspace");
 		}
 		container = workspace_wrap_children(workspace);
@@ -388,21 +388,21 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
 		no_auto_back_and_forth = true;
 		if (--argc < 3) {
-			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+			return cmd_results_new(CMD_INVALID, expected_syntax);
 		}
 		++argv;
 	}
 	while (strcasecmp(argv[1], "--no-auto-back-and-forth") == 0) {
 		no_auto_back_and_forth = true;
 		if (--argc < 3) {
-			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+			return cmd_results_new(CMD_INVALID, expected_syntax);
 		}
 		argv++;
 	}
 
 	while (strcasecmp(argv[1], "to") == 0) {
 		if (--argc < 3) {
-			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+			return cmd_results_new(CMD_INVALID, expected_syntax);
 		}
 		argv++;
 	}
@@ -429,7 +429,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 				if (seat->prev_workspace_name) {
 					ws_name = strdup(seat->prev_workspace_name);
 				} else {
-					return cmd_results_new(CMD_FAILURE, "move",
+					return cmd_results_new(CMD_FAILURE,
 							"No workspace was previously active.");
 				}
 			}
@@ -437,11 +437,10 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 			if (strcasecmp(argv[2], "number") == 0) {
 				// move "container to workspace number x"
 				if (argc < 4) {
-					return cmd_results_new(CMD_INVALID, "move",
-							expected_syntax);
+					return cmd_results_new(CMD_INVALID, expected_syntax);
 				}
 				if (!isdigit(argv[3][0])) {
-					return cmd_results_new(CMD_INVALID, "move",
+					return cmd_results_new(CMD_INVALID,
 							"Invalid workspace number '%s'", argv[3]);
 				}
 				ws_name = join_args(argv + 3, argc - 3);
@@ -472,7 +471,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 					workspace_get_initial_output(ws_name);
 				if (old_output == new_output) {
 					free(ws_name);
-					return cmd_results_new(CMD_FAILURE, "move",
+					return cmd_results_new(CMD_FAILURE,
 							"Can't move sticky container to another workspace "
 							"on the same output");
 				}
@@ -486,24 +485,24 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 		struct sway_output *new_output = output_in_direction(argv[2],
 				old_output, container->x, container->y);
 		if (!new_output) {
-			return cmd_results_new(CMD_FAILURE, "move workspace",
+			return cmd_results_new(CMD_FAILURE,
 				"Can't find output with name/direction '%s'", argv[2]);
 		}
 		destination = seat_get_focus_inactive(seat, &new_output->node);
 	} else if (strcasecmp(argv[1], "mark") == 0) {
 		struct sway_container *dest_con = container_find_mark(argv[2]);
 		if (dest_con == NULL) {
-			return cmd_results_new(CMD_FAILURE, "move",
+			return cmd_results_new(CMD_FAILURE,
 					"Mark '%s' not found", argv[2]);
 		}
 		destination = &dest_con->node;
 	} else {
-		return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	if (container->is_sticky && old_output &&
 			node_has_ancestor(destination, &old_output->node)) {
-		return cmd_results_new(CMD_FAILURE, "move", "Can't move sticky "
+		return cmd_results_new(CMD_FAILURE, "Can't move sticky "
 				"container to another workspace on the same output");
 	}
 
@@ -569,7 +568,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	}
 	arrange_node(node_get_parent(destination));
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static void workspace_move_to_output(struct sway_workspace *workspace,
@@ -611,13 +610,13 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 
 	while (strcasecmp(argv[1], "to") == 0) {
 		if (--argc < 3) {
-			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+			return cmd_results_new(CMD_INVALID, expected_syntax);
 		}
 		++argv;
 	}
 
 	if (strcasecmp(argv[1], "output") != 0) {
-		return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	struct sway_workspace *workspace = config->handler_context.workspace;
@@ -627,7 +626,7 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 	struct sway_output *new_output = output_in_direction(argv[2],
 			old_output, center_x, center_y);
 	if (!new_output) {
-		return cmd_results_new(CMD_FAILURE, "move workspace",
+		return cmd_results_new(CMD_FAILURE,
 			"Can't find output with name/direction '%s'", argv[2]);
 	}
 	workspace_move_to_output(workspace, new_output);
@@ -635,7 +634,7 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 	arrange_output(old_output);
 	arrange_output(new_output);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *cmd_move_in_direction(
@@ -645,19 +644,18 @@ static struct cmd_results *cmd_move_in_direction(
 		char *inv;
 		move_amt = (int)strtol(argv[1], &inv, 10);
 		if (*inv != '\0' && strcasecmp(inv, "px") != 0) {
-			return cmd_results_new(CMD_FAILURE, "move",
-					"Invalid distance specified");
+			return cmd_results_new(CMD_FAILURE, "Invalid distance specified");
 		}
 	}
 
 	struct sway_container *container = config->handler_context.container;
 	if (!container) {
-		return cmd_results_new(CMD_FAILURE, "move",
+		return cmd_results_new(CMD_FAILURE,
 				"Cannot move workspaces in a direction");
 	}
 	if (container_is_floating(container)) {
 		if (container->is_fullscreen) {
-			return cmd_results_new(CMD_FAILURE, "move",
+			return cmd_results_new(CMD_FAILURE,
 					"Cannot move fullscreen floating container");
 		}
 		double lx = container->x;
@@ -677,13 +675,13 @@ static struct cmd_results *cmd_move_in_direction(
 			break;
 		}
 		container_floating_move_to(container, lx, ly);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 	struct sway_workspace *old_ws = container->workspace;
 
 	if (!container_move_in_direction(container, direction)) {
 		// Container didn't move
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	struct sway_workspace *new_ws = container->workspace;
@@ -708,10 +706,10 @@ static struct cmd_results *cmd_move_in_direction(
 	}
 	container_end_mouse_operation(container);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static const char *expected_position_syntax =
+static const char expected_position_syntax[] =
 	"Expected 'move [absolute] position <x> [px] <y> [px]' or "
 	"'move [absolute] position center' or "
 	"'move position cursor|mouse|pointer'";
@@ -719,12 +717,11 @@ static const char *expected_position_syntax =
 static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	struct sway_container *container = config->handler_context.container;
 	if (!container || !container_is_floating(container)) {
-		return cmd_results_new(CMD_FAILURE, "move",
-				"Only floating containers "
+		return cmd_results_new(CMD_FAILURE, "Only floating containers "
 				"can be moved to an absolute position");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_FAILURE, "move", expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}
 
 	bool absolute = false;
@@ -734,25 +731,25 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		++argv;
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_FAILURE, "move", expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}
 	if (strcmp(argv[0], "position") == 0) {
 		--argc;
 		++argv;
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_FAILURE, "move", expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}
 	if (strcmp(argv[0], "cursor") == 0 || strcmp(argv[0], "mouse") == 0 ||
 			strcmp(argv[0], "pointer") == 0) {
 		struct sway_seat *seat = config->handler_context.seat;
 		if (!seat->cursor) {
-			return cmd_results_new(CMD_FAILURE, "move", "No cursor device");
+			return cmd_results_new(CMD_FAILURE, "No cursor device");
 		}
 		double lx = seat->cursor->cursor->x - container->width / 2;
 		double ly = seat->cursor->cursor->y - container->height / 2;
 		container_floating_move_to(container, lx, ly);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	} else if (strcmp(argv[0], "center") == 0) {
 		double lx, ly;
 		if (absolute) {
@@ -764,19 +761,18 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 			ly = ws->y + (ws->height - container->height) / 2;
 		}
 		container_floating_move_to(container, lx, ly);
-		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
 	if (argc < 2) {
-		return cmd_results_new(CMD_FAILURE, "move", expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}
 
 	double lx, ly;
 	char *inv;
 	lx = (double)strtol(argv[0], &inv, 10);
 	if (*inv != '\0' && strcasecmp(inv, "px") != 0) {
-		return cmd_results_new(CMD_FAILURE, "move",
-				"Invalid position specified");
+		return cmd_results_new(CMD_FAILURE, "Invalid position specified");
 	}
 	if (strcmp(argv[1], "px") == 0) {
 		--argc;
@@ -784,14 +780,13 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	}
 
 	if (argc > 3) {
-		return cmd_results_new(CMD_FAILURE, "move", expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}
 
 	ly = (double)strtol(argv[1], &inv, 10);
 	if ((*inv != '\0' && strcasecmp(inv, "px") != 0) ||
 			(argc == 3 && strcmp(argv[2], "px") != 0)) {
-		return cmd_results_new(CMD_FAILURE, "move",
-				"Invalid position specified");
+		return cmd_results_new(CMD_FAILURE, "Invalid position specified");
 	}
 
 	if (!absolute) {
@@ -799,7 +794,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		ly += container->workspace->y;
 	}
 	container_floating_move_to(container, lx, ly);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 static struct cmd_results *cmd_move_to_scratchpad(void) {
@@ -807,7 +802,7 @@ static struct cmd_results *cmd_move_to_scratchpad(void) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (node->type == N_WORKSPACE && ws->tiling->length == 0) {
-		return cmd_results_new(CMD_INVALID, "move",
+		return cmd_results_new(CMD_INVALID,
 				"Can't move an empty workspace to the scratchpad");
 	}
 	if (node->type == N_WORKSPACE) {
@@ -825,11 +820,11 @@ static struct cmd_results *cmd_move_to_scratchpad(void) {
 	}
 
 	if (con->scratchpad) {
-		return cmd_results_new(CMD_INVALID, "move",
+		return cmd_results_new(CMD_INVALID,
 				"Container is already in the scratchpad");
 	}
 	root_scratchpad_add_container(con);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_move(int argc, char **argv) {
@@ -838,7 +833,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "move",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 
@@ -867,7 +862,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "absolute") == 0) {
 		return cmd_move_to_position(argc, argv);
 	} else {
-		return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/no_focus.c
+++ b/sway/commands/no_focus.c
@@ -13,7 +13,7 @@ struct cmd_results *cmd_no_focus(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, "no_focus", err_str);
+		error = cmd_results_new(CMD_INVALID, err_str);
 		free(err_str);
 		return error;
 	}
@@ -21,5 +21,5 @@ struct cmd_results *cmd_no_focus(int argc, char **argv) {
 	criteria->type = CT_NO_FOCUS;
 	list_add(config->criteria, criteria);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/nop.c
+++ b/sway/commands/nop.c
@@ -1,5 +1,5 @@
 #include "sway/commands.h"
 
 struct cmd_results *cmd_nop(int argc, char **argv) {
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -22,18 +22,18 @@ struct cmd_results *cmd_opacity(int argc, char **argv) {
 	struct sway_container *con = config->handler_context.container;
 
 	if (con == NULL) {
-		return cmd_results_new(CMD_FAILURE, "opacity", "No current container");
+		return cmd_results_new(CMD_FAILURE, "No current container");
 	}
 
 	float opacity = 0.0f;
 
 	if (!parse_opacity(argv[0], &opacity)) {
-		return cmd_results_new(CMD_INVALID, "opacity <value>",
+		return cmd_results_new(CMD_INVALID,
 				"Invalid value (expected 0..1): %s", argv[0]);
 	}
 
 	con->alpha = opacity;
 	container_damage_whole(con);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -43,7 +43,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 			error = config_subcommand(argv, argc, output_handlers,
 					sizeof(output_handlers));
 		} else {
-			error = cmd_results_new(CMD_INVALID, "output",
+			error = cmd_results_new(CMD_INVALID,
 				"Invalid output subcommand: %s.", *argv);
 		}
 
@@ -68,7 +68,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 		apply_output_config_to_outputs(output);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 
 fail:
 	config->handler_context.output_config = NULL;

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -20,14 +20,14 @@ static const char *bg_options[] = {
 
 struct cmd_results *output_cmd_background(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output",
+		return cmd_results_new(CMD_INVALID,
 			"Missing background file or color specification.");
 	}
 	if (argc < 2) {
-		return cmd_results_new(CMD_INVALID, "output",
+		return cmd_results_new(CMD_INVALID,
 			"Missing background scaling mode or `solid_color`.");
 	}
 
@@ -57,7 +57,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			}
 		}
 		if (!valid) {
-			return cmd_results_new(CMD_INVALID, "output",
+			return cmd_results_new(CMD_INVALID,
 				"Missing background scaling mode.");
 		}
 
@@ -70,7 +70,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			*ptr = '\\';
 		}
 		if (wordexp(src, &p, 0) != 0 || p.we_wordv[0] == NULL) {
-			struct cmd_results *cmd_res = cmd_results_new(CMD_INVALID, "output",
+			struct cmd_results *cmd_res = cmd_results_new(CMD_INVALID,
 				"Invalid syntax (%s)", src);
 			free(src);
 			wordfree(&p);
@@ -81,8 +81,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		wordfree(&p);
 		if (!src) {
 			wlr_log(WLR_ERROR, "Failed to duplicate string");
-			return cmd_results_new(CMD_FAILURE, "output",
-				"Unable to allocate resource");
+			return cmd_results_new(CMD_FAILURE, "Unable to allocate resource");
 		}
 
 		if (config->reading && *src != '/') {
@@ -92,7 +91,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			if (!conf) {
 				wlr_log(WLR_ERROR, "Failed to duplicate string");
 				free(src);
-				return cmd_results_new(CMD_FAILURE, "output",
+				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate resources");
 			}
 
@@ -103,7 +102,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 				free(rel_path);
 				free(conf);
 				wlr_log(WLR_ERROR, "Unable to allocate memory");
-				return cmd_results_new(CMD_FAILURE, "output",
+				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate resources");
 			}
 

--- a/sway/commands/output/disable.c
+++ b/sway/commands/output/disable.c
@@ -3,7 +3,7 @@
 
 struct cmd_results *output_cmd_disable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	config->handler_context.output_config->enabled = 0;
 

--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -4,10 +4,10 @@
 
 struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output", "Missing dpms argument.");
+		return cmd_results_new(CMD_INVALID, "Missing dpms argument.");
 	}
 
 	if (parse_boolean(argv[0], true)) {

--- a/sway/commands/output/enable.c
+++ b/sway/commands/output/enable.c
@@ -3,7 +3,7 @@
 
 struct cmd_results *output_cmd_enable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	config->handler_context.output_config->enabled = 1;
 

--- a/sway/commands/output/mode.c
+++ b/sway/commands/output/mode.c
@@ -4,10 +4,10 @@
 
 struct cmd_results *output_cmd_mode(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output", "Missing mode argument.");
+		return cmd_results_new(CMD_INVALID, "Missing mode argument.");
 	}
 
 	struct output_config *output = config->handler_context.output_config;
@@ -17,20 +17,18 @@ struct cmd_results *output_cmd_mode(int argc, char **argv) {
 	if (*end) {
 		// Format is 1234x4321
 		if (*end != 'x') {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid mode width.");
+			return cmd_results_new(CMD_INVALID, "Invalid mode width.");
 		}
 		++end;
 		output->height = strtol(end, &end, 10);
 		if (*end) {
 			if (*end != '@') {
-				return cmd_results_new(CMD_INVALID, "output",
-					"Invalid mode height.");
+				return cmd_results_new(CMD_INVALID, "Invalid mode height.");
 			}
 			++end;
 			output->refresh_rate = strtof(end, &end);
 			if (strcasecmp("Hz", end) != 0) {
-				return cmd_results_new(CMD_INVALID, "output",
+				return cmd_results_new(CMD_INVALID,
 					"Invalid mode refresh rate.");
 			}
 		}
@@ -38,13 +36,12 @@ struct cmd_results *output_cmd_mode(int argc, char **argv) {
 		// Format is 1234 4321
 		argc--; argv++;
 		if (!argc) {
-			return cmd_results_new(CMD_INVALID, "output",
+			return cmd_results_new(CMD_INVALID,
 				"Missing mode argument (height).");
 		}
 		output->height = strtol(*argv, &end, 10);
 		if (*end) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid mode height.");
+			return cmd_results_new(CMD_INVALID, "Invalid mode height.");
 		}
 	}
 

--- a/sway/commands/output/position.c
+++ b/sway/commands/output/position.c
@@ -4,11 +4,10 @@
 
 struct cmd_results *output_cmd_position(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Missing position argument.");
+		return cmd_results_new(CMD_INVALID, "Missing position argument.");
 	}
 
 	char *end;
@@ -16,26 +15,22 @@ struct cmd_results *output_cmd_position(int argc, char **argv) {
 	if (*end) {
 		// Format is 1234,4321
 		if (*end != ',') {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position x.");
+			return cmd_results_new(CMD_INVALID, "Invalid position x.");
 		}
 		++end;
 		config->handler_context.output_config->y = strtol(end, &end, 10);
 		if (*end) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position y.");
+			return cmd_results_new(CMD_INVALID, "Invalid position y.");
 		}
 	} else {
 		// Format is 1234 4321 (legacy)
 		argc--; argv++;
 		if (!argc) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Missing position argument (y).");
+			return cmd_results_new(CMD_INVALID, "Missing position argument (y).");
 		}
 		config->handler_context.output_config->y = strtol(*argv, &end, 10);
 		if (*end) {
-			return cmd_results_new(CMD_INVALID, "output",
-				"Invalid position y.");
+			return cmd_results_new(CMD_INVALID, "Invalid position y.");
 		}
 	}
 

--- a/sway/commands/output/scale.c
+++ b/sway/commands/output/scale.c
@@ -4,17 +4,16 @@
 
 struct cmd_results *output_cmd_scale(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Missing scale argument.");
+		return cmd_results_new(CMD_INVALID, "Missing scale argument.");
 	}
 
 	char *end;
 	config->handler_context.output_config->scale = strtof(*argv, &end);
 	if (*end) {
-		return cmd_results_new(CMD_INVALID, "output", "Invalid scale.");
+		return cmd_results_new(CMD_INVALID, "Invalid scale.");
 	}
 
 	config->handler_context.leftovers.argc = argc - 1;

--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -6,11 +6,10 @@
 
 struct cmd_results *output_cmd_transform(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "output", "Missing output config");
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Missing transform argument.");
+		return cmd_results_new(CMD_INVALID, "Missing transform argument.");
 	}
 	enum wl_output_transform transform;
 	if (strcmp(*argv, "normal") == 0) {
@@ -30,8 +29,7 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 	} else if (strcmp(*argv, "flipped-270") == 0) {
 		transform = WL_OUTPUT_TRANSFORM_FLIPPED_270;
 	} else {
-		return cmd_results_new(CMD_INVALID, "output",
-			"Invalid output transform.");
+		return cmd_results_new(CMD_INVALID, "Invalid output transform.");
 	}
 	struct output_config *output = config->handler_context.output_config;
 	config->handler_context.leftovers.argc = argc - 1;
@@ -42,12 +40,12 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 			return NULL;
 		}
 		if (strcmp(output->name, "*") == 0) {
-			return cmd_results_new(CMD_INVALID, "output",
+			return cmd_results_new(CMD_INVALID,
 				"Cannot apply relative transform to all outputs.");
 		}
 		struct sway_output *s_output = output_by_name_or_id(output->name);
 		if (s_output == NULL) {
-			return cmd_results_new(CMD_INVALID, "output",
+			return cmd_results_new(CMD_INVALID,
 				"Cannot apply relative transform to unknown output %s", output->name);
 		}
 		if (strcmp(argv[1], "anticlockwise") == 0) {

--- a/sway/commands/popup_during_fullscreen.c
+++ b/sway/commands/popup_during_fullscreen.c
@@ -16,10 +16,9 @@ struct cmd_results *cmd_popup_during_fullscreen(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "leave_fullscreen") == 0) {
 		config->popup_during_fullscreen = POPUP_LEAVE;
 	} else {
-		return cmd_results_new(CMD_INVALID, "popup_during_fullscreen",
-				"Expected "
+		return cmd_results_new(CMD_INVALID, "Expected "
 				"'popup_during_fullscreen smart|ignore|leave_fullscreen'");
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -56,13 +56,12 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 	}
 
 	if (!load_main_config(config->current_config_path, true, true)) {
-		return cmd_results_new(CMD_FAILURE, "reload",
-				"Error(s) reloading config.");
+		return cmd_results_new(CMD_FAILURE, "Error(s) reloading config.");
 	}
 
 	// The reload command frees a lot of stuff, so to avoid use-after-frees
 	// we schedule the reload to happen using an idle event.
 	wl_event_loop_add_idle(server.wl_event_loop, do_reload, NULL);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -10,7 +10,7 @@
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"
 
-static const char* expected_syntax =
+static const char expected_syntax[] =
 	"Expected 'rename workspace <old_name> to <new_name>' or "
 	"'rename workspace to <new_name>'";
 
@@ -20,11 +20,11 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "rename",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	if (strcasecmp(argv[0], "workspace") != 0) {
-		return cmd_results_new(CMD_INVALID, "rename", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	int argn = 1;
@@ -36,7 +36,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	} else if (strcasecmp(argv[1], "number") == 0) {
 		// 'rename workspace number x to new_name'
 		if (!isdigit(argv[2][0])) {
-			return cmd_results_new(CMD_INVALID, "rename",
+			return cmd_results_new(CMD_INVALID,
 					"Invalid workspace number '%s'", argv[2]);
 		}
 		workspace = workspace_by_number(argv[2]);
@@ -56,14 +56,14 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	}
 
 	if (!workspace) {
-		return cmd_results_new(CMD_INVALID, "rename",
+		return cmd_results_new(CMD_INVALID,
 				"There is no workspace with that name");
 	}
 
 	++argn; // move past "to"
 
 	if (argn >= argc) {
-		return cmd_results_new(CMD_INVALID, "rename", expected_syntax);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	char *new_name = join_args(argv + argn, argc - argn);
@@ -75,17 +75,16 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 			strcasecmp(new_name, "current") == 0 ||
 			strcasecmp(new_name, "number") == 0) {
 		free(new_name);
-		return cmd_results_new(CMD_INVALID, "rename",
+		return cmd_results_new(CMD_INVALID,
 				"Cannot use special workspace name '%s'", argv[argn]);
 	}
 	struct sway_workspace *tmp_workspace = workspace_by_name(new_name);
 	if (tmp_workspace) {
 		free(new_name);
 		if (tmp_workspace == workspace) {
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			return cmd_results_new(CMD_SUCCESS, NULL);
 		} else {
-			return cmd_results_new(CMD_INVALID, "rename",
-					"Workspace already exists");
+			return cmd_results_new(CMD_INVALID, "Workspace already exists");
 		}
 	}
 
@@ -96,5 +95,5 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	output_sort_workspaces(workspace->output);
 	ipc_event_workspace(NULL, workspace, "rename");
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -340,8 +340,7 @@ static struct cmd_results *resize_adjust_floating(uint32_t axis,
 		grow_x = -grow_width;
 	}
 	if (grow_x == 0 && grow_y == 0) {
-		return cmd_results_new(CMD_INVALID, "resize",
-				"Cannot resize any further");
+		return cmd_results_new(CMD_INVALID, "Cannot resize any further");
 	}
 	con->x += grow_x;
 	con->y += grow_y;
@@ -355,7 +354,7 @@ static struct cmd_results *resize_adjust_floating(uint32_t axis,
 
 	arrange_container(con);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 /**
@@ -382,10 +381,9 @@ static struct cmd_results *resize_adjust_tiled(uint32_t axis,
 	double old_height = current->height;
 	resize_tiled(current, amount->amount, axis);
 	if (current->width == old_width && current->height == old_height) {
-		return cmd_results_new(CMD_INVALID, "resize",
-				"Cannot resize any further");
+		return cmd_results_new(CMD_INVALID, "Cannot resize any further");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 /**
@@ -433,7 +431,7 @@ static struct cmd_results *resize_set_tiled(struct sway_container *con,
 		}
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 /**
@@ -491,7 +489,7 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 
 	arrange_container(con);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 /**
@@ -506,7 +504,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 	if ((error = checkarg(argc, "resize", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	const char *usage = "Expected 'resize set [width] <width> [px|ppt]' or "
+	const char usage[] = "Expected 'resize set [width] <width> [px|ppt]' or "
 		"'resize set height <height> [px|ppt]' or "
 		"'resize set [width] <width> [px|ppt] [height] <height> [px|ppt]'";
 
@@ -520,7 +518,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (width.unit == RESIZE_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, "resize set", usage);
+			return cmd_results_new(CMD_INVALID, usage);
 		}
 	}
 
@@ -534,7 +532,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (width.unit == RESIZE_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, "resize set", usage);
+			return cmd_results_new(CMD_INVALID, usage);
 		}
 	}
 
@@ -562,11 +560,11 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
  */
 static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		int multiplier) {
-	const char *usage = "Expected 'resize grow|shrink <direction> "
+	const char usage[] = "Expected 'resize grow|shrink <direction> "
 		"[<amount> px|ppt [or <amount> px|ppt]]'";
 	uint32_t axis = parse_resize_axis(*argv);
 	if (axis == WLR_EDGE_NONE) {
-		return cmd_results_new(CMD_INVALID, "resize", usage);
+		return cmd_results_new(CMD_INVALID, usage);
 	}
 	--argc; ++argv;
 
@@ -577,7 +575,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (first_amount.unit == RESIZE_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, "resize", usage);
+			return cmd_results_new(CMD_INVALID, usage);
 		}
 	} else {
 		first_amount.amount = 10;
@@ -587,7 +585,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 	// "or"
 	if (argc) {
 		if (strcmp(*argv, "or") != 0) {
-			return cmd_results_new(CMD_INVALID, "resize", usage);
+			return cmd_results_new(CMD_INVALID, usage);
 		}
 		--argc; ++argv;
 	}
@@ -599,7 +597,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (second_amount.unit == RESIZE_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, "resize", usage);
+			return cmd_results_new(CMD_INVALID, usage);
 		}
 	} else {
 		second_amount.unit = RESIZE_UNIT_INVALID;
@@ -621,7 +619,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		} else if (second_amount.unit == RESIZE_UNIT_DEFAULT) {
 			return resize_adjust_floating(axis, &second_amount);
 		} else {
-			return cmd_results_new(CMD_INVALID, "resize",
+			return cmd_results_new(CMD_INVALID,
 					"Floating containers cannot use ppt measurements");
 		}
 	}
@@ -642,12 +640,12 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 
 struct cmd_results *cmd_resize(int argc, char **argv) {
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "resize",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	struct sway_container *current = config->handler_context.container;
 	if (!current) {
-		return cmd_results_new(CMD_INVALID, "resize", "Cannot resize nothing");
+		return cmd_results_new(CMD_INVALID, "Cannot resize nothing");
 	}
 
 	struct cmd_results *error;
@@ -665,8 +663,8 @@ struct cmd_results *cmd_resize(int argc, char **argv) {
 		return cmd_resize_adjust(argc - 1, &argv[1], -1);
 	}
 
-	const char *usage = "Expected 'resize <shrink|grow> "
+	const char usage[] = "Expected 'resize <shrink|grow> "
 		"<width|height|up|down|left|right> [<amount>] [px|ppt]'";
 
-	return cmd_results_new(CMD_INVALID, "resize", usage);
+	return cmd_results_new(CMD_INVALID, usage);
 }

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -84,16 +84,14 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		return error;
 	}
 	if (strcmp(argv[0], "show") != 0) {
-		return cmd_results_new(CMD_INVALID, "scratchpad",
-				"Expected 'scratchpad show'");
+		return cmd_results_new(CMD_INVALID, "Expected 'scratchpad show'");
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "scratchpad",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	if (!root->scratchpad->length) {
-		return cmd_results_new(CMD_INVALID, "scratchpad",
-				"Scratchpad is empty");
+		return cmd_results_new(CMD_INVALID, "Scratchpad is empty");
 	}
 
 	if (config->handler_context.using_criteria) {
@@ -111,12 +109,12 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		// matches the criteria. If this container isn't in the scratchpad,
 		// we'll just silently return a success.
 		if (!con->scratchpad) {
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+			return cmd_results_new(CMD_SUCCESS, NULL);
 		}
 		scratchpad_toggle_container(con);
 	} else {
 		scratchpad_toggle_auto();
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -21,8 +21,7 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 
 	config->handler_context.seat_config = new_seat_config(argv[0]);
 	if (!config->handler_context.seat_config) {
-		return cmd_results_new(CMD_FAILURE, NULL,
-				"Couldn't allocate config");
+		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}
 
 	struct cmd_results *res = config_subcommand(argv + 1, argc - 1,
@@ -40,5 +39,5 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	}
 
 	config->handler_context.seat_config = NULL;
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -10,16 +10,16 @@ struct cmd_results *seat_cmd_attach(int argc, char **argv) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {
-		return cmd_results_new(CMD_FAILURE, "attach", "No seat defined");
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
 	}
 
 	struct seat_attachment_config *attachment = seat_attachment_config_new();
 	if (!attachment) {
-		return cmd_results_new(CMD_FAILURE, "attach",
+		return cmd_results_new(CMD_FAILURE,
 				"Failed to allocate seat attachment config");
 	}
 	attachment->identifier = strdup(argv[0]);
 	list_add(config->handler_context.seat_config->attachments, attachment);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/seat/fallback.c
+++ b/sway/commands/seat/fallback.c
@@ -8,11 +8,11 @@ struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {
-		return cmd_results_new(CMD_FAILURE, "fallback", "No seat defined");
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
 	}
 
 	config->handler_context.seat_config->fallback =
 		parse_boolean(argv[0], false);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/seat/hide_cursor.c
+++ b/sway/commands/seat/hide_cursor.c
@@ -11,19 +11,18 @@ struct cmd_results *seat_cmd_hide_cursor(int argc, char **argv) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {
-		return cmd_results_new(CMD_FAILURE, "hide_cursor", "No seat defined");
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
 	}
 
 	char *end;
 	int timeout = strtol(argv[0], &end, 10);
 	if (*end) {
-		return cmd_results_new(CMD_INVALID, "hide_cursor",
-				"Expected an integer timeout");
+		return cmd_results_new(CMD_INVALID, "Expected an integer timeout");
 	}
 	if (timeout < 100 && timeout != 0) {
 		timeout = 100;
 	}
 	config->handler_context.seat_config->hide_cursor_timeout = timeout;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -31,7 +31,7 @@ struct cmd_results *cmd_set(int argc, char **argv) {
 	}
 
 	if (argv[0][0] != '$') {
-		return cmd_results_new(CMD_INVALID, "set", "variable '%s' must start with $", argv[0]);
+		return cmd_results_new(CMD_INVALID, "variable '%s' must start with $", argv[0]);
 	}
 
 	struct sway_variable *var = NULL;
@@ -49,12 +49,12 @@ struct cmd_results *cmd_set(int argc, char **argv) {
 	} else {
 		var = malloc(sizeof(struct sway_variable));
 		if (!var) {
-			return cmd_results_new(CMD_FAILURE, "set", "Unable to allocate variable");
+			return cmd_results_new(CMD_FAILURE, "Unable to allocate variable");
 		}
 		var->name = strdup(argv[0]);
 		list_add(config->symbols, var);
 		list_qsort(config->symbols, compare_set_qsort);
 	}
 	var->value = join_args(argv + 1, argc - 1);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -31,5 +31,5 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 		output_damage_whole(output);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/smart_borders.c
+++ b/sway/commands/smart_borders.c
@@ -21,5 +21,5 @@ struct cmd_results *cmd_smart_borders(int argc, char **argv) {
 
 	arrange_root();
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/smart_gaps.c
+++ b/sway/commands/smart_gaps.c
@@ -19,5 +19,5 @@ struct cmd_results *cmd_smart_gaps(int argc, char **argv) {
 
 	arrange_root();
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -24,7 +24,7 @@ static struct cmd_results *do_split(int layout) {
 
 	arrange_workspace(ws);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_split(int argc, char **argv) {
@@ -33,7 +33,7 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "split",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 	if (strcasecmp(argv[0], "v") == 0 || strcasecmp(argv[0], "vertical") == 0) {
@@ -51,10 +51,10 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 			return do_split(L_VERT);
 		}
 	} else {
-		return cmd_results_new(CMD_FAILURE, "split",
+		return cmd_results_new(CMD_FAILURE,
 			"Invalid split command (expected either horizontal or vertical).");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
 struct cmd_results *cmd_splitv(int argc, char **argv) {

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -19,11 +19,11 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 	struct sway_container *container = config->handler_context.container;
 	
 	if (container == NULL) {
-		return cmd_results_new(CMD_FAILURE, "sticky", "No current container");
+		return cmd_results_new(CMD_FAILURE, "No current container");
 	};
 	
 	if (!container_is_floating(container)) {
-		return cmd_results_new(CMD_FAILURE, "sticky",
+		return cmd_results_new(CMD_FAILURE,
 			"Can't set sticky on a tiled container");
 	}
 
@@ -43,5 +43,5 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 		}
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -11,7 +11,7 @@
 #include "sway/tree/workspace.h"
 #include "stringop.h"
 
-static const char* EXPECTED_SYNTAX =
+static const char expected_syntax[] =
 	"Expected 'swap container with id|con_id|mark <arg>'";
 
 static void swap_places(struct sway_container *con1,
@@ -171,12 +171,12 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 		return error;
 	}
 	if (!root->outputs->length) {
-		return cmd_results_new(CMD_INVALID, "swap",
+		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
 	}
 
 	if (strcasecmp(argv[0], "container") || strcasecmp(argv[1], "with")) {
-		return cmd_results_new(CMD_INVALID, "swap", EXPECTED_SYNTAX);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	struct sway_container *current = config->handler_context.container;
@@ -195,21 +195,21 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 		other = root_find_container(test_mark, value);
 	} else {
 		free(value);
-		return cmd_results_new(CMD_INVALID, "swap", EXPECTED_SYNTAX);
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	if (!other) {
-		error = cmd_results_new(CMD_FAILURE, "swap",
+		error = cmd_results_new(CMD_FAILURE,
 				"Failed to find %s '%s'", argv[2], value);
 	} else if (!current) {
-		error = cmd_results_new(CMD_FAILURE, "swap",
+		error = cmd_results_new(CMD_FAILURE,
 				"Can only swap with containers and views");
 	} else if (container_has_ancestor(current, other)
 			|| container_has_ancestor(other, current)) {
-		error = cmd_results_new(CMD_FAILURE, "swap",
+		error = cmd_results_new(CMD_FAILURE,
 				"Cannot swap ancestor and descendant");
 	} else if (container_is_floating(current) || container_is_floating(other)) {
-		error = cmd_results_new(CMD_FAILURE, "swap",
+		error = cmd_results_new(CMD_FAILURE,
 				"Swapping with floating containers is not supported");
 	}
 
@@ -226,5 +226,5 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 		arrange_node(node_get_parent(&other->node));
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/swaybg_command.c
+++ b/sway/commands/swaybg_command.c
@@ -21,5 +21,5 @@ struct cmd_results *cmd_swaybg_command(int argc, char **argv) {
 		free(new_command);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/swaynag_command.c
+++ b/sway/commands/swaynag_command.c
@@ -21,5 +21,5 @@ struct cmd_results *cmd_swaynag_command(int argc, char **argv) {
 		free(new_command);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/tiling_drag.c
+++ b/sway/commands/tiling_drag.c
@@ -9,5 +9,5 @@ struct cmd_results *cmd_tiling_drag(int argc, char **argv) {
 
 	config->tiling_drag = parse_boolean(argv[0], config->tiling_drag);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/tiling_drag_threshold.c
+++ b/sway/commands/tiling_drag_threshold.c
@@ -12,11 +12,10 @@ struct cmd_results *cmd_tiling_drag_threshold(int argc, char **argv) {
 	char *inv;
 	int value = strtol(argv[0], &inv, 10);
 	if (*inv != '\0' || value < 0) {
-		return cmd_results_new(CMD_INVALID, "tiling_drag_threshold",
-			"Invalid threshold specified");
+		return cmd_results_new(CMD_INVALID, "Invalid threshold specified");
 	}
 
 	config->tiling_drag_threshold = value;
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/title_align.c
+++ b/sway/commands/title_align.c
@@ -17,7 +17,7 @@ struct cmd_results *cmd_title_align(int argc, char **argv) {
 	} else if (strcmp(argv[0], "right") == 0) {
 		config->title_align = ALIGN_RIGHT;
 	} else {
-		return cmd_results_new(CMD_INVALID, "title_align",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'title_align left|center|right'");
 	}
 
@@ -26,5 +26,5 @@ struct cmd_results *cmd_title_align(int argc, char **argv) {
 		output_damage_whole(output);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -13,7 +13,7 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	}
 	struct sway_container *container = config->handler_context.container;
 	if (!container || !container->view) {
-		return cmd_results_new(CMD_INVALID, "title_format",
+		return cmd_results_new(CMD_INVALID,
 				"Only views can have a title_format");
 	}
 	struct sway_view *view = container->view;
@@ -24,5 +24,5 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	view->title_format = format;
 	view_update_title(view, true);
 	config_update_font_height(true);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/titlebar_border_thickness.c
+++ b/sway/commands/titlebar_border_thickness.c
@@ -14,8 +14,7 @@ struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
 	char *inv;
 	int value = strtol(argv[0], &inv, 10);
 	if (*inv != '\0' || value < 0 || value > config->titlebar_v_padding) {
-		return cmd_results_new(CMD_FAILURE, "titlebar_border_thickness",
-			"Invalid size specified");
+		return cmd_results_new(CMD_FAILURE, "Invalid size specified");
 	}
 
 	config->titlebar_border_thickness = value;
@@ -26,5 +25,5 @@ struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
 		output_damage_whole(output);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/titlebar_padding.c
+++ b/sway/commands/titlebar_padding.c
@@ -14,8 +14,7 @@ struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
 	char *inv;
 	int h_value = strtol(argv[0], &inv, 10);
 	if (*inv != '\0' || h_value < 0 || h_value < config->titlebar_border_thickness) {
-		return cmd_results_new(CMD_FAILURE, "titlebar_padding",
-			"Invalid size specified");
+		return cmd_results_new(CMD_FAILURE, "Invalid size specified");
 	}
 
 	int v_value;
@@ -24,8 +23,7 @@ struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
 	} else {
 		v_value = strtol(argv[1], &inv, 10);
 		if (*inv != '\0' || v_value < 0 || v_value < config->titlebar_border_thickness) {
-			return cmd_results_new(CMD_FAILURE, "titlebar_padding",
-				"Invalid size specified");
+			return cmd_results_new(CMD_FAILURE, "Invalid size specified");
 		}
 	}
 
@@ -38,5 +36,5 @@ struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
 		output_damage_whole(output);
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -49,5 +49,5 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 	}
 	free(mark);
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/urgent.c
+++ b/sway/commands/urgent.c
@@ -13,11 +13,10 @@ struct cmd_results *cmd_urgent(int argc, char **argv) {
 	}
 	struct sway_container *container = config->handler_context.container;
 	if (!container) {
-		return cmd_results_new(CMD_FAILURE, "urgent", "No current container");
+		return cmd_results_new(CMD_FAILURE, "No current container");
 	}
 	if (!container->view) {
-		return cmd_results_new(CMD_INVALID, "urgent",
-				"Only views can be urgent");
+		return cmd_results_new(CMD_INVALID, "Only views can be urgent");
 	}
 	struct sway_view *view = container->view;
 
@@ -29,5 +28,5 @@ struct cmd_results *cmd_urgent(int argc, char **argv) {
 		view_set_urgent(view, parse_boolean(argv[0], view_is_urgent(view)));
 	}
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -58,7 +58,7 @@ static void prevent_invalid_outer_gaps(struct workspace_config *wsc) {
 
 static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 		int gaps_location) {
-	const char *expected = "Expected 'workspace <name> gaps "
+	const char expected[] = "Expected 'workspace <name> gaps "
 		"inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO,
@@ -69,7 +69,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	struct workspace_config *wsc = workspace_config_find_or_create(ws_name);
 	free(ws_name);
 	if (!wsc) {
-		return cmd_results_new(CMD_FAILURE, "workspace gaps",
+		return cmd_results_new(CMD_FAILURE,
 				"Unable to allocate workspace output");
 	}
 
@@ -77,7 +77,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	int amount = strtol(argv[gaps_location + 2], &end, 10);
 	if (strlen(end)) {
 		free(end);
-		return cmd_results_new(CMD_FAILURE, "workspace gaps", expected);
+		return cmd_results_new(CMD_FAILURE, expected);
 	}
 
 	bool valid = false;
@@ -108,7 +108,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 		}
 	}
 	if (!valid) {
-		return cmd_results_new(CMD_INVALID, "workspace gaps", expected);
+		return cmd_results_new(CMD_INVALID, expected);
 	}
 
 	// Prevent invalid gaps configurations.
@@ -150,7 +150,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		struct workspace_config *wsc = workspace_config_find_or_create(ws_name);
 		free(ws_name);
 		if (!wsc) {
-			return cmd_results_new(CMD_FAILURE, "workspace output",
+			return cmd_results_new(CMD_FAILURE,
 					"Unable to allocate workspace output");
 		}
 		for (int i = output_location + 1; i < argc; ++i) {
@@ -162,9 +162,9 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 	} else {
 		if (config->reading || !config->active) {
-			return cmd_results_new(CMD_DEFER, "workspace", NULL);
+			return cmd_results_new(CMD_DEFER, NULL);
 		} else if (!root->outputs->length) {
-			return cmd_results_new(CMD_INVALID, "workspace",
+			return cmd_results_new(CMD_INVALID,
 					"Can't run this command while there's no outputs connected.");
 		}
 
@@ -181,11 +181,11 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		struct sway_workspace *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
 			if (argc < 2) {
-				return cmd_results_new(CMD_INVALID, "workspace",
+				return cmd_results_new(CMD_INVALID,
 						"Expected workspace number");
 			}
 			if (!isdigit(argv[1][0])) {
-				return cmd_results_new(CMD_INVALID, "workspace",
+				return cmd_results_new(CMD_INVALID,
 						"Invalid workspace number '%s'", argv[1]);
 			}
 			if (!(ws = workspace_by_number(argv[1]))) {
@@ -202,7 +202,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
 			struct sway_seat *seat = config->handler_context.seat;
 			if (!seat->prev_workspace_name) {
-				return cmd_results_new(CMD_INVALID, "workspace",
+				return cmd_results_new(CMD_INVALID,
 						"There is no previous workspace");
 			}
 			if (!(ws = workspace_by_name(argv[0]))) {
@@ -218,5 +218,5 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		workspace_switch(ws, no_auto_back_and_forth);
 		seat_consider_warp_to_focus(config->handler_context.seat);
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/workspace_layout.c
+++ b/sway/commands/workspace_layout.c
@@ -14,8 +14,8 @@ struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "tabbed") == 0) {
 		config->default_layout = L_TABBED;
 	} else {
-		return cmd_results_new(CMD_INVALID, "workspace_layout",
+		return cmd_results_new(CMD_INVALID,
 				"Expected 'workspace_layout <default|stacking|tabbed>'");
 	}
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/ws_auto_back_and_forth.c
+++ b/sway/commands/ws_auto_back_and_forth.c
@@ -10,5 +10,5 @@ struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
 	}
 	config->auto_back_and_forth = 
 		parse_boolean(argv[0], config->auto_back_and_forth);
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -17,5 +17,5 @@ struct cmd_results *cmd_xwayland(int argc, char **argv) {
 		"sway hasn't been built with Xwayland support");
 #endif
 
-	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -710,11 +710,12 @@ bool read_config(FILE *file, struct sway_config *config,
 		config->current_config_line_number = line_number;
 		config->current_config_line = line;
 		struct cmd_results *res;
+		char *new_block = NULL;
 		if (block && strcmp(block, "<commands>") == 0) {
 			// Special case
 			res = config_commands_command(expanded);
 		} else {
-			res = config_command(expanded);
+			res = config_command(expanded, &new_block);
 		}
 		switch(res->status) {
 		case CMD_FAILURE:
@@ -740,9 +741,9 @@ bool read_config(FILE *file, struct sway_config *config,
 			break;
 
 		case CMD_BLOCK:
-			wlr_log(WLR_DEBUG, "Entering block '%s'", res->input);
-			list_insert(stack, 0, strdup(res->input));
-			if (strcmp(res->input, "bar") == 0) {
+			wlr_log(WLR_DEBUG, "Entering block '%s'", new_block);
+			list_insert(stack, 0, strdup(new_block));
+			if (strcmp(new_block, "bar") == 0) {
 				config->current_bar = NULL;
 			}
 			break;
@@ -764,6 +765,7 @@ bool read_config(FILE *file, struct sway_config *config,
 					sizeof(config->handler_context));
 		default:;
 		}
+		free(new_block);
 		free(expanded);
 		free_cmd_results(res);
 	}


### PR DESCRIPTION
Which "input" field?

    $ swaymsg -r bindsym ae

    [
      {
        "success": false,
        "parse_error": true,
        "error": "Invalid bindsym command (expected at least 2 arguments, got 1)",
        "input": "bindsym"
      }
    ]

Pro:
* Not in i3 protocol; nor used by `swaymsg` pretty-printed output; nor printed by config error messages; nor yet documented anywhere
* Code only provides it if `input` field of a given `struct cmd_results` is not NULL
* Information is redundant and imprecise: in config file, location of error already given; with IPC, return list already indicates which of the commands is responsible
* A very small step toward not relying on heap allocation success for command handler return values
* Net removal of code

Con:
* Backwards compatibility? (it is not in 0.15.2, at least)
* @ddevault wrote the code a year ago in d7d21bb0f895248cafefc3d12e4 and probably can explain why this is all a dumb idea

~If people are fine with this, I will add another commit removing the second "input" argument from `cmd_results_new`.~ Done.