### PR TITLE
input_cmd_events: allow toggle modes to be listed

### DIFF
--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -7,14 +7,14 @@
 #include "sway/input/input-manager.h"
 #include "log.h"
 
-static void toggle_send_events_for_device(struct input_config *ic,
+static void toggle_supported_send_events_for_device(struct input_config *ic,
 		struct sway_input_device *input_device) {
 	struct wlr_input_device *wlr_device = input_device->wlr_device;
 	if (!wlr_input_device_is_libinput(wlr_device)) {
 		return;
 	}
-	struct libinput_device *libinput_dev
-		= wlr_libinput_get_device_handle(wlr_device);
+	struct libinput_device *libinput_dev =
+		wlr_libinput_get_device_handle(wlr_device);
 
 	enum libinput_config_send_events_mode mode =
 		libinput_device_config_send_events_get_mode(libinput_dev);
@@ -43,23 +43,64 @@ static void toggle_send_events_for_device(struct input_config *ic,
 	ic->send_events = mode;
 }
 
-static void toggle_send_events(struct input_config *ic) {
+static int mode_for_name(const char *name) {
+	if (!strcmp(name, "enabled")) {
+		return LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
+	} else if (!strcmp(name, "disabled_on_external_mouse")) {
+		return LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE;
+	} else if (!strcmp(name, "disabled")) {
+		return LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
+	}
+	return -1;
+}
+
+static void toggle_select_send_events_for_device(struct input_config *ic,
+		struct sway_input_device *input_device, int argc, char **argv) {
+	if (!wlr_input_device_is_libinput(input_device->wlr_device)) {
+		return;
+	}
+	// Get the currently set event mode since ic is a new config that will be
+	// merged on the existing later. It should be set to INT_MIN before this.
+	ic->send_events = libinput_device_config_send_events_get_mode(
+			wlr_libinput_get_device_handle(input_device->wlr_device));
+
+	int index;
+	for (index = 0; index < argc; ++index) {
+		if (mode_for_name(argv[index]) == ic->send_events) {
+			++index;
+			break;
+		}
+	}
+	ic->send_events = mode_for_name(argv[index % argc]);
+}
+
+static void toggle_send_events(struct input_config *ic, int argc, char **argv) {
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &server.input->devices, link) {
 		if (strcmp(input_device->identifier, ic->identifier) == 0) {
-			toggle_send_events_for_device(ic, input_device);
+			if (argc) {
+				toggle_select_send_events_for_device(ic, input_device,
+						argc, argv);
+			} else {
+				toggle_supported_send_events_for_device(ic, input_device);
+			}
+			return;
 		}
 	}
 }
 
-static void toggle_wildcard_send_events() {
+static void toggle_wildcard_send_events(int argc, char **argv) {
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &server.input->devices, link) {
 		struct input_config *ic = new_input_config(input_device->identifier);
 		if (!ic) {
 			break;
 		}
-		toggle_send_events_for_device(ic, input_device);
+		if (argc) {
+			toggle_select_send_events_for_device(ic, input_device, argc, argv);
+		} else {
+			toggle_supported_send_events_for_device(ic, input_device);
+		}
 		store_input_config(ic);
 	}
 }
@@ -85,15 +126,21 @@ struct cmd_results *input_cmd_events(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID,
 			"Expected 'events <enabled|disabled|disabled_on_external_mouse>'");
 	} else if (strcasecmp(argv[0], "toggle") == 0) {
+		for (int i = 1; i < argc; ++i) {
+			if (mode_for_name(argv[i]) == -1) {
+				return cmd_results_new(CMD_INVALID,
+						"Invalid toggle mode %s", argv[i]);
+			}
+		}
 		if (strcmp(ic->identifier, "*") == 0) {
 			// Update the device input configs and then reset the wildcard
 			// config send events mode so that is does not override the device
 			// ones. The device ones will be applied when attempting to apply
 			// the wildcard config
-			toggle_wildcard_send_events();
+			toggle_wildcard_send_events(argc - 1, argv + 1);
 			ic->send_events = INT_MIN;
 		} else {
-			toggle_send_events(ic);
+			toggle_send_events(ic, argc - 1, argv + 1);
 		}
 	} else {
 		return cmd_results_new(CMD_INVALID,

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -82,12 +82,16 @@ The following commands may only be used in the configuration file.
 *input* <identifier> dwt enabled|disabled
 	Enables or disables disable-while-typing for the specified input device.
 
-*input* <identifier> events enabled|disabled|disabled\_on\_external\_mouse|toggle
+*input* <identifier> events enabled|disabled|disabled\_on\_external\_mouse|toggle [<toggle-modes>]
 	Enables or disables send\_events for specified input device. Disabling
-	send\_events disables the input device. The _toggle_ option cannot be used
-	in the config. The order is enabled, disabled\_on\_external\_mouse,
-	disabled, (loop back to enabled). Any mode which is not supported by the
-	device will be skipped during the toggle.
+	send\_events disables the input device.
+
+	The _toggle_ option cannot be used in the config. If no toggle modes are
+	listed, all supported modes for the device will be toggled through in the
+	order: enabled,	disabled\_on\_external\_mouse, disabled, (loop back). If
+	toggle modes are listed, they will be cycled through, defaulting to the
+	first mode listed if the current mode is not in the list. They will also
+	not be checked to see if they are supported for the device and may fail.
 
 *input* <identifier> left\_handed enabled|disabled
 	Enables or disables left handed mode for specified input device.


### PR DESCRIPTION
Closes #3470 

This extends `input <identifier> events toggle` to allow for an optional
list of modes to toggle through. If no event modes are listed, all
supported modes are cycled through (current behavior). If event modes
are listed, they will be cycled through, defaulting to the first mode
listed when the current mode is not in the list. This modes listed will
also not be checked to see if the device supports them and may fail.