### PR TITLE
i3 command behaviour compatibility fixes

### DIFF
--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -45,7 +45,7 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 				"Cannot set floating status on a hidden scratchpad container");
 	}
 
-	bool wants_floating = 
+	bool wants_floating =
 		parse_boolean(argv[0], container_is_floating(container));
 
 	container_set_floating(container, wants_floating);

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -40,11 +40,6 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		}
 	}
 
-	if (container->scratchpad && !container->workspace) {
-		return cmd_results_new(CMD_FAILURE,
-				"Cannot set floating status on a hidden scratchpad container");
-	}
-
 	bool wants_floating =
 		parse_boolean(argv[0], container_is_floating(container));
 

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -22,14 +22,9 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "No current container");
 	};
 	
-	if (!container_is_floating(container)) {
-		return cmd_results_new(CMD_FAILURE,
-			"Can't set sticky on a tiled container");
-	}
-
 	container->is_sticky = parse_boolean(argv[0], container->is_sticky);
 
-	if (container->is_sticky &&
+	if (container->is_sticky && container_is_floating_or_child(container) &&
 			(!container->scratchpad || container->workspace)) {
 		// move container to active workspace
 		struct sway_workspace *active_workspace =

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -708,7 +708,6 @@ void container_set_floating(struct sway_container *container, bool enable) {
 				container->border = container->saved_border;
 			}
 		}
-		container->is_sticky = false;
 	}
 
 	container_end_mouse_operation(container);


### PR DESCRIPTION
1. Allow tiled containers to be stickied
This also stops stickied containers from losing its sticky status when
it is tiled, allowing it to be immediately stickied when floated again.*
2. Allow setting floating on scratchpad containers

* There's a quirk in i3 that if the container is not on the active workspace when floated (and is sticky), it is not moved to the current workspace, but sticks when switching to that workspace. This matches that behaviour, though I'm not sure if it is a bug.

I've tested it a bit, but not sure if I've missed some edge case.

Looking into it more, it seems like there are a number of commands that, if run on hidden scratchpad containers, result in failure on sway but success on i3 (though I haven't tested which ones), so if compatibility is the goal then current handling should be changed.