### PR TITLE
Implement pointer-constraints-unstable-v1 and relative-pointer-unstable-v1

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -153,6 +153,7 @@ sway_cmd cmd_new_window;
 sway_cmd cmd_no_focus;
 sway_cmd cmd_output;
 sway_cmd cmd_permit;
+sway_cmd cmd_pointer_constraint;
 sway_cmd cmd_popup_during_fullscreen;
 sway_cmd cmd_reject;
 sway_cmd cmd_reload;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -143,6 +143,7 @@ struct seat_config {
 	int fallback; // -1 means not set
 	list_t *attachments; // list of seat_attachment configs
 	int hide_cursor_timeout;
+	bool allow_constrain;
 };
 
 enum config_dpms {

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -2,6 +2,7 @@
 #define _SWAY_INPUT_CURSOR_H
 #include <stdbool.h>
 #include <stdint.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include "sway/input/seat.h"
 
@@ -26,6 +27,9 @@ struct sway_cursor {
 	struct wlr_surface *image_surface;
 	int hotspot_x, hotspot_y;
 
+	struct wlr_pointer_constraint_v1 *active_constraint;
+	pixman_region32_t confine; // invalid if active_constraint == NULL
+
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;
 	struct wl_listener button;
@@ -42,6 +46,8 @@ struct sway_cursor {
 	uint32_t tool_buttons;
 
 	struct wl_listener request_set_cursor;
+
+	struct wl_listener constraint_commit;
 
 	struct wl_event_source *hide_source;
 	bool hidden;
@@ -75,7 +81,8 @@ int cursor_get_timeout(struct sway_cursor *cursor);
  * Like cursor_rebase, but also allows focus to change when the cursor enters a
  * new container.
  */
-void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec);
+void cursor_send_pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
+	struct sway_node *node, struct wlr_surface *surface, double sx, double sy);
 
 void dispatch_cursor_button(struct sway_cursor *cursor,
 	struct wlr_input_device *device, uint32_t time_msec, uint32_t button,
@@ -96,6 +103,10 @@ void cursor_warp_to_container(struct sway_cursor *cursor,
 
 void cursor_warp_to_workspace(struct sway_cursor *cursor,
 		struct sway_workspace *workspace);
+
+
+void sway_cursor_constrain(struct sway_cursor *cursor,
+	struct wlr_pointer_constraint_v1 *constraint);
 
 uint32_t get_mouse_bindsym(const char *name, char **error);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -84,6 +84,12 @@ struct sway_seat {
 	struct wl_list link; // input_manager::seats
 };
 
+struct sway_pointer_constraint {
+	struct wlr_pointer_constraint_v1 *constraint;
+
+	struct wl_listener destroy;
+};
+
 struct sway_seat *seat_create(const char *seat_name);
 
 void seat_destroy(struct sway_seat *seat);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -9,6 +9,7 @@
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_xdg_shell.h>
@@ -50,6 +51,8 @@ struct sway_server {
 	struct wl_listener xwayland_surface;
 	struct wl_listener xwayland_ready;
 #endif
+
+	struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
 
 	struct wlr_server_decoration_manager *server_decoration_manager;
 	struct wl_listener server_decoration;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -61,6 +61,9 @@ struct sway_server {
 
 	struct wlr_presentation *presentation;
 
+	struct wlr_pointer_constraints_v1 *pointer_constraints;
+	struct wl_listener pointer_constraint;
+
 	size_t txn_timeout_ms;
 	list_t *transactions;
 	list_t *dirty_nodes;
@@ -86,5 +89,6 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data);
 #endif
 void handle_server_decoration(struct wl_listener *listener, void *data);
 void handle_xdg_decoration(struct wl_listener *listener, void *data);
+void handle_pointer_constraint(struct wl_listener *listener, void *data);
 
 #endif

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -39,6 +39,7 @@ server_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
+	[wl_protocol_dir, 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
 	['wlr-input-inhibitor-unstable-v1.xml'],
 ]

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -81,6 +81,7 @@ static struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "pointer_constraint", cmd_pointer_constraint },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/pointer_constraint.c
+++ b/sway/commands/pointer_constraint.c
@@ -1,0 +1,51 @@
+#include <string.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/cursor.h"
+#include "sway/input/seat.h"
+
+enum operation {
+	OP_ENABLE,
+	OP_DISABLE,
+	OP_ESCAPE,
+};
+
+// pointer_constraint [enable|disable|escape]
+struct cmd_results *cmd_pointer_constraint(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "pointer_constraint", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	enum operation op;
+	if (strcmp(argv[0], "enable") == 0) {
+		op = OP_ENABLE;
+	} else if (strcmp(argv[0], "disable") == 0) {
+		op = OP_DISABLE;
+	} else if (strcmp(argv[0], "escape") == 0) {
+		op = OP_ESCAPE;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "Expected enable|disable|escape");
+	}
+
+	if (op == OP_ESCAPE && config->reading) {
+		return cmd_results_new(CMD_FAILURE, "Can only escape at runtime.");
+	}
+
+	struct sway_cursor *cursor = config->handler_context.seat->cursor;
+	struct seat_config *seat_config = seat_get_config(cursor->seat);
+	switch (op) {
+	case OP_ENABLE:
+		seat_config->allow_constrain = true;
+		break;
+	case OP_DISABLE:
+		seat_config->allow_constrain = false;
+		/* fallthrough */
+	case OP_ESCAPE:
+		sway_cursor_constrain(cursor, NULL);
+		break;
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -26,6 +26,7 @@ struct seat_config *new_seat_config(const char* name) {
 		return NULL;
 	}
 	seat->hide_cursor_timeout = -1;
+	seat->allow_constrain = true;
 
 	return seat;
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1454,6 +1454,11 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data) {
 
 void sway_cursor_constrain(struct sway_cursor *cursor,
 		struct wlr_pointer_constraint_v1 *constraint) {
+	struct seat_config *config = seat_get_config(cursor->seat);
+	if (!config->allow_constrain) {
+		return;
+	}
+
 	if (cursor->active_constraint == constraint) {
 		return;
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -403,6 +403,14 @@ static void handle_cursor_motion(struct wl_listener *listener, void *data) {
 	double dx = event->delta_x;
 	double dy = event->delta_y;
 
+	double dx_unaccel = event->unaccel_dx;
+	double dy_unaccel = event->unaccel_dy;
+
+	wlr_relative_pointer_manager_v1_send_relative_motion(
+		server.relative_pointer_manager,
+		cursor->seat->wlr_seat, event->time_msec, dx, dy,
+		dx_unaccel, dy_unaccel);
+
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
 	struct sway_node *node = node_at_coords(cursor->seat,
@@ -437,6 +445,12 @@ static void cursor_motion_absolute(struct sway_cursor *cursor,
 	double lx, ly;
 	wlr_cursor_absolute_to_layout_coords(cursor->cursor, dev,
 		x, y, &lx, &ly);
+
+	double dx = lx - cursor->cursor->x;
+	double dy = ly - cursor->cursor->y;
+	wlr_relative_pointer_manager_v1_send_relative_motion(
+		server.relative_pointer_manager,
+		cursor->seat->wlr_seat, (uint64_t)time_msec * 1000, dx, dy, dx, dy);
 
 	struct wlr_surface *surface = NULL;
 	double sx, sy;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -105,6 +105,11 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 			wlr_seat_keyboard_notify_enter(
 					seat->wlr_seat, view->surface, NULL, 0, NULL);
 		}
+
+		struct wlr_pointer_constraint_v1 *constraint =
+			wlr_pointer_constraints_v1_constraint_for_surface(
+				server.pointer_constraints, view->surface, seat->wlr_seat);
+		sway_cursor_constrain(seat->cursor, constraint);
 	}
 }
 
@@ -684,6 +689,7 @@ static void send_unfocus(struct sway_container *con, void *data) {
 
 // Unfocus the container and any children (eg. when leaving `focus parent`)
 static void seat_send_unfocus(struct sway_node *node, struct sway_seat *seat) {
+	sway_cursor_constrain(seat->cursor, NULL);
 	wlr_seat_keyboard_clear_focus(seat->wlr_seat);
 	if (node->type == N_WORKSPACE) {
 		workspace_for_each_container(node->sway_workspace, send_unfocus, seat);

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -26,14 +26,19 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 
 static void handle_finish(struct sway_seat *seat) {
 	struct seatop_down_event *e = seat->seatop_data;
+	struct sway_cursor *cursor = seat->cursor;
 	// Set the cursor's previous coords to the x/y at the start of the
 	// operation, so the container change will be detected if using
 	// focus_follows_mouse and the cursor moved off the original container
 	// during the operation.
-	seat->cursor->previous.x = e->ref_lx;
-	seat->cursor->previous.y = e->ref_ly;
+	cursor->previous.x = e->ref_lx;
+	cursor->previous.y = e->ref_ly;
 	if (e->moved) {
-		cursor_send_pointer_motion(seat->cursor, 0);
+		struct wlr_surface *surface = NULL;
+		double sx, sy;
+		struct sway_node *node = node_at_coords(seat,
+				cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+		cursor_send_pointer_motion(cursor, 0, node, surface, sx, sy);
 	}
 }
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -75,6 +75,7 @@ sway_sources = files(
 	'commands/nop.c',
 	'commands/output.c',
 	'commands/popup_during_fullscreen.c',
+	'commands/pointer_constraint.c',
 	'commands/reload.c',
 	'commands/rename.c',
 	'commands/resize.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -15,6 +15,7 @@
 #include <wlr/types/wlr_gtk_primary_selection.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
@@ -105,6 +106,9 @@ bool server_init(struct sway_server *server) {
 			&server->xdg_decoration);
 	server->xdg_decoration.notify = handle_xdg_decoration;
 	wl_list_init(&server->xdg_decorations);
+
+	server->relative_pointer_manager =
+		wlr_relative_pointer_manager_v1_create(server->wl_display);
 
 	server->pointer_constraints =
 		wlr_pointer_constraints_v1_create(server->wl_display);

--- a/sway/server.c
+++ b/sway/server.c
@@ -10,11 +10,12 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
-#include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_gamma_control.h>
+#include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_xcursor_manager.h>
@@ -104,6 +105,12 @@ bool server_init(struct sway_server *server) {
 			&server->xdg_decoration);
 	server->xdg_decoration.notify = handle_xdg_decoration;
 	wl_list_init(&server->xdg_decorations);
+
+	server->pointer_constraints =
+		wlr_pointer_constraints_v1_create(server->wl_display);
+	server->pointer_constraint.notify = handle_pointer_constraint;
+	wl_signal_add(&server->pointer_constraints->events.new_constraint,
+		&server->pointer_constraint);
 
 	server->presentation =
 		wlr_presentation_create(server->wl_display, server->backend);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -539,6 +539,11 @@ The default colors are:
 	\* may be used in lieu of a specific output name to configure all outputs.
 	A list of output names may be obtained via *swaymsg -t get_outputs*.
 
+*pointer_constraint* enable|disable|escape
+	Enables or disables the ability for clients to capture the cursor (enabled
+	by default). This is primarily useful for video games. The "escape" command
+	can be used at runtime to escape from a captured client.
+
 *popup_during_fullscreen* smart|ignore|leave_fullscreen
 	Determines what to do when a fullscreen view opens a dialog.
 	If _smart_ (the default), the dialog will be displayed. If _ignore_, the


### PR DESCRIPTION
It's fully functional and has been tested with the example wlroots clients, although there is one thing I'd like to fix, which I'd like input from you on how to fix it:
In `sway/input/cursor.c` I duplicate some code from wlroots, because the code from wlroots isn't always run before this function runs, since the focus will be moved to the new surface before all surface commit listeners have been executed. If you remove the duplicated code, pointer constraints will still work fine, but the cursor won't always be able to warp into the region, which can be quite annoying for the user.
The duplicated code (`sway/input/cursor.c:1433`):
```c
	// FIXME: Big hack, stolen from wlr_pointer_constraints_v1.c:121.
	// This is necessary because the focus may be set before the surface
	// has finished committing, which means that warping won't work properly,
	// since this code will be run *after* the focus has been set.
	// That is why we duplicate the code here.
	if (pixman_region32_not_empty(&constraint->current.region)) {
		pixman_region32_intersect(&constraint->region,
			&constraint->surface->input_region, &constraint->current.region);
	} else {
		pixman_region32_copy(&constraint->region,
			&constraint->surface->input_region);
	}
```

In addition, should I add any config commands to control pointer constraints? I do not know how you'd like them to be designed, so I refrained from doing that. You can however even now just shift focus to the parent (or anything else really) to break the constraint.