### PR TITLE
Allocate minimum size necessary in pango text functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ install_manifest.txt
 bin/
 test/
 build/
+build-*/
 .lvimrc
 config-debug
 wayland-*-protocol.*

--- a/common/pango.c
+++ b/common/pango.c
@@ -91,6 +91,10 @@ void get_text_size(cairo_t *cairo, const char *font, int *width, int *height,
 	va_end(args);
 
 	char *buf = malloc(length);
+	if (buf == NULL) {
+		wlr_log(WLR_ERROR, "Failed to allocate memory");
+		return;
+	}
 	va_start(args, fmt);
 	vsnprintf(buf, length, fmt, args);
 	va_end(args);
@@ -114,6 +118,10 @@ void pango_printf(cairo_t *cairo, const char *font,
 	va_end(args);
 
 	char *buf = malloc(length);
+	if (buf == NULL) {
+		wlr_log(WLR_ERROR, "Failed to allocate memory");
+		return;
+	}
 	va_start(args, fmt);
 	vsnprintf(buf, length, fmt, args);
 	va_end(args);


### PR DESCRIPTION
Almost forgot about this. See [here](https://github.com/swaywm/sway/pull/3438/files/338a8c051df8290eb7863ba0c566139747b7b224#r248228815) (annoyingly this doesn't link directly to the comment. It's in one of the resolved conversations...).