### PR TITLE
swaynag: Small graphical fix, add offset of +1 to X/Y.

### DIFF
--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -191,8 +191,8 @@ static uint32_t render_button(cairo_t *cairo, struct swaynag *swaynag,
 		return ideal_surface_height;
 	}
 
-	button->x = *x - border - text_width - padding * 2;
-	button->y = (int)(ideal_height - text_height) / 2 - padding;
+	button->x = *x - border - text_width - padding * 2 + 1;
+	button->y = (int)(ideal_height - text_height) / 2 - padding + 1;
 	button->width = text_width + padding * 2;
 	button->height = text_height + padding * 2;
 


### PR DESCRIPTION
I noticed this a long time ago but only just got round to fixing it. 

Before:
![082002-2019-01-22](https://user-images.githubusercontent.com/38229097/51521721-5b887600-1e1f-11e9-92ca-8724a81f816b.png)

After:
![082544-2019-01-22](https://user-images.githubusercontent.com/38229097/51521726-604d2a00-1e1f-11e9-8816-a299f9e908fa.png)

(screenshots taken with slurp + grim... god I love Wayland)