### PR TITLE
Remove bad assertion in container_handle_fullscreen_reparent

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1182,10 +1182,7 @@ list_t *container_get_current_siblings(struct sway_container *container) {
 }
 
 void container_handle_fullscreen_reparent(struct sway_container *con) {
-	if (!sway_assert(con->workspace, "Expected con to have a workspace")) {
-		return;
-	}
-	if (con->fullscreen_mode != FULLSCREEN_WORKSPACE ||
+	if (con->fullscreen_mode != FULLSCREEN_WORKSPACE || !con->workspace ||
 			con->workspace->fullscreen == con) {
 		return;
 	}


### PR DESCRIPTION
The assertion could trigger when called from `workspace_wrap_children`.

Fixes #3527.