### PR TITLE
cmd_workspace_gaps: fix double free on bad amount

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -76,7 +76,6 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	char *end;
 	int amount = strtol(argv[gaps_location + 2], &end, 10);
 	if (strlen(end)) {
-		free(end);
 		return cmd_results_new(CMD_FAILURE, expected);
 	}
 


### PR DESCRIPTION
Fixes #3577 

This fixes a double free in cmd_workspace_gaps when the amount given is
invalid. The end pointer from strtol is part of the argument and should
not be freed. Freeing the end pointer could result in a double free or
bad free depending on whether or not the end pointer was at the start of
the argument