### PR TITLE
Replace wlr_log with sway_log

### DIFF
--- a/common/background-image.c
+++ b/common/background-image.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <stdbool.h>
-#include <wlr/util/log.h>
 #include "background-image.h"
 #include "cairo.h"
+#include "log.h"
 
 enum background_mode parse_background_mode(const char *mode) {
 	if (strcmp(mode, "stretch") == 0) {
@@ -18,7 +18,7 @@ enum background_mode parse_background_mode(const char *mode) {
 	} else if (strcmp(mode, "solid_color") == 0) {
 		return BACKGROUND_MODE_SOLID_COLOR;
 	}
-	wlr_log(WLR_ERROR, "Unsupported background mode: %s", mode);
+	sway_log(SWAY_ERROR, "Unsupported background mode: %s", mode);
 	return BACKGROUND_MODE_INVALID;
 }
 
@@ -28,7 +28,7 @@ cairo_surface_t *load_background_image(const char *path) {
 	GError *err = NULL;
 	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file(path, &err);
 	if (!pixbuf) {
-		wlr_log(WLR_ERROR, "Failed to load background image (%s).",
+		sway_log(SWAY_ERROR, "Failed to load background image (%s).",
 				err->message);
 		return false;
 	}
@@ -38,11 +38,11 @@ cairo_surface_t *load_background_image(const char *path) {
 	image = cairo_image_surface_create_from_png(path);
 #endif // HAVE_GDK_PIXBUF
 	if (!image) {
-		wlr_log(WLR_ERROR, "Failed to read background image.");
+		sway_log(SWAY_ERROR, "Failed to read background image.");
 		return NULL;
 	}
 	if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS) {
-		wlr_log(WLR_ERROR, "Failed to read background image: %s."
+		sway_log(SWAY_ERROR, "Failed to read background image: %s."
 #if !HAVE_GDK_PIXBUF
 				"\nSway was compiled without gdk_pixbuf support, so only"
 				"\nPNG images can be loaded. This is the likely cause."

--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -111,7 +111,7 @@ error_2:
 	free(response);
 	free(payload);
 error_1:
-	wlr_log(WLR_ERROR, "Unable to allocate memory for IPC response");
+	sway_log(SWAY_ERROR, "Unable to allocate memory for IPC response");
 	return NULL;
 }
 

--- a/common/log.c
+++ b/common/log.c
@@ -1,16 +1,20 @@
+#define _POSIX_C_SOURCE 199506L
 #include <signal.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
 #include "log.h"
 
-void sway_terminate(int code);
+static terminate_callback_t log_terminate = exit;
 
 void _sway_abort(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
-	_wlr_vlog(WLR_ERROR, format, args);
+	_sway_vlog(SWAY_ERROR, format, args);
 	va_end(args);
-	sway_terminate(EXIT_FAILURE);
+	log_terminate(EXIT_FAILURE);
 }
 
 bool _sway_assert(bool condition, const char *format, ...) {
@@ -20,7 +24,7 @@ bool _sway_assert(bool condition, const char *format, ...) {
 
 	va_list args;
 	va_start(args, format);
-	_wlr_vlog(WLR_ERROR, format, args);
+	_sway_vlog(SWAY_ERROR, format, args);
 	va_end(args);
 
 #ifndef NDEBUG
@@ -28,4 +32,81 @@ bool _sway_assert(bool condition, const char *format, ...) {
 #endif
 
 	return false;
+}
+
+static bool colored = true;
+static sway_log_importance_t log_importance = SWAY_ERROR;
+
+static const char *verbosity_colors[] = {
+	[SWAY_SILENT] = "",
+	[SWAY_ERROR ] = "\x1B[1;31m",
+	[SWAY_INFO  ] = "\x1B[1;34m",
+	[SWAY_DEBUG ] = "\x1B[1;30m",
+};
+
+static void sway_log_stderr(sway_log_importance_t verbosity, const char *fmt,
+		va_list args) {
+	if (verbosity > log_importance) {
+		return;
+	}
+	// prefix the time to the log message
+	struct tm result;
+	time_t t = time(NULL);
+	struct tm *tm_info = localtime_r(&t, &result);
+	char buffer[26];
+
+	// generate time prefix
+	strftime(buffer, sizeof(buffer), "%F %T - ", tm_info);
+	fprintf(stderr, "%s", buffer);
+
+	unsigned c = (verbosity < SWAY_LOG_IMPORTANCE_LAST) ? verbosity :
+		SWAY_LOG_IMPORTANCE_LAST - 1;
+
+	if (colored && isatty(STDERR_FILENO)) {
+		fprintf(stderr, "%s", verbosity_colors[c]);
+	}
+
+	vfprintf(stderr, fmt, args);
+
+	if (colored && isatty(STDERR_FILENO)) {
+		fprintf(stderr, "\x1B[0m");
+	}
+	fprintf(stderr, "\n");
+}
+
+void sway_log_init(sway_log_importance_t verbosity, terminate_callback_t callback) {
+	if (verbosity < SWAY_LOG_IMPORTANCE_LAST) {
+		log_importance = verbosity;
+	}
+	if (callback) {
+		log_terminate = callback;
+	}
+}
+
+void _sway_vlog(sway_log_importance_t verbosity, const char *fmt, va_list args) {
+	sway_log_stderr(verbosity, fmt, args);
+}
+
+void _sway_log(sway_log_importance_t verbosity, const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	sway_log_stderr(verbosity, fmt, args);
+	va_end(args);
+}
+
+// strips the path prefix from filepath
+// will try to strip SWAY_SRC_DIR as well as a relative src dir
+// e.g. '/src/build/sway/util/log.c' and
+// '../util/log.c' will both be stripped to
+// 'util/log.c'
+const char *_sway_strip_path(const char *filepath) {
+	static int srclen = sizeof(SWAY_SRC_DIR);
+	if (strstr(filepath, SWAY_SRC_DIR) == filepath) {
+		filepath += srclen;
+	} else if (*filepath == '.') {
+		while (*filepath == '.' || *filepath == '/') {
+			++filepath;
+		}
+	}
+	return filepath;
 }

--- a/common/loop.c
+++ b/common/loop.c
@@ -34,7 +34,7 @@ struct loop {
 struct loop *loop_create(void) {
 	struct loop *loop = calloc(1, sizeof(struct loop));
 	if (!loop) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for loop");
+		sway_log(SWAY_ERROR, "Unable to allocate memory for loop");
 		return NULL;
 	}
 	loop->fd_capacity = 10;
@@ -107,7 +107,7 @@ void loop_add_fd(struct loop *loop, int fd, short mask,
 		void (*callback)(int fd, short mask, void *data), void *data) {
 	struct loop_fd_event *event = calloc(1, sizeof(struct loop_fd_event));
 	if (!event) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for event");
+		sway_log(SWAY_ERROR, "Unable to allocate memory for event");
 		return;
 	}
 	event->callback = callback;
@@ -129,7 +129,7 @@ struct loop_timer *loop_add_timer(struct loop *loop, int ms,
 		void (*callback)(void *data), void *data) {
 	struct loop_timer *timer = calloc(1, sizeof(struct loop_timer));
 	if (!timer) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for timer");
+		sway_log(SWAY_ERROR, "Unable to allocate memory for timer");
 		return NULL;
 	}
 	timer->callback = callback;

--- a/common/pango.c
+++ b/common/pango.c
@@ -61,7 +61,7 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font,
 			pango_layout_set_text(layout, buf, -1);
 			free(buf);
 		} else {
-			wlr_log(WLR_ERROR, "pango_parse_markup '%s' -> error %s", text,
+			sway_log(SWAY_ERROR, "pango_parse_markup '%s' -> error %s", text,
 					error->message);
 			g_error_free(error);
 			markup = false; // fallback to plain text
@@ -92,7 +92,7 @@ void get_text_size(cairo_t *cairo, const char *font, int *width, int *height,
 
 	char *buf = malloc(length);
 	if (buf == NULL) {
-		wlr_log(WLR_ERROR, "Failed to allocate memory");
+		sway_log(SWAY_ERROR, "Failed to allocate memory");
 		return;
 	}
 	va_start(args, fmt);
@@ -119,7 +119,7 @@ void pango_printf(cairo_t *cairo, const char *font,
 
 	char *buf = malloc(length);
 	if (buf == NULL) {
-		wlr_log(WLR_ERROR, "Failed to allocate memory");
+		sway_log(SWAY_ERROR, "Failed to allocate memory");
 		return;
 	}
 	va_start(args, fmt);

--- a/common/util.c
+++ b/common/util.c
@@ -116,7 +116,7 @@ uint32_t parse_color(const char *color) {
 
 	int len = strlen(color);
 	if (len != 6 && len != 8) {
-		wlr_log(WLR_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
+		sway_log(SWAY_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
 		return 0xFFFFFFFF;
 	}
 	uint32_t res = (uint32_t)strtoul(color, NULL, 16);
@@ -147,7 +147,7 @@ float parse_float(const char *value) {
 	char *end;
 	float flt = strtof(value, &end);
 	if (*end || errno) {
-		wlr_log(WLR_DEBUG, "Invalid float value '%s', defaulting to NAN", value);
+		sway_log(SWAY_DEBUG, "Invalid float value '%s', defaulting to NAN", value);
 		return NAN;
 	}
 	return flt;

--- a/include/log.h
+++ b/include/log.h
@@ -1,7 +1,18 @@
 #ifndef _SWAY_LOG_H
 #define _SWAY_LOG_H
+
 #include <stdbool.h>
-#include <wlr/util/log.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+typedef enum {
+	SWAY_SILENT = 0,
+	SWAY_ERROR = 1,
+	SWAY_INFO = 2,
+	SWAY_DEBUG = 3,
+	SWAY_LOG_IMPORTANCE_LAST,
+} sway_log_importance_t;
 
 #ifdef __GNUC__
 #define ATTRIB_PRINTF(start, end) __attribute__((format(printf, start, end)))
@@ -9,14 +20,35 @@
 #define ATTRIB_PRINTF(start, end)
 #endif
 
-void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
-#define sway_abort(FMT, ...) \
-    _sway_abort("[%s:%d] " FMT, _wlr_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
-
-bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
-#define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, "[%s:%d] %s:" FMT, _wlr_strip_path(__FILE__), __LINE__, __func__, ##__VA_ARGS__)
-
 void error_handler(int sig);
+
+typedef void (*terminate_callback_t)(int exit_code);
+
+// Will log all messages less than or equal to `verbosity`
+// The `terminate` callback is called by `sway_abort`
+void sway_log_init(sway_log_importance_t verbosity, terminate_callback_t terminate);
+
+void _sway_log(sway_log_importance_t verbosity, const char *format, ...) ATTRIB_PRINTF(2, 3);
+void _sway_vlog(sway_log_importance_t verbosity, const char *format, va_list args) ATTRIB_PRINTF(2, 0);
+void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
+bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
+
+// TODO: get meson to precompute this, for better reproducibility/less overhead
+const char *_sway_strip_path(const char *filepath);
+
+#define sway_log(verb, fmt, ...) \
+	_sway_log(verb, "[%s:%d] " fmt, _sway_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+
+#define sway_vlog(verb, fmt, args) \
+	_sway_vlog(verb, "[%s:%d] " fmt, _sway_strip_path(__FILE__), __LINE__, args)
+
+#define sway_log_errno(verb, fmt, ...) \
+	sway_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))
+
+#define sway_abort(FMT, ...) \
+	_sway_abort("[%s:%d] " FMT, _sway_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+
+#define sway_assert(COND, FMT, ...) \
+	_sway_assert(COND, "[%s:%d] %s:" FMT, _sway_strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ project(
 
 add_project_arguments(
 	[
+		'-DSWAY_SRC_DIR="@0@"'.format(meson.current_source_dir()),
+
 		'-DWL_HIDE_DEPRECATED',
 		'-DWLR_USE_UNSTABLE',
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -142,7 +142,7 @@ struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
 		int handlers_size) {
 	struct cmd_handler d = { .command=line };
 	struct cmd_handler *res = NULL;
-	wlr_log(WLR_DEBUG, "find_handler(%s)", line);
+	sway_log(SWAY_DEBUG, "find_handler(%s)", line);
 
 	bool config_loading = config->reading || !config->active;
 
@@ -247,10 +247,10 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			cmd = argsep(&cmdlist, ",");
 			for (; isspace(*cmd); ++cmd) {}
 			if (strcmp(cmd, "") == 0) {
-				wlr_log(WLR_INFO, "Ignoring empty command.");
+				sway_log(SWAY_INFO, "Ignoring empty command.");
 				continue;
 			}
-			wlr_log(WLR_INFO, "Handling command '%s'", cmd);
+			sway_log(SWAY_INFO, "Handling command '%s'", cmd);
 			//TODO better handling of argv
 			int argc;
 			char **argv = split_args(cmd, &argc);
@@ -353,7 +353,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 	}
 
 	// Determine the command handler
-	wlr_log(WLR_INFO, "Config command: %s", exec);
+	sway_log(SWAY_INFO, "Config command: %s", exec);
 	struct cmd_handler *handler = find_handler(argv[0], NULL, 0);
 	if (!handler || !handler->handle) {
 		const char *error = handler
@@ -373,7 +373,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 		argv[1] = temp;
 	}
 	char *command = do_var_replacement(join_args(argv, argc));
-	wlr_log(WLR_INFO, "After replacement: %s", command);
+	sway_log(SWAY_INFO, "After replacement: %s", command);
 	free_argv(argc, argv);
 	argv = split_args(command, &argc);
 	free(command);
@@ -402,7 +402,7 @@ cleanup:
 struct cmd_results *config_subcommand(char **argv, int argc,
 		struct cmd_handler *handlers, size_t handlers_size) {
 	char *command = join_args(argv, argc);
-	wlr_log(WLR_DEBUG, "Subcommand: %s", command);
+	sway_log(SWAY_DEBUG, "Subcommand: %s", command);
 	free(command);
 
 	struct cmd_handler *handler = find_handler(argv[0], handlers,
@@ -489,7 +489,7 @@ struct cmd_results *config_commands_command(char *exec) {
 	}
 	policy->context = context;
 
-	wlr_log(WLR_INFO, "Set command policy for %s to %d",
+	sway_log(SWAY_INFO, "Set command policy for %s to %d",
 			policy->command, policy->context);
 
 	results = cmd_results_new(CMD_SUCCESS, NULL);
@@ -503,7 +503,7 @@ struct cmd_results *cmd_results_new(enum cmd_status status,
 		const char *format, ...) {
 	struct cmd_results *results = malloc(sizeof(struct cmd_results));
 	if (!results) {
-		wlr_log(WLR_ERROR, "Unable to allocate command results");
+		sway_log(SWAY_ERROR, "Unable to allocate command results");
 		return NULL;
 	}
 	results->status = status;

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -56,7 +56,7 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	criteria->target = join_args(argv, argc);
 
 	list_add(config->criteria, criteria);
-	wlr_log(WLR_DEBUG, "assign: '%s' -> '%s' added", criteria->raw,
+	sway_log(SWAY_DEBUG, "assign: '%s' -> '%s' added", criteria->raw,
 			criteria->target);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -1,9 +1,9 @@
 #define _POSIX_C_SOURCE 200809
 #include <string.h>
 #include <strings.h>
-#include <wlr/util/log.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "log.h"
 #include "util.h"
 
 // Must be in alphabetical order for bsearch
@@ -60,14 +60,14 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		for (int i = 0; i < config->bars->length; ++i) {
 			struct bar_config *item = config->bars->items[i];
 			if (strcmp(item->id, argv[0]) == 0) {
-				wlr_log(WLR_DEBUG, "Selecting bar: %s", argv[0]);
+				sway_log(SWAY_DEBUG, "Selecting bar: %s", argv[0]);
 				bar = item;
 				break;
 			}
 		}
 		if (!bar) {
 			spawn = !config->reading;
-			wlr_log(WLR_DEBUG, "Creating bar: %s", argv[0]);
+			sway_log(SWAY_DEBUG, "Creating bar: %s", argv[0]);
 			bar = default_bar_config();
 			if (!bar) {
 				return cmd_results_new(CMD_FAILURE,
@@ -99,7 +99,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 
 		// Set current bar
 		config->current_bar = bar;
-		wlr_log(WLR_DEBUG, "Creating bar %s", bar->id);
+		sway_log(SWAY_DEBUG, "Creating bar %s", bar->id);
 	}
 
 	if (find_handler(argv[0], bar_config_handlers,

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -59,7 +59,7 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 			overwritten = true;
 			bindings->items[i] = binding;
 			free_bar_binding(other);
-			wlr_log(WLR_DEBUG, "[bar %s] Updated binding for %u (%s)%s",
+			sway_log(SWAY_DEBUG, "[bar %s] Updated binding for %u (%s)%s",
 					config->current_bar->id, binding->button, name,
 					binding->release ? " - release" : "");
 			break;
@@ -67,7 +67,7 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 	}
 	if (!overwritten) {
 		list_add(bindings, binding);
-		wlr_log(WLR_DEBUG, "[bar %s] Added binding for %u (%s)%s",
+		sway_log(SWAY_DEBUG, "[bar %s] Added binding for %u (%s)%s",
 				config->current_bar->id, binding->button, name,
 				binding->release ? " - release" : "");
 	}

--- a/sway/commands/bar/binding_mode_indicator.c
+++ b/sway/commands/bar/binding_mode_indicator.c
@@ -16,10 +16,10 @@ struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {
 	config->current_bar->binding_mode_indicator = 
 		parse_boolean(argv[0], config->current_bar->binding_mode_indicator);
 	if (config->current_bar->binding_mode_indicator) {
-		wlr_log(WLR_DEBUG, "Enabling binding mode indicator on bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling binding mode indicator on bar: %s",
 				config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Disabling binding mode indicator on bar: %s",
+		sway_log(SWAY_DEBUG, "Disabling binding mode indicator on bar: %s",
 				config->current_bar->id);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -15,7 +15,7 @@ struct cmd_results *bar_cmd_font(int argc, char **argv) {
 	char *font = join_args(argv, argc);
 	free(config->current_bar->font);
 	config->current_bar->font = font;
-	wlr_log(WLR_DEBUG, "Settings font '%s' for bar: %s",
+	sway_log(SWAY_DEBUG, "Settings font '%s' for bar: %s",
 			config->current_bar->font, config->current_bar->id);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/gaps.c
+++ b/sway/commands/bar/gaps.c
@@ -47,7 +47,7 @@ struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
 	config->current_bar->gaps.bottom = bottom;
 	config->current_bar->gaps.left = left;
 
-	wlr_log(WLR_DEBUG, "Setting bar gaps to %d %d %d %d on bar: %s",
+	sway_log(SWAY_DEBUG, "Setting bar gaps to %d %d %d %d on bar: %s",
 			config->current_bar->gaps.top, config->current_bar->gaps.right,
 			config->current_bar->gaps.bottom, config->current_bar->gaps.left,
 			config->current_bar->id);

--- a/sway/commands/bar/height.c
+++ b/sway/commands/bar/height.c
@@ -14,7 +14,7 @@ struct cmd_results *bar_cmd_height(int argc, char **argv) {
 				"Invalid height value: %s", argv[0]);
 	}
 	config->current_bar->height = height;
-	wlr_log(WLR_DEBUG, "Setting bar height to %d on bar: %s",
+	sway_log(SWAY_DEBUG, "Setting bar height to %d on bar: %s",
 			height, config->current_bar->id);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/hidden_state.c
+++ b/sway/commands/bar/hidden_state.c
@@ -26,7 +26,7 @@ static struct cmd_results *bar_set_hidden_state(struct bar_config *bar,
 		if (!config->reading) {
 			ipc_event_barconfig_update(bar);
 		}
-		wlr_log(WLR_DEBUG, "Setting hidden_state: '%s' for bar: %s",
+		sway_log(SWAY_DEBUG, "Setting hidden_state: '%s' for bar: %s",
 				bar->hidden_state, bar->id);
 	}
 	// free old mode

--- a/sway/commands/bar/icon_theme.c
+++ b/sway/commands/bar/icon_theme.c
@@ -16,7 +16,7 @@ struct cmd_results *bar_cmd_icon_theme(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "No bar defined.");
 	}
 
-	wlr_log(WLR_DEBUG, "[Bar %s] Setting icon theme to %s",
+	sway_log(SWAY_DEBUG, "[Bar %s] Setting icon theme to %s",
 			config->current_bar->id, argv[0]);
 	free(config->current_bar->icon_theme);
 	config->current_bar->icon_theme = strdup(argv[0]);

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -26,7 +26,7 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 		}
 	}
 
-	wlr_log(WLR_DEBUG, "Renaming bar: '%s' to '%s'", oldname, name);
+	sway_log(SWAY_DEBUG, "Renaming bar: '%s' to '%s'", oldname, name);
 
 	// free old bar id
 	free(config->current_bar->id);

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -28,7 +28,7 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 		if (!config->reading) {
 			ipc_event_barconfig_update(bar);
 		}
-		wlr_log(WLR_DEBUG, "Setting mode: '%s' for bar: %s", bar->mode, bar->id);
+		sway_log(SWAY_DEBUG, "Setting mode: '%s' for bar: %s", bar->mode, bar->id);
 	}
 
 	// free old mode

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -29,7 +29,7 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	}
 	list_free_items_and_destroy(split);
 	config->current_bar->modifier = mod;
-	wlr_log(WLR_DEBUG,
+	sway_log(SWAY_DEBUG,
 			"Show/Hide the bar when pressing '%s' in hide mode.", argv[0]);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/output.c
+++ b/sway/commands/bar/output.c
@@ -42,7 +42,7 @@ struct cmd_results *bar_cmd_output(int argc, char **argv) {
 
 	if (add_output) {
 		list_add(outputs, strdup(output));
-		wlr_log(WLR_DEBUG, "Adding bar: '%s' to output '%s'",
+		sway_log(SWAY_DEBUG, "Adding bar: '%s' to output '%s'",
 				config->current_bar->id, output);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bar/pango_markup.c
+++ b/sway/commands/bar/pango_markup.c
@@ -15,10 +15,10 @@ struct cmd_results *bar_cmd_pango_markup(int argc, char **argv) {
 	config->current_bar->pango_markup 
 		= parse_boolean(argv[0], config->current_bar->pango_markup);
 	if (config->current_bar->pango_markup) {
-		wlr_log(WLR_DEBUG, "Enabling pango markup for bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling pango markup for bar: %s",
 				config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Disabling pango markup for bar: %s",
+		sway_log(SWAY_DEBUG, "Disabling pango markup for bar: %s",
 				config->current_bar->id);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -15,7 +15,7 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 	char *valid[] = { "top", "bottom" };
 	for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
 		if (strcasecmp(valid[i], argv[0]) == 0) {
-			wlr_log(WLR_DEBUG, "Setting bar position '%s' for bar: %s",
+			sway_log(SWAY_DEBUG, "Setting bar position '%s' for bar: %s",
 					argv[0], config->current_bar->id);
 			free(config->current_bar->position);
 			config->current_bar->position = strdup(argv[0]);

--- a/sway/commands/bar/separator_symbol.c
+++ b/sway/commands/bar/separator_symbol.c
@@ -13,7 +13,7 @@ struct cmd_results *bar_cmd_separator_symbol(int argc, char **argv) {
 	}
 	free(config->current_bar->separator_symbol);
 	config->current_bar->separator_symbol = strdup(argv[0]);
-	wlr_log(WLR_DEBUG, "Settings separator_symbol '%s' for bar: %s",
+	sway_log(SWAY_DEBUG, "Settings separator_symbol '%s' for bar: %s",
 			config->current_bar->separator_symbol, config->current_bar->id);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -17,7 +17,7 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {
 		config->current_bar->status_command = new_command;
-		wlr_log(WLR_DEBUG, "Feeding bar with status command: %s",
+		sway_log(SWAY_DEBUG, "Feeding bar with status command: %s",
 				config->current_bar->status_command);
 	} else {
 		free(new_command);

--- a/sway/commands/bar/status_edge_padding.c
+++ b/sway/commands/bar/status_edge_padding.c
@@ -15,7 +15,7 @@ struct cmd_results *bar_cmd_status_edge_padding(int argc, char **argv) {
 				"Padding must be a positive integer");
 	}
 	config->current_bar->status_edge_padding = padding;
-	wlr_log(WLR_DEBUG, "Status edge padding on bar %s: %d",
+	sway_log(SWAY_DEBUG, "Status edge padding on bar %s: %d",
 			config->current_bar->id, config->current_bar->status_edge_padding);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/status_padding.c
+++ b/sway/commands/bar/status_padding.c
@@ -15,7 +15,7 @@ struct cmd_results *bar_cmd_status_padding(int argc, char **argv) {
 				"Padding must be a positive integer");
 	}
 	config->current_bar->status_padding = padding;
-	wlr_log(WLR_DEBUG, "Status padding on bar %s: %d",
+	sway_log(SWAY_DEBUG, "Status padding on bar %s: %d",
 			config->current_bar->id, config->current_bar->status_padding);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/strip_workspace_name.c
+++ b/sway/commands/bar/strip_workspace_name.c
@@ -20,10 +20,10 @@ struct cmd_results *bar_cmd_strip_workspace_name(int argc, char **argv) {
 	if (config->current_bar->strip_workspace_name) {
 		config->current_bar->strip_workspace_numbers = false;
 
-		wlr_log(WLR_DEBUG, "Stripping workspace name on bar: %s",
+		sway_log(SWAY_DEBUG, "Stripping workspace name on bar: %s",
 				config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Enabling workspace name on bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling workspace name on bar: %s",
 				config->current_bar->id);
 	}
 

--- a/sway/commands/bar/strip_workspace_numbers.c
+++ b/sway/commands/bar/strip_workspace_numbers.c
@@ -20,10 +20,10 @@ struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv) {
 	if (config->current_bar->strip_workspace_numbers) {
 		config->current_bar->strip_workspace_name = false;
 
-		wlr_log(WLR_DEBUG, "Stripping workspace numbers on bar: %s",
+		sway_log(SWAY_DEBUG, "Stripping workspace numbers on bar: %s",
 				config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Enabling workspace numbers on bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling workspace numbers on bar: %s",
 				config->current_bar->id);
 	}
 

--- a/sway/commands/bar/swaybar_command.c
+++ b/sway/commands/bar/swaybar_command.c
@@ -13,7 +13,7 @@ struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
 	}
 	free(config->current_bar->swaybar_command);
 	config->current_bar->swaybar_command = join_args(argv, argc);
-	wlr_log(WLR_DEBUG, "Using custom swaybar command: %s",
+	sway_log(SWAY_DEBUG, "Using custom swaybar command: %s",
 			config->current_bar->swaybar_command);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/tray_bind.c
+++ b/sway/commands/bar/tray_bind.c
@@ -67,7 +67,7 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 			other->command = binding->command;
 			free(binding);
 			binding = other;
-			wlr_log(WLR_DEBUG,
+			sway_log(SWAY_DEBUG,
 					"[bar %s] Updated tray binding for %u (%s) to %s",
 					config->current_bar->id, binding->button, name,
 					binding->command);
@@ -76,7 +76,7 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 	}
 	if (!overwritten) {
 		wl_list_insert(&config->current_bar->tray_bindings, &binding->link);
-		wlr_log(WLR_DEBUG, "[bar %s] Added tray binding for %u (%s) to %s",
+		sway_log(SWAY_DEBUG, "[bar %s] Added tray binding for %u (%s) to %s",
 				config->current_bar->id, binding->button, name,
 				binding->command);
 	}

--- a/sway/commands/bar/tray_output.c
+++ b/sway/commands/bar/tray_output.c
@@ -23,13 +23,13 @@ struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
 	}
 
 	if (strcmp(argv[0], "none") == 0) {
-		wlr_log(WLR_DEBUG, "Hiding tray on bar: %s", config->current_bar->id);
+		sway_log(SWAY_DEBUG, "Hiding tray on bar: %s", config->current_bar->id);
 		for (int i = 0; i < outputs->length; ++i) {
 			free(outputs->items[i]);
 		}
 		outputs->length = 0;
 	} else {
-		wlr_log(WLR_DEBUG, "Showing tray on output '%s' for bar: %s", argv[0],
+		sway_log(SWAY_DEBUG, "Showing tray on output '%s' for bar: %s", argv[0],
 				config->current_bar->id);
 	}
 	list_add(outputs, strdup(argv[0]));

--- a/sway/commands/bar/tray_padding.c
+++ b/sway/commands/bar/tray_padding.c
@@ -32,7 +32,7 @@ struct cmd_results *bar_cmd_tray_padding(int argc, char **argv) {
 				"Expected 'tray_padding <px> [px]'");
 	}
 
-	wlr_log(WLR_DEBUG, "[Bar %s] Setting tray padding to %d", bar->id, padding);
+	sway_log(SWAY_DEBUG, "[Bar %s] Setting tray padding to %d", bar->id, padding);
 	config->current_bar->tray_padding = padding;
 	return cmd_results_new(CMD_SUCCESS, NULL);
 #else

--- a/sway/commands/bar/workspace_buttons.c
+++ b/sway/commands/bar/workspace_buttons.c
@@ -15,10 +15,10 @@ struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
 	config->current_bar->workspace_buttons = 
 		parse_boolean(argv[0], config->current_bar->workspace_buttons);
 	if (config->current_bar->workspace_buttons) {
-		wlr_log(WLR_DEBUG, "Enabling workspace buttons on bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling workspace buttons on bar: %s",
 				config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Disabling workspace buttons on bar: %s",
+		sway_log(SWAY_DEBUG, "Disabling workspace buttons on bar: %s",
 				config->current_bar->id);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bar/wrap_scroll.c
+++ b/sway/commands/bar/wrap_scroll.c
@@ -15,10 +15,10 @@ struct cmd_results *bar_cmd_wrap_scroll(int argc, char **argv) {
 	config->current_bar->wrap_scroll = 
 			parse_boolean(argv[0], config->current_bar->wrap_scroll);
 	if (config->current_bar->wrap_scroll) {
-		wlr_log(WLR_DEBUG, "Enabling wrap scroll on bar: %s",
+		sway_log(SWAY_DEBUG, "Enabling wrap scroll on bar: %s",
 			config->current_bar->id);
 	} else {
-		wlr_log(WLR_DEBUG, "Disabling wrap scroll on bar: %s",
+		sway_log(SWAY_DEBUG, "Disabling wrap scroll on bar: %s",
 				config->current_bar->id);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -291,7 +291,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 	for (int i = 0; i < mode_bindings->length; ++i) {
 		struct sway_binding *config_binding = mode_bindings->items[i];
 		if (binding_key_compare(binding, config_binding)) {
-			wlr_log(WLR_INFO, "Overwriting binding '%s' for device '%s' "
+			sway_log(SWAY_INFO, "Overwriting binding '%s' for device '%s' "
 					"from `%s` to `%s`", argv[0], binding->input,
 					binding->command, config_binding->command);
 			if (warn) {
@@ -310,7 +310,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 		list_add(mode_bindings, binding);
 	}
 
-	wlr_log(WLR_DEBUG, "%s - Bound %s to command `%s` for device '%s'",
+	sway_log(SWAY_DEBUG, "%s - Bound %s to command `%s` for device '%s'",
 		bindtype, argv[0], binding->command, binding->input);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
@@ -327,14 +327,14 @@ struct cmd_results *cmd_bindcode(int argc, char **argv) {
  * Execute the command associated to a binding
  */
 void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) {
-	wlr_log(WLR_DEBUG, "running command for binding: %s", binding->command);
+	sway_log(SWAY_DEBUG, "running command for binding: %s", binding->command);
 
 	list_t *res_list = execute_command(binding->command, seat, NULL);
 	bool success = true;
 	for (int i = 0; i < res_list->length; ++i) {
 		struct cmd_results *results = res_list->items[i];
 		if (results->status != CMD_SUCCESS) {
-			wlr_log(WLR_DEBUG, "could not run command for binding: %s (%s)",
+			sway_log(SWAY_DEBUG, "could not run command for binding: %s (%s)",
 				binding->command, results->error);
 			success = false;
 		}

--- a/sway/commands/client.c
+++ b/sway/commands/client.c
@@ -114,6 +114,6 @@ struct cmd_results *cmd_client_urgent(int argc, char **argv) {
 }
 
 struct cmd_results *cmd_client_noop(int argc, char **argv) {
-	wlr_log(WLR_INFO, "Warning: %s is ignored by sway", argv[-1]);
+	sway_log(SWAY_INFO, "Warning: %s is ignored by sway", argv[-1]);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -8,7 +8,7 @@ struct cmd_results *cmd_exec(int argc, char **argv) {
 	if (!config->active) return cmd_results_new(CMD_DEFER, NULL);
 	if (config->reloading) {
 		char *args = join_args(argv, argc);
-		wlr_log(WLR_DEBUG, "Ignoring 'exec %s' due to reload", args);
+		sway_log(SWAY_DEBUG, "Ignoring 'exec %s' due to reload", args);
 		free(args);
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -24,7 +24,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 
 	char *tmp = NULL;
 	if (strcmp(argv[0], "--no-startup-id") == 0) {
-		wlr_log(WLR_INFO, "exec switch '--no-startup-id' not supported, ignored.");
+		sway_log(SWAY_INFO, "exec switch '--no-startup-id' not supported, ignored.");
 		--argc; ++argv;
 		if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
 			return error;
@@ -43,11 +43,11 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	strncpy(cmd, tmp, sizeof(cmd) - 1);
 	cmd[sizeof(cmd) - 1] = 0;
 	free(tmp);
-	wlr_log(WLR_DEBUG, "Executing %s", cmd);
+	sway_log(SWAY_DEBUG, "Executing %s", cmd);
 
 	int fd[2];
 	if (pipe(fd) != 0) {
-		wlr_log(WLR_ERROR, "Unable to create pipe for fork");
+		sway_log(SWAY_ERROR, "Unable to create pipe for fork");
 	}
 
 	pid_t pid, child;
@@ -84,7 +84,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	// cleanup child process
 	waitpid(pid, NULL, 0);
 	if (child > 0) {
-		wlr_log(WLR_DEBUG, "Child process created with pid %d", child);
+		sway_log(SWAY_DEBUG, "Child process created with pid %d", child);
 		root_record_workspace_pid(child);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "Second fork() failed");

--- a/sway/commands/floating_minmax_size.c
+++ b/sway/commands/floating_minmax_size.c
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <wlr/util/log.h>
 #include "sway/commands.h"
 #include "log.h"
 

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -1,6 +1,5 @@
 #include <strings.h>
 #include <wlr/types/wlr_output_layout.h>
-#include <wlr/util/log.h>
 #include "log.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -23,7 +23,7 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 	criteria->cmdlist = join_args(argv + 1, argc - 1);
 
 	list_add(config->criteria, criteria);
-	wlr_log(WLR_DEBUG, "for_window: '%s' -> '%s' added", criteria->raw, criteria->cmdlist);
+	sway_log(SWAY_DEBUG, "for_window: '%s' -> '%s' added", criteria->raw, criteria->cmdlist);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -45,7 +45,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 		return error;
 	}
 
-	wlr_log(WLR_DEBUG, "entering input block: %s", argv[0]);
+	sway_log(SWAY_DEBUG, "entering input block: %s", argv[0]);
 
 	config->handler_context.input_config = new_input_config(argv[0]);
 	if (!config->handler_context.input_config) {

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -16,7 +16,7 @@ struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
 
 	ic->xkb_layout = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "set-xkb_layout for config: %s layout: %s",
+	sway_log(SWAY_DEBUG, "set-xkb_layout for config: %s layout: %s",
 			ic->identifier, ic->xkb_layout);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -16,7 +16,7 @@ struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
 
 	ic->xkb_model = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "set-xkb_model for config: %s model: %s",
+	sway_log(SWAY_DEBUG, "set-xkb_model for config: %s model: %s",
 			ic->identifier, ic->xkb_model);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -16,7 +16,7 @@ struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
 
 	ic->xkb_options = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "set-xkb_options for config: %s options: %s",
+	sway_log(SWAY_DEBUG, "set-xkb_options for config: %s options: %s",
 			ic->identifier, ic->xkb_options);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -16,7 +16,7 @@ struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
 
 	ic->xkb_rules = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "set-xkb_rules for config: %s rules: %s",
+	sway_log(SWAY_DEBUG, "set-xkb_rules for config: %s rules: %s",
 			ic->identifier, ic->xkb_rules);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -16,7 +16,7 @@ struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
 
 	ic->xkb_variant = strdup(argv[0]);
 
-	wlr_log(WLR_DEBUG, "set-xkb_variant for config: %s variant: %s",
+	sway_log(SWAY_DEBUG, "set-xkb_variant for config: %s variant: %s",
 			ic->identifier, ic->xkb_variant);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -1,4 +1,3 @@
-#include <wlr/util/log.h>
 #include "log.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -62,7 +62,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 		return error;
 	}
 	if ((config->reading && argc > 1) || (!config->reading && argc == 1)) {
-		wlr_log(WLR_DEBUG, "Switching to mode `%s' (pango=%d)",
+		sway_log(SWAY_DEBUG, "Switching to mode `%s' (pango=%d)",
 				mode->name, mode->pango);
 	}
 	// Set current mode

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -6,7 +6,6 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
-#include <wlr/util/log.h>
 #include "sway/commands.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
@@ -106,13 +105,13 @@ static void container_move_to_container_from_direction(
 	if (destination->view) {
 		if (destination->parent == container->parent &&
 				destination->workspace == container->workspace) {
-			wlr_log(WLR_DEBUG, "Swapping siblings");
+			sway_log(SWAY_DEBUG, "Swapping siblings");
 			list_t *siblings = container_get_siblings(container);
 			int container_index = list_find(siblings, container);
 			int destination_index = list_find(siblings, destination);
 			list_swap(siblings, container_index, destination_index);
 		} else {
-			wlr_log(WLR_DEBUG, "Promoting to sibling of cousin");
+			sway_log(SWAY_DEBUG, "Promoting to sibling of cousin");
 			int offset =
 				move_dir == WLR_DIRECTION_LEFT || move_dir == WLR_DIRECTION_UP;
 			int index = container_sibling_index(destination) + offset;
@@ -128,7 +127,7 @@ static void container_move_to_container_from_direction(
 	}
 
 	if (is_parallel(destination->layout, move_dir)) {
-		wlr_log(WLR_DEBUG, "Reparenting container (parallel)");
+		sway_log(SWAY_DEBUG, "Reparenting container (parallel)");
 		int index =
 			move_dir == WLR_DIRECTION_RIGHT || move_dir == WLR_DIRECTION_DOWN ?
 			0 : destination->children->length;
@@ -137,7 +136,7 @@ static void container_move_to_container_from_direction(
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "Reparenting container (perpendicular)");
+	sway_log(SWAY_DEBUG, "Reparenting container (perpendicular)");
 	struct sway_node *focus_inactive = seat_get_active_tiling_child(
 			config->handler_context.seat, &destination->node);
 	if (!focus_inactive || focus_inactive == &destination->node) {
@@ -157,7 +156,7 @@ static void container_move_to_workspace_from_direction(
 	container->width = container->height = 0;
 
 	if (is_parallel(workspace->layout, move_dir)) {
-		wlr_log(WLR_DEBUG, "Reparenting container (parallel)");
+		sway_log(SWAY_DEBUG, "Reparenting container (parallel)");
 		int index =
 			move_dir == WLR_DIRECTION_RIGHT || move_dir == WLR_DIRECTION_DOWN ?
 			0 : workspace->tiling->length;
@@ -165,7 +164,7 @@ static void container_move_to_workspace_from_direction(
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "Reparenting container (perpendicular)");
+	sway_log(SWAY_DEBUG, "Reparenting container (perpendicular)");
 	struct sway_container *focus_inactive = seat_get_focus_inactive_tiling(
 			config->handler_context.seat, workspace);
 	if (!focus_inactive) {
@@ -362,7 +361,7 @@ static bool container_move_in_direction(struct sway_container *container,
 		container_move_to_workspace_from_direction(container, ws, move_dir);
 		return true;
 	}
-	wlr_log(WLR_DEBUG, "Hit edge of output, nowhere else to go");
+	sway_log(SWAY_DEBUG, "Hit edge of output, nowhere else to go");
 	return false;
 }
 

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -28,7 +28,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 
 	struct output_config *output = new_output_config(argv[0]);
 	if (!output) {
-		wlr_log(WLR_ERROR, "Failed to allocate output config");
+		sway_log(SWAY_ERROR, "Failed to allocate output config");
 		return NULL;
 	}
 	argc--; argv++;

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -79,7 +79,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 		src = join_args(p.we_wordv, p.we_wordc);
 		wordfree(&p);
 		if (!src) {
-			wlr_log(WLR_ERROR, "Failed to duplicate string");
+			sway_log(SWAY_ERROR, "Failed to duplicate string");
 			return cmd_results_new(CMD_FAILURE, "Unable to allocate resource");
 		}
 
@@ -88,7 +88,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 
 			char *conf = strdup(config->current_config_path);
 			if (!conf) {
-				wlr_log(WLR_ERROR, "Failed to duplicate string");
+				sway_log(SWAY_ERROR, "Failed to duplicate string");
 				free(src);
 				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate resources");
@@ -100,7 +100,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			if (!src) {
 				free(rel_path);
 				free(conf);
-				wlr_log(WLR_ERROR, "Unable to allocate memory");
+				sway_log(SWAY_ERROR, "Unable to allocate memory");
 				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate resources");
 			}
@@ -112,7 +112,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 
 		bool can_access = access(src, F_OK) != -1;
 		if (!can_access) {
-			wlr_log(WLR_ERROR, "Unable to access background file '%s': %s",
+			sway_log(SWAY_ERROR, "Unable to access background file '%s': %s",
 					src, strerror(errno));
 			config_add_swaynag_warning("Unable to access background file '%s'",
 					src);

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -23,7 +23,7 @@ static void do_reload(void *data) {
 	}
 
 	if (!load_main_config(config->current_config_path, true, false)) {
-		wlr_log(WLR_ERROR, "Error(s) reloading config");
+		sway_log(SWAY_ERROR, "Error(s) reloading config");
 		list_free_items_and_destroy(bar_ids);
 		return;
 	}

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -88,7 +88,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 		}
 	}
 
-	wlr_log(WLR_DEBUG, "renaming workspace '%s' to '%s'", workspace->name, new_name);
+	sway_log(SWAY_DEBUG, "renaming workspace '%s' to '%s'", workspace->name, new_name);
 	free(workspace->name);
 	workspace->name = new_name;
 

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <strings.h>
 #include <wlr/util/edges.h>
-#include <wlr/util/log.h>
 #include "sway/commands.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/view.h"

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -23,7 +23,7 @@ static void scratchpad_toggle_auto(void) {
 	// Check if the currently focused window is a scratchpad window and should
 	// be hidden again.
 	if (focus && focus->scratchpad) {
-		wlr_log(WLR_DEBUG, "Focus is a scratchpad window - hiding %s",
+		sway_log(SWAY_DEBUG, "Focus is a scratchpad window - hiding %s",
 				focus->title);
 		root_scratchpad_hide(focus);
 		return;
@@ -34,7 +34,7 @@ static void scratchpad_toggle_auto(void) {
 	for (int i = 0; i < ws->floating->length; ++i) {
 		struct sway_container *floater = ws->floating->items[i];
 		if (floater->scratchpad && focus != floater) {
-			wlr_log(WLR_DEBUG,
+			sway_log(SWAY_DEBUG,
 					"Focusing other scratchpad window (%s) in this workspace",
 					floater->title);
 			root_scratchpad_show(floater);
@@ -47,7 +47,7 @@ static void scratchpad_toggle_auto(void) {
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *con = root->scratchpad->items[i];
 		if (con->parent) {
-			wlr_log(WLR_DEBUG,
+			sway_log(SWAY_DEBUG,
 					"Moving a visible scratchpad window (%s) to this workspace",
 					con->title);
 			root_scratchpad_show(con);
@@ -60,7 +60,7 @@ static void scratchpad_toggle_auto(void) {
 		return;
 	}
 	struct sway_container *con = root->scratchpad->items[0];
-	wlr_log(WLR_DEBUG, "Showing %s from list", con->title);
+	sway_log(SWAY_DEBUG, "Showing %s from list", con->title);
 	root_scratchpad_show(con);
 }
 

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -1,6 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
 #include <strings.h>
-#include <wlr/util/log.h>
 #include "config.h"
 #include "log.h"
 #include "sway/commands.h"
@@ -96,7 +95,7 @@ static void container_swap(struct sway_container *con1,
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "Swapping containers %zu and %zu",
+	sway_log(SWAY_DEBUG, "Swapping containers %zu and %zu",
 			con1->node.id, con2->node.id);
 
 	bool fs1 = con1->is_fullscreen;

--- a/sway/commands/swaybg_command.c
+++ b/sway/commands/swaybg_command.c
@@ -15,7 +15,7 @@ struct cmd_results *cmd_swaybg_command(int argc, char **argv) {
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {
 		config->swaybg_command = new_command;
-		wlr_log(WLR_DEBUG, "Using custom swaybg command: %s",
+		sway_log(SWAY_DEBUG, "Using custom swaybg command: %s",
 				config->swaybg_command);
 	} else {
 		free(new_command);

--- a/sway/commands/swaynag_command.c
+++ b/sway/commands/swaynag_command.c
@@ -15,7 +15,7 @@ struct cmd_results *cmd_swaynag_command(int argc, char **argv) {
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {
 		config->swaynag_command = new_command;
-		wlr_log(WLR_DEBUG, "Using custom swaynag command: %s",
+		sway_log(SWAY_DEBUG, "Using custom swaynag command: %s",
 				config->swaynag_command);
 	} else {
 		free(new_command);

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -13,7 +13,7 @@ struct cmd_results *cmd_xwayland(int argc, char **argv) {
 #ifdef HAVE_XWAYLAND
 	config->xwayland = parse_boolean(argv[0], config->xwayland);
 #else
-	wlr_log(WLR_INFO, "Ignoring `xwayland` command, "
+	sway_log(SWAY_INFO, "Ignoring `xwayland` command, "
 		"sway hasn't been built with Xwayland support");
 #endif
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -335,11 +335,11 @@ static char *get_config_path(void) {
 static bool load_config(const char *path, struct sway_config *config,
 		struct swaynag_instance *swaynag) {
 	if (path == NULL) {
-		wlr_log(WLR_ERROR, "Unable to find a config file!");
+		sway_log(SWAY_ERROR, "Unable to find a config file!");
 		return false;
 	}
 
-	wlr_log(WLR_INFO, "Loading config from %s", path);
+	sway_log(SWAY_INFO, "Loading config from %s", path);
 
 	struct stat sb;
 	if (stat(path, &sb) == 0 && S_ISDIR(sb.st_mode)) {
@@ -348,7 +348,7 @@ static bool load_config(const char *path, struct sway_config *config,
 
 	FILE *f = fopen(path, "r");
 	if (!f) {
-		wlr_log(WLR_ERROR, "Unable to open %s for reading", path);
+		sway_log(SWAY_ERROR, "Unable to open %s for reading", path);
 		return false;
 	}
 
@@ -356,7 +356,7 @@ static bool load_config(const char *path, struct sway_config *config,
 	fclose(f);
 
 	if (!config_load_success) {
-		wlr_log(WLR_ERROR, "Error(s) loading config!");
+		sway_log(SWAY_ERROR, "Error(s) loading config!");
 	}
 
 	return true;
@@ -379,7 +379,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	config_defaults(config);
 	config->validating = validating;
 	if (is_active) {
-		wlr_log(WLR_DEBUG, "Performing configuration file %s",
+		sway_log(SWAY_DEBUG, "Performing configuration file %s",
 			validating ? "validation" : "reload");
 		config->reloading = true;
 		config->active = true;
@@ -403,7 +403,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	/*
 	DIR *dir = opendir(SYSCONFDIR "/sway/security.d");
 	if (!dir) {
-		wlr_log(WLR_ERROR,
+		sway_log(SWAY_ERROR,
 			"%s does not exist, sway will have no security configuration"
 			" and will probably be broken", SYSCONFDIR "/sway/security.d");
 	} else {
@@ -432,7 +432,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 			if (stat(_path, &s) || s.st_uid != 0 || s.st_gid != 0 ||
 					(((s.st_mode & 0777) != 0644) &&
 					(s.st_mode & 0777) != 0444)) {
-				wlr_log(WLR_ERROR,
+				sway_log(SWAY_ERROR,
 					"Refusing to load %s - it must be owned by root "
 					"and mode 644 or 444", _path);
 				success = false;
@@ -488,7 +488,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 		len = len + strlen(parent_dir) + 2;
 		full_path = malloc(len * sizeof(char));
 		if (!full_path) {
-			wlr_log(WLR_ERROR,
+			sway_log(SWAY_ERROR,
 				"Unable to allocate full path to included config");
 			return false;
 		}
@@ -501,7 +501,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 	free(full_path);
 
 	if (real_path == NULL) {
-		wlr_log(WLR_DEBUG, "%s not found.", path);
+		sway_log(SWAY_DEBUG, "%s not found.", path);
 		return false;
 	}
 
@@ -510,7 +510,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 	for (j = 0; j < config->config_chain->length; ++j) {
 		char *old_path = config->config_chain->items[j];
 		if (strcmp(real_path, old_path) == 0) {
-			wlr_log(WLR_DEBUG,
+			sway_log(SWAY_DEBUG,
 				"%s already included once, won't be included again.",
 				real_path);
 			free(real_path);
@@ -565,7 +565,7 @@ bool load_include_configs(const char *path, struct sway_config *config,
 	// restore wd
 	if (chdir(wd) < 0) {
 		free(wd);
-		wlr_log(WLR_ERROR, "failed to restore working directory");
+		sway_log(SWAY_ERROR, "failed to restore working directory");
 		return false;
 	}
 
@@ -630,7 +630,7 @@ static char *expand_line(const char *block, const char *line, bool add_brace) {
 		+ (add_brace ? 2 : 0) + 1;
 	char *expanded = calloc(1, size);
 	if (!expanded) {
-		wlr_log(WLR_ERROR, "Cannot allocate expanded line buffer");
+		sway_log(SWAY_ERROR, "Cannot allocate expanded line buffer");
 		return NULL;
 	}
 	snprintf(expanded, size, "%s%s%s%s", block ? block : "",
@@ -649,7 +649,7 @@ bool read_config(FILE *file, struct sway_config *config,
 		int ret_seek = fseek(file, 0, SEEK_END);
 		long ret_tell = ftell(file);
 		if (ret_seek == -1 || ret_tell == -1) {
-			wlr_log(WLR_ERROR, "Unable to get size of config file");
+			sway_log(SWAY_ERROR, "Unable to get size of config file");
 			return false;
 		}
 		config_size = ret_tell;
@@ -657,7 +657,7 @@ bool read_config(FILE *file, struct sway_config *config,
 
 		config->current_config = this_config = calloc(1, config_size + 1);
 		if (this_config == NULL) {
-			wlr_log(WLR_ERROR, "Unable to allocate buffer for config contents");
+			sway_log(SWAY_ERROR, "Unable to allocate buffer for config contents");
 			return false;
 		}
 	}
@@ -673,7 +673,7 @@ bool read_config(FILE *file, struct sway_config *config,
 	while ((nread = getline_with_cont(&line, &line_size, file, &nlines)) != -1) {
 		if (reading_main_config) {
 			if (read + nread > config_size) {
-				wlr_log(WLR_ERROR, "Config file changed during reading");
+				sway_log(SWAY_ERROR, "Config file changed during reading");
 				success = false;
 				break;
 			}
@@ -687,7 +687,7 @@ bool read_config(FILE *file, struct sway_config *config,
 		}
 
 		line_number += nlines;
-		wlr_log(WLR_DEBUG, "Read line %d: %s", line_number, line);
+		sway_log(SWAY_DEBUG, "Read line %d: %s", line_number, line);
 
 		strip_whitespace(line);
 		if (!*line || line[0] == '#') {
@@ -698,7 +698,7 @@ bool read_config(FILE *file, struct sway_config *config,
 			brace_detected = detect_brace(file);
 			if (brace_detected > 0) {
 				line_number += brace_detected;
-				wlr_log(WLR_DEBUG, "Detected open brace on line %d", line_number);
+				sway_log(SWAY_DEBUG, "Detected open brace on line %d", line_number);
 			}
 		}
 		char *block = stack->length ? stack->items[0] : NULL;
@@ -720,7 +720,7 @@ bool read_config(FILE *file, struct sway_config *config,
 		switch(res->status) {
 		case CMD_FAILURE:
 		case CMD_INVALID:
-			wlr_log(WLR_ERROR, "Error on line %i '%s': %s (%s)", line_number,
+			sway_log(SWAY_ERROR, "Error on line %i '%s': %s (%s)", line_number,
 				line, res->error, config->current_config_path);
 			if (!config->validating) {
 				swaynag_log(config->swaynag_command, swaynag,
@@ -731,17 +731,17 @@ bool read_config(FILE *file, struct sway_config *config,
 			break;
 
 		case CMD_DEFER:
-			wlr_log(WLR_DEBUG, "Deferring command `%s'", line);
+			sway_log(SWAY_DEBUG, "Deferring command `%s'", line);
 			list_add(config->cmd_queue, strdup(expanded));
 			break;
 
 		case CMD_BLOCK_COMMANDS:
-			wlr_log(WLR_DEBUG, "Entering commands block");
+			sway_log(SWAY_DEBUG, "Entering commands block");
 			list_insert(stack, 0, "<commands>");
 			break;
 
 		case CMD_BLOCK:
-			wlr_log(WLR_DEBUG, "Entering block '%s'", new_block);
+			sway_log(SWAY_DEBUG, "Entering block '%s'", new_block);
 			list_insert(stack, 0, strdup(new_block));
 			if (strcmp(new_block, "bar") == 0) {
 				config->current_bar = NULL;
@@ -750,7 +750,7 @@ bool read_config(FILE *file, struct sway_config *config,
 
 		case CMD_BLOCK_END:
 			if (!block) {
-				wlr_log(WLR_DEBUG, "Unmatched '}' on line %i", line_number);
+				sway_log(SWAY_DEBUG, "Unmatched '}' on line %i", line_number);
 				success = false;
 				break;
 			}
@@ -758,7 +758,7 @@ bool read_config(FILE *file, struct sway_config *config,
 				config->current_bar = NULL;
 			}
 
-			wlr_log(WLR_DEBUG, "Exiting block '%s'", block);
+			sway_log(SWAY_DEBUG, "Exiting block '%s'", block);
 			list_del(stack, 0);
 			free(block);
 			memset(&config->handler_context, 0,
@@ -786,7 +786,7 @@ void config_add_swaynag_warning(char *fmt, ...) {
 
 		char *temp = malloc(length + 1);
 		if (!temp) {
-			wlr_log(WLR_ERROR, "Failed to allocate buffer for warning.");
+			sway_log(SWAY_ERROR, "Failed to allocate buffer for warning.");
 			return;
 		}
 
@@ -828,7 +828,7 @@ char *do_var_replacement(char *str) {
 				int vvlen = strlen(var->value);
 				char *newstr = malloc(strlen(str) - vnlen + vvlen + 1);
 				if (!newstr) {
-					wlr_log(WLR_ERROR,
+					sway_log(SWAY_ERROR,
 						"Unable to allocate replacement "
 						"during variable expansion");
 					break;

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -19,10 +19,10 @@
 #include "util.h"
 
 static void terminate_swaybar(pid_t pid) {
-	wlr_log(WLR_DEBUG, "Terminating swaybar %d", pid);
+	sway_log(SWAY_DEBUG, "Terminating swaybar %d", pid);
 	int ret = kill(-pid, SIGTERM);
 	if (ret != 0) {
-		wlr_log_errno(WLR_ERROR, "Unable to terminate swaybar %d", pid);
+		sway_log_errno(SWAY_ERROR, "Unable to terminate swaybar %d", pid);
 	} else {
 		int status;
 		waitpid(pid, &status, 0);
@@ -194,7 +194,7 @@ static void invoke_swaybar(struct bar_config *bar) {
 	// Pipe to communicate errors
 	int filedes[2];
 	if (pipe(filedes) == -1) {
-		wlr_log(WLR_ERROR, "Pipe setup failed! Cannot fork into bar");
+		sway_log(SWAY_ERROR, "Pipe setup failed! Cannot fork into bar");
 		return;
 	}
 
@@ -227,17 +227,17 @@ static void invoke_swaybar(struct bar_config *bar) {
 		execvp(cmd[0], cmd);
 		exit(1);
 	}
-	wlr_log(WLR_DEBUG, "Spawned swaybar %d", bar->pid);
+	sway_log(SWAY_DEBUG, "Spawned swaybar %d", bar->pid);
 	close(filedes[0]);
 	size_t len;
 	if (read(filedes[1], &len, sizeof(size_t)) == sizeof(size_t)) {
 		char *buf = malloc(len);
 		if(!buf) {
-			wlr_log(WLR_ERROR, "Cannot allocate error string");
+			sway_log(SWAY_ERROR, "Cannot allocate error string");
 			return;
 		}
 		if (read(filedes[1], buf, len)) {
-			wlr_log(WLR_ERROR, "%s", buf);
+			sway_log(SWAY_ERROR, "%s", buf);
 		}
 		free(buf);
 	}
@@ -248,7 +248,7 @@ void load_swaybar(struct bar_config *bar) {
 	if (bar->pid != 0) {
 		terminate_swaybar(bar->pid);
 	}
-	wlr_log(WLR_DEBUG, "Invoking swaybar for bar id '%s'", bar->id);
+	sway_log(SWAY_DEBUG, "Invoking swaybar for bar id '%s'", bar->id);
 	invoke_swaybar(bar);
 }
 

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -8,13 +8,13 @@
 struct input_config *new_input_config(const char* identifier) {
 	struct input_config *input = calloc(1, sizeof(struct input_config));
 	if (!input) {
-		wlr_log(WLR_DEBUG, "Unable to allocate input config");
+		sway_log(SWAY_DEBUG, "Unable to allocate input config");
 		return NULL;
 	}
-	wlr_log(WLR_DEBUG, "new_input_config(%s)", identifier);
+	sway_log(SWAY_DEBUG, "new_input_config(%s)", identifier);
 	if (!(input->identifier = strdup(identifier))) {
 		free(input);
-		wlr_log(WLR_DEBUG, "Unable to allocate input config");
+		sway_log(SWAY_DEBUG, "Unable to allocate input config");
 		return NULL;
 	}
 
@@ -136,7 +136,7 @@ static void merge_wildcard_on_all(struct input_config *wildcard) {
 	for (int i = 0; i < config->input_configs->length; i++) {
 		struct input_config *ic = config->input_configs->items[i];
 		if (strcmp(wildcard->identifier, ic->identifier) != 0) {
-			wlr_log(WLR_DEBUG, "Merging input * config on %s", ic->identifier);
+			sway_log(SWAY_DEBUG, "Merging input * config on %s", ic->identifier);
 			merge_input_config(ic, wildcard);
 		}
 	}
@@ -151,16 +151,16 @@ struct input_config *store_input_config(struct input_config *ic) {
 	int i = list_seq_find(config->input_configs, input_identifier_cmp,
 			ic->identifier);
 	if (i >= 0) {
-		wlr_log(WLR_DEBUG, "Merging on top of existing input config");
+		sway_log(SWAY_DEBUG, "Merging on top of existing input config");
 		struct input_config *current = config->input_configs->items[i];
 		merge_input_config(current, ic);
 		free_input_config(ic);
 		ic = current;
 	} else if (!wildcard) {
-		wlr_log(WLR_DEBUG, "Adding non-wildcard input config");
+		sway_log(SWAY_DEBUG, "Adding non-wildcard input config");
 		i = list_seq_find(config->input_configs, input_identifier_cmp, "*");
 		if (i >= 0) {
-			wlr_log(WLR_DEBUG, "Merging on top of input * config");
+			sway_log(SWAY_DEBUG, "Merging on top of input * config");
 			struct input_config *current = new_input_config(ic->identifier);
 			merge_input_config(current, config->input_configs->items[i]);
 			merge_input_config(current, ic);
@@ -170,11 +170,11 @@ struct input_config *store_input_config(struct input_config *ic) {
 		list_add(config->input_configs, ic);
 	} else {
 		// New wildcard config. Just add it
-		wlr_log(WLR_DEBUG, "Adding input * config");
+		sway_log(SWAY_DEBUG, "Adding input * config");
 		list_add(config->input_configs, ic);
 	}
 
-	wlr_log(WLR_DEBUG, "Config stored for input %s", ic->identifier);
+	sway_log(SWAY_DEBUG, "Config stored for input %s", ic->identifier);
 
 	return ic;
 }

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -7,7 +7,7 @@
 struct seat_config *new_seat_config(const char* name) {
 	struct seat_config *seat = calloc(1, sizeof(struct seat_config));
 	if (!seat) {
-		wlr_log(WLR_DEBUG, "Unable to allocate seat config");
+		sway_log(SWAY_DEBUG, "Unable to allocate seat config");
 		return NULL;
 	}
 
@@ -34,7 +34,7 @@ static void merge_wildcard_on_all(struct seat_config *wildcard) {
 	for (int i = 0; i < config->seat_configs->length; i++) {
 		struct seat_config *sc = config->seat_configs->items[i];
 		if (strcmp(wildcard->name, sc->name) != 0) {
-			wlr_log(WLR_DEBUG, "Merging seat * config on %s", sc->name);
+			sway_log(SWAY_DEBUG, "Merging seat * config on %s", sc->name);
 			merge_seat_config(sc, wildcard);
 		}
 	}
@@ -48,16 +48,16 @@ struct seat_config *store_seat_config(struct seat_config *sc) {
 
 	int i = list_seq_find(config->seat_configs, seat_name_cmp, sc->name);
 	if (i >= 0) {
-		wlr_log(WLR_DEBUG, "Merging on top of existing seat config");
+		sway_log(SWAY_DEBUG, "Merging on top of existing seat config");
 		struct seat_config *current = config->seat_configs->items[i];
 		merge_seat_config(current, sc);
 		free_seat_config(sc);
 		sc = current;
 	} else if (!wildcard) {
-		wlr_log(WLR_DEBUG, "Adding non-wildcard seat config");
+		sway_log(SWAY_DEBUG, "Adding non-wildcard seat config");
 		i = list_seq_find(config->seat_configs, seat_name_cmp, "*");
 		if (i >= 0) {
-			wlr_log(WLR_DEBUG, "Merging on top of seat * config");
+			sway_log(SWAY_DEBUG, "Merging on top of seat * config");
 			struct seat_config *current = new_seat_config(sc->name);
 			merge_seat_config(current, config->seat_configs->items[i]);
 			merge_seat_config(current, sc);
@@ -67,11 +67,11 @@ struct seat_config *store_seat_config(struct seat_config *sc) {
 		list_add(config->seat_configs, sc);
 	} else {
 		// New wildcard config. Just add it
-		wlr_log(WLR_DEBUG, "Adding seat * config");
+		sway_log(SWAY_DEBUG, "Adding seat * config");
 		list_add(config->seat_configs, sc);
 	}
 
-	wlr_log(WLR_DEBUG, "Config stored for seat %s", sc->name);
+	sway_log(SWAY_DEBUG, "Config stored for seat %s", sc->name);
 
 	return sc;
 }
@@ -80,7 +80,7 @@ struct seat_attachment_config *seat_attachment_config_new(void) {
 	struct seat_attachment_config *attachment =
 		calloc(1, sizeof(struct seat_attachment_config));
 	if (!attachment) {
-		wlr_log(WLR_DEBUG, "cannot allocate attachment config");
+		sway_log(SWAY_DEBUG, "cannot allocate attachment config");
 		return NULL;
 	}
 	return attachment;

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -626,7 +626,7 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 			}
 			unescape(value);
 		}
-		wlr_log(WLR_DEBUG, "Found pair: %s=%s", name, value);
+		sway_log(SWAY_DEBUG, "Found pair: %s=%s", name, value);
 		if (!parse_token(criteria, name, value)) {
 			*error_arg = error;
 			goto cleanup;

--- a/sway/debug-tree.c
+++ b/sway/debug-tree.c
@@ -1,7 +1,6 @@
 #include <pango/pangocairo.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_texture.h>
-#include <wlr/util/log.h>
 #include "config.h"
 #include "sway/debug.h"
 #include "sway/input/input-manager.h"

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -9,7 +9,7 @@
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_idle_inhibitor_v1 *inhibitor =
 		wl_container_of(listener, inhibitor, destroy);
-	wlr_log(WLR_DEBUG, "Sway idle inhibitor destroyed");
+	sway_log(SWAY_DEBUG, "Sway idle inhibitor destroyed");
 	wl_list_remove(&inhibitor->link);
 	wl_list_remove(&inhibitor->destroy.link);
 	idle_inhibit_v1_check_active(inhibitor->manager);
@@ -20,7 +20,7 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 	struct wlr_idle_inhibitor_v1 *wlr_inhibitor = data;
 	struct sway_idle_inhibit_manager_v1 *manager =
 		wl_container_of(listener, manager, new_idle_inhibitor_v1);
-	wlr_log(WLR_DEBUG, "New sway idle inhibitor");
+	sway_log(SWAY_DEBUG, "New sway idle inhibitor");
 
 	struct sway_idle_inhibitor_v1 *inhibitor =
 		calloc(1, sizeof(struct sway_idle_inhibitor_v1));

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -6,7 +6,6 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output.h>
-#include <wlr/util/log.h>
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
@@ -175,7 +174,7 @@ void arrange_layers(struct sway_output *output) {
 
 	if (memcmp(&usable_area, &output->usable_area,
 				sizeof(struct wlr_box)) != 0) {
-		wlr_log(WLR_DEBUG, "Usable area changed, rearranging output");
+		sway_log(SWAY_DEBUG, "Usable area changed, rearranging output");
 		memcpy(&output->usable_area, &usable_area, sizeof(struct wlr_box));
 		arrange_output(output);
 	}
@@ -308,7 +307,7 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_layer_surface *sway_layer =
 		wl_container_of(listener, sway_layer, destroy);
-	wlr_log(WLR_DEBUG, "Layer surface destroyed (%s)",
+	sway_log(SWAY_DEBUG, "Layer surface destroyed (%s)",
 		sway_layer->layer_surface->namespace);
 	if (sway_layer->layer_surface->mapped) {
 		unmap(sway_layer);
@@ -357,7 +356,7 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	struct wlr_layer_surface_v1 *layer_surface = data;
 	struct sway_server *server =
 		wl_container_of(listener, server, layer_shell_surface);
-	wlr_log(WLR_DEBUG, "new layer surface: namespace %s layer %d anchor %d "
+	sway_log(SWAY_DEBUG, "new layer surface: namespace %s layer %d anchor %d "
 			"size %dx%d margin %d,%d,%d,%d",
 		layer_surface->namespace, layer_surface->layer, layer_surface->layer,
 		layer_surface->client_pending.desired_width,
@@ -380,7 +379,7 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 		}
 		if (!output) {
 			if (!root->outputs->length) {
-				wlr_log(WLR_ERROR,
+				sway_log(SWAY_ERROR,
 						"no output to auto-assign layer surface '%s' to",
 						layer_surface->namespace);
 				wlr_layer_surface_v1_close(layer_surface);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -510,7 +510,7 @@ static void handle_mode(struct wl_listener *listener, void *data) {
 			// We want to enable this output, but it didn't work last time,
 			// possibly because we hadn't enough CRTCs. Try again now that the
 			// output has a mode.
-			wlr_log(WLR_DEBUG, "Output %s has gained a CRTC, "
+			sway_log(SWAY_DEBUG, "Output %s has gained a CRTC, "
 				"trying to enable it", output->wlr_output->name);
 			apply_output_config(oc, output);
 		}
@@ -580,7 +580,7 @@ static void handle_present(struct wl_listener *listener, void *data) {
 void handle_new_output(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;
-	wlr_log(WLR_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
+	sway_log(SWAY_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
 
 	struct sway_output *output = output_create(wlr_output);
 	if (!output) {

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -260,14 +260,14 @@ static void apply_container_state(struct sway_container *container,
  * Apply a transaction to the "current" state of the tree.
  */
 static void transaction_apply(struct sway_transaction *transaction) {
-	wlr_log(WLR_DEBUG, "Applying transaction %p", transaction);
+	sway_log(SWAY_DEBUG, "Applying transaction %p", transaction);
 	if (debug.txn_timings) {
 		struct timespec now;
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		struct timespec *commit = &transaction->commit_time;
 		float ms = (now.tv_sec - commit->tv_sec) * 1000 +
 			(now.tv_nsec - commit->tv_nsec) / 1000000.0;
-		wlr_log(WLR_DEBUG, "Transaction %p: %.1fms waiting "
+		sway_log(SWAY_DEBUG, "Transaction %p: %.1fms waiting "
 				"(%.1f frames if 60Hz)", transaction, ms, ms / (1000.0f / 60));
 	}
 
@@ -363,7 +363,7 @@ static void transaction_progress_queue(void) {
 
 static int handle_timeout(void *data) {
 	struct sway_transaction *transaction = data;
-	wlr_log(WLR_DEBUG, "Transaction %p timed out (%zi waiting)",
+	sway_log(SWAY_DEBUG, "Transaction %p timed out (%zi waiting)",
 			transaction, transaction->num_waiting);
 	transaction->num_waiting = 0;
 	transaction_progress_queue();
@@ -398,7 +398,7 @@ static bool should_configure(struct sway_node *node,
 }
 
 static void transaction_commit(struct sway_transaction *transaction) {
-	wlr_log(WLR_DEBUG, "Transaction %p committing with %i instructions",
+	sway_log(SWAY_DEBUG, "Transaction %p committing with %i instructions",
 			transaction, transaction->instructions->length);
 	transaction->num_waiting = 0;
 	for (int i = 0; i < transaction->instructions->length; ++i) {
@@ -449,7 +449,7 @@ static void transaction_commit(struct sway_transaction *transaction) {
 			wl_event_source_timer_update(transaction->timer,
 					server.txn_timeout_ms);
 		} else {
-			wlr_log(WLR_ERROR, "Unable to create transaction timer (%s). "
+			sway_log(SWAY_ERROR, "Unable to create transaction timer (%s). "
 					"Some imperfect frames might be rendered.",
 					strerror(errno));
 			transaction->num_waiting = 0;
@@ -472,7 +472,7 @@ static void set_instruction_ready(
 		struct timespec *start = &transaction->commit_time;
 		float ms = (now.tv_sec - start->tv_sec) * 1000 +
 			(now.tv_nsec - start->tv_nsec) / 1000000.0;
-		wlr_log(WLR_DEBUG, "Transaction %p: %zi/%zi ready in %.1fms (%s)",
+		sway_log(SWAY_DEBUG, "Transaction %p: %zi/%zi ready in %.1fms (%s)",
 				transaction,
 				transaction->num_configures - transaction->num_waiting + 1,
 				transaction->num_configures, ms,
@@ -481,7 +481,7 @@ static void set_instruction_ready(
 
 	// If the transaction has timed out then its num_waiting will be 0 already.
 	if (transaction->num_waiting > 0 && --transaction->num_waiting == 0) {
-		wlr_log(WLR_DEBUG, "Transaction %p is ready", transaction);
+		sway_log(SWAY_DEBUG, "Transaction %p is ready", transaction);
 		wl_event_source_timer_update(transaction->timer, 0);
 	}
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -485,11 +485,11 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_surface *xdg_surface = data;
 
 	if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
-		wlr_log(WLR_DEBUG, "New xdg_shell popup");
+		sway_log(SWAY_DEBUG, "New xdg_shell popup");
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "New xdg_shell toplevel title='%s' app_id='%s'",
+	sway_log(SWAY_DEBUG, "New xdg_shell toplevel title='%s' app_id='%s'",
 		xdg_surface->toplevel->title, xdg_surface->toplevel->app_id);
 	wlr_xdg_surface_ping(xdg_surface);
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -469,11 +469,11 @@ void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
 	struct wlr_xdg_surface_v6 *xdg_surface = data;
 
 	if (xdg_surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP) {
-		wlr_log(WLR_DEBUG, "New xdg_shell_v6 popup");
+		sway_log(SWAY_DEBUG, "New xdg_shell_v6 popup");
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "New xdg_shell_v6 toplevel title='%s' app_id='%s'",
+	sway_log(SWAY_DEBUG, "New xdg_shell_v6 toplevel title='%s' app_id='%s'",
 		xdg_surface->toplevel->title, xdg_surface->toplevel->app_id);
 	wlr_xdg_surface_v6_ping(xdg_surface);
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -118,7 +118,7 @@ static struct sway_xwayland_unmanaged *create_unmanaged(
 	struct sway_xwayland_unmanaged *surface =
 		calloc(1, sizeof(struct sway_xwayland_unmanaged));
 	if (surface == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
+		sway_log(SWAY_ERROR, "Allocation failed");
 		return NULL;
 	}
 
@@ -578,12 +578,12 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	struct wlr_xwayland_surface *xsurface = data;
 
 	if (xsurface->override_redirect) {
-		wlr_log(WLR_DEBUG, "New xwayland unmanaged surface");
+		sway_log(SWAY_DEBUG, "New xwayland unmanaged surface");
 		create_unmanaged(xsurface);
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "New xwayland surface title='%s' class='%s'",
+	sway_log(SWAY_DEBUG, "New xwayland surface title='%s' class='%s'",
 		xsurface->title, xsurface->class);
 
 	struct sway_xwayland_view *xwayland_view =
@@ -655,7 +655,7 @@ void handle_xwayland_ready(struct wl_listener *listener, void *data) {
 	xcb_connection_t *xcb_conn = xcb_connect(NULL, NULL);
 	int err = xcb_connection_has_error(xcb_conn);
 	if (err) {
-		wlr_log(WLR_ERROR, "XCB connect failed: %d", err);
+		sway_log(SWAY_ERROR, "XCB connect failed: %d", err);
 		return;
 	}
 
@@ -674,7 +674,7 @@ void handle_xwayland_ready(struct wl_listener *listener, void *data) {
 		free(reply);
 
 		if (error != NULL) {
-			wlr_log(WLR_ERROR, "could not resolve atom %s, X11 error code %d",
+			sway_log(SWAY_ERROR, "could not resolve atom %s, X11 error code %d",
 				atom_map[i], error->error_code);
 			free(error);
 			break;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -713,7 +713,7 @@ static uint32_t wl_axis_to_button(struct wlr_event_pointer_axis *event) {
 	case WLR_AXIS_ORIENTATION_HORIZONTAL:
 		return event->delta < 0 ? SWAY_SCROLL_LEFT : SWAY_SCROLL_RIGHT;
 	default:
-		wlr_log(WLR_DEBUG, "Unknown axis orientation");
+		sway_log(SWAY_DEBUG, "Unknown axis orientation");
 		return 0;
 	}
 }
@@ -1004,7 +1004,7 @@ static void handle_request_set_cursor(struct wl_listener *listener,
 	// TODO: check cursor mode
 	if (focused_client == NULL ||
 			event->seat_client->client != focused_client) {
-		wlr_log(WLR_DEBUG, "denying request to set cursor from unfocused client");
+		sway_log(SWAY_DEBUG, "denying request to set cursor from unfocused client");
 		return;
 	}
 

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -62,7 +62,7 @@ char *input_device_get_identifier(struct wlr_input_device *device) {
 	int len = snprintf(NULL, 0, fmt, vendor, product, name) + 1;
 	char *identifier = malloc(len);
 	if (!identifier) {
-		wlr_log(WLR_ERROR, "Unable to allocate unique input device name");
+		sway_log(SWAY_ERROR, "Unable to allocate unique input device name");
 		return NULL;
 	}
 
@@ -98,7 +98,7 @@ static bool input_has_seat_fallback_configuration(void) {
 void input_manager_verify_fallback_seat(void) {
 	struct sway_seat *seat = NULL;
 	if (!input_has_seat_fallback_configuration()) {
-		wlr_log(WLR_DEBUG, "no fallback seat config - creating default");
+		sway_log(SWAY_DEBUG, "no fallback seat config - creating default");
 		seat = input_manager_get_default_seat();
 		struct seat_config *sc = new_seat_config(seat->wlr_seat->name);
 		sc->fallback = true;
@@ -118,11 +118,11 @@ static void input_manager_libinput_config_keyboard(
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	wlr_log(WLR_DEBUG, "input_manager_libinput_config_keyboard(%s)",
+	sway_log(SWAY_DEBUG, "input_manager_libinput_config_keyboard(%s)",
 		ic->identifier);
 
 	if (ic->send_events != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_keyboard(%s) send_events_set_mode(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_keyboard(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
 		libinput_device_config_send_events_set_mode(libinput_device,
 			ic->send_events);
@@ -142,7 +142,7 @@ static void input_manager_libinput_reset_keyboard(
 
 	uint32_t send_events =
 		libinput_device_config_send_events_get_default_mode(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_keyboard(%s) send_events_set_mode(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_keyboard(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
 	libinput_device_config_send_events_set_mode(libinput_device, send_events);
 }
@@ -158,11 +158,11 @@ static void input_manager_libinput_config_touch(
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	wlr_log(WLR_DEBUG, "input_manager_libinput_config_touch(%s)",
+	sway_log(SWAY_DEBUG, "input_manager_libinput_config_touch(%s)",
 		ic->identifier);
 
 	if (ic->send_events != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_touch(%s) send_events_set_mode(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_touch(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
 		libinput_device_config_send_events_set_mode(libinput_device,
 			ic->send_events);
@@ -182,7 +182,7 @@ static void input_manager_libinput_reset_touch(
 
 	uint32_t send_events =
 		libinput_device_config_send_events_get_default_mode(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_touch(%s) send_events_set_mode(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_touch(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
 	libinput_device_config_send_events_set_mode(libinput_device, send_events);
 }
@@ -198,92 +198,92 @@ static void input_manager_libinput_config_pointer(
 	}
 
 	libinput_device = wlr_libinput_get_device_handle(wlr_device);
-	wlr_log(WLR_DEBUG, "input_manager_libinput_config_pointer(%s)",
+	sway_log(SWAY_DEBUG, "input_manager_libinput_config_pointer(%s)",
 		ic->identifier);
 
 	if (ic->accel_profile != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
 			ic->identifier, ic->accel_profile);
 		libinput_device_config_accel_set_profile(libinput_device,
 			ic->accel_profile);
 	}
 	if (ic->click_method != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
 			ic->identifier, ic->click_method);
 		libinput_device_config_click_set_method(libinput_device,
 			ic->click_method);
 	}
 	if (ic->drag != INT_MIN) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"libinput_config_pointer(%s) tap_set_drag_enabled(%d)",
 			ic->identifier, ic->drag);
 		libinput_device_config_tap_set_drag_enabled(libinput_device,
 			ic->drag);
 	}
 	if (ic->drag_lock != INT_MIN) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			ic->identifier, ic->drag_lock);
 		libinput_device_config_tap_set_drag_lock_enabled(libinput_device,
 			ic->drag_lock);
 	}
 	if (ic->dwt != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
 			ic->identifier, ic->dwt);
 		libinput_device_config_dwt_set_enabled(libinput_device, ic->dwt);
 	}
 	if (ic->left_handed != INT_MIN) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"libinput_config_pointer(%s) left_handed_set_enabled(%d)",
 			ic->identifier, ic->left_handed);
 		libinput_device_config_left_handed_set(libinput_device,
 			ic->left_handed);
 	}
 	if (ic->middle_emulation != INT_MIN) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
 			ic->identifier, ic->middle_emulation);
 		libinput_device_config_middle_emulation_set_enabled(libinput_device,
 			ic->middle_emulation);
 	}
 	if (ic->natural_scroll != INT_MIN) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
 			ic->identifier, ic->natural_scroll);
 		libinput_device_config_scroll_set_natural_scroll_enabled(
 			libinput_device, ic->natural_scroll);
 	}
 	if (ic->pointer_accel != FLT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
 			ic->identifier, ic->pointer_accel);
 		libinput_device_config_accel_set_speed(libinput_device,
 			ic->pointer_accel);
 	}
 	if (ic->scroll_button != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_button(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) scroll_set_button(%d)",
 			ic->identifier, ic->scroll_button);
 		libinput_device_config_scroll_set_button(libinput_device,
 			ic->scroll_button);
 	}
 	if (ic->scroll_method != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
 			ic->identifier, ic->scroll_method);
 		libinput_device_config_scroll_set_method(libinput_device,
 			ic->scroll_method);
 	}
 	if (ic->send_events != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
 		libinput_device_config_send_events_set_mode(libinput_device,
 			ic->send_events);
 	}
 	if (ic->tap != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",
 			ic->identifier, ic->tap);
 		libinput_device_config_tap_set_enabled(libinput_device, ic->tap);
 	}
 	if (ic->tap_button_map != INT_MIN) {
-		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) tap_set_button_map(%d)",
+		sway_log(SWAY_DEBUG, "libinput_config_pointer(%s) tap_set_button_map(%d)",
 			ic->identifier, ic->tap_button_map);
 		libinput_device_config_tap_set_button_map(libinput_device,
 			ic->tap_button_map);
@@ -303,26 +303,26 @@ static void input_manager_libinput_reset_pointer(
 
 	enum libinput_config_accel_profile accel_profile =
 		libinput_device_config_accel_get_default_profile(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) accel_set_profile(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) accel_set_profile(%d)",
 			input_device->identifier, accel_profile);
 	libinput_device_config_accel_set_profile(libinput_device, accel_profile);
 
 	enum libinput_config_click_method click_method =
 		libinput_device_config_click_get_default_method(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) click_set_method(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) click_set_method(%d)",
 		input_device->identifier, click_method);
 	libinput_device_config_click_set_method(libinput_device, click_method);
 
 	enum libinput_config_drag_state drag =
 		libinput_device_config_tap_get_default_drag_enabled(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_drag_enabled(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) tap_set_drag_enabled(%d)",
 			input_device->identifier, drag);
 	libinput_device_config_tap_set_drag_enabled(libinput_device, drag);
 
 	enum libinput_config_drag_lock_state drag_lock =
 		libinput_device_config_tap_get_default_drag_lock_enabled(
 				libinput_device);
-	wlr_log(WLR_DEBUG,
+	sway_log(SWAY_DEBUG,
 			"libinput_reset_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			input_device->identifier, drag_lock);
 	libinput_device_config_tap_set_drag_lock_enabled(libinput_device,
@@ -330,13 +330,13 @@ static void input_manager_libinput_reset_pointer(
 
 	enum libinput_config_dwt_state dwt =
 		libinput_device_config_dwt_get_default_enabled(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) dwt_set_enabled(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) dwt_set_enabled(%d)",
 		input_device->identifier, dwt);
 	libinput_device_config_dwt_set_enabled(libinput_device, dwt);
 
 	int left_handed =
 		libinput_device_config_left_handed_get_default(libinput_device);
-	wlr_log(WLR_DEBUG,
+	sway_log(SWAY_DEBUG,
 		"libinput_reset_pointer(%s) left_handed_set_enabled(%d)",
 		input_device->identifier, left_handed);
 	libinput_device_config_left_handed_set(libinput_device, left_handed);
@@ -344,7 +344,7 @@ static void input_manager_libinput_reset_pointer(
 	enum libinput_config_middle_emulation_state middle_emulation =
 		libinput_device_config_middle_emulation_get_default_enabled(
 				libinput_device);
-	wlr_log(WLR_DEBUG,
+	sway_log(SWAY_DEBUG,
 		"libinput_reset_pointer(%s) middle_emulation_set_enabled(%d)",
 		input_device->identifier, middle_emulation);
 	libinput_device_config_middle_emulation_set_enabled(libinput_device,
@@ -353,7 +353,7 @@ static void input_manager_libinput_reset_pointer(
 	int natural_scroll =
 		libinput_device_config_scroll_get_default_natural_scroll_enabled(
 				libinput_device);
-	wlr_log(WLR_DEBUG,
+	sway_log(SWAY_DEBUG,
 		"libinput_reset_pointer(%s) natural_scroll_set_enabled(%d)",
 		input_device->identifier, natural_scroll);
 	libinput_device_config_scroll_set_natural_scroll_enabled(
@@ -361,37 +361,37 @@ static void input_manager_libinput_reset_pointer(
 
 	double pointer_accel =
 		libinput_device_config_accel_get_default_speed(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) accel_set_speed(%f)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) accel_set_speed(%f)",
 		input_device->identifier, pointer_accel);
 	libinput_device_config_accel_set_speed(libinput_device, pointer_accel);
 
 	uint32_t scroll_button =
 		libinput_device_config_scroll_get_default_button(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) scroll_set_button(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) scroll_set_button(%d)",
 		input_device->identifier, scroll_button);
 	libinput_device_config_scroll_set_button(libinput_device, scroll_button);
 
 	enum libinput_config_scroll_method scroll_method =
 		libinput_device_config_scroll_get_default_method(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) scroll_set_method(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) scroll_set_method(%d)",
 		input_device->identifier, scroll_method);
 	libinput_device_config_scroll_set_method(libinput_device, scroll_method);
 
 	uint32_t send_events =
 		libinput_device_config_send_events_get_default_mode(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) send_events_set_mode(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
 	libinput_device_config_send_events_set_mode(libinput_device, send_events);
 
 	enum libinput_config_tap_state tap =
 		libinput_device_config_tap_get_default_enabled(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_enabled(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) tap_set_enabled(%d)",
 		input_device->identifier, tap);
 	libinput_device_config_tap_set_enabled(libinput_device, tap);
 
 	enum libinput_config_tap_button_map tap_button_map =
 		libinput_device_config_tap_get_button_map(libinput_device);
-	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_button_map(%d)",
+	sway_log(SWAY_DEBUG, "libinput_reset_pointer(%s) tap_set_button_map(%d)",
 		input_device->identifier, tap_button_map);
 	libinput_device_config_tap_set_button_map(libinput_device, tap_button_map);
 }
@@ -405,7 +405,7 @@ static void handle_device_destroy(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "removing device: '%s'",
+	sway_log(SWAY_DEBUG, "removing device: '%s'",
 		input_device->identifier);
 
 	struct sway_seat *seat = NULL;
@@ -435,7 +435,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	input_device->identifier = input_device_get_identifier(device);
 	wl_list_insert(&input->devices, &input_device->link);
 
-	wlr_log(WLR_DEBUG, "adding device: '%s'",
+	sway_log(SWAY_DEBUG, "adding device: '%s'",
 		input_device->identifier);
 
 	if (input_device->wlr_device->type == WLR_INPUT_DEVICE_POINTER ||
@@ -477,7 +477,7 @@ static void handle_new_input(struct wl_listener *listener, void *data) {
 	}
 
 	if (!added) {
-		wlr_log(WLR_DEBUG,
+		sway_log(SWAY_DEBUG,
 			"device '%s' is not configured on any seats",
 			input_device->identifier);
 	}
@@ -527,7 +527,7 @@ void handle_virtual_keyboard(struct wl_listener *listener, void *data) {
 	input_device->identifier = input_device_get_identifier(device);
 	wl_list_insert(&input_manager->devices, &input_device->link);
 
-	wlr_log(WLR_DEBUG, "adding virtual keyboard: '%s'",
+	sway_log(SWAY_DEBUG, "adding virtual keyboard: '%s'",
 		input_device->identifier);
 
 	wl_signal_add(&device->events.destroy, &input_device->device_destroy);
@@ -633,7 +633,7 @@ void input_manager_reset_all_inputs() {
 
 
 void input_manager_apply_seat_config(struct seat_config *seat_config) {
-	wlr_log(WLR_DEBUG, "applying seat config for seat %s", seat_config->name);
+	sway_log(SWAY_DEBUG, "applying seat config for seat %s", seat_config->name);
 	if (strcmp(seat_config->name, "*") == 0) {
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -126,7 +126,7 @@ static void get_active_binding(const struct sway_shortcut_state *state,
 
 		if (*current_binding && *current_binding != binding &&
 				strcmp((*current_binding)->input, binding->input) == 0) {
-			wlr_log(WLR_DEBUG, "encountered duplicate bindings %d and %d",
+			sway_log(SWAY_DEBUG, "encountered duplicate bindings %d and %d",
 					(*current_binding)->order, binding->order);
 		} else if (!*current_binding ||
 				strcmp((*current_binding)->input, "*") == 0) {
@@ -219,7 +219,7 @@ void sway_keyboard_disarm_key_repeat(struct sway_keyboard *keyboard) {
 	}
 	keyboard->repeat_binding = NULL;
 	if (wl_event_source_timer_update(keyboard->key_repeat_source, 0) < 0) {
-		wlr_log(WLR_DEBUG, "failed to disarm key repeat timer");
+		sway_log(SWAY_DEBUG, "failed to disarm key repeat timer");
 	}
 }
 
@@ -313,7 +313,7 @@ static void handle_keyboard_key(struct wl_listener *listener, void *data) {
 		keyboard->repeat_binding = binding;
 		if (wl_event_source_timer_update(keyboard->key_repeat_source,
 				wlr_device->keyboard->repeat_info.delay) < 0) {
-			wlr_log(WLR_DEBUG, "failed to set key repeat timer");
+			sway_log(SWAY_DEBUG, "failed to set key repeat timer");
 		}
 	} else if (keyboard->repeat_binding) {
 		sway_keyboard_disarm_key_repeat(keyboard);
@@ -356,7 +356,7 @@ static int handle_keyboard_repeat(void *data) {
 			// We queue the next event first, as the command might cancel it
 			if (wl_event_source_timer_update(keyboard->key_repeat_source,
 					1000 / wlr_device->repeat_info.rate) < 0) {
-				wlr_log(WLR_DEBUG, "failed to update key repeat timer");
+				sway_log(SWAY_DEBUG, "failed to update key repeat timer");
 			}
 		}
 
@@ -460,7 +460,7 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 		xkb_keymap_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
 
 	if (!keymap) {
-		wlr_log(WLR_DEBUG, "cannot configure keyboard: keymap does not exist");
+		sway_log(SWAY_DEBUG, "cannot configure keyboard: keymap does not exist");
 		xkb_context_unref(context);
 		return;
 	}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -62,7 +62,7 @@ static void seat_node_destroy(struct sway_seat_node *seat_node) {
 static void seat_send_activate(struct sway_node *node, struct sway_seat *seat) {
 	if (node_is_view(node)) {
 		if (!seat_is_input_allowed(seat, node->sway_container->view->surface)) {
-			wlr_log(WLR_DEBUG, "Refusing to set focus, input is inhibited");
+			sway_log(SWAY_DEBUG, "Refusing to set focus, input is inhibited");
 			return;
 		}
 		view_set_activated(node->sway_container->view, true);
@@ -208,7 +208,7 @@ static struct sway_seat_node *seat_node_from_node(
 
 	seat_node = calloc(1, sizeof(struct sway_seat_node));
 	if (seat_node == NULL) {
-		wlr_log(WLR_ERROR, "could not allocate seat node");
+		sway_log(SWAY_ERROR, "could not allocate seat node");
 		return NULL;
 	}
 
@@ -289,7 +289,7 @@ static void handle_new_drag_icon(struct wl_listener *listener, void *data) {
 
 	struct sway_drag_icon *icon = calloc(1, sizeof(struct sway_drag_icon));
 	if (icon == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
+		sway_log(SWAY_ERROR, "Allocation failed");
 		return;
 	}
 	icon->seat = seat;
@@ -407,7 +407,7 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 
 static void seat_reset_input_config(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
-	wlr_log(WLR_DEBUG, "Resetting output mapping for input device %s",
+	sway_log(SWAY_DEBUG, "Resetting output mapping for input device %s",
 		sway_device->input_device->identifier);
 	wlr_cursor_map_input_to_output(seat->cursor->cursor,
 		sway_device->input_device->wlr_device, NULL);
@@ -420,7 +420,7 @@ static void seat_apply_input_config(struct sway_seat *seat,
 	struct input_config *ic = input_device_get_config(
 			sway_device->input_device);
 	if (ic != NULL) {
-		wlr_log(WLR_DEBUG, "Applying input config to %s",
+		sway_log(SWAY_DEBUG, "Applying input config to %s",
 			sway_device->input_device->identifier);
 
 		mapped_to_output = ic->mapped_to_output;
@@ -430,19 +430,19 @@ static void seat_apply_input_config(struct sway_seat *seat,
 		mapped_to_output = sway_device->input_device->wlr_device->output_name;
 	}
 	if (mapped_to_output != NULL) {
-		wlr_log(WLR_DEBUG, "Mapping input device %s to output %s",
+		sway_log(SWAY_DEBUG, "Mapping input device %s to output %s",
 			sway_device->input_device->identifier, mapped_to_output);
 		if (strcmp("*", mapped_to_output) == 0) {
 			wlr_cursor_map_input_to_output(seat->cursor->cursor,
 				sway_device->input_device->wlr_device, NULL);
-			wlr_log(WLR_DEBUG, "Reset output mapping");
+			sway_log(SWAY_DEBUG, "Reset output mapping");
 			return;
 		}
 		struct sway_output *output = output_by_name_or_id(mapped_to_output);
 		if (output) {
 			wlr_cursor_map_input_to_output(seat->cursor->cursor,
 				sway_device->input_device->wlr_device, output->wlr_output);
-			wlr_log(WLR_DEBUG, "Mapped to output %s", output->wlr_output->name);
+			sway_log(SWAY_DEBUG, "Mapped to output %s", output->wlr_output->name);
 		}
 	}
 }
@@ -522,10 +522,10 @@ void seat_configure_device(struct sway_seat *seat,
 			seat_configure_tablet_tool(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
-			wlr_log(WLR_DEBUG, "TODO: configure tablet pad");
+			sway_log(SWAY_DEBUG, "TODO: configure tablet pad");
 			break;
 		case WLR_INPUT_DEVICE_SWITCH:
-			wlr_log(WLR_DEBUG, "TODO: configure switch device");
+			sway_log(SWAY_DEBUG, "TODO: configure switch device");
 			break;
 	}
 }
@@ -552,10 +552,10 @@ void seat_reset_device(struct sway_seat *seat,
 			seat_reset_input_config(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
-			wlr_log(WLR_DEBUG, "TODO: reset tablet pad");
+			sway_log(SWAY_DEBUG, "TODO: reset tablet pad");
 			break;
 		case WLR_INPUT_DEVICE_SWITCH:
-			wlr_log(WLR_DEBUG, "TODO: reset switch device");
+			sway_log(SWAY_DEBUG, "TODO: reset switch device");
 			break;
 	}
 }
@@ -570,11 +570,11 @@ void seat_add_device(struct sway_seat *seat,
 	struct sway_seat_device *seat_device =
 		calloc(1, sizeof(struct sway_seat_device));
 	if (!seat_device) {
-		wlr_log(WLR_DEBUG, "could not allocate seat device");
+		sway_log(SWAY_DEBUG, "could not allocate seat device");
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "adding device %s to seat %s",
+	sway_log(SWAY_DEBUG, "adding device %s to seat %s",
 		input_device->identifier, seat->wlr_seat->name);
 
 	seat_device->sway_seat = seat;
@@ -594,7 +594,7 @@ void seat_remove_device(struct sway_seat *seat,
 		return;
 	}
 
-	wlr_log(WLR_DEBUG, "removing device %s from seat %s",
+	sway_log(SWAY_DEBUG, "removing device %s from seat %s",
 		input_device->identifier, seat->wlr_seat->name);
 
 	seat_device_destroy(seat_device);
@@ -790,7 +790,7 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 				wl_event_source_timer_update(view->urgent_timer,
 						config->urgent_timeout);
 			} else {
-				wlr_log(WLR_ERROR, "Unable to create urgency timer (%s)",
+				sway_log(SWAY_ERROR, "Unable to create urgency timer (%s)",
 						strerror(errno));
 				handle_urgent_timeout(view);
 			}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -147,32 +147,32 @@ struct sockaddr_un *ipc_user_sockaddr(void) {
 int ipc_handle_connection(int fd, uint32_t mask, void *data) {
 	(void) fd;
 	struct sway_server *server = data;
-	wlr_log(WLR_DEBUG, "Event on IPC listening socket");
+	sway_log(SWAY_DEBUG, "Event on IPC listening socket");
 	assert(mask == WL_EVENT_READABLE);
 
 	int client_fd = accept(ipc_socket, NULL, NULL);
 	if (client_fd == -1) {
-		wlr_log_errno(WLR_ERROR, "Unable to accept IPC client connection");
+		sway_log_errno(SWAY_ERROR, "Unable to accept IPC client connection");
 		return 0;
 	}
 
 	int flags;
 	if ((flags = fcntl(client_fd, F_GETFD)) == -1
 			|| fcntl(client_fd, F_SETFD, flags|FD_CLOEXEC) == -1) {
-		wlr_log_errno(WLR_ERROR, "Unable to set CLOEXEC on IPC client socket");
+		sway_log_errno(SWAY_ERROR, "Unable to set CLOEXEC on IPC client socket");
 		close(client_fd);
 		return 0;
 	}
 	if ((flags = fcntl(client_fd, F_GETFL)) == -1
 			|| fcntl(client_fd, F_SETFL, flags|O_NONBLOCK) == -1) {
-		wlr_log_errno(WLR_ERROR, "Unable to set NONBLOCK on IPC client socket");
+		sway_log_errno(SWAY_ERROR, "Unable to set NONBLOCK on IPC client socket");
 		close(client_fd);
 		return 0;
 	}
 
 	struct ipc_client *client = malloc(sizeof(struct ipc_client));
 	if (!client) {
-		wlr_log(WLR_ERROR, "Unable to allocate ipc client");
+		sway_log(SWAY_ERROR, "Unable to allocate ipc client");
 		close(client_fd);
 		return 0;
 	}
@@ -188,12 +188,12 @@ int ipc_handle_connection(int fd, uint32_t mask, void *data) {
 	client->write_buffer_len = 0;
 	client->write_buffer = malloc(client->write_buffer_size);
 	if (!client->write_buffer) {
-		wlr_log(WLR_ERROR, "Unable to allocate ipc client write buffer");
+		sway_log(SWAY_ERROR, "Unable to allocate ipc client write buffer");
 		close(client_fd);
 		return 0;
 	}
 
-	wlr_log(WLR_DEBUG, "New client: fd %d", client_fd);
+	sway_log(SWAY_DEBUG, "New client: fd %d", client_fd);
 	list_add(ipc_client_list, client);
 	return 0;
 }
@@ -202,22 +202,22 @@ int ipc_client_handle_readable(int client_fd, uint32_t mask, void *data) {
 	struct ipc_client *client = data;
 
 	if (mask & WL_EVENT_ERROR) {
-		wlr_log(WLR_ERROR, "IPC Client socket error, removing client");
+		sway_log(SWAY_ERROR, "IPC Client socket error, removing client");
 		ipc_client_disconnect(client);
 		return 0;
 	}
 
 	if (mask & WL_EVENT_HANGUP) {
-		wlr_log(WLR_DEBUG, "Client %d hung up", client->fd);
+		sway_log(SWAY_DEBUG, "Client %d hung up", client->fd);
 		ipc_client_disconnect(client);
 		return 0;
 	}
 
-	wlr_log(WLR_DEBUG, "Client %d readable", client->fd);
+	sway_log(SWAY_DEBUG, "Client %d readable", client->fd);
 
 	int read_available;
 	if (ioctl(client_fd, FIONREAD, &read_available) == -1) {
-		wlr_log_errno(WLR_INFO, "Unable to read IPC socket buffer size");
+		sway_log_errno(SWAY_INFO, "Unable to read IPC socket buffer size");
 		ipc_client_disconnect(client);
 		return 0;
 	}
@@ -239,13 +239,13 @@ int ipc_client_handle_readable(int client_fd, uint32_t mask, void *data) {
 	// Should be fully available, because read_available >= IPC_HEADER_SIZE
 	ssize_t received = recv(client_fd, buf, IPC_HEADER_SIZE, 0);
 	if (received == -1) {
-		wlr_log_errno(WLR_INFO, "Unable to receive header from IPC client");
+		sway_log_errno(SWAY_INFO, "Unable to receive header from IPC client");
 		ipc_client_disconnect(client);
 		return 0;
 	}
 
 	if (memcmp(buf, ipc_magic, sizeof(ipc_magic)) != 0) {
-		wlr_log(WLR_DEBUG, "IPC header check failed");
+		sway_log(SWAY_DEBUG, "IPC header check failed");
 		ipc_client_disconnect(client);
 		return 0;
 	}
@@ -279,7 +279,7 @@ static void ipc_send_event(const char *json_string, enum ipc_command_type event)
 		}
 		client->current_command = event;
 		if (!ipc_send_reply(client, json_string, (uint32_t) strlen(json_string))) {
-			wlr_log_errno(WLR_INFO, "Unable to send reply to IPC client");
+			sway_log_errno(SWAY_INFO, "Unable to send reply to IPC client");
 			/* ipc_send_reply destroys client on error, which also
 			 * removes it from the list, so we need to process
 			 * current index again */
@@ -293,7 +293,7 @@ void ipc_event_workspace(struct sway_workspace *old,
 	if (!ipc_has_event_listeners(IPC_EVENT_WORKSPACE)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending workspace::%s event", change);
+	sway_log(SWAY_DEBUG, "Sending workspace::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
 	if (old) {
@@ -319,7 +319,7 @@ void ipc_event_window(struct sway_container *window, const char *change) {
 	if (!ipc_has_event_listeners(IPC_EVENT_WINDOW)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending window::%s event", change);
+	sway_log(SWAY_DEBUG, "Sending window::%s event", change);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(change));
 	json_object_object_add(obj, "container",
@@ -334,7 +334,7 @@ void ipc_event_barconfig_update(struct bar_config *bar) {
 	if (!ipc_has_event_listeners(IPC_EVENT_BARCONFIG_UPDATE)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending barconfig_update event");
+	sway_log(SWAY_DEBUG, "Sending barconfig_update event");
 	json_object *json = ipc_json_describe_bar_config(bar);
 
 	const char *json_string = json_object_to_json_string(json);
@@ -346,7 +346,7 @@ void ipc_event_bar_state_update(struct bar_config *bar) {
 	if (!ipc_has_event_listeners(IPC_EVENT_BAR_STATE_UPDATE)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending bar_state_update event");
+	sway_log(SWAY_DEBUG, "Sending bar_state_update event");
 
 	json_object *json = json_object_new_object();
 	json_object_object_add(json, "id", json_object_new_string(bar->id));
@@ -362,7 +362,7 @@ void ipc_event_mode(const char *mode, bool pango) {
 	if (!ipc_has_event_listeners(IPC_EVENT_MODE)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending mode::%s event", mode);
+	sway_log(SWAY_DEBUG, "Sending mode::%s event", mode);
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string(mode));
 	json_object_object_add(obj, "pango_markup",
@@ -377,7 +377,7 @@ void ipc_event_shutdown(const char *reason) {
 	if (!ipc_has_event_listeners(IPC_EVENT_SHUTDOWN)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending shutdown::%s event", reason);
+	sway_log(SWAY_DEBUG, "Sending shutdown::%s event", reason);
 
 	json_object *json = json_object_new_object();
 	json_object_object_add(json, "change", json_object_new_string(reason));
@@ -391,7 +391,7 @@ void ipc_event_binding(struct sway_binding *binding) {
 	if (!ipc_has_event_listeners(IPC_EVENT_BINDING)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending binding event");
+	sway_log(SWAY_DEBUG, "Sending binding event");
 
 	json_object *json_binding = json_object_new_object();
 	json_object_object_add(json_binding, "command", json_object_new_string(binding->command));
@@ -464,7 +464,7 @@ static void ipc_event_tick(const char *payload) {
 	if (!ipc_has_event_listeners(IPC_EVENT_TICK)) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Sending tick event");
+	sway_log(SWAY_DEBUG, "Sending tick event");
 
 	json_object *json = json_object_new_object();
 	json_object_object_add(json, "first", json_object_new_boolean(false));
@@ -479,13 +479,13 @@ int ipc_client_handle_writable(int client_fd, uint32_t mask, void *data) {
 	struct ipc_client *client = data;
 
 	if (mask & WL_EVENT_ERROR) {
-		wlr_log(WLR_ERROR, "IPC Client socket error, removing client");
+		sway_log(SWAY_ERROR, "IPC Client socket error, removing client");
 		ipc_client_disconnect(client);
 		return 0;
 	}
 
 	if (mask & WL_EVENT_HANGUP) {
-		wlr_log(WLR_DEBUG, "Client %d hung up", client->fd);
+		sway_log(SWAY_DEBUG, "Client %d hung up", client->fd);
 		ipc_client_disconnect(client);
 		return 0;
 	}
@@ -494,14 +494,14 @@ int ipc_client_handle_writable(int client_fd, uint32_t mask, void *data) {
 		return 0;
 	}
 
-	wlr_log(WLR_DEBUG, "Client %d writable", client->fd);
+	sway_log(SWAY_DEBUG, "Client %d writable", client->fd);
 
 	ssize_t written = write(client->fd, client->write_buffer, client->write_buffer_len);
 
 	if (written == -1 && errno == EAGAIN) {
 		return 0;
 	} else if (written == -1) {
-		wlr_log_errno(WLR_INFO, "Unable to send data from queue to IPC client");
+		sway_log_errno(SWAY_INFO, "Unable to send data from queue to IPC client");
 		ipc_client_disconnect(client);
 		return 0;
 	}
@@ -524,7 +524,7 @@ void ipc_client_disconnect(struct ipc_client *client) {
 
 	shutdown(client->fd, SHUT_RDWR);
 
-	wlr_log(WLR_INFO, "IPC Client %d disconnected", client->fd);
+	sway_log(SWAY_INFO, "IPC Client %d disconnected", client->fd);
 	wl_event_source_remove(client->event_source);
 	if (client->writable_event_source) {
 		wl_event_source_remove(client->writable_event_source);
@@ -573,7 +573,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 
 	char *buf = malloc(client->payload_length + 1);
 	if (!buf) {
-		wlr_log_errno(WLR_INFO, "Unable to allocate IPC payload");
+		sway_log_errno(SWAY_INFO, "Unable to allocate IPC payload");
 		ipc_client_disconnect(client);
 		return;
 	}
@@ -582,7 +582,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		ssize_t received = recv(client->fd, buf, client->payload_length, 0);
 		if (received == -1)
 		{
-			wlr_log_errno(WLR_INFO, "Unable to receive payload from IPC client");
+			sway_log_errno(SWAY_INFO, "Unable to receive payload from IPC client");
 			ipc_client_disconnect(client);
 			free(buf);
 			return;
@@ -667,7 +667,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		if (request == NULL || !json_object_is_type(request, json_type_array)) {
 			const char msg[] = "{\"success\": false}";
 			client_valid = ipc_send_reply(client, msg, strlen(msg));
-			wlr_log(WLR_INFO, "Failed to parse subscribe request");
+			sway_log(SWAY_INFO, "Failed to parse subscribe request");
 			goto exit_cleanup;
 		}
 
@@ -696,7 +696,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				const char msg[] = "{\"success\": false}";
 				client_valid = ipc_send_reply(client, msg, strlen(msg));
 				json_object_put(request);
-				wlr_log(WLR_INFO, "Unsupported event type in subscribe request");
+				sway_log(SWAY_INFO, "Unsupported event type in subscribe request");
 				goto exit_cleanup;
 			}
 		}
@@ -845,7 +845,7 @@ void ipc_client_handle_command(struct ipc_client *client) {
 	}
 
 	default:
-		wlr_log(WLR_INFO, "Unknown IPC command type %i", client->current_command);
+		sway_log(SWAY_INFO, "Unknown IPC command type %i", client->current_command);
 		goto exit_cleanup;
 	}
 
@@ -873,14 +873,14 @@ bool ipc_send_reply(struct ipc_client *client, const char *payload, uint32_t pay
 	}
 
 	if (client->write_buffer_size > 4e6) { // 4 MB
-		wlr_log(WLR_ERROR, "Client write buffer too big, disconnecting client");
+		sway_log(SWAY_ERROR, "Client write buffer too big, disconnecting client");
 		ipc_client_disconnect(client);
 		return false;
 	}
 
 	char *new_buffer = realloc(client->write_buffer, client->write_buffer_size);
 	if (!new_buffer) {
-		wlr_log(WLR_ERROR, "Unable to reallocate ipc client write buffer");
+		sway_log(SWAY_ERROR, "Unable to reallocate ipc client write buffer");
 		ipc_client_disconnect(client);
 		return false;
 	}
@@ -897,6 +897,6 @@ bool ipc_send_reply(struct ipc_client *client, const char *payload, uint32_t pay
 				ipc_client_handle_writable, client);
 	}
 
-	wlr_log(WLR_DEBUG, "Added IPC reply to client %d queue: %s", client->fd, payload);
+	sway_log(SWAY_DEBUG, "Added IPC reply to client %d queue: %s", client->fd, payload);
 	return true;
 }

--- a/sway/server.c
+++ b/sway/server.c
@@ -19,9 +19,9 @@
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
-#include <wlr/util/log.h>
 #include "config.h"
 #include "list.h"
+#include "log.h"
 #include "sway/config.h"
 #include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
@@ -32,20 +32,20 @@
 #endif
 
 bool server_privileged_prepare(struct sway_server *server) {
-	wlr_log(WLR_DEBUG, "Preparing Wayland server initialization");
+	sway_log(SWAY_DEBUG, "Preparing Wayland server initialization");
 	server->wl_display = wl_display_create();
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 	server->backend = wlr_backend_autocreate(server->wl_display, NULL);
 
 	if (!server->backend) {
-		wlr_log(WLR_ERROR, "Unable to create backend");
+		sway_log(SWAY_ERROR, "Unable to create backend");
 		return false;
 	}
 	return true;
 }
 
 bool server_init(struct sway_server *server) {
-	wlr_log(WLR_DEBUG, "Initializing Wayland server");
+	sway_log(SWAY_DEBUG, "Initializing Wayland server");
 
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(server->backend);
 	assert(renderer);
@@ -111,7 +111,7 @@ bool server_init(struct sway_server *server) {
 
 	server->socket = wl_display_add_socket_auto(server->wl_display);
 	if (!server->socket) {
-		wlr_log(WLR_ERROR, "Unable to open wayland socket");
+		sway_log(SWAY_ERROR, "Unable to open wayland socket");
 		wlr_backend_destroy(server->backend);
 		return false;
 	}
@@ -155,7 +155,7 @@ bool server_start(struct sway_server *server) {
 
 #if HAVE_XWAYLAND
 	if (config->xwayland) {
-		wlr_log(WLR_DEBUG, "Initializing Xwayland");
+		sway_log(SWAY_DEBUG, "Initializing Xwayland");
 		server->xwayland.wlr_xwayland =
 			wlr_xwayland_create(server->wl_display, server->compositor, true);
 		wl_signal_add(&server->xwayland.wlr_xwayland->events.new_surface,
@@ -179,10 +179,10 @@ bool server_start(struct sway_server *server) {
 	}
 #endif
 
-	wlr_log(WLR_INFO, "Starting backend on wayland display '%s'",
+	sway_log(SWAY_INFO, "Starting backend on wayland display '%s'",
 			server->socket);
 	if (!wlr_backend_start(server->backend)) {
-		wlr_log(WLR_ERROR, "Failed to start backend");
+		sway_log(SWAY_ERROR, "Failed to start backend");
 		wlr_backend_destroy(server->backend);
 		return false;
 	}
@@ -190,7 +190,7 @@ bool server_start(struct sway_server *server) {
 }
 
 void server_run(struct sway_server *server) {
-	wlr_log(WLR_INFO, "Running compositor on wayland display '%s'",
+	sway_log(SWAY_INFO, "Running compositor on wayland display '%s'",
 			server->socket);
 	wl_display_run(server->wl_display);
 }

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -17,7 +17,7 @@ bool swaynag_spawn(const char *swaynag_command,
 
 	if (swaynag->detailed) {
 		if (pipe(swaynag->fd) != 0) {
-			wlr_log(WLR_ERROR, "Failed to create pipe for swaynag");
+			sway_log(SWAY_ERROR, "Failed to create pipe for swaynag");
 			return false;
 		}
 		fcntl(swaynag->fd[1], F_SETFD, FD_CLOEXEC);
@@ -37,7 +37,7 @@ bool swaynag_spawn(const char *swaynag_command,
 		execl("/bin/sh", "/bin/sh", "-c", cmd, NULL);
 		_exit(0);
 	} else if (pid < 0) {
-		wlr_log(WLR_ERROR, "Failed to create fork for swaynag");
+		sway_log(SWAY_ERROR, "Failed to create fork for swaynag");
 		if (swaynag->detailed) {
 			close(swaynag->fd[0]);
 			close(swaynag->fd[1]);
@@ -67,7 +67,7 @@ void swaynag_log(const char *swaynag_command, struct swaynag_instance *swaynag,
 	}
 
 	if (!swaynag->detailed) {
-		wlr_log(WLR_ERROR, "Attempting to write to non-detailed swaynag inst");
+		sway_log(SWAY_ERROR, "Attempting to write to non-detailed swaynag inst");
 		return;
 	}
 
@@ -82,7 +82,7 @@ void swaynag_log(const char *swaynag_command, struct swaynag_instance *swaynag,
 
 	char *temp = malloc(length + 1);
 	if (!temp) {
-		wlr_log(WLR_ERROR, "Failed to allocate buffer for swaynag log entry.");
+		sway_log(SWAY_ERROR, "Failed to allocate buffer for swaynag log entry.");
 		return;
 	}
 

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -35,7 +35,7 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 	double scale = parent->width / total_width;
 
 	// Resize windows
-	wlr_log(WLR_DEBUG, "Arranging %p horizontally", parent);
+	sway_log(SWAY_DEBUG, "Arranging %p horizontally", parent);
 	double child_x = parent->x;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
@@ -75,7 +75,7 @@ static void apply_vert_layout(list_t *children, struct wlr_box *parent) {
 	double scale = parent->height / total_height;
 
 	// Resize
-	wlr_log(WLR_DEBUG, "Arranging %p vertically", parent);
+	sway_log(SWAY_DEBUG, "Arranging %p vertically", parent);
 	double child_y = parent->y;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
@@ -186,7 +186,7 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	}
 	struct sway_output *output = workspace->output;
 	struct wlr_box *area = &output->usable_area;
-	wlr_log(WLR_DEBUG, "Usable area for ws: %dx%d@%d,%d",
+	sway_log(SWAY_DEBUG, "Usable area for ws: %dx%d@%d,%d",
 			area->width, area->height, area->x, area->y);
 	workspace_remove_gaps(workspace);
 
@@ -217,7 +217,7 @@ void arrange_workspace(struct sway_workspace *workspace) {
 
 	workspace_add_gaps(workspace);
 	node_set_dirty(&workspace->node);
-	wlr_log(WLR_DEBUG, "Arranging workspace '%s' at %f, %f", workspace->name,
+	sway_log(SWAY_DEBUG, "Arranging workspace '%s' at %f, %f", workspace->name,
 			workspace->x, workspace->y);
 	if (workspace->fullscreen) {
 		struct sway_container *fs = workspace->fullscreen;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -28,7 +28,7 @@
 struct sway_container *container_create(struct sway_view *view) {
 	struct sway_container *c = calloc(1, sizeof(struct sway_container));
 	if (!c) {
-		wlr_log(WLR_ERROR, "Unable to allocate sway_container");
+		sway_log(SWAY_ERROR, "Unable to allocate sway_container");
 		return NULL;
 	}
 	node_init(&c->node, N_CONTAINER, c);
@@ -983,7 +983,7 @@ void container_discover_outputs(struct sway_container *con) {
 
 		if (intersects && index == -1) {
 			// Send enter
-			wlr_log(WLR_DEBUG, "Container %p entered output %p", con, output);
+			sway_log(SWAY_DEBUG, "Container %p entered output %p", con, output);
 			if (con->view) {
 				view_for_each_surface(con->view,
 						surface_send_enter_iterator, output->wlr_output);
@@ -991,7 +991,7 @@ void container_discover_outputs(struct sway_container *con) {
 			list_add(con->outputs, output);
 		} else if (!intersects && index != -1) {
 			// Send leave
-			wlr_log(WLR_DEBUG, "Container %p left output %p", con, output);
+			sway_log(SWAY_DEBUG, "Container %p left output %p", con, output);
 			if (con->view) {
 				view_for_each_surface(con->view,
 					surface_send_leave_iterator, output->wlr_output);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -97,7 +97,7 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	if (!output->workspaces->length) {
 		// Create workspace
 		char *ws_name = workspace_next_name(wlr_output->name);
-		wlr_log(WLR_DEBUG, "Creating default workspace %s", ws_name);
+		sway_log(SWAY_DEBUG, "Creating default workspace %s", ws_name);
 		ws = workspace_create(output, ws_name);
 		// Set each seat's focus if not already set
 		struct sway_seat *seat = NULL;
@@ -212,7 +212,7 @@ void output_disable(struct sway_output *output) {
 	if (!sway_assert(output->enabled, "Expected an enabled output")) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Disabling output '%s'", output->wlr_output->name);
+	sway_log(SWAY_DEBUG, "Disabling output '%s'", output->wlr_output->name);
 	wl_signal_emit(&output->events.destroy, output);
 
 	output_evacuate(output);
@@ -237,7 +237,7 @@ void output_begin_destroy(struct sway_output *output) {
 	if (!sway_assert(!output->enabled, "Expected a disabled output")) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Destroying output '%s'", output->wlr_output->name);
+	sway_log(SWAY_DEBUG, "Destroying output '%s'", output->wlr_output->name);
 
 	output->node.destroying = true;
 	node_set_dirty(&output->node);
@@ -258,11 +258,11 @@ struct output_config *output_find_config(struct sway_output *output) {
 
 		if (strcasecmp(name, cur->name) == 0 ||
 				strcasecmp(identifier, cur->name) == 0) {
-			wlr_log(WLR_DEBUG, "Matched output config for %s", name);
+			sway_log(SWAY_DEBUG, "Matched output config for %s", name);
 			oc = cur;
 		}
 		if (strcasecmp("*", cur->name) == 0) {
-			wlr_log(WLR_DEBUG, "Matched wildcard output config for %s", name);
+			sway_log(SWAY_DEBUG, "Matched wildcard output config for %s", name);
 			all = cur;
 		}
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -26,7 +26,7 @@ static void output_layout_handle_change(struct wl_listener *listener,
 struct sway_root *root_create(void) {
 	struct sway_root *root = calloc(1, sizeof(struct sway_root));
 	if (!root) {
-		wlr_log(WLR_ERROR, "Unable to allocate sway_root");
+		sway_log(SWAY_ERROR, "Unable to allocate sway_root");
 		return NULL;
 	}
 	node_init(&root->node, N_ROOT, root);
@@ -178,14 +178,14 @@ struct sway_workspace *root_workspace_for_pid(pid_t pid) {
 	struct sway_workspace *ws = NULL;
 	struct pid_workspace *pw = NULL;
 
-	wlr_log(WLR_DEBUG, "Looking up workspace for pid %d", pid);
+	sway_log(SWAY_DEBUG, "Looking up workspace for pid %d", pid);
 
 	do {
 		struct pid_workspace *_pw = NULL;
 		wl_list_for_each(_pw, &pid_workspaces, link) {
 			if (pid == _pw->pid) {
 				pw = _pw;
-				wlr_log(WLR_DEBUG,
+				sway_log(SWAY_DEBUG,
 						"found pid_workspace for pid %d, workspace %s",
 						pid, pw->workspace);
 				goto found;
@@ -199,7 +199,7 @@ found:
 		ws = workspace_by_name(pw->workspace);
 
 		if (!ws) {
-			wlr_log(WLR_DEBUG,
+			sway_log(SWAY_DEBUG,
 					"Creating workspace %s for pid %d because it disappeared",
 					pw->workspace, pid);
 			ws = workspace_create(pw->output, pw->workspace);
@@ -222,7 +222,7 @@ static void pw_handle_output_destroy(struct wl_listener *listener, void *data) {
 }
 
 void root_record_workspace_pid(pid_t pid) {
-	wlr_log(WLR_DEBUG, "Recording workspace for process %d", pid);
+	sway_log(SWAY_DEBUG, "Recording workspace for process %d", pid);
 	if (!pid_workspaces.prev && !pid_workspaces.next) {
 		wl_list_init(&pid_workspaces);
 	}
@@ -230,12 +230,12 @@ void root_record_workspace_pid(pid_t pid) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 	if (!ws) {
-		wlr_log(WLR_DEBUG, "Bailing out, no workspace");
+		sway_log(SWAY_DEBUG, "Bailing out, no workspace");
 		return;
 	}
 	struct sway_output *output = ws->output;
 	if (!output) {
-		wlr_log(WLR_DEBUG, "Bailing out, no output");
+		sway_log(SWAY_DEBUG, "Bailing out, no output");
 		return;
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -328,7 +328,7 @@ void view_request_activate(struct sway_view *view) {
 }
 
 void view_set_csd_from_server(struct sway_view *view, bool enabled) {
-	wlr_log(WLR_DEBUG, "Telling view %p to set CSD to %i", view, enabled);
+	sway_log(SWAY_DEBUG, "Telling view %p to set CSD to %i", view, enabled);
 	if (view->xdg_decoration) {
 		uint32_t mode = enabled ?
 			WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE :
@@ -340,7 +340,7 @@ void view_set_csd_from_server(struct sway_view *view, bool enabled) {
 }
 
 void view_update_csd_from_client(struct sway_view *view, bool enabled) {
-	wlr_log(WLR_DEBUG, "View %p updated CSD to %i", view, enabled);
+	sway_log(SWAY_DEBUG, "View %p updated CSD to %i", view, enabled);
 	struct sway_container *con = view->container;
 	if (enabled && con && con->border != B_CSD) {
 		con->saved_border = con->border;
@@ -429,12 +429,12 @@ void view_execute_criteria(struct sway_view *view) {
 	list_t *criterias = criteria_for_view(view, CT_COMMAND);
 	for (int i = 0; i < criterias->length; i++) {
 		struct criteria *criteria = criterias->items[i];
-		wlr_log(WLR_DEBUG, "Checking criteria %s", criteria->raw);
+		sway_log(SWAY_DEBUG, "Checking criteria %s", criteria->raw);
 		if (view_has_executed_criteria(view, criteria)) {
-			wlr_log(WLR_DEBUG, "Criteria already executed");
+			sway_log(SWAY_DEBUG, "Criteria already executed");
 			continue;
 		}
-		wlr_log(WLR_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
+		sway_log(SWAY_DEBUG, "for_window '%s' matches view %p, cmd: '%s'",
 				criteria->raw, view, criteria->cmdlist);
 		list_add(view->executed_criteria, criteria);
 		list_t *res_list = execute_command(
@@ -721,7 +721,7 @@ static void view_subsurface_create(struct sway_view *view,
 	struct sway_subsurface *subsurface =
 		calloc(1, sizeof(struct sway_subsurface));
 	if (subsurface == NULL) {
-		wlr_log(WLR_ERROR, "Allocation failed");
+		sway_log(SWAY_ERROR, "Allocation failed");
 		return;
 	}
 	view_child_init(&subsurface->child, &subsurface_impl, view,
@@ -860,7 +860,7 @@ struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
 	}
 
 	const char *role = wlr_surface->role ? wlr_surface->role->name : NULL;
-	wlr_log(WLR_DEBUG, "Surface of unknown type (role %s): %p",
+	sway_log(SWAY_DEBUG, "Surface of unknown type (role %s): %p",
 		role, wlr_surface);
 	return NULL;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -69,12 +69,12 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 		output = workspace_get_initial_output(name);
 	}
 
-	wlr_log(WLR_DEBUG, "Adding workspace %s for output %s", name,
+	sway_log(SWAY_DEBUG, "Adding workspace %s for output %s", name,
 			output->wlr_output->name);
 
 	struct sway_workspace *ws = calloc(1, sizeof(struct sway_workspace));
 	if (!ws) {
-		wlr_log(WLR_ERROR, "Unable to allocate sway_workspace");
+		sway_log(SWAY_ERROR, "Unable to allocate sway_workspace");
 		return NULL;
 	}
 	node_init(&ws->node, N_WORKSPACE, ws);
@@ -152,7 +152,7 @@ void workspace_destroy(struct sway_workspace *workspace) {
 }
 
 void workspace_begin_destroy(struct sway_workspace *workspace) {
-	wlr_log(WLR_DEBUG, "Destroying workspace '%s'", workspace->name);
+	sway_log(SWAY_DEBUG, "Destroying workspace '%s'", workspace->name);
 	ipc_event_workspace(NULL, workspace, "empty"); // intentional
 	wl_signal_emit(&workspace->node.events.destroy, &workspace->node);
 
@@ -223,7 +223,7 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 		char *_target = strdup(name);
 		_target = do_var_replacement(_target);
 		strip_quotes(_target);
-		wlr_log(WLR_DEBUG, "Got valid workspace command for target: '%s'",
+		sway_log(SWAY_DEBUG, "Got valid workspace command for target: '%s'",
 				_target);
 
 		// Make sure that the command references an actual workspace
@@ -248,7 +248,7 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 			temp[length - 1] = '\0';
 			free(_target);
 			_target = temp;
-			wlr_log(WLR_DEBUG, "Isolated name from workspace number: '%s'", _target);
+			sway_log(SWAY_DEBUG, "Isolated name from workspace number: '%s'", _target);
 
 			// Make sure the workspace number doesn't already exist
 			if (isdigit(_target[0]) && workspace_by_number(_target)) {
@@ -277,7 +277,7 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 			*min_order = binding->order;
 			free(*earliest_name);
 			*earliest_name = _target;
-			wlr_log(WLR_DEBUG, "Workspace: Found free name %s", _target);
+			sway_log(SWAY_DEBUG, "Workspace: Found free name %s", _target);
 		} else {
 			free(_target);
 		}
@@ -286,7 +286,7 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 }
 
 char *workspace_next_name(const char *output_name) {
-	wlr_log(WLR_DEBUG, "Workspace: Generating new workspace name for output %s",
+	sway_log(SWAY_DEBUG, "Workspace: Generating new workspace name for output %s",
 			output_name);
 	// Scan for available workspace names by looking through output-workspace
 	// assignments primarily, falling back to bindings and numbers.
@@ -468,13 +468,13 @@ bool workspace_switch(struct sway_workspace *workspace,
 		free(seat->prev_workspace_name);
 		seat->prev_workspace_name = malloc(strlen(active_ws->name) + 1);
 		if (!seat->prev_workspace_name) {
-			wlr_log(WLR_ERROR, "Unable to allocate previous workspace name");
+			sway_log(SWAY_ERROR, "Unable to allocate previous workspace name");
 			return false;
 		}
 		strcpy(seat->prev_workspace_name, active_ws->name);
 	}
 
-	wlr_log(WLR_DEBUG, "Switching to workspace %p:%s",
+	sway_log(SWAY_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);
 	struct sway_node *next = seat_get_focus_inactive(seat, &workspace->node);
 	if (next == NULL) {

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -10,7 +10,6 @@
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
-#include <wlr/util/log.h>
 #include "config.h"
 #include "swaybar/bar.h"
 #include "swaybar/config.h"
@@ -44,7 +43,7 @@ static void swaybar_output_free(struct swaybar_output *output) {
 	if (!output) {
 		return;
 	}
-	wlr_log(WLR_DEBUG, "Removing output %s", output->name);
+	sway_log(SWAY_DEBUG, "Removing output %s", output->name);
 	if (output->layer_surface != NULL) {
 		zwlr_layer_surface_v1_destroy(output->layer_surface);
 	}
@@ -157,7 +156,7 @@ bool determine_bar_visibility(struct swaybar *bar, bool moving_layer) {
 		bar->visible = visible;
 
 		if (bar->status) {
-			wlr_log(WLR_DEBUG, "Sending %s signal to status command",
+			sway_log(SWAY_DEBUG, "Sending %s signal to status command",
 					visible ? "cont" : "stop");
 			kill(bar->status->pid, visible ?
 					bar->status->cont_signal : bar->status->stop_signal);
@@ -271,7 +270,7 @@ static void xdg_output_handle_description(void *data,
 		size_t length = paren - description;
 		output->identifier = malloc(length);
 		if (!output->identifier) {
-			wlr_log(WLR_ERROR, "Failed to allocate output identifier");
+			sway_log(SWAY_ERROR, "Failed to allocate output identifier");
 			return;
 		}
 		strncpy(output->identifier, description, length);

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -1,12 +1,12 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <string.h>
-#include <wlr/util/log.h>
 #include "swaybar/config.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "config.h"
 #include "stringop.h"
 #include "list.h"
+#include "log.h"
 
 uint32_t parse_position(const char *position) {
 	uint32_t horiz = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
@@ -16,7 +16,7 @@ uint32_t parse_position(const char *position) {
 	} else if (strcmp("bottom", position) == 0) {
 		return ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM | horiz;
 	} else {
-		wlr_log(WLR_ERROR, "Invalid position: %s, defaulting to bottom", position);
+		sway_log(SWAY_ERROR, "Invalid position: %s, defaulting to bottom", position);
 		return ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM | horiz;
 	}
 }

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
+#include "log.h"
 #include "swaybar/bar.h"
 #include "swaybar/config.h"
 #include "swaybar/i3bar.h"
@@ -120,7 +120,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 				memmove(status->buffer, &status->buffer[c], status->buffer_index);
 				break;
 			} else if (!isspace(status->buffer[c])) {
-				wlr_log(WLR_DEBUG, "Invalid i3bar json: expected '[' but encountered '%c'",
+				sway_log(SWAY_DEBUG, "Invalid i3bar json: expected '[' but encountered '%c'",
 						status->buffer[c]);
 				status_error(status, "[invalid i3bar json]");
 				return true;
@@ -160,7 +160,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 					++buffer_pos;
 					break;
 				} else if (!isspace(status->buffer[buffer_pos])) {
-					wlr_log(WLR_DEBUG, "Invalid i3bar json: expected ',' but encountered '%c'",
+					sway_log(SWAY_DEBUG, "Invalid i3bar json: expected ',' but encountered '%c'",
 							status->buffer[buffer_pos]);
 					status_error(status, "[invalid i3bar json]");
 					return true;
@@ -195,7 +195,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 				}
 				*last_char_pos = '\0';
 				size_t offset = strspn(&status->buffer[buffer_pos], " \f\n\r\t\v");
-				wlr_log(WLR_DEBUG, "Received i3bar json: '%s%c'",
+				sway_log(SWAY_DEBUG, "Received i3bar json: '%s%c'",
 						&status->buffer[buffer_pos + offset], last_char);
 				*last_char_pos = last_char;
 
@@ -229,7 +229,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 			} else {
 				char last_char = status->buffer[status->buffer_index - 1];
 				status->buffer[status->buffer_index - 1] = '\0';
-				wlr_log(WLR_DEBUG, "Failed to parse i3bar json - %s: '%s%c'",
+				sway_log(SWAY_DEBUG, "Failed to parse i3bar json - %s: '%s%c'",
 						json_tokener_error_desc(err), &status->buffer[buffer_pos], last_char);
 				status_error(status, "[failed to parse i3bar json]");
 				return true;
@@ -250,7 +250,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 	}
 
 	if (last_object) {
-		wlr_log(WLR_DEBUG, "Rendering last received json");
+		sway_log(SWAY_DEBUG, "Rendering last received json");
 		i3bar_parse_json(status, last_object);
 		json_object_put(last_object);
 		return true;
@@ -262,7 +262,7 @@ bool i3bar_handle_readable(struct status_line *status) {
 enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, int x, int y, int rx, int ry, int w, int h,
 		uint32_t button) {
-	wlr_log(WLR_DEBUG, "block %s clicked", block->name);
+	sway_log(SWAY_DEBUG, "block %s clicked", block->name);
 	if (!block->name || !status->click_events) {
 		return HOTSPOT_PROCESS;
 	}

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
-#include <wlr/util/log.h>
 #include "list.h"
 #include "log.h"
 #include "swaybar/bar.h"
@@ -55,7 +54,7 @@ static uint32_t wl_axis_to_button(uint32_t axis, wl_fixed_t value) {
 	case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
 		return negative ? SWAY_SCROLL_LEFT : SWAY_SCROLL_RIGHT;
 	default:
-		wlr_log(WLR_DEBUG, "Unexpected axis value on mouse scroll");
+		sway_log(SWAY_DEBUG, "Unexpected axis value on mouse scroll");
 		return 0;
 	}
 }

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -3,12 +3,12 @@
 #include <string.h>
 #include <strings.h>
 #include <json-c/json.h>
-#include <wlr/util/log.h>
 #include "swaybar/config.h"
 #include "swaybar/ipc.h"
 #include "config.h"
 #include "ipc-client.h"
 #include "list.h"
+#include "log.h"
 
 void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
 	const char *fmt = "workspace \"%s\"";
@@ -150,7 +150,7 @@ static bool ipc_parse_config(
 	json_object *success;
 	if (json_object_object_get_ex(bar_config, "success", &success)
 			&& !json_object_get_boolean(success)) {
-		wlr_log(WLR_ERROR, "No bar with that ID. Use 'swaymsg -t get_bar_config to get the available bar configs.");
+		sway_log(SWAY_ERROR, "No bar with that ID. Use 'swaymsg -t get_bar_config to get the available bar configs.");
 		json_object_put(bar_config);
 		return false;
 	}
@@ -441,7 +441,7 @@ static void ipc_get_outputs(struct swaybar *bar) {
 }
 
 void ipc_execute_binding(struct swaybar *bar, struct swaybar_binding *bind) {
-	wlr_log(WLR_DEBUG, "Executing binding for button %u (release=%d): `%s`",
+	sway_log(SWAY_DEBUG, "Executing binding for button %u (release=%d): `%s`",
 			bind->button, bind->release, bind->command);
 	uint32_t len = strlen(bind->command);
 	free(ipc_single_command(bar->ipc_socketfd,
@@ -500,7 +500,7 @@ static bool handle_barconfig_update(struct swaybar *bar,
 	const char *new_state = json_object_get_string(json_state);
 	char *old_state = config->hidden_state;
 	if (strcmp(new_state, old_state) != 0) {
-		wlr_log(WLR_DEBUG, "Changing bar hidden state to %s", new_state);
+		sway_log(SWAY_DEBUG, "Changing bar hidden state to %s", new_state);
 		free(old_state);
 		config->hidden_state = strdup(new_state);
 		return determine_bar_visibility(bar, false);
@@ -510,7 +510,7 @@ static bool handle_barconfig_update(struct swaybar *bar,
 	json_object *json_mode;
 	json_object_object_get_ex(json_config, "mode", &json_mode);
 	config->mode = strdup(json_object_get_string(json_mode));
-	wlr_log(WLR_DEBUG, "Changing bar mode to %s", config->mode);
+	sway_log(SWAY_DEBUG, "Changing bar mode to %s", config->mode);
 
 	json_object *gaps;
 	json_object_object_get_ex(json_config, "gaps", &gaps);
@@ -544,7 +544,7 @@ bool handle_ipc_readable(struct swaybar *bar) {
 
 	json_object *result = json_tokener_parse(resp->payload);
 	if (!result) {
-		wlr_log(WLR_ERROR, "failed to parse payload as json");
+		sway_log(SWAY_ERROR, "failed to parse payload as json");
 		free_ipc_response(resp);
 		return false;
 	}
@@ -561,7 +561,7 @@ bool handle_ipc_readable(struct swaybar *bar) {
 			free(bar->mode);
 			bar->mode = strcmp(change, "default") != 0 ? strdup(change) : NULL;
 		} else {
-			wlr_log(WLR_ERROR, "failed to parse response");
+			sway_log(SWAY_ERROR, "failed to parse response");
 			bar_is_dirty = false;
 			break;
 		}

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -4,9 +4,9 @@
 #include <string.h>
 #include <stdbool.h>
 #include <getopt.h>
-#include <wlr/util/log.h>
 #include "swaybar/bar.h"
 #include "ipc-client.h"
+#include "log.h"
 
 static struct swaybar swaybar;
 
@@ -74,13 +74,13 @@ int main(int argc, char **argv) {
 	}
 
 	if (debug) {
-		wlr_log_init(WLR_DEBUG, NULL);
+		sway_log_init(SWAY_DEBUG, NULL);
 	} else {
-		wlr_log_init(WLR_INFO, NULL);
+		sway_log_init(SWAY_INFO, NULL);
 	}
 
 	if (!swaybar.id) {
-		wlr_log(WLR_ERROR, "No bar_id passed. "
+		sway_log(SWAY_ERROR, "No bar_id passed. "
 				"Provide --bar_id or let sway start swaybar");
 		return 1;
 	}
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
 	if (!socket_path) {
 		socket_path = get_socketpath();
 		if (!socket_path) {
-			wlr_log(WLR_ERROR, "Unable to retrieve socket path");
+			sway_log(SWAY_ERROR, "Unable to retrieve socket path");
 			return 1;
 		}
 	}

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <wlr/util/log.h>
 #include "cairo.h"
 #include "pango.h"
 #include "pool-buffer.h"

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
+#include "log.h"
 #include "loop.h"
 #include "swaybar/bar.h"
 #include "swaybar/config.h"
@@ -38,7 +38,7 @@ bool status_handle_readable(struct status_line *status) {
 		errno = 0;
 		int available_bytes;
 		if (ioctl(status->read_fd, FIONREAD, &available_bytes) == -1) {
-			wlr_log(WLR_ERROR, "Unable to read status command output size");
+			sway_log(SWAY_ERROR, "Unable to read status command output size");
 			status_error(status, "[error reading from status command]");
 			return true;
 		}
@@ -49,7 +49,7 @@ bool status_handle_readable(struct status_line *status) {
 			status->buffer = realloc(status->buffer, status->buffer_size);
 		}
 		if (status->buffer == NULL) {
-			wlr_log_errno(WLR_ERROR, "Unable to read status line");
+			sway_log_errno(SWAY_ERROR, "Unable to read status line");
 			status_error(status, "[error reading from status command]");
 			return true;
 		}
@@ -68,13 +68,13 @@ bool status_handle_readable(struct status_line *status) {
 				&& (header = json_tokener_parse(status->buffer))
 				&& json_object_object_get_ex(header, "version", &version)
 				&& json_object_get_int(version) == 1) {
-			wlr_log(WLR_DEBUG, "Using i3bar protocol.");
+			sway_log(SWAY_DEBUG, "Using i3bar protocol.");
 			status->protocol = PROTOCOL_I3BAR;
 
 			json_object *click_events;
 			if (json_object_object_get_ex(header, "click_events", &click_events)
 					&& json_object_get_boolean(click_events)) {
-				wlr_log(WLR_DEBUG, "Enabling click events.");
+				sway_log(SWAY_DEBUG, "Enabling click events.");
 				status->click_events = true;
 				if (write(status->write_fd, "[\n", 2) != 2) {
 					status_error(status, "[failed to write to status command]");
@@ -86,11 +86,11 @@ bool status_handle_readable(struct status_line *status) {
 			json_object *signal;
 			if (json_object_object_get_ex(header, "stop_signal", &signal)) {
 				status->stop_signal = json_object_get_int(signal);
-				wlr_log(WLR_DEBUG, "Setting stop signal to %d", status->stop_signal);
+				sway_log(SWAY_DEBUG, "Setting stop signal to %d", status->stop_signal);
 			}
 			if (json_object_object_get_ex(header, "cont_signal", &signal)) {
 				status->cont_signal = json_object_get_int(signal);
-				wlr_log(WLR_DEBUG, "Setting cont signal to %d", status->cont_signal);
+				sway_log(SWAY_DEBUG, "Setting cont signal to %d", status->cont_signal);
 			}
 
 			json_object_put(header);
@@ -102,7 +102,7 @@ bool status_handle_readable(struct status_line *status) {
 			return i3bar_handle_readable(status);
 		}
 
-		wlr_log(WLR_DEBUG, "Using text protocol.");
+		sway_log(SWAY_DEBUG, "Using text protocol.");
 		status->protocol = PROTOCOL_TEXT;
 		status->text = status->buffer;
 		// intentional fall-through
@@ -140,7 +140,7 @@ struct status_line *status_line_init(char *cmd) {
 	int pipe_read_fd[2];
 	int pipe_write_fd[2];
 	if (pipe(pipe_read_fd) != 0 || pipe(pipe_write_fd) != 0) {
-		wlr_log(WLR_ERROR, "Unable to create pipes for status_command fork");
+		sway_log(SWAY_ERROR, "Unable to create pipes for status_command fork");
 		exit(1);
 	}
 

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -317,7 +317,7 @@ void init_themes(list_t **themes, list_t **basedirs) {
 		list_add(theme_names, theme->name);
 	}
 	char *theme_list = join_list(theme_names, ", ");
-	wlr_log(WLR_DEBUG, "Loaded themes: %s", theme_list);
+	sway_log(SWAY_DEBUG, "Loaded themes: %s", theme_list);
 	free(theme_list);
 	list_free(theme_names);
 }

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -17,7 +17,7 @@ static int handle_lost_watcher(sd_bus_message *msg,
 	char *service, *old_owner, *new_owner;
 	int ret = sd_bus_message_read(msg, "sss", &service, &old_owner, &new_owner);
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to parse owner change message: %s", strerror(-ret));
+		sway_log(SWAY_ERROR, "Failed to parse owner change message: %s", strerror(-ret));
 		return ret;
 	}
 
@@ -34,12 +34,12 @@ static int handle_lost_watcher(sd_bus_message *msg,
 }
 
 struct swaybar_tray *create_tray(struct swaybar *bar) {
-	wlr_log(WLR_DEBUG, "Initializing tray");
+	sway_log(SWAY_DEBUG, "Initializing tray");
 
 	sd_bus *bus;
 	int ret = sd_bus_open_user(&bus);
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to connect to user bus: %s", strerror(-ret));
+		sway_log(SWAY_ERROR, "Failed to connect to user bus: %s", strerror(-ret));
 		return NULL;
 	}
 
@@ -58,7 +58,7 @@ struct swaybar_tray *create_tray(struct swaybar *bar) {
 			"/org/freedesktop/DBus", "org.freedesktop.DBus",
 			"NameOwnerChanged", handle_lost_watcher, tray);
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to subscribe to unregistering events: %s",
+		sway_log(SWAY_ERROR, "Failed to subscribe to unregistering events: %s",
 				strerror(-ret));
 	}
 
@@ -96,7 +96,7 @@ void tray_in(int fd, short mask, void *data) {
 		// This space intentionally left blank
 	}
 	if (ret < 0) {
-		wlr_log(WLR_ERROR, "Failed to process bus: %s", strerror(-ret));
+		sway_log(SWAY_ERROR, "Failed to process bus: %s", strerror(-ret));
 	}
 }
 

--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -6,9 +6,9 @@
 #include <string.h>
 #include <time.h>
 #include <wayland-client.h>
-#include <wlr/util/log.h>
 #include "background-image.h"
 #include "cairo.h"
+#include "log.h"
 #include "pool-buffer.h"
 #include "util.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
@@ -62,7 +62,7 @@ struct swaybg_state {
 bool is_valid_color(const char *color) {
 	int len = strlen(color);
 	if (len != 7 || color[0] != '#') {
-		wlr_log(WLR_ERROR, "%s is not a valid color for swaybg. "
+		sway_log(SWAY_ERROR, "%s is not a valid color for swaybg. "
 				"Color should be specified as #rrggbb (no alpha).", color);
 		return false;
 	}
@@ -253,14 +253,14 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, const char **argv) {
-	wlr_log_init(WLR_DEBUG, NULL);
+	sway_log_init(SWAY_DEBUG, NULL);
 
 	struct swaybg_args args = {0};
 	struct swaybg_state state = { .args = &args };
 	wl_list_init(&state.outputs);
 
 	if (argc < 4 || argc > 5) {
-		wlr_log(WLR_ERROR, "Do not run this program manually. "
+		sway_log(SWAY_ERROR, "Do not run this program manually. "
 				"See `man 5 sway-output` and look for background options.");
 		return 1;
 	}
@@ -281,7 +281,7 @@ int main(int argc, const char **argv) {
 
 	state.display = wl_display_connect(NULL);
 	if (!state.display) {
-		wlr_log(WLR_ERROR, "Unable to connect to the compositor. "
+		sway_log(SWAY_ERROR, "Unable to connect to the compositor. "
 				"If your compositor is running, check or set the "
 				"WAYLAND_DISPLAY environment variable.");
 		return 1;
@@ -292,7 +292,7 @@ int main(int argc, const char **argv) {
 	wl_display_roundtrip(state.display);
 	if (state.compositor == NULL || state.shm == NULL ||
 			state.layer_shell == NULL || state.xdg_output_manager == NULL) {
-		wlr_log(WLR_ERROR, "Missing a required Wayland interface");
+		sway_log(SWAY_ERROR, "Missing a required Wayland interface");
 		return 1;
 	}
 
@@ -306,7 +306,7 @@ int main(int argc, const char **argv) {
 	// Second roundtrip to get xdg_output properties
 	wl_display_roundtrip(state.display);
 	if (state.output == NULL) {
-		wlr_log(WLR_ERROR, "Cannot find output '%s'", args.output);
+		sway_log(SWAY_ERROR, "Cannot find output '%s'", args.output);
 		return 1;
 	}
 

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -317,7 +317,7 @@ int main(int argc, char **argv) {
 	char *socket_path = NULL;
 	char *cmdtype = NULL;
 
-	wlr_log_init(WLR_INFO, NULL);
+	sway_log_init(SWAY_INFO, NULL);
 
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
@@ -421,7 +421,7 @@ int main(int argc, char **argv) {
 	free(cmdtype);
 
 	if (monitor && type != IPC_SUBSCRIBE) {
-		wlr_log(WLR_ERROR, "Monitor can only be used with -t SUBSCRIBE");
+		sway_log(SWAY_ERROR, "Monitor can only be used with -t SUBSCRIBE");
 		free(socket_path);
 		return 1;
 	}

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -47,13 +47,13 @@ int main(int argc, char **argv) {
 		exit_code = launch_status;
 		goto cleanup;
 	}
-	wlr_log_init(debug ? WLR_DEBUG : WLR_ERROR, NULL);
+	sway_log_init(debug ? SWAY_DEBUG : SWAY_ERROR, NULL);
 
 	if (!config_path) {
 		config_path = swaynag_get_config_path();
 	}
 	if (config_path) {
-		wlr_log(WLR_DEBUG, "Loading config file: %s", config_path);
+		sway_log(SWAY_DEBUG, "Loading config file: %s", config_path);
 		int config_status = swaynag_load_config(config_path, &swaynag, types);
 		free(config_path);
 		if (config_status != 0) {
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (!swaynag.message) {
-		wlr_log(WLR_ERROR, "No message passed. Please provide --message/-m");
+		sway_log(SWAY_ERROR, "No message passed. Please provide --message/-m");
 		exit_code = EXIT_FAILURE;
 		goto cleanup;
 	}
@@ -106,15 +106,15 @@ int main(int argc, char **argv) {
 		free(swaynag.details.button_details);
 	}
 
-	wlr_log(WLR_DEBUG, "Output: %s", swaynag.type->output);
-	wlr_log(WLR_DEBUG, "Anchors: %d", swaynag.type->anchors);
-	wlr_log(WLR_DEBUG, "Type: %s", swaynag.type->name);
-	wlr_log(WLR_DEBUG, "Message: %s", swaynag.message);
-	wlr_log(WLR_DEBUG, "Font: %s", swaynag.type->font);
-	wlr_log(WLR_DEBUG, "Buttons");
+	sway_log(SWAY_DEBUG, "Output: %s", swaynag.type->output);
+	sway_log(SWAY_DEBUG, "Anchors: %d", swaynag.type->anchors);
+	sway_log(SWAY_DEBUG, "Type: %s", swaynag.type->name);
+	sway_log(SWAY_DEBUG, "Message: %s", swaynag.message);
+	sway_log(SWAY_DEBUG, "Font: %s", swaynag.type->font);
+	sway_log(SWAY_DEBUG, "Buttons");
 	for (int i = 0; i < swaynag.buttons->length; i++) {
 		struct swaynag_button *button = swaynag.buttons->items[i];
-		wlr_log(WLR_DEBUG, "\t[%s] `%s`", button->text, button->action);
+		sway_log(SWAY_DEBUG, "\t[%s] `%s`", button->text, button->action);
 	}
 
 	signal(SIGTERM, sig_handler);

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -281,7 +281,7 @@ void render_frame(struct swaynag *swaynag) {
 				swaynag->width * swaynag->scale,
 				swaynag->height * swaynag->scale);
 		if (!swaynag->current_buffer) {
-			wlr_log(WLR_DEBUG, "Failed to get buffer. Skipping frame.");
+			sway_log(SWAY_DEBUG, "Failed to get buffer. Skipping frame.");
 			goto cleanup;
 		}
 

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -21,24 +21,24 @@ static bool terminal_execute(char *terminal, char *command) {
 	char fname[] = "/tmp/swaynagXXXXXX";
 	FILE *tmp= fdopen(mkstemp(fname), "w");
 	if (!tmp) {
-		wlr_log(WLR_ERROR, "Failed to create temp script");
+		sway_log(SWAY_ERROR, "Failed to create temp script");
 		return false;
 	}
-	wlr_log(WLR_DEBUG, "Created temp script: %s", fname);
+	sway_log(SWAY_DEBUG, "Created temp script: %s", fname);
 	fprintf(tmp, "#!/bin/sh\nrm %s\n%s", fname, command);
 	fclose(tmp);
 	chmod(fname, S_IRUSR | S_IWUSR | S_IXUSR);
 	char *cmd = malloc(sizeof(char) * (strlen(terminal) + strlen(" -e ") + strlen(fname) + 1));
 	sprintf(cmd, "%s -e %s", terminal, fname);
 	execl("/bin/sh", "/bin/sh", "-c", cmd, NULL);
-	wlr_log_errno(WLR_ERROR, "Failed to run command, execl() returned.");
+	sway_log_errno(SWAY_ERROR, "Failed to run command, execl() returned.");
 	free(cmd);
 	return false;
 }
 
 static void swaynag_button_execute(struct swaynag *swaynag,
 		struct swaynag_button *button) {
-	wlr_log(WLR_DEBUG, "Executing [%s]: %s", button->text, button->action);
+	sway_log(SWAY_DEBUG, "Executing [%s]: %s", button->text, button->action);
 	if (button->type == SWAYNAG_ACTION_DISMISS) {
 		swaynag->run_display = false;
 	} else if (button->type == SWAYNAG_ACTION_EXPAND) {
@@ -52,14 +52,14 @@ static void swaynag_button_execute(struct swaynag *swaynag,
 				// Child of the child. Will be reparented to the init process
 				char *terminal = getenv("TERMINAL");
 				if (button->terminal && terminal && strlen(terminal)) {
-					wlr_log(WLR_DEBUG, "Found $TERMINAL: %s", terminal);
+					sway_log(SWAY_DEBUG, "Found $TERMINAL: %s", terminal);
 					if (!terminal_execute(terminal, button->action)) {
 						swaynag_destroy(swaynag);
 						exit(EXIT_FAILURE);
 					}
 				} else {
 					if (button->terminal) {
-						wlr_log(WLR_DEBUG,
+						sway_log(SWAY_DEBUG,
 								"$TERMINAL not found. Running directly");
 					}
 					execl("/bin/sh", "/bin/sh", "-c", button->action, NULL);
@@ -98,7 +98,7 @@ static void surface_enter(void *data, struct wl_surface *surface,
 	struct swaynag_output *swaynag_output;
 	wl_list_for_each(swaynag_output, &swaynag->outputs, link) {
 		if (swaynag_output->wl_output == output) {
-			wlr_log(WLR_DEBUG, "Surface enter on output %s",
+			sway_log(SWAY_DEBUG, "Surface enter on output %s",
 					swaynag_output->name);
 			swaynag->output = swaynag_output;
 			swaynag->scale = swaynag->output->scale;
@@ -273,10 +273,10 @@ static void xdg_output_handle_name(void *data,
 		struct zxdg_output_v1 *xdg_output, const char *name) {
 	struct swaynag_output *swaynag_output = data;
 	char *outname = swaynag_output->swaynag->type->output;
-	wlr_log(WLR_DEBUG, "Checking against output %s for %s", name, outname);
+	sway_log(SWAY_DEBUG, "Checking against output %s for %s", name, outname);
 	if (!swaynag_output->swaynag->output && outname && name
 			&& strcmp(outname, name) == 0) {
-		wlr_log(WLR_DEBUG, "Using output %s", name);
+		sway_log(SWAY_DEBUG, "Using output %s", name);
 		swaynag_output->swaynag->output = swaynag_output;
 	}
 	swaynag_output->name = strdup(name);
@@ -368,7 +368,7 @@ void swaynag_setup(struct swaynag *swaynag) {
 	}
 
 	if (!swaynag->output && swaynag->type->output) {
-		wlr_log(WLR_ERROR, "Output '%s' not found", swaynag->type->output);
+		sway_log(SWAY_ERROR, "Output '%s' not found", swaynag->type->output);
 		swaynag_destroy(swaynag);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Following @ddevault 's recommendation in #3474 , this PR replaces `wlr_log` with `sway_log`,
and WLR_(ERROR|DEBUG|INFO) with SWAY_(ERROR|DEBUG|INFO). See also #2009.

(Note: I'd really like to replace `SWAY_SRC_DIR` +` _sway_strip_path` with a per-file `PROJECT_FILE_PATH` macro, since  the former combination leaks the path into the executable, and calls the slow function `strstr` at runtime. It's not obvious how to do this with meson.)