### PR TITLE
Clarify error for options and positional args

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -320,7 +320,13 @@ int main(int argc, char **argv) {
 
 	if (optind < argc) { // Behave as IPC client
 		if (optind != 1) {
-			sway_log(SWAY_ERROR, "Don't use options with the IPC client");
+			sway_log(SWAY_ERROR,
+					"Detected both options and positional arguments. If you "
+					"are trying to use the IPC client, options are not "
+					"supported. Otherwise, check the provided arguments for "
+					"issues. See `man 1 sway` or `sway -h` for usage. If you "
+					"are trying to generate a debug log, use "
+					"`sway -d 2>sway.log`.");
 			exit(EXIT_FAILURE);
 		}
 		if (!drop_permissions()) {


### PR DESCRIPTION
When both options and positional arguments are given, sway would print
the error `Don't use options with the IPC client`. Over the past
several months, it seems like a large number users are including this error
message in issues instead of a debug log due to not understanding that
the error message means there is an issue with their command.

This makes the error message more verbose and will hopefully make it so
more users understand that the message is not a bug in sway, but with
the command used.