### PR TITLE
util.c: remove numlen function

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -11,15 +11,6 @@ int wrap(int i, int max) {
 	return ((i % max) + max) % max;
 }
 
-int numlen(int n) {
-	int j = n <= 0 ? 1 : 0;
-	while (n) {
-		j++;
-		n /= 10;
-	}
-	return j;
-}
-
 uint32_t parse_color(const char *color) {
 	if (color[0] == '#') {
 		++color;

--- a/include/util.h
+++ b/include/util.h
@@ -10,11 +10,6 @@
 int wrap(int i, int max);
 
 /**
- * Count number of digits in int, including '-' sign if there is one
- */
-int numlen(int n);
-
-/**
  * Given a string that represents an RGB(A) color, return a uint32_t
  * version of the color.
  */

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -1,10 +1,10 @@
 #define _POSIX_C_SOURCE 200809
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "log.h"
-#include "util.h"
 
 // Must be in alphabetical order for bsearch
 static struct cmd_handler bar_handlers[] = {
@@ -89,7 +89,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		}
 
 		// set bar id
-		const int len = 5 + numlen(config->bars->length - 1); // "bar-"+i+\0
+		const int len = snprintf(NULL, 0, "bar-%d", config->bars->length - 1) + 1;
 		bar->id = malloc(len * sizeof(char));
 		if (bar->id) {
 			snprintf(bar->id, len, "bar-%d", config->bars->length - 1);

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809
 #include <limits.h>
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include <json-c/json.h>
@@ -9,6 +10,7 @@
 #include "ipc-client.h"
 #include "list.h"
 #include "log.h"
+#include "util.h"
 
 void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
 	const char *fmt = "workspace \"%s\"";
@@ -372,15 +374,14 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 				ws->label = strdup(ws->name);
 				// ws->num will be -1 if workspace name doesn't begin with int.
 				if (ws->num != -1) {
-					size_t len_offset = numlen(ws->num);
+					size_t len_offset = snprintf(NULL, 0, "%d", ws->num);
 					if (bar->config->strip_workspace_name) {
 						free(ws->label);
-						ws->label = malloc(len_offset + 1 * sizeof(char));
-						ws->label[len_offset] = '\0';
-						strncpy(ws->label, ws->name, len_offset);
+						ws->label = malloc(len_offset + 1);
+						snprintf(ws->label, len_offset + 1, "%d", ws->num);
 					} else if (bar->config->strip_workspace_numbers) {
 						len_offset += ws->label[len_offset] == ':';
-						if (strlen(ws->name) > len_offset) {
+						if (ws->name[len_offset] != '\0') {
 							free(ws->label);
 							// Strip number prefix [1-?:] using len_offset.
 							ws->label = strdup(ws->name + len_offset);


### PR DESCRIPTION
Its uses have been replaced by snprintf, which is more in line with its usage.

Also cleaned headers.