### PR TITLE
If validating the config, do it as early as possible.

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -312,6 +312,18 @@ int main(int argc, char **argv) {
 		wlr_log_init(WLR_ERROR, NULL);
 	}
 
+	log_kernel();
+	log_distro();
+	log_env();
+	detect_proprietary(allow_unsupported_gpu);
+	detect_raspi();
+
+	if (validate) {
+		bool valid = load_main_config(config_path, false, true);
+		free(config_path);
+		return valid ? 0 : 1;
+	}
+
 	if (optind < argc) { // Behave as IPC client
 		if (optind != 1) {
 			sway_log(SWAY_ERROR, "Don't use options with the IPC client");
@@ -334,11 +346,6 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	log_kernel();
-	log_distro();
-	detect_proprietary(allow_unsupported_gpu);
-	detect_raspi();
-
 	if (!drop_permissions()) {
 		server_fini(&server);
 		exit(EXIT_FAILURE);
@@ -359,12 +366,6 @@ int main(int argc, char **argv) {
 	}
 
 	ipc_init(&server);
-	log_env();
-
-	if (validate) {
-		bool valid = load_main_config(config_path, false, true);
-		return valid ? 0 : 1;
-	}
 
 	setenv("WAYLAND_DISPLAY", server.socket, true);
 	if (!load_main_config(config_path, false, false)) {


### PR DESCRIPTION
I may be missing something, but I can't see why we would initialize the server and IPC when we only want to validate the config file. It was causing a memory leak (not that it matters since Sway exits almost immediately) due to the server not being destroyed.

This change has the caveat that various debug information in wlroots code won't appear.

I also think that verbose logging when validating a config file is unnecessary, but I won't submit that change unless others agree.