### PR TITLE
criteria & scratchpad verify if show in another workspace

### DIFF
--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -75,7 +75,7 @@ static void scratchpad_toggle_container(struct sway_container *con) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 	// Check if it matches a currently visible scratchpad window and hide it.
-	if (con->workspace && (ws == con->workspace)) {
+	if (con->workspace && ws == con->workspace) {
 		root_scratchpad_hide(con);
 		return;
 	}

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -72,8 +72,10 @@ static void scratchpad_toggle_container(struct sway_container *con) {
 		return;
 	}
 
+	struct sway_seat *seat = input_manager_current_seat();
+	struct sway_workspace *ws = seat_get_focused_workspace(seat);
 	// Check if it matches a currently visible scratchpad window and hide it.
-	if (con->workspace) {
+	if (con->workspace && (ws == con->workspace)) {
 		root_scratchpad_hide(con);
 		return;
 	}


### PR DESCRIPTION
sway version 1.0-beta.2-274-g5f45a4bb (Jan 27 2019, branch 'master')
example:
1) mark window en scratchpad
2) show it
3) change workspace
Need send swaymsg "[con_mark="mark"] scratchpad show  twice for show it.

short explain. 
set $criteria swayTerm
for_window [app_id="(?i)$criteria"] floating enable, resize set 800px 400px, move position 1110px 10px, move to scratchpad, scratchpad show, mark $criteria

bindsym Menu exec (pgrep -a $term| grep $criteria) && \
(swaymsg "[con_mark=$criteria ] scratchpad show"  || \
swaymsg "[tiling con_mark=$criteria] move container to workspace current, move to scratchpad, scratchpad show, resize set 800px 400px, move position 1110px 10px") || \
exec $term --name $criteria

Need press Menu key twice if show in another workspace. ($term is termite)