### PR TITLE
swaynag: remove trailing newlines in config

### DIFF
--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -348,6 +348,10 @@ int swaynag_load_config(char *path, struct swaynag *swaynag, list_t *types) {
 			continue;
 		}
 
+		if (line[nread - 1] == '\n') {
+			line[nread - 1] = '\0';
+		}
+
 		if (line[0] == '[') {
 			char *close = strchr(line, ']');
 			if (!close) {


### PR DESCRIPTION
Fixes #3571 

Now that swaynag uses getline (instead of the old readline), the
trailing newline characters have to be removed when reading the config