### PR TITLE
Log libinput_config_status errors

### DIFF
--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -107,6 +107,12 @@ void input_manager_verify_fallback_seat(void) {
 	}
 }
 
+static void log_libinput_config_status(enum libinput_config_status status) {
+	if (status != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+		wlr_log(WLR_DEBUG, "Error: %s", libinput_config_status_to_str(status));
+	}
+}
+
 static void input_manager_libinput_config_keyboard(
 		struct sway_input_device *input_device) {
 	struct wlr_input_device *wlr_device = input_device->wlr_device;
@@ -124,8 +130,8 @@ static void input_manager_libinput_config_keyboard(
 	if (ic->send_events != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_keyboard(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
-		libinput_device_config_send_events_set_mode(libinput_device,
-			ic->send_events);
+		log_libinput_config_status(libinput_device_config_send_events_set_mode(
+					libinput_device, ic->send_events));
 	}
 }
 
@@ -144,7 +150,8 @@ static void input_manager_libinput_reset_keyboard(
 		libinput_device_config_send_events_get_default_mode(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_keyboard(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
-	libinput_device_config_send_events_set_mode(libinput_device, send_events);
+	log_libinput_config_status(libinput_device_config_send_events_set_mode(
+				libinput_device, send_events));
 }
 
 static void input_manager_libinput_config_touch(
@@ -164,8 +171,8 @@ static void input_manager_libinput_config_touch(
 	if (ic->send_events != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_touch(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
-		libinput_device_config_send_events_set_mode(libinput_device,
-			ic->send_events);
+		log_libinput_config_status(libinput_device_config_send_events_set_mode(
+					libinput_device, ic->send_events));
 	}
 }
 
@@ -184,7 +191,8 @@ static void input_manager_libinput_reset_touch(
 		libinput_device_config_send_events_get_default_mode(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_touch(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
-	libinput_device_config_send_events_set_mode(libinput_device, send_events);
+	log_libinput_config_status(libinput_device_config_send_events_set_mode(
+				libinput_device, send_events));
 }
 
 static void input_manager_libinput_config_pointer(
@@ -204,89 +212,94 @@ static void input_manager_libinput_config_pointer(
 	if (ic->accel_profile != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) accel_set_profile(%d)",
 			ic->identifier, ic->accel_profile);
-		libinput_device_config_accel_set_profile(libinput_device,
-			ic->accel_profile);
+		log_libinput_config_status(libinput_device_config_accel_set_profile(
+					libinput_device, ic->accel_profile));
 	}
 	if (ic->click_method != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) click_set_method(%d)",
 			ic->identifier, ic->click_method);
-		libinput_device_config_click_set_method(libinput_device,
-			ic->click_method);
+		log_libinput_config_status(libinput_device_config_click_set_method(
+					libinput_device, ic->click_method));
 	}
 	if (ic->drag != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) tap_set_drag_enabled(%d)",
 			ic->identifier, ic->drag);
-		libinput_device_config_tap_set_drag_enabled(libinput_device,
-			ic->drag);
+		log_libinput_config_status(libinput_device_config_tap_set_drag_enabled(
+					libinput_device, ic->drag));
 	}
 	if (ic->drag_lock != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			ic->identifier, ic->drag_lock);
-		libinput_device_config_tap_set_drag_lock_enabled(libinput_device,
-			ic->drag_lock);
+		log_libinput_config_status(
+				libinput_device_config_tap_set_drag_lock_enabled(
+					libinput_device, ic->drag_lock));
 	}
 	if (ic->dwt != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) dwt_set_enabled(%d)",
 			ic->identifier, ic->dwt);
-		libinput_device_config_dwt_set_enabled(libinput_device, ic->dwt);
+		log_libinput_config_status(libinput_device_config_dwt_set_enabled(
+					libinput_device, ic->dwt));
 	}
 	if (ic->left_handed != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) left_handed_set_enabled(%d)",
 			ic->identifier, ic->left_handed);
-		libinput_device_config_left_handed_set(libinput_device,
-			ic->left_handed);
+		log_libinput_config_status(libinput_device_config_left_handed_set(
+					libinput_device, ic->left_handed));
 	}
 	if (ic->middle_emulation != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) middle_emulation_set_enabled(%d)",
 			ic->identifier, ic->middle_emulation);
-		libinput_device_config_middle_emulation_set_enabled(libinput_device,
-			ic->middle_emulation);
+		log_libinput_config_status(
+				libinput_device_config_middle_emulation_set_enabled(
+					libinput_device, ic->middle_emulation));
 	}
 	if (ic->natural_scroll != INT_MIN) {
 		wlr_log(WLR_DEBUG,
 			"libinput_config_pointer(%s) natural_scroll_set_enabled(%d)",
 			ic->identifier, ic->natural_scroll);
-		libinput_device_config_scroll_set_natural_scroll_enabled(
-			libinput_device, ic->natural_scroll);
+		log_libinput_config_status(
+				libinput_device_config_scroll_set_natural_scroll_enabled(
+					libinput_device, ic->natural_scroll));
 	}
 	if (ic->pointer_accel != FLT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) accel_set_speed(%f)",
 			ic->identifier, ic->pointer_accel);
-		libinput_device_config_accel_set_speed(libinput_device,
-			ic->pointer_accel);
+		log_libinput_config_status(libinput_device_config_accel_set_speed(
+					libinput_device, ic->pointer_accel));
 	}
 	if (ic->scroll_button != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_button(%d)",
 			ic->identifier, ic->scroll_button);
-		libinput_device_config_scroll_set_button(libinput_device,
-			ic->scroll_button);
+		log_libinput_config_status(libinput_device_config_scroll_set_button(
+					libinput_device, ic->scroll_button));
 	}
 	if (ic->scroll_method != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) scroll_set_method(%d)",
 			ic->identifier, ic->scroll_method);
-		libinput_device_config_scroll_set_method(libinput_device,
-			ic->scroll_method);
+		log_libinput_config_status(libinput_device_config_scroll_set_method(
+					libinput_device, ic->scroll_method));
 	}
 	if (ic->send_events != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) send_events_set_mode(%d)",
 			ic->identifier, ic->send_events);
-		libinput_device_config_send_events_set_mode(libinput_device,
-			ic->send_events);
+		log_libinput_config_status(libinput_device_config_send_events_set_mode(
+					libinput_device, ic->send_events));
 	}
 	if (ic->tap != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) tap_set_enabled(%d)",
 			ic->identifier, ic->tap);
-		libinput_device_config_tap_set_enabled(libinput_device, ic->tap);
+		log_libinput_config_status(libinput_device_config_tap_set_enabled(
+					libinput_device, ic->tap));
 	}
 	if (ic->tap_button_map != INT_MIN) {
 		wlr_log(WLR_DEBUG, "libinput_config_pointer(%s) tap_set_button_map(%d)",
 			ic->identifier, ic->tap_button_map);
-		libinput_device_config_tap_set_button_map(libinput_device,
-			ic->tap_button_map);
+		log_libinput_config_status(libinput_device_config_tap_set_button_map(
+					libinput_device, ic->tap_button_map));
 	}
 }
 
@@ -305,19 +318,22 @@ static void input_manager_libinput_reset_pointer(
 		libinput_device_config_accel_get_default_profile(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) accel_set_profile(%d)",
 			input_device->identifier, accel_profile);
-	libinput_device_config_accel_set_profile(libinput_device, accel_profile);
+	log_libinput_config_status(libinput_device_config_accel_set_profile(
+				libinput_device, accel_profile));
 
 	enum libinput_config_click_method click_method =
 		libinput_device_config_click_get_default_method(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) click_set_method(%d)",
 		input_device->identifier, click_method);
-	libinput_device_config_click_set_method(libinput_device, click_method);
+	log_libinput_config_status(libinput_device_config_click_set_method(
+				libinput_device, click_method));
 
 	enum libinput_config_drag_state drag =
 		libinput_device_config_tap_get_default_drag_enabled(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_drag_enabled(%d)",
 			input_device->identifier, drag);
-	libinput_device_config_tap_set_drag_enabled(libinput_device, drag);
+	log_libinput_config_status(libinput_device_config_tap_set_drag_enabled(
+				libinput_device, drag));
 
 	enum libinput_config_drag_lock_state drag_lock =
 		libinput_device_config_tap_get_default_drag_lock_enabled(
@@ -325,21 +341,24 @@ static void input_manager_libinput_reset_pointer(
 	wlr_log(WLR_DEBUG,
 			"libinput_reset_pointer(%s) tap_set_drag_lock_enabled(%d)",
 			input_device->identifier, drag_lock);
-	libinput_device_config_tap_set_drag_lock_enabled(libinput_device,
-			drag_lock);
+	log_libinput_config_status(
+			libinput_device_config_tap_set_drag_lock_enabled(
+				libinput_device, drag_lock));
 
 	enum libinput_config_dwt_state dwt =
 		libinput_device_config_dwt_get_default_enabled(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) dwt_set_enabled(%d)",
 		input_device->identifier, dwt);
-	libinput_device_config_dwt_set_enabled(libinput_device, dwt);
+	log_libinput_config_status(libinput_device_config_dwt_set_enabled(
+				libinput_device, dwt));
 
 	int left_handed =
 		libinput_device_config_left_handed_get_default(libinput_device);
 	wlr_log(WLR_DEBUG,
 		"libinput_reset_pointer(%s) left_handed_set_enabled(%d)",
 		input_device->identifier, left_handed);
-	libinput_device_config_left_handed_set(libinput_device, left_handed);
+	log_libinput_config_status(libinput_device_config_left_handed_set(
+				libinput_device, left_handed));
 
 	enum libinput_config_middle_emulation_state middle_emulation =
 		libinput_device_config_middle_emulation_get_default_enabled(
@@ -347,8 +366,9 @@ static void input_manager_libinput_reset_pointer(
 	wlr_log(WLR_DEBUG,
 		"libinput_reset_pointer(%s) middle_emulation_set_enabled(%d)",
 		input_device->identifier, middle_emulation);
-	libinput_device_config_middle_emulation_set_enabled(libinput_device,
-		middle_emulation);
+	log_libinput_config_status(
+			libinput_device_config_middle_emulation_set_enabled(
+				libinput_device, middle_emulation));
 
 	int natural_scroll =
 		libinput_device_config_scroll_get_default_natural_scroll_enabled(
@@ -356,44 +376,51 @@ static void input_manager_libinput_reset_pointer(
 	wlr_log(WLR_DEBUG,
 		"libinput_reset_pointer(%s) natural_scroll_set_enabled(%d)",
 		input_device->identifier, natural_scroll);
-	libinput_device_config_scroll_set_natural_scroll_enabled(
-		libinput_device, natural_scroll);
+	log_libinput_config_status(
+			libinput_device_config_scroll_set_natural_scroll_enabled(
+				libinput_device, natural_scroll));
 
 	double pointer_accel =
 		libinput_device_config_accel_get_default_speed(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) accel_set_speed(%f)",
 		input_device->identifier, pointer_accel);
-	libinput_device_config_accel_set_speed(libinput_device, pointer_accel);
+	log_libinput_config_status(libinput_device_config_accel_set_speed(
+				libinput_device, pointer_accel));
 
 	uint32_t scroll_button =
 		libinput_device_config_scroll_get_default_button(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) scroll_set_button(%d)",
 		input_device->identifier, scroll_button);
-	libinput_device_config_scroll_set_button(libinput_device, scroll_button);
+	log_libinput_config_status(libinput_device_config_scroll_set_button(
+				libinput_device, scroll_button));
 
 	enum libinput_config_scroll_method scroll_method =
 		libinput_device_config_scroll_get_default_method(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) scroll_set_method(%d)",
 		input_device->identifier, scroll_method);
-	libinput_device_config_scroll_set_method(libinput_device, scroll_method);
+	log_libinput_config_status(libinput_device_config_scroll_set_method(
+				libinput_device, scroll_method));
 
 	uint32_t send_events =
 		libinput_device_config_send_events_get_default_mode(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) send_events_set_mode(%d)",
 		input_device->identifier, send_events);
-	libinput_device_config_send_events_set_mode(libinput_device, send_events);
+	log_libinput_config_status(libinput_device_config_send_events_set_mode(
+				libinput_device, send_events));
 
 	enum libinput_config_tap_state tap =
 		libinput_device_config_tap_get_default_enabled(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_enabled(%d)",
 		input_device->identifier, tap);
-	libinput_device_config_tap_set_enabled(libinput_device, tap);
+	log_libinput_config_status(libinput_device_config_tap_set_enabled(
+				libinput_device, tap));
 
 	enum libinput_config_tap_button_map tap_button_map =
 		libinput_device_config_tap_get_button_map(libinput_device);
 	wlr_log(WLR_DEBUG, "libinput_reset_pointer(%s) tap_set_button_map(%d)",
 		input_device->identifier, tap_button_map);
-	libinput_device_config_tap_set_button_map(libinput_device, tap_button_map);
+	log_libinput_config_status(libinput_device_config_tap_set_button_map(
+				libinput_device, tap_button_map));
 }
 
 static void handle_device_destroy(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
This add errors from calls to `libinput_device_config_*_set` to the
debug log. This may be useful when looking at issues related to input
devices and config settings not working.