### PR TITLE
swaybar: allow identifiers for output and tray

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -61,6 +61,7 @@ struct swaybar_output {
 	struct wl_list hotspots; // swaybar_hotspot::link
 
 	char *name;
+	char *identifier;
 	bool focused;
 
 	uint32_t width, height;

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -101,13 +101,17 @@ void tray_in(int fd, short mask, void *data) {
 }
 
 static int cmp_output(const void *item, const void *cmp_to) {
-	return strcmp(item, cmp_to);
+	const struct swaybar_output *output = cmp_to;
+	if (output->identifier && strcmp(item, output->identifier) == 0) {
+		return 0;
+	}
+	return strcmp(item, output->name);
 }
 
 uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 	struct swaybar_config *config = output->bar->config;
 	if (config->tray_outputs) {
-		if (list_seq_find(config->tray_outputs, cmp_output, output->name) == -1) {
+		if (list_seq_find(config->tray_outputs, cmp_output, output) == -1) {
 			return 0;
 		}
 	} // else display on all


### PR DESCRIPTION
Closes #3414

This allows `bar output` and `bar tray_output` to specify an output
identifier. Output names should still work as well.

This parses the output identifier from the xdg_output description,
which wlroots currently sets to `make model serial (name)`. Since this
could change in the future, all identifier comparisons are guarded by
NULL-checks in case the description cannot be parsed to an identifier.