### PR TITLE
[DO NOT MERGE] Fix crash in cursor_rebase with multiple screens

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -83,8 +83,8 @@ struct sway_node *node_at_coords(
 		return NULL;
 	}
 	struct sway_output *output = wlr_output->data;
-	if (!output) {
-		// output is being destroyed
+	if (!output || !output->configured) {
+		// output is being destroyed or is being configured
 		return NULL;
 	}
 	double ox = lx, oy = ly;


### PR DESCRIPTION
I tried fixing this crash in the most logical way possible. Let me know if you have other ideas.

Designing the output configuration sequence without invalid state is tricky.

We have one function, apply_output_config, that takes an output and (besides
other things) performs a modeset and inserts the output in the output layout.
The modeset can fail, in which case we don't want the output to be enabled.
We also have an output_enable function, which calls output_apply_config and
also configures the output's workspace and inserts it in the root container.

Now, we have two choices.

Either we configure the output before it's been inserted in the root container
and then, if the modeset was successful, we insert it and create the workspace.
The main issue with this approach is that configuring the output triggers a
handful of signals, namely wlr_output.mode and wlr_output_layout.change. In
those event handlers, we need to make sure to ignore these outputs in the
process of being configured.

Either we first insert the output, create the workspace and then try to
configure it. It means we need to undo everything if the modeset fails. The
main issue with this solution is that it enables and disables the output very
quickly, creates a workspace and immediately destroys it, and maybe moves
views back and forth (see output_evacuate).

I've tried to make it so an output isn't enabled then immediately disabled. We
already have code for ignoring outputs when the output is being destructed.

Fixes https://github.com/swaywm/sway/issues/3462