### PR TITLE
swaybar: adjustable status padding

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -198,6 +198,7 @@ sway_cmd bar_cmd_id;
 sway_cmd bar_cmd_position;
 sway_cmd bar_cmd_separator_symbol;
 sway_cmd bar_cmd_status_command;
+sway_cmd bar_cmd_status_padding;
 sway_cmd bar_cmd_pango_markup;
 sway_cmd bar_cmd_strip_workspace_numbers;
 sway_cmd bar_cmd_strip_workspace_name;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -198,6 +198,7 @@ sway_cmd bar_cmd_id;
 sway_cmd bar_cmd_position;
 sway_cmd bar_cmd_separator_symbol;
 sway_cmd bar_cmd_status_command;
+sway_cmd bar_cmd_status_edge_padding;
 sway_cmd bar_cmd_status_padding;
 sway_cmd bar_cmd_pango_markup;
 sway_cmd bar_cmd_strip_workspace_numbers;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -233,6 +233,7 @@ struct bar_config {
 	struct side_gaps gaps;
 	pid_t pid;
 	int status_padding;
+	int status_edge_padding;
 	struct {
 		char *background;
 		char *statusline;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -232,6 +232,7 @@ struct bar_config {
 	bool verbose;
 	struct side_gaps gaps;
 	pid_t pid;
+	int status_padding;
 	struct {
 		char *background;
 		char *statusline;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -44,6 +44,7 @@ struct swaybar_config {
 	bool all_outputs;
 	int height;
 	int status_padding;
+	int status_edge_padding;
 	struct {
 		int top;
 		int right;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -43,6 +43,7 @@ struct swaybar_config {
 	struct wl_list outputs; // config_output::link
 	bool all_outputs;
 	int height;
+	int status_padding;
 	struct {
 		int top;
 		int right;

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -23,6 +23,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "position", bar_cmd_position },
 	{ "separator_symbol", bar_cmd_separator_symbol },
 	{ "status_command", bar_cmd_status_command },
+	{ "status_edge_padding", bar_cmd_status_edge_padding },
 	{ "status_padding", bar_cmd_status_padding },
 	{ "strip_workspace_name", bar_cmd_strip_workspace_name },
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -23,6 +23,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "position", bar_cmd_position },
 	{ "separator_symbol", bar_cmd_separator_symbol },
 	{ "status_command", bar_cmd_status_command },
+	{ "status_padding", bar_cmd_status_padding },
 	{ "strip_workspace_name", bar_cmd_strip_workspace_name },
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
 	{ "tray_bindsym", bar_cmd_tray_bindsym },

--- a/sway/commands/bar/status_edge_padding.c
+++ b/sway/commands/bar/status_edge_padding.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <string.h>
+#include "sway/commands.h"
+#include "log.h"
+
+struct cmd_results *bar_cmd_status_edge_padding(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "status_edge_padding", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	char *end;
+	int padding = strtol(argv[0], &end, 10);
+	if (strlen(end) || padding < 0) {
+		return cmd_results_new(CMD_INVALID, "status_edge_padding",
+				"Padding must be a positive integer");
+	}
+	config->current_bar->status_edge_padding = padding;
+	wlr_log(WLR_DEBUG, "Status edge padding on bar %s: %d",
+			config->current_bar->id, config->current_bar->status_edge_padding);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/commands/bar/status_padding.c
+++ b/sway/commands/bar/status_padding.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <string.h>
+#include "sway/commands.h"
+#include "log.h"
+
+struct cmd_results *bar_cmd_status_padding(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "status_padding", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	char *end;
+	int padding = strtol(argv[0], &end, 10);
+	if (strlen(end) || padding < 0) {
+		return cmd_results_new(CMD_INVALID, "status_padding",
+				"Padding must be a positive integer");
+	}
+	config->current_bar->status_padding = padding;
+	wlr_log(WLR_DEBUG, "Status padding on bar %s: %d",
+			config->current_bar->id, config->current_bar->status_padding);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -107,6 +107,7 @@ struct bar_config *default_bar_config(void) {
 	bar->pid = 0;
 	bar->modifier = get_modifier_mask_by_name("Mod4");
 	bar->status_padding = 1;
+	bar->status_edge_padding = 3;
 	if (!(bar->mode = strdup("dock"))) {
 	       goto cleanup;
 	}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -106,6 +106,7 @@ struct bar_config *default_bar_config(void) {
 	bar->verbose = false;
 	bar->pid = 0;
 	bar->modifier = get_modifier_mask_by_name("Mod4");
+	bar->status_padding = 1;
 	if (!(bar->mode = strdup("dock"))) {
 	       goto cleanup;
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -662,6 +662,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 			json_object_new_int(bar->height));
 	json_object_object_add(json, "status_padding",
 			json_object_new_int(bar->status_padding));
+	json_object_object_add(json, "status_edge_padding",
+			json_object_new_int(bar->status_edge_padding));
 	json_object_object_add(json, "wrap_scroll",
 			json_object_new_boolean(bar->wrap_scroll));
 	json_object_object_add(json, "workspace_buttons",

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -660,6 +660,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	}
 	json_object_object_add(json, "bar_height",
 			json_object_new_int(bar->height));
+	json_object_object_add(json, "status_padding",
+			json_object_new_int(bar->status_padding));
 	json_object_object_add(json, "wrap_scroll",
 			json_object_new_boolean(bar->wrap_scroll));
 	json_object_object_add(json, "workspace_buttons",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -116,6 +116,7 @@ sway_sources = files(
 	'commands/bar/position.c',
 	'commands/bar/separator_symbol.c',
 	'commands/bar/status_command.c',
+	'commands/bar/status_edge_padding.c',
 	'commands/bar/status_padding.c',
 	'commands/bar/strip_workspace_numbers.c',
 	'commands/bar/strip_workspace_name.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -116,6 +116,7 @@ sway_sources = files(
 	'commands/bar/position.c',
 	'commands/bar/separator_symbol.c',
 	'commands/bar/status_command.c',
+	'commands/bar/status_padding.c',
 	'commands/bar/strip_workspace_numbers.c',
 	'commands/bar/strip_workspace_name.c',
 	'commands/bar/swaybar_command.c',

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -92,6 +92,11 @@ Sway allows configuring swaybar in the sway configuration file.
 *modifier* <Modifier>|none
 	Specifies the modifier key that shows a hidden bar. Default is _Mod4_.
 
+*status\_padding* <padding>
+	Sets the vertical padding that is used for the status line. The default is
+	_1_. If _padding_ is _0_, blocks will be able to take up the full height of
+	the bar. This value will be multiplied by the output scale.
+
 ## TRAY
 
 Swaybar provides a system tray where third-party applications may place icons.

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -97,6 +97,11 @@ Sway allows configuring swaybar in the sway configuration file.
 	_1_. If _padding_ is _0_, blocks will be able to take up the full height of
 	the bar. This value will be multiplied by the output scale.
 
+*status\_edge\_padding* <padding>
+	Sets the padding that is used when the status line is at the right edge of
+	the bar. This value will be multiplied by the output scale. The default is
+	_3_.
+
 ## TRAY
 
 Swaybar provides a system tray where third-party applications may place icons.

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -37,6 +37,7 @@ struct swaybar_config *init_config(void) {
 	config->workspace_buttons = true;
 	config->bindings = create_list();
 	wl_list_init(&config->outputs);
+	config->status_padding = 1;
 
 	/* height */
 	config->height = 0;

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -38,6 +38,7 @@ struct swaybar_config *init_config(void) {
 	config->bindings = create_list();
 	wl_list_init(&config->outputs);
 	config->status_padding = 1;
+	config->status_edge_padding = 3;
 
 	/* height */
 	config->height = 0;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -157,7 +157,7 @@ static bool ipc_parse_config(
 	json_object *font, *gaps, *bar_height, *wrap_scroll, *workspace_buttons;
 	json_object *strip_workspace_numbers, *strip_workspace_name;
 	json_object *binding_mode_indicator, *verbose, *colors, *sep_symbol;
-	json_object *outputs, *bindings;
+	json_object *outputs, *bindings, *status_padding;
 	json_object_object_get_ex(bar_config, "mode", &mode);
 	json_object_object_get_ex(bar_config, "hidden_state", &hidden_state);
 	json_object_object_get_ex(bar_config, "position", &position);
@@ -176,6 +176,7 @@ static bool ipc_parse_config(
 	json_object_object_get_ex(bar_config, "outputs", &outputs);
 	json_object_object_get_ex(bar_config, "pango_markup", &markup);
 	json_object_object_get_ex(bar_config, "bindings", &bindings);
+	json_object_object_get_ex(bar_config, "status_padding", &status_padding);
 	if (status_command) {
 		free(config->status_command);
 		config->status_command = strdup(json_object_get_string(status_command));
@@ -208,6 +209,9 @@ static bool ipc_parse_config(
 	}
 	if (bar_height) {
 		config->height = json_object_get_int(bar_height);
+	}
+	if (status_padding) {
+		config->status_padding = json_object_get_int(status_padding);
 	}
 	if (gaps) {
 		json_object *top = json_object_object_get(gaps, "top");

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -157,7 +157,7 @@ static bool ipc_parse_config(
 	json_object *font, *gaps, *bar_height, *wrap_scroll, *workspace_buttons;
 	json_object *strip_workspace_numbers, *strip_workspace_name;
 	json_object *binding_mode_indicator, *verbose, *colors, *sep_symbol;
-	json_object *outputs, *bindings, *status_padding;
+	json_object *outputs, *bindings, *status_padding, *status_edge_padding;
 	json_object_object_get_ex(bar_config, "mode", &mode);
 	json_object_object_get_ex(bar_config, "hidden_state", &hidden_state);
 	json_object_object_get_ex(bar_config, "position", &position);
@@ -177,6 +177,8 @@ static bool ipc_parse_config(
 	json_object_object_get_ex(bar_config, "pango_markup", &markup);
 	json_object_object_get_ex(bar_config, "bindings", &bindings);
 	json_object_object_get_ex(bar_config, "status_padding", &status_padding);
+	json_object_object_get_ex(bar_config, "status_edge_padding",
+			&status_edge_padding);
 	if (status_command) {
 		free(config->status_command);
 		config->status_command = strdup(json_object_get_string(status_command));
@@ -212,6 +214,9 @@ static bool ipc_parse_config(
 	}
 	if (status_padding) {
 		config->status_padding = json_object_get_int(status_padding);
+	}
+	if (status_edge_padding) {
+		config->status_edge_padding = json_object_get_int(status_edge_padding);
 	}
 	if (gaps) {
 		json_object *top = json_object_object_get(gaps, "top");

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -35,7 +35,8 @@ static uint32_t render_status_line_error(cairo_t *cairo,
 	cairo_set_source_u32(cairo, 0xFF0000FF);
 
 	int margin = 3 * output->scale;
-	int ws_vertical_padding = WS_VERTICAL_PADDING * output->scale;
+	double ws_vertical_padding =
+		output->bar->config->status_padding * output->scale;
 
 	char *font = output->bar->config->font;
 	int text_width, text_height;
@@ -71,7 +72,7 @@ static uint32_t render_status_line_text(cairo_t *cairo,
 	get_text_size(cairo, config->font, &text_width, &text_height, NULL,
 			output->scale, config->pango_markup, "%s", text);
 
-	int ws_vertical_padding = WS_VERTICAL_PADDING * output->scale;
+	double ws_vertical_padding = config->status_padding * output->scale;
 	int margin = 3 * output->scale;
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2;
@@ -153,7 +154,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 			output->scale, block->markup, "%s", block->full_text);
 
 	int margin = 3 * output->scale;
-	double ws_vertical_padding = WS_VERTICAL_PADDING * 2 * output->scale;
+	double ws_vertical_padding = config->status_padding * output->scale;
 
 	int width = text_width;
 	if (width < block->min_width) {
@@ -212,8 +213,8 @@ static uint32_t render_status_block(cairo_t *cairo,
 	}
 
 	double x_pos = *x;
-	double y_pos = WS_VERTICAL_PADDING * output->scale;
-	double render_height = height - ws_vertical_padding + output->scale;
+	double y_pos = ws_vertical_padding;
+	double render_height = height - ws_vertical_padding * 2;
 
 	uint32_t bg_color = block->urgent
 		? config->colors.urgent_workspace.background : block->background;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -194,8 +194,8 @@ static uint32_t render_status_block(cairo_t *cairo,
 			}
 		}
 		*x -= sep_block_width;
-	} else {
-		*x -= margin;
+	} else if (config->status_edge_padding) {
+		*x -= config->status_edge_padding * output->scale;
 	}
 
 	uint32_t height = output->height * output->scale;
@@ -287,7 +287,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 static uint32_t render_status_line_i3bar(cairo_t *cairo,
 		struct swaybar_output *output, double *x) {
 	uint32_t max_height = 0;
-	bool edge = true;
+	bool edge = *x == output->width * output->scale;
 	struct i3bar_block *block;
 	wl_list_for_each(block, &output->bar->status->blocks, link) {
 		uint32_t h = render_status_block(cairo, output, block, x, edge);


### PR DESCRIPTION
Closes #3329 
Related to #3394

Adds the bar subcommand `status_padding <padding>` which allows setting
the padding used for swaybar. If `status_padding` is set to `0`, blocks
will be able to take up the full height of the bar.

Adds the bar subcommand `status_edge_padding <padding>` to set the
padding used when the status line is on the right edge of the bar.