### PR TITLE
Fix re-enabling outputs gaining a CRTC

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -503,18 +503,20 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
-	if (!output->configured) {
-		return;
-	}
-	if (!output->enabled) {
+	if (!output->configured && !output->enabled) {
 		struct output_config *oc = output_find_config(output);
 		if (output->wlr_output->current_mode != NULL &&
 				(!oc || oc->enabled)) {
 			// We want to enable this output, but it didn't work last time,
 			// possibly because we hadn't enough CRTCs. Try again now that the
 			// output has a mode.
-			output_enable(output, oc);
+			wlr_log(WLR_DEBUG, "Output %s has gained a CRTC, "
+				"trying to enable it", output->wlr_output->name);
+			apply_output_config(oc, output);
 		}
+		return;
+	}
+	if (!output->enabled || !output->configured) {
 		return;
 	}
 	arrange_layers(output);


### PR DESCRIPTION
If output->configured is true, then the output has been modeset correctly and
we don't need to try again. If output->enabled is true, then we are in the
process of configuring the output and we shouldn't do anything.

With https://github.com/swaywm/wlroots/pull/1479, this PR makes it so various sequences of hotplugging and/or enabling/disabling outputs work properly. For instance, this is now possible on a laptop only supporting two outputs:

* Start with the internal screen connected and nothing else
* Plug in the laptop on a dock with two external outputs connected, one of them turns on, the other doesn't (limit reached, no more CRTC)
* Disable the internal screen, the other external output turns one (CRTC moved from internal screen to the external one)
* Enable the internal screen again, nothing happens (no more CRTC)
* Unplug the laptop, internal screen turns on again (since two CRTCs have been free'd)