### PR TITLE
root_scratchpad_remove_container: do not show 

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -515,6 +515,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	// move container
 	if (container->scratchpad) {
 		root_scratchpad_remove_container(container);
+		root_scratchpad_show(container);
 	}
 	switch (destination->type) {
 	case N_WORKSPACE:

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/ipc-server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/workspace.h"
@@ -51,6 +52,7 @@ static void scratchpad_toggle_auto(void) {
 					"Moving a visible scratchpad window (%s) to this workspace",
 					con->title);
 			root_scratchpad_show(con);
+			ipc_event_window(con, "move");
 			return;
 		}
 	}
@@ -62,6 +64,7 @@ static void scratchpad_toggle_auto(void) {
 	struct sway_container *con = root->scratchpad->items[0];
 	sway_log(SWAY_DEBUG, "Showing %s from list", con->title);
 	root_scratchpad_show(con);
+	ipc_event_window(con, "move");
 }
 
 static void scratchpad_toggle_container(struct sway_container *con) {
@@ -76,6 +79,7 @@ static void scratchpad_toggle_container(struct sway_container *con) {
 	}
 
 	root_scratchpad_show(con);
+	ipc_event_window(con, "move");
 }
 
 struct cmd_results *cmd_scratchpad(int argc, char **argv) {

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -87,9 +87,6 @@ void root_scratchpad_remove_container(struct sway_container *con) {
 	if (!sway_assert(con->scratchpad, "Container is not in scratchpad")) {
 		return;
 	}
-	if (!con->workspace) {
-		root_scratchpad_show(con);
-	}
 	con->scratchpad = false;
 	int index = list_find(root->scratchpad, con);
 	if (index != -1) {
@@ -135,10 +132,6 @@ void root_scratchpad_show(struct sway_container *con) {
 
 	arrange_workspace(new_ws);
 	seat_set_focus(seat, seat_get_focus_inactive(seat, &con->node));
-
-	if (new_ws != old_ws) {
-		ipc_event_window(con, "move");
-	}
 }
 
 void root_scratchpad_hide(struct sway_container *con) {


### PR DESCRIPTION
Fixes #3461

This removes the call to `root_scratchpad_show` from
`root_scratchpad_remove_container` and places it in the
`cmd_move_container`. This also moved the IPC `window::move` event to
`cmd_scratchpad`.