### PR TITLE
Remove wlroots dependency for sway(bar|bg|msg|nag)

### DIFF
--- a/client/meson.build
+++ b/client/meson.build
@@ -8,8 +8,7 @@ lib_sway_client = static_library(
 		gdk_pixbuf,
 		pango,
 		pangocairo,
-		wlroots,
-		wayland_client,
+		wayland_client
 	],
 	link_with: [lib_sway_common],
 	include_directories: sway_inc

--- a/common/meson.build
+++ b/common/meson.build
@@ -15,8 +15,7 @@ lib_sway_common = static_library(
 		cairo,
 		gdk_pixbuf,
 		pango,
-		pangocairo,
-		wlroots
+		pangocairo
 	],
 	include_directories: sway_inc
 )

--- a/common/util.c
+++ b/common/util.c
@@ -1,17 +1,9 @@
 #define _POSIX_C_SOURCE 200809L
-#include <assert.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <float.h>
 #include <math.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <xkbcommon/xkbcommon-names.h>
-#include <wlr/types/wlr_keyboard.h>
 #include "log.h"
 #include "util.h"
 
@@ -25,88 +17,6 @@ int numlen(int n) {
 	}
 	// Account for the '-' in negative numbers.
 	return log10(abs(n)) + (n > 0 ? 1 : 2);
-}
-
-static struct modifier_key {
-	char *name;
-	uint32_t mod;
-} modifiers[] = {
-	{ XKB_MOD_NAME_SHIFT, WLR_MODIFIER_SHIFT },
-	{ XKB_MOD_NAME_CAPS, WLR_MODIFIER_CAPS },
-	{ XKB_MOD_NAME_CTRL, WLR_MODIFIER_CTRL },
-	{ "Ctrl", WLR_MODIFIER_CTRL },
-	{ XKB_MOD_NAME_ALT, WLR_MODIFIER_ALT },
-	{ "Alt", WLR_MODIFIER_ALT },
-	{ XKB_MOD_NAME_NUM, WLR_MODIFIER_MOD2 },
-	{ "Mod3", WLR_MODIFIER_MOD3 },
-	{ XKB_MOD_NAME_LOGO, WLR_MODIFIER_LOGO },
-	{ "Mod5", WLR_MODIFIER_MOD5 },
-};
-
-uint32_t get_modifier_mask_by_name(const char *name) {
-	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
-		if (strcasecmp(modifiers[i].name, name) == 0) {
-			return modifiers[i].mod;
-		}
-	}
-
-	return 0;
-}
-
-const char *get_modifier_name_by_mask(uint32_t modifier) {
-	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
-		if (modifiers[i].mod == modifier) {
-			return modifiers[i].name;
-		}
-	}
-
-	return NULL;
-}
-
-int get_modifier_names(const char **names, uint32_t modifier_masks) {
-	int length = 0;
-	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
-		if ((modifier_masks & modifiers[i].mod) != 0) {
-			names[length] = modifiers[i].name;
-			++length;
-			modifier_masks ^= modifiers[i].mod;
-		}
-	}
-
-	return length;
-}
-
-pid_t get_parent_pid(pid_t child) {
-	pid_t parent = -1;
-	char file_name[100];
-	char *buffer = NULL;
-	char *token = NULL;
-	const char *sep = " ";
-	FILE *stat = NULL;
-	size_t buf_size = 0;
-
-	sprintf(file_name, "/proc/%d/stat", child);
-
-	if ((stat = fopen(file_name, "r"))) {
-		if (getline(&buffer, &buf_size, stat) != -1) {
-			token = strtok(buffer, sep); // pid
-			token = strtok(NULL, sep);   // executable name
-			token = strtok(NULL, sep);   // state
-			token = strtok(NULL, sep);   // parent pid
-			parent = strtol(token, NULL, 10);
-		}
-		free(buffer);
-		fclose(stat);
-	}
-
-	if (parent) {
-		return (parent == child) ? -1 : parent;
-	}
-
-	return -1;
 }
 
 uint32_t parse_color(const char *color) {
@@ -151,19 +61,4 @@ float parse_float(const char *value) {
 		return NAN;
 	}
 	return flt;
-}
-
-enum wlr_direction opposite_direction(enum wlr_direction d) {
-	switch (d) {
-	case WLR_DIRECTION_UP:
-		return WLR_DIRECTION_DOWN;
-	case WLR_DIRECTION_DOWN:
-		return WLR_DIRECTION_UP;
-	case WLR_DIRECTION_RIGHT:
-		return WLR_DIRECTION_LEFT;
-	case WLR_DIRECTION_LEFT:
-		return WLR_DIRECTION_RIGHT;
-	}
-	assert(false);
-	return 0;
 }

--- a/common/util.c
+++ b/common/util.c
@@ -12,11 +12,12 @@ int wrap(int i, int max) {
 }
 
 int numlen(int n) {
-	if (n == 0) {
-		return 1;
+	int j = n <= 0 ? 1 : 0;
+	while (n) {
+		j++;
+		n /= 10;
 	}
-	// Account for the '-' in negative numbers.
-	return log10(abs(n)) + (n > 0 ? 1 : 2);
+	return j;
 }
 
 uint32_t parse_color(const char *color) {

--- a/include/cairo.h
+++ b/include/cairo.h
@@ -4,7 +4,7 @@
 #include "config.h"
 #include <stdint.h>
 #include <cairo/cairo.h>
-#include <wlr/types/wlr_output.h>
+#include <wayland-client-protocol.h>
 #if HAVE_GDK_PIXBUF
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #endif

--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -5,6 +5,27 @@
 
 #define SWAY_KEYBOARD_PRESSED_KEYS_CAP 32
 
+/**
+ * Get modifier mask from modifier name.
+ *
+ * Returns the modifer mask or 0 if the name isn't found.
+ */
+uint32_t get_modifier_mask_by_name(const char *name);
+
+/**
+ * Get modifier name from modifier mask.
+ *
+ * Returns the modifier name or NULL if it isn't found.
+ */
+const char *get_modifier_name_by_mask(uint32_t modifier);
+
+/**
+ * Get an array of modifier names from modifier_masks
+ *
+ * Populates the names array and return the number of names added.
+ */
+int get_modifier_names(const char **names, uint32_t modifier_masks);
+
 struct sway_shortcut_state {
 	/**
 	 * A list of pressed key ids (either keysyms or keycodes),

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -152,4 +152,6 @@ void premultiply_alpha(float color[4], float opacity);
 
 void scale_box(struct wlr_box *box, float scale);
 
+enum wlr_direction opposite_direction(enum wlr_direction d);
+
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -3,9 +3,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <unistd.h>
-#include <wlr/types/wlr_output_layout.h>
-#include <xkbcommon/xkbcommon.h>
 
 /**
  * Wrap i into the range [0, max[
@@ -13,37 +10,9 @@
 int wrap(int i, int max);
 
 /**
- * Count number of digits in int
+ * Count number of digits in int, including '-' sign if there is one
  */
 int numlen(int n);
-
-/**
- * Get modifier mask from modifier name.
- *
- * Returns the modifer mask or 0 if the name isn't found.
- */
-uint32_t get_modifier_mask_by_name(const char *name);
-
-/**
- * Get modifier name from modifier mask.
- *
- * Returns the modifier name or NULL if it isn't found.
- */
-const char *get_modifier_name_by_mask(uint32_t modifier);
-
-/**
- * Get an array of modifier names from modifier_masks
- *
- * Populates the names array and return the number of names added.
- */
-int get_modifier_names(const char **names, uint32_t modifier_masks);
-
-/**
- * Get the pid of a parent process given the pid of a child process.
- *
- * Returns the parent pid or NULL if the parent pid cannot be determined.
- */
-pid_t get_parent_pid(pid_t pid);
 
 /**
  * Given a string that represents an RGB(A) color, return a uint32_t
@@ -64,7 +33,5 @@ bool parse_boolean(const char *boolean, bool current);
  * Returns NAN on error.
  */
 float parse_float(const char *value);
-
-enum wlr_direction opposite_direction(enum wlr_direction d);
 
 #endif

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "sway/commands.h"
+#include "sway/input/keyboard.h"
 #include "log.h"
 #include "stringop.h"
-#include "util.h"
 
 struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	struct cmd_results *error = NULL;

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -8,6 +8,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/input/cursor.h"
+#include "sway/input/keyboard.h"
 #include "sway/ipc-server.h"
 #include "list.h"
 #include "log.h"

--- a/sway/commands/floating_modifier.c
+++ b/sway/commands/floating_modifier.c
@@ -1,7 +1,7 @@
 #include "strings.h"
 #include "sway/commands.h"
 #include "sway/config.h"
-#include "util.h"
+#include "sway/input/keyboard.h"
 
 struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 	struct cmd_results *error = NULL;

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -11,12 +11,12 @@
 #include <strings.h>
 #include <signal.h>
 #include "sway/config.h"
+#include "sway/input/keyboard.h"
 #include "sway/output.h"
 #include "config.h"
-#include "stringop.h"
 #include "list.h"
 #include "log.h"
-#include "util.h"
+#include "stringop.h"
 
 static void terminate_swaybar(pid_t pid) {
 	sway_log(SWAY_DEBUG, "Terminating swaybar %d", pid);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -1,9 +1,11 @@
 #include <assert.h>
 #include <limits.h>
+#include <strings.h>
 #include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/interfaces/wlr_keyboard.h>
+#include <xkbcommon/xkbcommon-names.h>
 #include "sway/commands.h"
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
@@ -11,6 +13,58 @@
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
 #include "log.h"
+
+static struct modifier_key {
+	char *name;
+	uint32_t mod;
+} modifiers[] = {
+	{ XKB_MOD_NAME_SHIFT, WLR_MODIFIER_SHIFT },
+	{ XKB_MOD_NAME_CAPS, WLR_MODIFIER_CAPS },
+	{ XKB_MOD_NAME_CTRL, WLR_MODIFIER_CTRL },
+	{ "Ctrl", WLR_MODIFIER_CTRL },
+	{ XKB_MOD_NAME_ALT, WLR_MODIFIER_ALT },
+	{ "Alt", WLR_MODIFIER_ALT },
+	{ XKB_MOD_NAME_NUM, WLR_MODIFIER_MOD2 },
+	{ "Mod3", WLR_MODIFIER_MOD3 },
+	{ XKB_MOD_NAME_LOGO, WLR_MODIFIER_LOGO },
+	{ "Mod5", WLR_MODIFIER_MOD5 },
+};
+
+uint32_t get_modifier_mask_by_name(const char *name) {
+	int i;
+	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+		if (strcasecmp(modifiers[i].name, name) == 0) {
+			return modifiers[i].mod;
+		}
+	}
+
+	return 0;
+}
+
+const char *get_modifier_name_by_mask(uint32_t modifier) {
+	int i;
+	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+		if (modifiers[i].mod == modifier) {
+			return modifiers[i].name;
+		}
+	}
+
+	return NULL;
+}
+
+int get_modifier_names(const char **names, uint32_t modifier_masks) {
+	int length = 0;
+	int i;
+	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+		if ((modifier_masks & modifiers[i].mod) != 0) {
+			names[length] = modifiers[i].name;
+			++length;
+			modifier_masks ^= modifiers[i].mod;
+		}
+	}
+
+	return length;
+}
 
 /**
  * Remove all key ids associated to a keycode from the list of pressed keys

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -23,6 +23,7 @@
 #include "sway/output.h"
 #include "sway/server.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/keyboard.h"
 #include "sway/input/seat.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
@@ -11,6 +12,21 @@
 #include "sway/tree/workspace.h"
 #include "log.h"
 #include "util.h"
+
+enum wlr_direction opposite_direction(enum wlr_direction d) {
+	switch (d) {
+	case WLR_DIRECTION_UP:
+		return WLR_DIRECTION_DOWN;
+	case WLR_DIRECTION_DOWN:
+		return WLR_DIRECTION_UP;
+	case WLR_DIRECTION_RIGHT:
+		return WLR_DIRECTION_LEFT;
+	case WLR_DIRECTION_LEFT:
+		return WLR_DIRECTION_RIGHT;
+	}
+	assert(false);
+	return 0;
+}
 
 static void restore_workspaces(struct sway_output *output) {
 	// Workspace output priority

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -16,8 +16,7 @@ swaybar_deps = [
 	pangocairo,
 	rt,
 	wayland_client,
-	wayland_cursor,
-	wlroots,
+	wayland_cursor
 ]
 if have_tray
 	if systemd.found()

--- a/swaybg/meson.build
+++ b/swaybg/meson.build
@@ -7,11 +7,9 @@ executable(
 		client_protos,
 		gdk_pixbuf,
 		jsonc,
-		math,
 		pango,
 		pangocairo,
-		wayland_client,
-		wlroots,
+		wayland_client
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true

--- a/swaymsg/meson.build
+++ b/swaymsg/meson.build
@@ -2,7 +2,7 @@ executable(
 	'swaymsg',
 	'main.c',
 	include_directories: [sway_inc],
-	dependencies: [jsonc, wlroots],
+	dependencies: [jsonc],
 	link_with: [lib_sway_common],
 	install: true
 )

--- a/swaynag/meson.build
+++ b/swaynag/meson.build
@@ -11,12 +11,10 @@ executable(
 		cairo,
 		client_protos,
 		gdk_pixbuf,
-		math,
 		pango,
 		pangocairo,
 		wayland_client,
 		wayland_cursor,
-		wlroots,
 	],
 	link_with: [lib_sway_common, lib_sway_client],
 	install: true


### PR DESCRIPTION
This PR:
* Moves functions in `common/util.c` that are specific to the main sway executable to the best corresponding places in the `sway/` subdirectory that I could find.
* Fixes an edge case bug in `numlen`, removing the use of `log10` from libm
* Removes wlroots (and sometimes libm) dependencies from subfolders `common/`, `client/`,  `swaybar/`, `swaybg/`, `swaymsg/`, and `swaynag/`.

Closes #3476.