### PR TITLE
swaybg: remove assert crashing on hotplug

### DIFF
--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -194,8 +194,7 @@ static void xdg_output_handle_name(void *data,
 		struct zxdg_output_v1 *xdg_output, const char *name) {
 	struct swaybg_output *output = data;
 	struct swaybg_state *state = output->state;
-	if (strcmp(name, state->args->output) == 0) {
-		assert(state->output == NULL);
+	if (strcmp(name, state->args->output) == 0 && state->output == NULL) {
 		state->output = output;
 	}
 }


### PR DESCRIPTION
When hotplugging, an output may disappear and re-appear. This commit makes it
so swaybg doesn't crash anymore in this case.