### PR TITLE
Introduce container_is_scratchpad_hidden

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -299,9 +299,9 @@ enum sway_container_layout container_parent_layout(struct sway_container *con);
 enum sway_container_layout container_current_parent_layout(
 		struct sway_container *con);
 
-list_t *container_get_siblings(const struct sway_container *container);
+list_t *container_get_siblings(struct sway_container *container);
 
-int container_sibling_index(const struct sway_container *child);
+int container_sibling_index(struct sway_container *child);
 
 list_t *container_get_current_siblings(struct sway_container *container);
 
@@ -353,5 +353,7 @@ void container_add_mark(struct sway_container *container, char *mark);
 void container_update_marks_textures(struct sway_container *container);
 
 void container_raise_floating(struct sway_container *con);
+
+bool container_is_scratchpad_hidden(struct sway_container *con);
 
 #endif

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -271,7 +271,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	}
 
 	if (argc == 0 && container) {
-		if (container->scratchpad && !container->workspace) {
+		if (container_is_scratchpad_hidden(container)) {
 			root_scratchpad_show(container);
 		}
 		seat_set_focus_container(seat, container);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -659,7 +659,7 @@ static struct cmd_results *cmd_move_in_direction(
 		return cmd_results_new(CMD_FAILURE,
 				"Cannot move workspaces in a direction");
 	}
-	if (container->scratchpad && !container->workspace) {
+	if (container_is_scratchpad_hidden(container)) {
 		return cmd_results_new(CMD_FAILURE,
 				"Cannot move a hidden scratchpad container");
 	}
@@ -734,7 +734,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Only floating containers "
 				"can be moved to an absolute position");
 	}
-	if (container->scratchpad && !container->workspace) {
+	if (container_is_scratchpad_hidden(container)) {
 		return cmd_results_new(CMD_FAILURE,
 				"Cannot move a hidden scratchpad container");
 	}

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -86,7 +86,8 @@ static void calculate_constraints(int *min_width, int *max_width,
 		*min_height = config->floating_minimum_height;
 	}
 
-	if (config->floating_maximum_width == -1 || !con->workspace) { // no max
+	if (config->floating_maximum_width == -1 ||
+			container_is_scratchpad_hidden(con)) { // no max
 		*max_width = INT_MAX;
 	} else if (config->floating_maximum_width == 0) { // automatic
 		*max_width = con->workspace->width;
@@ -94,7 +95,8 @@ static void calculate_constraints(int *min_width, int *max_width,
 		*max_width = config->floating_maximum_width;
 	}
 
-	if (config->floating_maximum_height == -1 || !con->workspace) { // no max
+	if (config->floating_maximum_height == -1 ||
+			container_is_scratchpad_hidden(con)) { // no max
 		*max_height = INT_MAX;
 	} else if (config->floating_maximum_height == 0) { // automatic
 		*max_height = con->workspace->height;
@@ -386,7 +388,7 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 	if (width->amount) {
 		switch (width->unit) {
 		case RESIZE_UNIT_PPT:
-			if (con->scratchpad && !con->workspace) {
+			if (container_is_scratchpad_hidden(con)) {
 				return cmd_results_new(CMD_FAILURE,
 						"Cannot resize a hidden scratchpad container by ppt");
 			}
@@ -410,7 +412,7 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
 	if (height->amount) {
 		switch (height->unit) {
 		case RESIZE_UNIT_PPT:
-			if (con->scratchpad && !con->workspace) {
+			if (container_is_scratchpad_hidden(con)) {
 				return cmd_results_new(CMD_FAILURE,
 						"Cannot resize a hidden scratchpad container by ppt");
 			}

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -13,7 +13,7 @@ static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (con) {
-		if (con->scratchpad && !con->workspace) {
+		if (container_is_scratchpad_hidden(con)) {
 			return cmd_results_new(CMD_FAILURE,
 					"Cannot split a hidden scratchpad container");
 		}

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -17,15 +17,15 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;
-	
+
 	if (container == NULL) {
 		return cmd_results_new(CMD_FAILURE, "No current container");
 	};
-	
+
 	container->is_sticky = parse_boolean(argv[0], container->is_sticky);
 
 	if (container->is_sticky && container_is_floating_or_child(container) &&
-			(!container->scratchpad || container->workspace)) {
+			!container_is_scratchpad_hidden(container)) {
 		// move container to active workspace
 		struct sway_workspace *active_workspace =
 			output_get_active_workspace(container->workspace->output);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -252,8 +252,7 @@ static void output_for_each_surface(struct sway_output *output,
 
 	struct sway_workspace *workspace = output_get_active_workspace(output);
 	struct sway_container *fullscreen_con = root->fullscreen_global;
-	if (fullscreen_con && fullscreen_con->scratchpad &&
-			!fullscreen_con->workspace) {
+	if (fullscreen_con && container_is_scratchpad_hidden(fullscreen_con)) {
 		fullscreen_con = NULL;
 	}
 	if (!fullscreen_con) {

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -986,8 +986,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 	}
 
 	struct sway_container *fullscreen_con = root->fullscreen_global;
-	if (fullscreen_con && fullscreen_con->scratchpad &&
-			!fullscreen_con->workspace) {
+	if (fullscreen_con && container_is_scratchpad_hidden(fullscreen_con)) {
 		fullscreen_con = NULL;
 	}
 	if (!fullscreen_con) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -282,7 +282,7 @@ static json_object *ipc_json_describe_scratchpad_output(void) {
 	json_object *floating_array = json_object_new_array();
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *container = root->scratchpad->items[i];
-		if (!container->workspace) {
+		if (container_is_scratchpad_hidden(container)) {
 			json_object_array_add(floating_array,
 				ipc_json_describe_node_recursive(&container->node));
 		}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1156,11 +1156,11 @@ enum sway_container_layout container_current_parent_layout(
 	return con->current.workspace->current.layout;
 }
 
-list_t *container_get_siblings(const struct sway_container *container) {
+list_t *container_get_siblings(struct sway_container *container) {
 	if (container->parent) {
 		return container->parent->children;
 	}
-	if (!container->workspace) {
+	if (container_is_scratchpad_hidden(container)) {
 		return NULL;
 	}
 	if (list_find(container->workspace->tiling, container) != -1) {
@@ -1169,7 +1169,7 @@ list_t *container_get_siblings(const struct sway_container *container) {
 	return container->workspace->floating;
 }
 
-int container_sibling_index(const struct sway_container *child) {
+int container_sibling_index(struct sway_container *child) {
 	return list_find(container_get_siblings(child), child);
 }
 
@@ -1181,7 +1181,10 @@ list_t *container_get_current_siblings(struct sway_container *container) {
 }
 
 void container_handle_fullscreen_reparent(struct sway_container *con) {
-	if (con->fullscreen_mode != FULLSCREEN_WORKSPACE || !con->workspace ||
+	if (!sway_assert(con->workspace, "Expected con to have a workspace")) {
+		return;
+	}
+	if (con->fullscreen_mode != FULLSCREEN_WORKSPACE ||
 			con->workspace->fullscreen == con) {
 		return;
 	}
@@ -1459,4 +1462,8 @@ void container_raise_floating(struct sway_container *con) {
 		list_move_to_end(floater->workspace->floating, floater);
 		node_set_dirty(&floater->workspace->node);
 	}
+}
+
+bool container_is_scratchpad_hidden(struct sway_container *con) {
+	return con->scratchpad && !con->workspace;
 }

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -310,10 +310,7 @@ void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 	// Scratchpad
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *container = root->scratchpad->items[i];
-		// If the container has a workspace then it's visible on a workspace
-		// and will have been iterated in the previous for loop. So we only
-		// iterate the hidden scratchpad containers here.
-		if (!container->workspace) {
+		if (container_is_scratchpad_hidden(container)) {
 			f(container, data);
 			container_for_each_child(container, f, data);
 		}
@@ -362,7 +359,7 @@ struct sway_container *root_find_container(
 	// Scratchpad
 	for (int i = 0; i < root->scratchpad->length; ++i) {
 		struct sway_container *container = root->scratchpad->items[i];
-		if (!container->workspace) {
+		if (container_is_scratchpad_hidden(container)) {
 			if (test(container, data)) {
 				return container;
 			}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -197,8 +197,7 @@ static bool gaps_to_edge(struct sway_view *view) {
 
 void view_autoconfigure(struct sway_view *view) {
 	struct sway_container *con = view->container;
-	if (!con->workspace) {
-		// Hidden in the scratchpad
+	if (container_is_scratchpad_hidden(con)) {
 		return;
 	}
 	struct sway_output *output = con->workspace->output;
@@ -1054,7 +1053,7 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 
 	ipc_event_window(view->container, "urgent");
 
-	if (view->container->workspace) {
+	if (!container_is_scratchpad_hidden(view->container)) {
 		workspace_detect_urgent(view->container->workspace);
 	}
 }


### PR DESCRIPTION
Just a convenience function that improves readability of the code.

Other things worth noting:

* `container_get_siblings` and `container_sibling_index` no longer use the `const` keyword.
* `container_handle_fullscreen_reparent` is only ever called after attaching the container to a workspace, so its `con->workspace` check has been changed to an assertion.