### PR TITLE
CONTRIBUTING.md: mention tab width for line length

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,9 +135,9 @@ balance the lines.
 
 ### Line Length
 
-Try to keep your lines under 80 columns, but you can go up to 100 if it
-improves readability. Don't break lines indiscriminately, try to find nice
-breaking points so your code is easy to read.
+Try to keep your lines under 80 columns, assuming a tab width equal to 4 spaces,
+but you can go up to 100 if it improves readability. Don't break lines
+indiscriminately, try to find nice breaking points so your code is easy to read.
 
 ### Names
 


### PR DESCRIPTION
Follow-up to https://github.com/swaywm/sway/pull/3403#issuecomment-453995544

Adds a note about assuming a tab width equal to 4 spaces when
determining the line length to CONTRIBUTING.md