### PR TITLE
execute_command: dont strip quotes for exec_always

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -254,7 +254,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			//TODO better handling of argv
 			int argc;
 			char **argv = split_args(cmd, &argc);
-			if (strcmp(argv[0], "exec") != 0) {
+			if (!strcmp(argv[0], "exec") && !strcmp(argv[0], "exec_always")) {
 				int i;
 				for (i = 1; i < argc; ++i) {
 					if (*argv[i] == '\"' || *argv[i] == '\'') {


### PR DESCRIPTION
This removes quote stripping for `exec_always` in `execute_command`.
Since `exec_always` commands will be deferred in the config and
processed by `execute_command`, the quotes need to be left intact
like they are for `exec`.