### PR TITLE
Better handle outputs without CRTC

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -568,7 +568,7 @@ struct output_config *new_output_config(const char *name);
 
 void merge_output_config(struct output_config *dst, struct output_config *src);
 
-void apply_output_config(struct output_config *oc, struct sway_output *output);
+bool apply_output_config(struct output_config *oc, struct sway_output *output);
 
 struct output_config *store_output_config(struct output_config *oc);
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -31,7 +31,7 @@ struct sway_output {
 	int lx, ly;
 	int width, height;
 
-	bool enabled;
+	bool enabled, configured;
 	list_t *workspaces;
 
 	struct sway_output_state current;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -78,6 +78,12 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	}
 
 	output->enabled = true;
+	if (!apply_output_config(oc, output)) {
+		output->enabled = false;
+		return;
+	}
+
+	output->configured = true;
 	list_add(root->outputs, output);
 
 	output->lx = wlr_output->lx;
@@ -103,8 +109,6 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 		free(ws_name);
 		ipc_event_workspace(NULL, ws, "init");
 	}
-
-	apply_output_config(oc, output);
 
 	if (ws && config->default_orientation == L_NONE) {
 		// Since the output transformation and resolution could have changed


### PR DESCRIPTION
~~Depends on #3454~~

This happens if you plug in more outputs than supported by your GPU.

This patch makes it so outputs without CRTCs appear as disabled. As soon as
they get a CRTC (signalled via the mode event), we can enable them.