### PR TITLE
Do not send ipc_event_shutdown from ipc client

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -31,10 +31,16 @@ static int exit_value = 0;
 struct sway_server server = {0};
 
 void sway_terminate(int exit_code) {
-	terminate_request = true;
-	exit_value = exit_code;
-	ipc_event_shutdown("exit");
-	wl_display_terminate(server.wl_display);
+	if (!server.wl_display) {
+		// Running as IPC client
+		exit(exit_code);
+	} else {
+		// Running as server
+		terminate_request = true;
+		exit_value = exit_code;
+		ipc_event_shutdown("exit");
+		wl_display_terminate(server.wl_display);
+	}
 }
 
 void sig_handler(int signal) {


### PR DESCRIPTION
Related to #3433 

In `sway_terminate`, `ipc_event_shutdown` was being sent regardless
which mode sway was running in. When running as an ipc client,
`sway_terminate` should just exit