### PR TITLE
seatop_begin_down: raise floating

### DIFF
--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -74,4 +74,6 @@ void seatop_begin_down(struct sway_seat *seat,
 	seat->seatop_impl = &seatop_impl;
 	seat->seatop_data = e;
 	seat->seatop_button = button;
+
+	container_raise_floating(con);
 }


### PR DESCRIPTION
Fixes #3436 

In `seatop_begin_down`, raise the floating container. This appears to
have been dropped in the transition to seatops (https://github.com/swaywm/sway/pull/3402/files#diff-57d5973ad58d843753d353531e8cb85eL1039)