### PR TITLE
Cleanup stringop.c (partly)

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -1,13 +1,13 @@
 #define _POSIX_C_SOURCE 200809L
-#include <stdlib.h>
+#include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <ctype.h>
-#include "stringop.h"
-#include "log.h"
-#include "string.h"
 #include "list.h"
+#include "log.h"
+#include "stringop.h"
 
 static const char whitespace[] = " \f\n\r\t\v";
 

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -78,12 +78,10 @@ int lenient_strcmp(char *a, char *b) {
 list_t *split_string(const char *str, const char *delims) {
 	list_t *res = create_list();
 	char *copy = strdup(str);
-	char *token;
 
-	token = strtok(copy, delims);
-	while(token) {
-		token = strdup(token);
-		list_add(res, token);
+	char *token = strtok(copy, delims);
+	while (token) {
+		list_add(res, strdup(token));
 		token = strtok(NULL, delims);
 	}
 	free(copy);
@@ -268,13 +266,13 @@ char *argsep(char **stringp, const char *delim) {
 			escaped = !escaped;
 		} else if (*end == '\0') {
 			*stringp = NULL;
-			goto found;
+			break;
 		} else if (!in_string && !in_char && !escaped && strchr(delim, *end)) {
 			if (end - start) {
 				*(end++) = 0;
 				*stringp = end + strspn(end, delim);;
 				if (!**stringp) *stringp = NULL;
-				goto found;
+				break;
 			} else {
 				++start;
 				end = start;
@@ -285,6 +283,5 @@ char *argsep(char **stringp, const char *delim) {
 		}
 		++end;
 	}
-	found:
 	return start;
 }

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -150,29 +150,6 @@ void free_argv(int argc, char **argv) {
 	free(argv);
 }
 
-char *code_strstr(const char *haystack, const char *needle) {
-	/* TODO */
-	return strstr(haystack, needle);
-}
-
-char *code_strchr(const char *str, char delimiter) {
-	int in_string = 0, in_character = 0;
-	int i = 0;
-	while (str[i] != '\0') {
-		if (str[i] == '"' && !in_character) {
-			in_string = !in_string;
-		} else if (str[i] == '\'' && !in_string) {
-			in_character = !in_character;
-		} else if (!in_character && !in_string) {
-			if (str[i] == delimiter) {
-				return (char *)str + i;
-			}
-		}
-		++i;
-	}
-	return NULL;
-}
-
 int unescape_string(char *string) {
 	/* TODO: More C string escapes */
 	int len = strlen(string);
@@ -276,84 +253,6 @@ char *join_args(char **argv, int argc) {
 	return res;
 }
 
-static bool has_whitespace(const char *str) {
-	while (*str) {
-		if (isspace(*str)) {
-			return true;
-		}
-		++str;
-	}
-	return false;
-}
-
-/**
- * Add quotes around any argv with whitespaces.
- */
-void add_quotes(char **argv, int argc) {
-	int i;
-	for (i = 0; i < argc; ++i) {
-		if (has_whitespace(argv[i])) {
-			int len = strlen(argv[i]) + 3;
-			char *tmp = argv[i];
-			argv[i] = malloc(len * sizeof(char));
-			snprintf(argv[i], len, "\"%s\"", tmp);
-			free(tmp);
-		}
-	}
-}
-
-/*
- * Join a list of strings, adding separator in between. Separator can be NULL.
- */
-char *join_list(list_t *list, char *separator) {
-	if (!sway_assert(list != NULL, "list != NULL") || list->length == 0) {
-		return NULL;
-	}
-
-	size_t len = 1; // NULL terminator
-	size_t sep_len = 0;
-	if (separator != NULL) {
-		sep_len = strlen(separator);
-		len += (list->length - 1) * sep_len;
-	}
-
-	for (int i = 0; i < list->length; i++) {
-		len += strlen(list->items[i]);
-	}
-
-	char *res = malloc(len);
-
-	char *p = res + strlen(list->items[0]);
-	strcpy(res, list->items[0]);
-
-	for (int i = 1; i < list->length; i++) {
-		if (sep_len) {
-			memcpy(p, separator, sep_len);
-			p += sep_len;
-		}
-		strcpy(p, list->items[i]);
-		p += strlen(list->items[i]);
-	}
-
-	*p = '\0';
-
-	return res;
-}
-
-char *cmdsep(char **stringp, const char *delim) {
-	// skip over leading delims
-	char *head = *stringp + strspn(*stringp, delim);
-	// Find end token
-	char *tail = *stringp += strcspn(*stringp, delim);
-	// Set stringp to beginning of next token
-	*stringp += strspn(*stringp, delim);
-	// Set stringp to null if last token
-	if (!**stringp) *stringp = NULL;
-	// Nullify end of first token
-	*tail = 0;
-	return head;
-}
-
 char *argsep(char **stringp, const char *delim) {
 	char *start = *stringp;
 	char *end = start;
@@ -388,18 +287,4 @@ char *argsep(char **stringp, const char *delim) {
 	}
 	found:
 	return start;
-}
-
-const char *strcasestr(const char *haystack, const char *needle) {
-	size_t needle_len = strlen(needle);
-	const char *pos = haystack;
-	const char *end = pos + strlen(haystack) - needle_len;
-
-	while (pos <= end) {
-		if (strncasecmp(pos, needle, needle_len) == 0) {
-			return pos;
-		}
-		++pos;
-	}
-	return NULL;
 }

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -4,7 +4,6 @@
 #include "list.h"
 
 void strip_whitespace(char *str);
-char *strip_comments(char *str);
 void strip_quotes(char *str);
 
 // strcat that does nothing if dest or src is NULL
@@ -21,22 +20,10 @@ list_t *split_string(const char *str, const char *delims);
 char **split_args(const char *str, int *argc);
 void free_argv(int argc, char **argv);
 
-char *code_strchr(const char *string, char delimiter);
-char *code_strstr(const char *haystack, const char *needle);
 int unescape_string(char *string);
 char *join_args(char **argv, int argc);
-char *join_list(list_t *list, char *separator);
 
-/**
- * Add quotes around any argv with whitespaces.
- */
-void add_quotes(char **argv, int argc);
-
-// split string into 2 by delim.
-char *cmdsep(char **stringp, const char *delim);
 // Split string into 2 by delim, handle quotes
 char *argsep(char **stringp, const char *delim);
-
-const char *strcasestr(const char *haystack, const char *needle);
 
 #endif

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -301,6 +301,43 @@ static list_t *load_themes_in_dir(char *basedir) {
 	return themes;
 }
 
+static void log_loaded_themes(list_t *themes) {
+	if (themes->length == 0) {
+		sway_log(SWAY_INFO, "Warning: no icon themes loaded");
+		return;
+	}
+
+	const char *sep = ", ";
+	size_t sep_len = strlen(sep);
+
+	size_t len = 1 - sep_len;
+	for (int i = 0; i < themes->length; ++i) {
+		struct icon_theme *theme = themes->items[i];
+		len += strlen(theme->name) + sep_len;
+	}
+
+	char *str = malloc(len);
+	if (!str) {
+		return;
+	}
+	char *p = str;
+	for (int i = 0; i < themes->length; ++i) {
+		if (i > 0) {
+			memcpy(p, sep, sep_len);
+			p += sep_len;
+		}
+
+		struct icon_theme *theme = themes->items[i];
+		size_t name_len = strlen(theme->name);
+		memcpy(p, theme->name, name_len);
+		p += name_len;
+	}
+	*p = '\0';
+
+	sway_log(SWAY_DEBUG, "Loaded icon themes: %s", str);
+	free(str);
+}
+
 void init_themes(list_t **themes, list_t **basedirs) {
 	*basedirs = get_basedirs();
 
@@ -311,15 +348,7 @@ void init_themes(list_t **themes, list_t **basedirs) {
 		list_free(dir_themes);
 	}
 
-	list_t *theme_names = create_list();
-	for (int i = 0; i < (*themes)->length; ++i) {
-		struct icon_theme *theme = (*themes)->items[i];
-		list_add(theme_names, theme->name);
-	}
-	char *theme_list = join_list(theme_names, ", ");
-	sway_log(SWAY_DEBUG, "Loaded themes: %s", theme_list);
-	free(theme_list);
-	list_free(theme_names);
+	log_loaded_themes(*themes);
 }
 
 void finish_themes(list_t *themes, list_t *basedirs) {


### PR DESCRIPTION
I've removed a lot of old and unused functions.

I want to refactor some of the other functions. In particular `unescape_string`, and maybe move it to `sway/commands.c` since it is the only place it is used, but I'm not sure about its specification to be confident in rewriting it correctly.