### PR TITLE
seat_configure_tablet_tool: configure xcursor

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -525,6 +525,7 @@ static void seat_configure_touch(struct sway_seat *seat,
 
 static void seat_configure_tablet_tool(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
+	seat_configure_xcursor(seat);
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 	seat_apply_input_config(seat, sway_device);


### PR DESCRIPTION
Fixes #3512 

Since a tablet tool provides the WL_SEAT_CAPABILITY_POINTER capability,
sway will attempt to use the xcursor manager to set a cursor image. If
the tablet tool was the first (and possibly only) device to provide the
capability for the seat, the xcursor manager was not being configured
before attempting to set a cursor image. This was due to
`seat_configure_xcursor` only being called in `seat_configure_pointer`.
Since the xcursor manager was NULL in this case, it would cause a
segfault when attempting to set a cursor image. This adds a call to
`seat_configure_xcursor` in `seat_configure_tablet_tool` to ensure that
the seat has a xcursor manager.

@YaLTeR, can you please test this and confirm that it fixes your issue? I think
this should fix it, but I do not have a tablet tool to be able to test with.