### PR TITLE
Add note about required scdoc version to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install dependencies:
 * pango
 * cairo
 * gdk-pixbuf2 \*\*
-* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*
+* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) >= 1.8.0 (optional: man pages) \*
 * git \*
 
 _\*Compile-time dep_


### PR DESCRIPTION
scdoc is outdated on Fedora 29 (it was ~1.3.0 or something like that) and probably is on many other distros, so I wasn't able to generate manpages until I built the latest version.