### PR TITLE
Handle hidden scratchpad containers in commands

### DIFF
--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -40,6 +40,11 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		}
 	}
 
+	if (container->scratchpad && !container->workspace) {
+		return cmd_results_new(CMD_FAILURE,
+				"Cannot set floating status on a hidden scratchpad container");
+	}
+
 	bool wants_floating = 
 		parse_boolean(argv[0], container_is_floating(container));
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -653,6 +653,10 @@ static struct cmd_results *cmd_move_in_direction(
 		return cmd_results_new(CMD_FAILURE,
 				"Cannot move workspaces in a direction");
 	}
+	if (container->scratchpad && !container->workspace) {
+		return cmd_results_new(CMD_FAILURE,
+				"Cannot move a hidden scratchpad container");
+	}
 	if (container_is_floating(container)) {
 		if (container->is_fullscreen) {
 			return cmd_results_new(CMD_FAILURE,
@@ -720,6 +724,11 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Only floating containers "
 				"can be moved to an absolute position");
 	}
+	if (container->scratchpad && !container->workspace) {
+		return cmd_results_new(CMD_FAILURE,
+				"Cannot move a hidden scratchpad container");
+	}
+
 	if (!argc) {
 		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
 	}

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -589,6 +589,11 @@ struct cmd_results *cmd_resize(int argc, char **argv) {
 	if (!current) {
 		return cmd_results_new(CMD_INVALID, "Cannot resize nothing");
 	}
+	if (current->scratchpad && !current->workspace) {
+		return cmd_results_new(CMD_FAILURE,
+				"Cannot resize a hidden scratchpad container");
+	}
+
 
 	struct cmd_results *error;
 	if ((error = checkarg(argc, "resize", EXPECTED_AT_LEAST, 2))) {

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -13,6 +13,10 @@ static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (con) {
+		if (con->scratchpad && !con->workspace) {
+			return cmd_results_new(CMD_FAILURE,
+					"Cannot split a hidden scratchpad container");
+		}
 		container_split(con, layout);
 	} else {
 		workspace_split(ws, layout);

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -29,7 +29,8 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 
 	container->is_sticky = parse_boolean(argv[0], container->is_sticky);
 
-	if (container->is_sticky) {
+	if (container->is_sticky &&
+			(!container->scratchpad || container->workspace)) {
 		// move container to active workspace
 		struct sway_workspace *active_workspace =
 			output_get_active_workspace(container->workspace->output);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -87,6 +87,9 @@ void root_scratchpad_remove_container(struct sway_container *con) {
 	if (!sway_assert(con->scratchpad, "Container is not in scratchpad")) {
 		return;
 	}
+	if (!con->workspace) {
+		root_scratchpad_show(con);
+	}
 	con->scratchpad = false;
 	int index = list_find(root->scratchpad, con);
 	if (index != -1) {


### PR DESCRIPTION
Fixes #3236

This fixes the handling of hidden scratchpad containers for some
commands. For the most part, this just prevents running the commands on
hidden scratchpad containers, but there are some commands that have some
special handling for them.