### PR TITLE
load_main_config: use given path, store realpath

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -385,7 +385,6 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		free(path);
 		return false;
 	}
-	free(path);
 
 	struct sway_config *old_config = config;
 	config = calloc(1, sizeof(struct sway_config));
@@ -409,7 +408,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		input_manager_reset_all_inputs();
 	}
 
-	config->current_config_path = real_path;
+	config->current_config_path = path;
 	list_add(config->config_chain, real_path);
 
 	config->reading = true;
@@ -462,7 +461,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	}
 	*/
 
-	success = success && load_config(real_path, config,
+	success = success && load_config(path, config,
 			&config->swaynag_config_errors);
 
 	if (validating) {


### PR DESCRIPTION
Fixes #3605 

Since `load_include_config` compares against the realpath of a config
file when checking if a config has already been added, the main config's
realpath has to be added to the config_chain.

However, includes from the main config should be processed relative to
the path given to allow for symbolic links. This stores the realpath in
`config->config_chain`, but uses the given path for all other
operations.