### PR TITLE
Fix dead stores found by scan-build

### DIFF
--- a/client/pool-buffer.c
+++ b/client/pool-buffer.c
@@ -85,7 +85,6 @@ static struct pool_buffer *create_buffer(struct wl_shm *shm,
 	close(fd);
 	unlink(name);
 	free(name);
-	fd = -1;
 
 	buf->size = size;
 	buf->width = width;

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -123,7 +123,6 @@ static struct sway_node *node_get_in_direction(struct sway_container *container,
 
 		if (can_move) {
 			if (desired < 0 || desired >= siblings->length) {
-				can_move = false;
 				int len = siblings->length;
 				if (config->focus_wrapping != WRAP_NO && !wrap_candidate
 						&& len > 1) {

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -478,8 +478,9 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 			argc--; argv++;
 		}
 		int num_consumed_args = parse_resize_amount(argc, argv, &height);
-		argc -= num_consumed_args;
-		argv += num_consumed_args;
+		if (argc > num_consumed_args) {
+			return cmd_results_new(CMD_INVALID, usage);
+		}
 		if (width.unit == RESIZE_UNIT_INVALID) {
 			return cmd_results_new(CMD_INVALID, usage);
 		}
@@ -543,12 +544,14 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 	struct resize_amount second_amount;
 	if (argc) {
 		int num_consumed_args = parse_resize_amount(argc, argv, &second_amount);
-		argc -= num_consumed_args;
-		argv += num_consumed_args;
+		if (argc > num_consumed_args) {
+			return cmd_results_new(CMD_INVALID, usage);
+		}
 		if (second_amount.unit == RESIZE_UNIT_INVALID) {
 			return cmd_results_new(CMD_INVALID, usage);
 		}
 	} else {
+		second_amount.amount = 0;
 		second_amount.unit = RESIZE_UNIT_INVALID;
 	}
 

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -354,8 +354,6 @@ struct sway_layer_surface *layer_from_wlr_layer_surface_v1(
 
 void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	struct wlr_layer_surface_v1 *layer_surface = data;
-	struct sway_server *server =
-		wl_container_of(listener, server, layer_shell_surface);
 	sway_log(SWAY_DEBUG, "new layer surface: namespace %s layer %d anchor %d "
 			"size %dx%d margin %d,%d,%d,%d",
 		layer_surface->namespace, layer_surface->layer, layer_surface->layer,

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -13,7 +13,6 @@
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
-#include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
@@ -480,8 +479,6 @@ struct sway_view *view_from_wlr_xdg_surface(
 }
 
 void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(listener, server,
-		xdg_shell_surface);
 	struct wlr_xdg_surface *xdg_surface = data;
 
 	if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -12,7 +12,6 @@
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
-#include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
@@ -464,8 +463,6 @@ struct sway_view *view_from_wlr_xdg_surface_v6(
 }
 
 void handle_xdg_shell_v6_surface(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(listener, server,
-		xdg_shell_v6_surface);
 	struct wlr_xdg_surface_v6 *xdg_surface = data;
 
 	if (xdg_surface->role == WLR_XDG_SURFACE_V6_ROLE_POPUP) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -12,7 +12,6 @@
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/output.h"
-#include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
@@ -573,8 +572,6 @@ struct sway_view *view_from_wlr_xwayland_surface(
 }
 
 void handle_xwayland_surface(struct wl_listener *listener, void *data) {
-	struct sway_server *server = wl_container_of(listener, server,
-		xwayland_surface);
 	struct wlr_xwayland_surface *xsurface = data;
 
 	if (xsurface->override_redirect) {

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -169,7 +169,6 @@ static pid_t get_parent_pid(pid_t child) {
 	pid_t parent = -1;
 	char file_name[100];
 	char *buffer = NULL;
-	char *token = NULL;
 	const char *sep = " ";
 	FILE *stat = NULL;
 	size_t buf_size = 0;
@@ -178,10 +177,10 @@ static pid_t get_parent_pid(pid_t child) {
 
 	if ((stat = fopen(file_name, "r"))) {
 		if (getline(&buffer, &buf_size, stat) != -1) {
-			token = strtok(buffer, sep); // pid
-			token = strtok(NULL, sep);   // executable name
-			token = strtok(NULL, sep);   // state
-			token = strtok(NULL, sep);   // parent pid
+			strtok(buffer, sep); // pid
+			strtok(NULL, sep);   // executable name
+			strtok(NULL, sep);   // state
+			char *token = strtok(NULL, sep);   // parent pid
 			parent = strtol(token, NULL, 10);
 		}
 		free(buffer);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -236,8 +236,6 @@ void view_autoconfigure(struct sway_view *view) {
 		con->border_bottom = bottom_y != ws->y + ws->height;
 	}
 
-	double x, y, width, height;
-	x = y = width = height = 0;
 	double y_offset = 0;
 
 	// In a tabbed or stacked container, the container's y is the top of the
@@ -253,7 +251,9 @@ void view_autoconfigure(struct sway_view *view) {
 		con->border_top = false;
 	}
 
+	double x, y, width, height;
 	switch (con->border) {
+	default:
 	case B_CSD:
 	case B_NONE:
 		x = con->x;

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -334,7 +334,7 @@ static void handle_click(struct swaybar_sni *sni, int x, int y,
 
 	if (strncmp(method, "Scroll", strlen("Scroll")) == 0) {
 		char dir = method[strlen("Scroll")];
-		char *orientation = (dir = 'U' || dir == 'D') ? "vertical" : "horizontal";
+		char *orientation = (dir == 'U' || dir == 'D') ? "vertical" : "horizontal";
 		int sign = (dir == 'U' || dir == 'L') ? -1 : 1;
 
 		sd_bus_call_method_async(sni->tray->bus, NULL, sni->service, sni->path,

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -8,9 +8,6 @@
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 static uint32_t render_message(cairo_t *cairo, struct swaynag *swaynag) {
-	uint32_t height = swaynag->height * swaynag->scale;
-	height -= swaynag->type->bar_border_thickness * swaynag->scale;
-
 	int text_width, text_height;
 	get_text_size(cairo, swaynag->type->font, &text_width, &text_height, NULL,
 			swaynag->scale, true, "%s", swaynag->message);
@@ -77,8 +74,6 @@ static int get_detailed_scroll_button_width(cairo_t *cairo,
 static uint32_t render_detailed(cairo_t *cairo, struct swaynag *swaynag,
 		uint32_t y) {
 	uint32_t width = swaynag->width * swaynag->scale;
-	uint32_t height = swaynag->height * swaynag->scale;
-	height -= swaynag->type->bar_border_thickness * swaynag->scale;
 
 	int border = swaynag->type->details_border_thickness * swaynag->scale;
 	int padding = swaynag->type->message_padding * swaynag->scale;
@@ -174,8 +169,6 @@ static uint32_t render_detailed(cairo_t *cairo, struct swaynag *swaynag,
 
 static uint32_t render_button(cairo_t *cairo, struct swaynag *swaynag,
 		int button_index, int *x) {
-	uint32_t height = swaynag->height * swaynag->scale;
-	height -= swaynag->type->bar_border_thickness * swaynag->scale;
 	struct swaynag_button *button = swaynag->buttons->items[button_index];
 
 	int text_width, text_height;


### PR DESCRIPTION
`ninja scan-build` was used to invoke the [clang static analyzer](https://clang-analyzer.llvm.org/). 

In addition to removing unused code, two minor problems are fixed:
* `resize set` and `resize adjust` did not yield an error when given too many arguments. Now

        bindsym Ctrl+Return resize set width 400 px height 400 px
    
    still works, but the following fails:

        bindsym Ctrl+Return resize set width 400 px height 400 px oops

* `orientation` was incorrectly overridden to be 'U' for scroll events in the swaybar tray `handle_click` function.