### PR TITLE
Cleanup config reading failure error logs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -516,6 +516,11 @@ bool read_config(FILE *file, struct sway_config *config,
 		struct swaynag_instance *swaynag);
 
 /**
+ * Run the commands that were deferred when reading the config file.
+ */
+void run_deferred_commands(void);
+
+/**
  * Adds a warning entry to the swaynag instance used for errors.
  */
 void config_add_swaynag_warning(char *fmt, ...);


### PR DESCRIPTION
Related https://www.reddit.com/r/swaywm/comments/akqofn/sway_wont_start_at_all_on_intel_graphics/

This cleans up the log when sway fails to read a config file. The
following changes have been made:
- A missing error message has been added to the log when the config file
is a directory instead of a regular file
- In main, `goto` statements have been added after the `sway_terminate`
calls instead of wrapping every block in `if (!terminate_request)`
- Unnecessary NULL-checks around calls to free in `main` have been
removed
- Deferred command execution has been extracted to a separate function
and the `Running deferred commands` log message will not be shown when
there are no deferred commands.