### PR TITLE
Use noop output when there's no outputs connected

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -24,6 +24,7 @@ struct sway_server {
 	const char *socket;
 
 	struct wlr_backend *backend;
+	struct wlr_backend *noop_backend;
 
 	struct wlr_compositor *compositor;
 	struct wlr_data_device_manager *data_device_manager;

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -31,7 +31,9 @@ struct sway_root {
 
 	list_t *outputs; // struct sway_output
 	list_t *scratchpad; // struct sway_container
-	list_t *saved_workspaces; // For when there's no connected outputs
+
+	// For when there's no connected outputs
+	struct sway_output *noop_output;
 
 	struct {
 		struct wl_signal new_node;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -1,3 +1,4 @@
+#include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/output.h"
@@ -24,6 +25,13 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	struct cmd_results *error = checkarg(argc, "output", EXPECTED_AT_LEAST, 1);
 	if (error != NULL) {
 		return error;
+	}
+
+	// The NOOP-1 output is a dummy output used when there's no outputs
+	// connected. It should never be configured.
+	if (strcasecmp(argv[0], "NOOP-1") == 0) {
+		return cmd_results_new(CMD_FAILURE,
+				"Refusing to configure the no op output");
 	}
 
 	struct output_config *output = new_output_config(argv[0]);

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -29,7 +29,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 
 	// The NOOP-1 output is a dummy output used when there's no outputs
 	// connected. It should never be configured.
-	if (strcasecmp(argv[0], "NOOP-1") == 0) {
+	if (strcasecmp(argv[0], root->noop_output->wlr_output->name) == 0) {
 		return cmd_results_new(CMD_FAILURE,
 				"Refusing to configure the no op output");
 	}

--- a/sway/commands/output/enable.c
+++ b/sway/commands/output/enable.c
@@ -1,3 +1,4 @@
+#include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 
@@ -5,6 +6,15 @@ struct cmd_results *output_cmd_enable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
+
+	// The NOOP-1 output is a dummy output used when there's no outputs
+	// connected. It should never be enabled.
+	char *output_name = config->handler_context.output_config->name;
+	if (strcasecmp(output_name, "NOOP-1") == 0) {
+		return cmd_results_new(CMD_FAILURE,
+				"Refusing to enable the no op output");
+	}
+
 	config->handler_context.output_config->enabled = 1;
 
 	config->handler_context.leftovers.argc = argc;

--- a/sway/commands/output/enable.c
+++ b/sway/commands/output/enable.c
@@ -1,18 +1,9 @@
-#include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 
 struct cmd_results *output_cmd_enable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
-	}
-
-	// The NOOP-1 output is a dummy output used when there's no outputs
-	// connected. It should never be enabled.
-	char *output_name = config->handler_context.output_config->name;
-	if (strcasecmp(output_name, "NOOP-1") == 0) {
-		return cmd_results_new(CMD_FAILURE,
-				"Refusing to enable the no op output");
 	}
 
 	config->handler_context.output_config->enabled = 1;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -176,6 +176,10 @@ void terminate_swaybg(pid_t pid) {
 }
 
 bool apply_output_config(struct output_config *oc, struct sway_output *output) {
+	if (output == root->noop_output) {
+		return false;
+	}
+
 	struct wlr_output *wlr_output = output->wlr_output;
 
 	if (oc && !oc->enabled) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -386,7 +386,7 @@ static void damage_handle_frame(struct wl_listener *listener, void *data) {
 void output_damage_whole(struct sway_output *output) {
 	// The output can exist with no wlr_output if it's just been disconnected
 	// and the transaction to evacuate it has't completed yet.
-	if (output && output->wlr_output) {
+	if (output && output->wlr_output && output->damage) {
 		wlr_output_damage_add_whole(output->damage);
 	}
 }

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -637,7 +637,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 		struct sway_output *output;
 		wl_list_for_each(output, &root->all_outputs, link) {
-			if (!output->enabled) {
+			if (!output->enabled && output != root->noop_output) {
 				json_object_array_add(outputs,
 						ipc_json_describe_disabled_output(output));
 			}

--- a/sway/server.c
+++ b/sway/server.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/backend.h>
+#include <wlr/backend/noop.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
@@ -25,6 +26,7 @@
 #include "sway/config.h"
 #include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
+#include "sway/output.h"
 #include "sway/server.h"
 #include "sway/tree/root.h"
 #if HAVE_XWAYLAND
@@ -36,6 +38,7 @@ bool server_privileged_prepare(struct sway_server *server) {
 	server->wl_display = wl_display_create();
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 	server->backend = wlr_backend_autocreate(server->wl_display, NULL);
+	server->noop_backend = wlr_noop_backend_create(server->wl_display);
 
 	if (!server->backend) {
 		wlr_log(WLR_ERROR, "Unable to create backend");
@@ -115,6 +118,9 @@ bool server_init(struct sway_server *server) {
 		wlr_backend_destroy(server->backend);
 		return false;
 	}
+
+	struct wlr_output *wlr_output = wlr_noop_add_output(server->noop_backend);
+	root->noop_output = output_create(wlr_output);
 
 	// This may have been set already via -Dtxn-timeout
 	if (!server->txn_timeout_ms) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -41,12 +41,12 @@ static void restore_workspaces(struct sway_output *output) {
 	}
 
 	// Saved workspaces
-	for (int i = 0; i < root->saved_workspaces->length; ++i) {
-		struct sway_workspace *ws = root->saved_workspaces->items[i];
+	while (root->noop_output->workspaces->length) {
+		struct sway_workspace *ws = root->noop_output->workspaces->items[0];
+		workspace_detach(ws);
 		output_add_workspace(output, ws);
 		ipc_event_workspace(NULL, ws, "move");
 	}
-	root->saved_workspaces->length = 0;
 
 	output_sort_workspaces(output);
 }
@@ -161,6 +161,9 @@ static void output_evacuate(struct sway_output *output) {
 		if (!new_output) {
 			new_output = fallback_output;
 		}
+		if (!new_output) {
+			new_output = root->noop_output;
+		}
 
 		if (workspace_is_empty(workspace)) {
 			// If floating is not empty, there are sticky containers to move
@@ -171,14 +174,10 @@ static void output_evacuate(struct sway_output *output) {
 			continue;
 		}
 
-		if (new_output) {
-			workspace_output_add_priority(workspace, new_output);
-			output_add_workspace(new_output, workspace);
-			output_sort_workspaces(new_output);
-			ipc_event_workspace(NULL, workspace, "move");
-		} else {
-			list_add(root->saved_workspaces, workspace);
-		}
+		workspace_output_add_priority(workspace, new_output);
+		output_add_workspace(new_output, workspace);
+		output_sort_workspaces(new_output);
+		ipc_event_workspace(NULL, workspace, "move");
 	}
 }
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -39,7 +39,6 @@ struct sway_root *root_create(void) {
 	wl_signal_init(&root->events.new_node);
 	root->outputs = create_list();
 	root->scratchpad = create_list();
-	root->saved_workspaces = create_list();
 
 	root->output_layout_change.notify = output_layout_handle_change;
 	wl_signal_add(&root->output_layout->events.change,
@@ -50,7 +49,6 @@ struct sway_root *root_create(void) {
 void root_destroy(struct sway_root *root) {
 	wl_list_remove(&root->output_layout_change.link);
 	list_free(root->scratchpad);
-	list_free(root->saved_workspaces);
 	list_free(root->outputs);
 	wlr_output_layout_destroy(root->output_layout);
 	free(root);
@@ -292,8 +290,8 @@ void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 	}
 
 	// Saved workspaces
-	for (int i = 0; i < root->saved_workspaces->length; ++i) {
-		struct sway_workspace *ws = root->saved_workspaces->items[i];
+	for (int i = 0; i < root->noop_output->workspaces->length; ++i) {
+		struct sway_workspace *ws = root->noop_output->workspaces->items[i];
 		workspace_for_each_container(ws, f, data);
 	}
 }
@@ -345,8 +343,8 @@ struct sway_container *root_find_container(
 	}
 
 	// Saved workspaces
-	for (int i = 0; i < root->saved_workspaces->length; ++i) {
-		struct sway_workspace *ws = root->saved_workspaces->items[i];
+	for (int i = 0; i < root->noop_output->workspaces->length; ++i) {
+		struct sway_workspace *ws = root->noop_output->workspaces->items[i];
 		if ((result = workspace_find_container(ws, test, data))) {
 			return result;
 		}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -518,9 +518,10 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 		return node->sway_container->workspace;
 	}
 
-	// If there's no focus_inactive workspace then we must be running without
-	// any outputs connected
-	return root->saved_workspaces->items[0];
+	// When there's no outputs connected, the above should match a workspace on
+	// the noop output.
+	sway_assert(false, "Expected to find a workspace");
+	return NULL;
 }
 
 static bool should_focus(struct sway_view *view) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -158,13 +158,7 @@ void workspace_begin_destroy(struct sway_workspace *workspace) {
 
 	if (workspace->output) {
 		workspace_detach(workspace);
-	} else {
-		int index = list_find(root->saved_workspaces, workspace);
-		if (index != -1) {
-			list_del(root->saved_workspaces, index);
-		}
 	}
-
 	workspace->node.destroying = true;
 	node_set_dirty(&workspace->node);
 }


### PR DESCRIPTION
Instead of having `NULL` `workspace->output` pointers, use a <s>headless</s> noop output. This should be safer.

I've tested this with the wayland backend by closing the output window and then using swaymsg to connect to the socket and run the `create_output` command. Upon creation, I had some issues with the alignment of the first output's contents within the output window, but I'm not sure this is related to my change.

I have not tested on DRM yet.

The output is returned in the IPC `get_outputs` list, so perhaps we should hide it. Also, we never enable the output (we never have to), so perhaps we should add a check to make sure it can't be enabled using config or IPC.