### PR TITLE
seat_create: set initial focus for added seats

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -357,6 +357,14 @@ struct sway_seat *seat_create(const char *seat_name) {
 	root_for_each_workspace(collect_focus_workspace_iter, seat);
 	root_for_each_container(collect_focus_container_iter, seat);
 
+	if (!wl_list_empty(&server.input->seats)) {
+		// Since this is not the first seat, attempt to set initial focus
+		struct sway_seat *current_seat = input_manager_current_seat();
+		struct sway_node *current_focus =
+			seat_get_focus_inactive(current_seat, &root->node);
+		seat_set_focus(seat, current_focus);
+	}
+
 	wl_signal_add(&root->events.new_node, &seat->new_node);
 	seat->new_node.notify = handle_new_node;
 


### PR DESCRIPTION
Fixes #3458 

This sets the initial focus for all seats other than the first seat,
which gets it focus on launch. The ensures that all seats have
something focused.