### PR TITLE
config: do not reset pos when braces found

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -613,7 +613,9 @@ static int detect_brace(FILE *file) {
 		}
 	}
 	free(line);
-	fseek(file, pos, SEEK_SET);
+	if (ret == 0) {
+		fseek(file, pos, SEEK_SET);
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Fixes #3410 

When a brace is found, the config file should not seek back to before
the brace, otherwise the brace will be read multiple times.