### PR TITLE
Fix quote stripping

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -254,7 +254,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			//TODO better handling of argv
 			int argc;
 			char **argv = split_args(cmd, &argc);
-			if (!strcmp(argv[0], "exec") && !strcmp(argv[0], "exec_always")) {
+			if (strcmp(argv[0], "exec") != 0 &&
+					strcmp(argv[0], "exec_always") != 0) {
 				int i;
 				for (i = 1; i < argc; ++i) {
 					if (*argv[i] == '\"' || *argv[i] == '\'') {


### PR DESCRIPTION
Let's not use `!strcmp(…)` anymore.

Fixes https://github.com/swaywm/sway/issues/3575