### PR TITLE
apply_output_config: remove output_i

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -234,13 +234,6 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_output_layout_add_auto(root->output_layout, wlr_output);
 	}
 
-	int output_i;
-	for (output_i = 0; output_i < root->outputs->length; ++output_i) {
-		if (root->outputs->items[output_i] == output) {
-			break;
-		}
-	}
-
 	if (output->bg_pid != 0) {
 		terminate_swaybg(output->bg_pid);
 	}


### PR DESCRIPTION
output_i was used in apply_output_config when swaybar used wl_output
index numbers instead of xdg-output names. This is no longer needed.