### PR TITLE
Implement fullscreen global

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -25,6 +25,12 @@ enum sway_container_border {
 	B_CSD,
 };
 
+enum sway_fullscreen_mode {
+	FULLSCREEN_NONE,
+	FULLSCREEN_WORKSPACE,
+	FULLSCREEN_GLOBAL,
+};
+
 struct sway_root;
 struct sway_output;
 struct sway_workspace;
@@ -38,7 +44,7 @@ struct sway_container_state {
 	double x, y;
 	double width, height;
 
-	bool is_fullscreen;
+	enum sway_fullscreen_mode fullscreen_mode;
 
 	struct sway_workspace *workspace;
 	struct sway_container *parent;
@@ -85,7 +91,7 @@ struct sway_container {
 	double content_x, content_y;
 	int content_width, content_height;
 
-	bool is_fullscreen;
+	enum sway_fullscreen_mode fullscreen_mode;
 
 	enum sway_container_border border;
 
@@ -249,7 +255,13 @@ bool container_has_urgent_child(struct sway_container *container);
  */
 void container_end_mouse_operation(struct sway_container *container);
 
-void container_set_fullscreen(struct sway_container *container, bool enable);
+void container_set_fullscreen(struct sway_container *con,
+		enum sway_fullscreen_mode mode);
+
+/**
+ * Convenience function.
+ */
+void container_fullscreen_disable(struct sway_container *con);
 
 /**
  * Return true if the container is floating, or a child of a floating split

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -35,6 +35,8 @@ struct sway_root {
 	// For when there's no connected outputs
 	struct sway_output *noop_output;
 
+	struct sway_container *fullscreen_global;
+
 	struct {
 		struct wl_signal new_node;
 	} events;

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -26,7 +26,11 @@ static struct cmd_results *do_split(int layout) {
 		container_flatten(con->parent->parent);
 	}
 
-	arrange_workspace(ws);
+	if (root->fullscreen_global) {
+		arrange_root();
+	} else {
+		arrange_workspace(ws);
+	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -168,6 +168,11 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 					"Can't run this command while there's no outputs connected.");
 		}
 
+		if (root->fullscreen_global) {
+			return cmd_results_new(CMD_FAILURE, "workspace",
+				"Can't switch workspaces while fullscreen global");
+		}
+
 		bool no_auto_back_and_forth = false;
 		while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
 			no_auto_back_and_forth = true;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -251,17 +251,27 @@ static void output_for_each_surface(struct sway_output *output,
 	};
 
 	struct sway_workspace *workspace = output_get_active_workspace(output);
-	if (workspace->current.fullscreen) {
-		for_each_surface_container_iterator(
-			workspace->current.fullscreen, &data);
-		container_for_each_child(workspace->current.fullscreen,
+	struct sway_container *fullscreen_con = root->fullscreen_global;
+	if (fullscreen_con && fullscreen_con->scratchpad &&
+			!fullscreen_con->workspace) {
+		fullscreen_con = NULL;
+	}
+	if (!fullscreen_con) {
+		fullscreen_con = workspace->current.fullscreen;
+	}
+	if (fullscreen_con) {
+		for_each_surface_container_iterator(fullscreen_con, &data);
+		container_for_each_child(fullscreen_con,
 			for_each_surface_container_iterator, &data);
-		for (int i = 0; i < workspace->current.floating->length; ++i) {
-			struct sway_container *floater =
-				workspace->current.floating->items[i];
-			if (container_is_transient_for(floater,
-					workspace->current.fullscreen)) {
-				for_each_surface_container_iterator(floater, &data);
+
+		// TODO: Show transient containers for fullscreen global
+		if (fullscreen_con == workspace->current.fullscreen) {
+			for (int i = 0; i < workspace->current.floating->length; ++i) {
+				struct sway_container *floater =
+					workspace->current.floating->items[i];
+				if (container_is_transient_for(floater, fullscreen_con)) {
+					for_each_surface_container_iterator(floater, &data);
+				}
 			}
 		}
 #if HAVE_XWAYLAND

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -985,7 +985,15 @@ void output_render(struct sway_output *output, struct timespec *when,
 		goto render_overlay;
 	}
 
-	struct sway_container *fullscreen_con = workspace->current.fullscreen;
+	struct sway_container *fullscreen_con = root->fullscreen_global;
+	if (fullscreen_con && fullscreen_con->scratchpad &&
+			!fullscreen_con->workspace) {
+		fullscreen_con = NULL;
+	}
+	if (!fullscreen_con) {
+		fullscreen_con = workspace->current.fullscreen;
+	}
+
 	if (fullscreen_con) {
 		float clear_color[] = {0.0f, 0.0f, 0.0f, 1.0f};
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -134,7 +134,7 @@ static void copy_container_state(struct sway_container *container,
 	state->y = container->y;
 	state->width = container->width;
 	state->height = container->height;
-	state->is_fullscreen = container->is_fullscreen;
+	state->fullscreen_mode = container->fullscreen_mode;
 	state->parent = container->parent;
 	state->workspace = container->workspace;
 	state->border = container->border;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -349,7 +349,7 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 
 	container_set_fullscreen(view->container, e->fullscreen);
 
-	arrange_workspace(view->container->workspace);
+	arrange_root();
 	transaction_commit_dirty();
 }
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -342,7 +342,7 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 
 	container_set_fullscreen(view->container, e->fullscreen);
 
-	arrange_workspace(view->container->workspace);
+	arrange_root();
 	transaction_commit_dirty();
 }
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -453,7 +453,7 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 	}
 	container_set_fullscreen(view->container, xsurface->fullscreen);
 
-	arrange_workspace(view->container->workspace);
+	arrange_root();
 	transaction_commit_dirty();
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -90,6 +90,16 @@ struct sway_node *node_at_coords(
 	double ox = lx, oy = ly;
 	wlr_output_layout_output_coords(root->output_layout, wlr_output, &ox, &oy);
 
+	if (root->fullscreen_global) {
+		// Try fullscreen container
+		struct sway_container *con = tiling_container_at(
+				&root->fullscreen_global->node, lx, ly, surface, sx, sy);
+		if (con) {
+			return &con->node;
+		}
+		return NULL;
+	}
+
 	// find the focused workspace on the output for this seat
 	struct sway_workspace *ws = output_get_active_workspace(output);
 
@@ -659,7 +669,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle moving a tiling container
 	if (config->tiling_drag && (mod_pressed || on_titlebar) &&
 			state == WLR_BUTTON_PRESSED && !is_floating_or_child &&
-			cont && !cont->is_fullscreen) {
+			cont && cont->fullscreen_mode == FULLSCREEN_NONE) {
 		struct sway_container *focus = seat_get_focused_container(seat);
 		bool focused = focus == cont || container_has_ancestor(focus, cont);
 		if (on_titlebar && !focused) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -753,6 +753,18 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 			return;
 		}
 	}
+	// Deny setting focus to a workspace node when using fullscreen global
+	if (root->fullscreen_global && !container && new_workspace) {
+		return;
+	}
+	// Deny setting focus to a view which is hidden by a fullscreen global
+	if (root->fullscreen_global && container != root->fullscreen_global &&
+				!container_has_ancestor(container, root->fullscreen_global)) {
+		// Unless it's a transient container
+		if (!container_is_transient_for(container, root->fullscreen_global)) {
+			return;
+		}
+	}
 
 	struct sway_output *new_output = new_workspace->output;
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -425,7 +425,9 @@ static void ipc_json_describe_container(struct sway_container *c, json_object *o
 		view_is_urgent(c->view) : container_has_urgent_child(c);
 	json_object_object_add(object, "urgent", json_object_new_boolean(urgent));
 	json_object_object_add(object, "sticky", json_object_new_boolean(c->is_sticky));
-	json_object_object_add(object, "fullscreen_mode", json_object_new_int(c->is_fullscreen));
+
+	json_object_object_add(object, "fullscreen_mode",
+			json_object_new_int(c->fullscreen_mode));
 
 	struct sway_node *parent = node_get_parent(&c->node);
 	struct wlr_box parent_box = {0, 0, 0, 0};

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -134,9 +134,10 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *focus* mode\_toggle
 	Moves focus between the floating and tiled layers.
 
-*fullscreen* [enable|disable|toggle]
+*fullscreen* [enable|disable|toggle] [global]
 	Makes focused view fullscreen, non-fullscreen, or the opposite of what it
-	is now. If no argument is given, it does the same as _toggle_.
+	is now. If no argument is given, it does the same as _toggle_. If _global_
+	is specified, the view will be fullscreen across all outputs.
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left all|current
 set|plus|minus <amount>

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -261,9 +261,19 @@ void arrange_root(void) {
 	root->y = layout_box->y;
 	root->width = layout_box->width;
 	root->height = layout_box->height;
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
-		arrange_output(output);
+
+	if (root->fullscreen_global) {
+		struct sway_container *fs = root->fullscreen_global;
+		fs->x = root->x;
+		fs->y = root->y;
+		fs->width = root->width;
+		fs->height = root->height;
+		arrange_container(fs);
+	} else {
+		for (int i = 0; i < root->outputs->length; ++i) {
+			struct sway_output *output = root->outputs->items[i];
+			arrange_output(output);
+		}
 	}
 }
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -101,7 +101,10 @@ void root_scratchpad_show(struct sway_container *con) {
 	// If the current con or any of its parents are in fullscreen mode, we
 	// first need to disable it before showing the scratchpad con.
 	if (new_ws->fullscreen) {
-		container_set_fullscreen(new_ws->fullscreen, false);
+		container_fullscreen_disable(new_ws->fullscreen);
+	}
+	if (root->fullscreen_global) {
+		container_fullscreen_disable(root->fullscreen_global);
 	}
 
 	// Show the container


### PR DESCRIPTION
The fullscreen container is stored in the root struct.

I'm not sure how it's supposed it behave in regards to using `fullscreen disable` or `fullscreen toggle` (without global) while the container is fullscreen global. Or whether a container can be both workspace-fullscreen and global-fullscreen at the same time.

I've added checks in the `focus` and `workspace` commands to prevent moving focus off the fullscreen global container. Not sure if similar checks are needed elsewhere or whether they should go in `seat_set_focus` instead.

Please test thoroughly.

Closes #3255.