### PR TITLE
Add comment about load_include_configs.

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -513,7 +513,7 @@ bool load_main_config(const char *path, bool is_active, bool validating);
 /**
  * Loads an included config. Can only be used after load_main_config.
  */
-bool load_include_configs(const char *path, struct sway_config *config,
+void load_include_configs(const char *path, struct sway_config *config,
 		struct swaynag_instance *swaynag);
 
 /**

--- a/sway/commands/include.c
+++ b/sway/commands/include.c
@@ -7,11 +7,8 @@ struct cmd_results *cmd_include(int argc, char **argv) {
 		return error;
 	}
 
-	if (!load_include_configs(argv[0], config,
-				&config->swaynag_config_errors)) {
-		return cmd_results_new(CMD_INVALID,
-				"Failed to include sub configuration file: %s", argv[0]);
-	}
+	// We don't care if the included config(s) fails to load.
+	load_include_configs(argv[0], config, &config->swaynag_config_errors);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }


### PR DESCRIPTION
Related #3595, #3619.

I made `load_include_configs` void and added a comment that emphasises we don't care if config files fail to load (unless something abnormal occurs).

Also re-reverts improved error handling that fixes a case where the working directory would not be restored.