### PR TITLE
swaybar: fix command malloc in workspace command

### DIFF
--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -20,7 +20,7 @@ void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
 		}
 	}
 
-	char *command = malloc(size) + 1;
+	char *command = malloc(size + 1);
 	if (!command) {
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/commit/d8f3e6e19a12514ed6f8c8f470b89fde0f39dc59#commitcomment-32026156

This fixes a typo on the malloc line in ipc_send_workspace_command. The
plus one to the size for the null-terminator was outside of the malloc
call, which was causing the incorrect pointer to be freed later in the
function.