### PR TITLE
Fix build failure in config.c

### DIFF
--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <wordexp.h>
+#include <unistd.h>
 #include "log.h"
 #include "list.h"
 #include "swaynag/swaynag.h"


### PR DESCRIPTION
Build problem was introduced in commit d7ff7765. Here, unistd.h was removed from utils.h, but 
swaynag/config.c needs to include it. 

Sway master was failing to build on Fedora 29 without this fix:

```
Found ninja-1.8.2 at /usr/bin/ninja
[211/220] Compiling C object 'swaynag/183c222@@swaynag@exe/config.c.o'.
FAILED: swaynag/183c222@@swaynag@exe/config.c.o 
ccache cc -Iswaynag/183c222@@swaynag@exe -Iswaynag -I../swaynag -Iinclude -I../include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/uuid -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -g '-DSWAY_SRC_DIR="/home/brad/git/sway"' -DWL_HIDE_DEPRECATED -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-unused-result -Wundef -Wvla '-DSYSCONFDIR="//usr/local/etc"' '-DSWAY_VERSION="1.0-beta.2-268-g8b056cfc (" __DATE__ ", branch '"'"'master'"'"')"'  -MD -MQ 'swaynag/183c222@@swaynag@exe/config.c.o' -MF 'swaynag/183c222@@swaynag@exe/config.c.o.d' -o 'swaynag/183c222@@swaynag@exe/config.c.o' -c ../swaynag/config.c
../swaynag/config.c: In function ‘file_exists’:
../swaynag/config.c:297:17: error: implicit declaration of function ‘access’; did you mean ‘acosl’? [-Werror=implicit-function-declaration]
  return path && access(path, R_OK) != -1;
                 ^~~~~~
                 acosl
../swaynag/config.c:297:30: error: ‘R_OK’ undeclared (first use in this function)
  return path && access(path, R_OK) != -1;
                              ^~~~
../swaynag/config.c:297:30: note: each undeclared identifier is reported only once for each function it appears in
../swaynag/config.c:298:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1: all warnings being treated as errors
[217/220] Linking target sway/sway.
ninja: build stopped: subcommand failed.
```