### PR TITLE
bar_cmd_modifier: add support for none

### DIFF
--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -15,19 +15,26 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	}
 
 	uint32_t mod = 0;
-	list_t *split = split_string(argv[0], "+");
-	for (int i = 0; i < split->length; ++i) {
-		uint32_t tmp_mod;
-		if ((tmp_mod = get_modifier_mask_by_name(split->items[i])) > 0) {
-			mod |= tmp_mod;
-		} else {
-			error = cmd_results_new(CMD_INVALID,
-				"Unknown modifier '%s'", (char *)split->items[i]);
-			list_free_items_and_destroy(split);
-			return error;
+	if (strcmp(argv[0], "none") != 0) {
+		list_t *split = split_string(argv[0], "+");
+		for (int i = 0; i < split->length; ++i) {
+			uint32_t tmp_mod;
+			if ((tmp_mod = get_modifier_mask_by_name(split->items[i])) > 0) {
+				mod |= tmp_mod;
+			} else if (strcmp(split->items[i], "none") == 0) {
+				error = cmd_results_new(CMD_INVALID,
+						"none cannot be used along with other modifiers");
+				list_free_items_and_destroy(split);
+				return error;
+			} else {
+				error = cmd_results_new(CMD_INVALID,
+					"Unknown modifier '%s'", (char *)split->items[i]);
+				list_free_items_and_destroy(split);
+				return error;
+			}
 		}
+		list_free_items_and_destroy(split);
 	}
-	list_free_items_and_destroy(split);
 	config->current_bar->modifier = mod;
 	sway_log(SWAY_DEBUG,
 			"Show/Hide the bar when pressing '%s' in hide mode.", argv[0]);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -425,7 +425,8 @@ static void determine_bar_visibility(uint32_t modifiers) {
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *bar = config->bars->items[i];
 		if (strcmp(bar->mode, bar->hidden_state) == 0) { // both are "hide"
-			bool should_be_visible = (~modifiers & bar->modifier) == 0;
+			bool should_be_visible = 
+				bar->modifier != 0 && (~modifiers & bar->modifier) == 0;
 			if (bar->visible_by_modifier != should_be_visible) {
 				bar->visible_by_modifier = should_be_visible;
 				ipc_event_bar_state_update(bar);


### PR DESCRIPTION
Fixes #3601 

sway-bar(5) documents `modifier none`, which comes from i3. This
implements the functionality for `modifier none` since it was not
previously implemented. The bar modifier toggles visibility of the bar
when the bar mode is set to hide. When the bar modifier is set to
`none`, the ability to toggle visibility of the bar will be disabled.