### PR TITLE
swaylock: Add caps lock state to indicator

### DIFF
--- a/include/swaylock/swaylock.h
+++ b/include/swaylock/swaylock.h
@@ -22,6 +22,7 @@ enum auth_state {
 struct swaylock_colorset {
 	uint32_t input;
 	uint32_t cleared;
+	uint32_t caps_lock;
 	uint32_t verifying;
 	uint32_t wrong;
 };
@@ -30,6 +31,8 @@ struct swaylock_colors {
 	uint32_t background;
 	uint32_t bs_highlight;
 	uint32_t key_highlight;
+	uint32_t caps_lock_bs_highlight;
+	uint32_t caps_lock_key_highlight;
 	uint32_t separator;
 	struct swaylock_colorset inside;
 	struct swaylock_colorset line;
@@ -45,6 +48,8 @@ struct swaylock_args {
 	uint32_t thickness;
 	bool ignore_empty;
 	bool show_indicator;
+	bool show_caps_lock_text;
+	bool show_caps_lock_indicator;
 	bool daemonize;
 };
 

--- a/swaylock/swaylock.1.scd
+++ b/swaylock/swaylock.1.scd
@@ -44,6 +44,12 @@ Locks your Wayland session.
 	Display the given image, optionally only on the given output. Use -c to set
 	a background color.
 
+*-L, --disable-caps-lock-text*
+	Disable the Caps Lock Text.
+
+*-l, --indicator-caps-lock*
+	Show the current Caps Lock state also on the indicator.
+
 *-s, --scaling*
 	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_.
 
@@ -57,6 +63,12 @@ Locks your Wayland session.
 
 *--bs-hl-color* <rrggbb[aa]>
 	Sets the color of backspace highlight segments.
+
+*--caps-lock-bs-hl-color* <rrggbb[aa]>
+	Sets the color of backspace highlight segments when Caps Lock is active.
+
+*--caps-lock-bs-hl-color* <rrggbb[aa]>
+	Sets the color of the key press highlight segments when Caps Lock is active.
 
 *--font* <font>
 	Sets the font of the text inside the indicator.
@@ -75,6 +87,9 @@ Locks your Wayland session.
 *--inside-clear-color* <rrggbb[aa]>
 	Sets the color of the inside of the indicator when cleared.
 
+*--inside-caps-lock-color* <rrggbb[aa]>
+	Sets the color of the inside of the indicator when Caps Lock is active.
+
 *--inside-ver-color* <rrggbb[aa]>
 	Sets the color of the inside of the indicator when verifying.
 
@@ -91,6 +106,10 @@ Locks your Wayland session.
 *--line-clear-color* <rrggbb[aa]>
 	Sets the color of the lines that separate the inside and outside of the
 	indicator when cleared.
+
+*--line-caps-lock-color* <rrggbb[aa]>
+	Sets the color of the line between the inside and ring when Caps Lock
+	is active.
 
 *--line-ver-color* <rrggbb[aa]>
 	Sets the color of the lines that separate the inside and outside of the
@@ -114,6 +133,9 @@ Locks your Wayland session.
 *--ring-clear-color* <rrggbb[aa]>
 	Sets the color of the outside of the indicator when cleared.
 
+*--ring-caps-lock-color* <rrggbb[aa]>
+	Sets the color of the ring of the indicator when Caps Lock is active.
+
 *--ring-ver-color* <rrggbb[aa]>
 	Sets the color of the outside of the indicator when verifying.
 
@@ -128,6 +150,9 @@ Locks your Wayland session.
 
 *--text-clear-color* <rrggbb[aa]>
 	Sets the color of the text inside the indicator when cleared.
+
+*--text-caps-lock-color* <rrggbb[aa]>
+	Sets the color of the text when Caps Lock is active.
 
 *--text-ver-color* <rrggbb[aa]>
 	Sets the color of the text inside the indicator when verifying.


### PR DESCRIPTION
This implements customization for the indicator as proposed in #2788 with comments from #3367 in mind.
The default behaviour does not change exept for the caps lock text color.

@RedSoxFan Could you review this? Thank you :)