### PR TITLE
Fix backup methods in get_socketpath for IPC client

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -22,9 +22,13 @@ char *get_socketpath(void) {
 	size_t line_size = 0;
 	FILE *fp = popen("sway --get-socketpath 2>/dev/null", "r");
 	if (fp) {
-		getline(&line, &line_size, fp);
+		ssize_t nret = getline(&line, &line_size, fp);
 		pclose(fp);
-		if (line && *line) {
+		if (nret > 0) {
+			// remove trailing newline, if there is one
+			if (line[nret - 1] == '\n') {
+				line[nret - 1] = '\0';
+			}
 			return line;
 		}
 	}
@@ -35,9 +39,13 @@ char *get_socketpath(void) {
 	}
 	fp = popen("i3 --get-socketpath 2>/dev/null", "r");
 	if (fp) {
-		getline(&line, &line_size, fp);
+		ssize_t nret = getline(&line, &line_size, fp);
 		pclose(fp);
-		if (line && *line) {
+		if (nret > 0) {
+			// remove trailing newline, if there is one
+			if (line[nret - 1] == '\n') {
+				line[nret - 1] = '\0';
+			}
 			return line;
 		}
 	}


### PR DESCRIPTION
When environment variables I3SOCK and SWAYSOCK are cleared, the fallback to calling  `sway --get-socketpath` handled errors for [getline](https://linux.die.net/man/3/getline) incorrectly, relying on the fact that newly allocated memory is almost always zeroed out. (Also, the trailing newline was not removed.)