### PR TITLE
systemd --user support files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,9 @@ subdir('client')
 subdir('swaybg')
 subdir('swaybar')
 subdir('swaynag')
+if systemd.found()
+  subdir('systemd')
+endif
 
 config = configuration_data()
 config.set('datadir', join_paths(prefix, datadir))

--- a/systemd/10-systemd
+++ b/systemd/10-systemd
@@ -1,0 +1,4 @@
+# should go to /etc/sway/config.d/10-systemd
+#
+exec systemctl --user import-environment
+exec systemctl --user start sway-session.target

--- a/systemd/meson.build
+++ b/systemd/meson.build
@@ -1,0 +1,15 @@
+systemd_dep = dependency('systemd')
+
+if systemd_dep.found()
+  systemd_units = files(
+      'sway-session.target',
+  )
+  user_units_dir = systemd_dep.get_pkgconfig_variable('systemduserunitdir')
+  install_data(systemd_units, install_dir: user_units_dir)
+
+  sway_systemd_scripts = files(
+      '10-systemd',
+  )
+
+  install_data(sway_systemd_scripts, install_dir: sysconfdir + '/sway/config.d')
+endif

--- a/systemd/sway-session.target
+++ b/systemd/sway-session.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=sway compositor session
+Documentation=man:systemd.special(7)
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+


### PR DESCRIPTION
* adds a sway-session.target that binds to graphical-session.target
  (see man systemd.special)
* also adds a 10-systemd script that should (must?) be included from sway
  that starts imports the sway environment variables into the systemd
  --user instance, and then starts sway-session.target

The idea is that, any --user units that are wanted by either
sway-session.target or graphical-session.target will be started when
sway runs, and will have the correct environment from sway too.