### PR TITLE
load_include_configs: fix wordexp fail condition

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -557,7 +557,7 @@ bool load_include_configs(const char *path, struct sway_config *config,
 
 	wordexp_t p;
 
-	if (wordexp(path, &p, 0) < 0) {
+	if (wordexp(path, &p, 0) != 0) {
 		free(parent_path);
 		free(wd);
 		return false;


### PR DESCRIPTION
Fixes #3565 

This fixes the failure condition for the wordexp call in
load_include_configs. The only success value is zero. Since the error
codes are positive, having the check be less than zero was causing
segfaults on failure when accessing the words.