### PR TITLE
Disarm key repeat on reload

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -51,4 +51,5 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard);
 
 void sway_keyboard_destroy(struct sway_keyboard *keyboard);
 
+void sway_keyboard_disarm_key_repeat(struct sway_keyboard *keyboard);
 #endif

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -542,6 +542,7 @@ void seat_reset_device(struct sway_seat *seat,
 			seat_reset_input_config(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_KEYBOARD:
+			sway_keyboard_disarm_key_repeat(seat_device->keyboard);
 			sway_keyboard_configure(seat_device->keyboard);
 			break;
 		case WLR_INPUT_DEVICE_TOUCH:


### PR DESCRIPTION
Fixes #3420

When resetting the keyboard during reload, disarm the key repeat on all
keyboards since the bindings (and possibly keyboard) will be freed before
the key repeat can go off.