### PR TITLE
cmd_seat: allow - to be used as alias for current

### DIFF
--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -2,6 +2,7 @@
 #include <strings.h>
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/seat.h"
 #include "log.h"
 #include "stringop.h"
 
@@ -20,7 +21,16 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 		return error;
 	}
 
-	config->handler_context.seat_config = new_seat_config(argv[0]);
+	if (!strcmp(argv[0], "-")) {
+		if (config->reading) {
+			return cmd_results_new(CMD_FAILURE,
+					"Current seat alias (-) cannot be used in the config");
+		}
+		config->handler_context.seat_config =
+			new_seat_config(config->handler_context.seat->wlr_seat->name);
+	} else {
+		config->handler_context.seat_config = new_seat_config(argv[0]);
+	}
 	if (!config->handler_context.seat_config) {
 		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -140,10 +140,11 @@ Configure options for multiseat mode.
 
 A *seat* is a collection of input devices that act independently of each other.
 Seats are identified by name and the default seat is _seat0_ if no seats are
-configured. Each seat has an independent keyboard focus and a separate cursor that
-is controlled by the pointer devices of the seat. This is useful for multiple
-people using the desktop at the same time with their own devices (each sitting
-in their own "seat").
+configured. While sway is running, _-_ (hyphen) can be used as an alias for the
+current seat. Each seat has an independent keyboard focus and a separate cursor
+that is controlled by the pointer devices of the seat. This is useful for
+multiple people using the desktop at the same time with their own devices (each
+sitting in their own "seat").
 
 *seat* <name> attach <input_identifier>
 	Attach an input device to this seat by its input identifier. A special


### PR DESCRIPTION
This allows for `-` (hyphen) to be used as an alias for the current seat
while sway is running. This alias was chosen since it is unlikely to
interfere with any desirable seat identifier