### PR TITLE
output_cmd_background: fix no file + valid mode

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -258,6 +258,9 @@ int unescape_string(char *string) {
 }
 
 char *join_args(char **argv, int argc) {
+	if (!sway_assert(argc > 0, "argc should be positive")) {
+		return NULL;
+	}
 	int len = 0, i;
 	for (i = 0; i < argc; ++i) {
 		len += strlen(argv[i]) + 1;

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -61,6 +61,9 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			return cmd_results_new(CMD_INVALID,
 				"Missing background scaling mode.");
 		}
+		if (j == 0) {
+			return cmd_results_new(CMD_INVALID, "Missing background file");
+		}
 
 		wordexp_t p = {0};
 		char *src = join_args(argv, j);


### PR DESCRIPTION
Fixes #3580 

If output_cmd_background is given a valid mode as the first argument,
then there is no file given and an error should be returned.

join_args should not be called with an argc of zero since it sets the
last character to the null terminator. With an argc of zero, the length
is zero causing a heap buffer overflow when setting the byte before the
start of argv to '\0'. This probably will not ever generate a segfault,
but may cause data corruption to whatever is directly before it in
memory. To make other such cases easier to detect, this also adds a
sway_assert in join_args when argc is zero. 

_If desired, I can split the second part into a separate commit or PR_.