### PR TITLE
Fix wildcard seat constrain crashes during reconfig

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -141,6 +141,11 @@ static void destroy_removed_seats(struct sway_config *old_config,
 	int i;
 	for (i = 0; i < old_config->seat_configs->length; i++) {
 		seat_config = old_config->seat_configs->items[i];
+		// Skip the wildcard seat config, it won't have a matching real seat.
+		if (strcmp(seat_config->name, "*") == 0) {
+			continue;
+		}
+
 		/* Also destroy seats that aren't present in new config */
 		if (new_config && list_seq_find(new_config->seat_configs,
 				seat_name_cmp, seat_config->name) < 0) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1459,6 +1459,10 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data) {
 void sway_cursor_constrain(struct sway_cursor *cursor,
 		struct wlr_pointer_constraint_v1 *constraint) {
 	struct seat_config *config = seat_get_config(cursor->seat);
+	if (!config) {
+		config = seat_get_config_by_name("*");
+	}
+
 	if (!config || config->allow_constrain == CONSTRAIN_DISABLE) {
 		return;
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1459,7 +1459,7 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data) {
 void sway_cursor_constrain(struct sway_cursor *cursor,
 		struct wlr_pointer_constraint_v1 *constraint) {
 	struct seat_config *config = seat_get_config(cursor->seat);
-	if (config->allow_constrain == CONSTRAIN_DISABLE) {
+	if (!config || config->allow_constrain == CONSTRAIN_DISABLE) {
 		return;
 	}
 


### PR DESCRIPTION
This fixes a couple of issues that led to the below traceback:
- `destroy_removed_seats` should not attempt to operate on the wildcard seat config if one is present
- `sway_cursor_constrain` should fall back to the wildcard seat config when checking if constraints are disabled
- It should also bail if no config could be found at all

To reproduce this crash in master, issue something like `swaymsg seat * hide_cursor 0` (to cause the wildcard config to be present) and then reload the config.

```
(gdb) bt full
#0  0x000055c371d839e6 in sway_cursor_constrain (cursor=0x55c372d01890, constraint=0x0)
    at ../sway/sway/input/cursor.c:1462
        config = 0x0
#1  0x000055c371d7a76d in seat_send_focus (node=0x55c372c79160, seat=0x55c372d86680)
    at ../sway/sway/input/seat.c:112
        keyboard = 0x0
        constraint = 0x0
        view = 0x55c372dceb90
#2  0x000055c371d7c3e1 in seat_set_focus (seat=0x55c372d86680, node=0x55c372c79160)
    at ../sway/sway/input/seat.c:808
        last_focus = 0x0
        last_workspace = 0x0
        new_workspace = 0x55c372e6b280
        container = 0x55c372c79160
        new_output = 0x55c37313c690
        new_output_last_ws = 0x55c372e6b280
#3  0x000055c371d7b265 in seat_create (seat_name=0x55c372bc3290 "*") at ../sway/sway/input/seat.c:389
        current_seat = 0x55c372b5c240
        current_focus = 0x55c372c79160
        seat = 0x55c372d86680
        __PRETTY_FUNCTION__ = "seat_create"
#4  0x000055c371d78069 in input_manager_get_seat (seat_name=0x55c372bc3290 "*")
    at ../sway/sway/input/input-manager.c:45
        seat = 0x55c372b5bf48
#5  0x000055c371d60ce5 in destroy_removed_seats (old_config=0x55c372d6f480, new_config=0x55c372c44eb0)
    at ../sway/sway/config.c:147
        seat_config = 0x55c372e2bc00
        seat = 0x55c371db28fd
        i = 0
#6  0x000055c371d61d7f in load_main_config
    (file=0x55c372cc6f80 "/home/vil/.config/sway/config", is_active=true, validating=false)
    at ../sway/sway/config.c:475
        path = 0x55c372e12d50 "/home/vil/.config/sway/config"
        old_config = 0x55c372d6f480
        success = true
#7  0x000055c371d91aa4 in do_reload (data=0x0) at ../sway/sway/commands/reload.c:25
        bar_ids = 0x55c3731368f0
...
```