### PR TITLE
seat_cmd_cursor: do not create non-existing seat

### DIFF
--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -45,7 +45,7 @@ void input_manager_apply_seat_config(struct seat_config *seat_config);
 
 struct sway_seat *input_manager_get_default_seat(void);
 
-struct sway_seat *input_manager_get_seat(const char *seat_name);
+struct sway_seat *input_manager_get_seat(const char *seat_name, bool create);
 
 /**
  * If none of the seat configs have a fallback setting (either true or false),

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -61,9 +61,10 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 	}
 
 	if (strcmp(sc->name, "*") != 0) {
-		struct sway_seat *seat = input_manager_get_seat(sc->name);
+		struct sway_seat *seat = input_manager_get_seat(sc->name, false);
 		if (!seat) {
-			return cmd_results_new(CMD_FAILURE, "Failed to get seat");
+			return cmd_results_new(CMD_FAILURE,
+					"Seat %s does not exist", sc->name);
 		}
 		error = handle_command(seat->cursor, argc, argv);
 	} else {

--- a/sway/config.c
+++ b/sway/config.c
@@ -149,8 +149,10 @@ static void destroy_removed_seats(struct sway_config *old_config,
 		/* Also destroy seats that aren't present in new config */
 		if (new_config && list_seq_find(new_config->seat_configs,
 				seat_name_cmp, seat_config->name) < 0) {
-			seat = input_manager_get_seat(seat_config->name);
-			seat_destroy(seat);
+			seat = input_manager_get_seat(seat_config->name, false);
+			if (seat) {
+				seat_destroy(seat);
+			}
 		}
 	}
 }

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -31,10 +31,10 @@ struct sway_seat *input_manager_current_seat(void) {
 }
 
 struct sway_seat *input_manager_get_default_seat(void) {
-	return input_manager_get_seat(DEFAULT_SEAT);
+	return input_manager_get_seat(DEFAULT_SEAT, true);
 }
 
-struct sway_seat *input_manager_get_seat(const char *seat_name) {
+struct sway_seat *input_manager_get_seat(const char *seat_name, bool create) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &server.input->seats, link) {
 		if (strcmp(seat->wlr_seat->name, seat_name) == 0) {
@@ -42,7 +42,7 @@ struct sway_seat *input_manager_get_seat(const char *seat_name) {
 		}
 	}
 
-	return seat_create(seat_name);
+	return create ? seat_create(seat_name) : NULL;
 }
 
 char *input_device_get_identifier(struct wlr_input_device *device) {
@@ -674,7 +674,8 @@ void input_manager_apply_seat_config(struct seat_config *seat_config) {
 			seat_apply_config(seat, sc);
 		}
 	} else {
-		struct sway_seat *seat = input_manager_get_seat(seat_config->name);
+		struct sway_seat *seat =
+			input_manager_get_seat(seat_config->name, true);
 		if (!seat) {
 			return;
 		}


### PR DESCRIPTION
If a seat does not exist in seat_cmd_cursor, do not create it. A seat
without any attachments is useless since it will have no capabilities.

This changes `input_manager_get_seat` to have an additional argument
that dictates whether or not to create the seat if it does not exist.