### PR TITLE
Fix #3445: swaybar tray inherited themes not processed

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -135,7 +135,7 @@ static int entry_handler(char *group, char *key, char *value,
 			theme->name = strdup(value);
 		} else if (strcmp(key, "Comment") == 0) {
 			theme->comment = strdup(value);
-		} else if (strcmp(key, "Inherists") == 0) {
+		} else if (strcmp(key, "Inherits") == 0) {
 			theme->inherits = strdup(value);
 		} else if (strcmp(key, "Directories") == 0) {
 			theme->directories = split_string(value, ",");


### PR DESCRIPTION
Fixing typo error while matching "Inherits" parameter of theme configuration file.