### PR TITLE
container_at_stacked: skip titles when zero pixels

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -251,10 +251,12 @@ static struct sway_container *container_at_stacked(struct sway_node *parent,
 
 	// Title bars
 	int title_height = container_titlebar_height();
-	int child_index = (ly - box.y) / title_height;
-	if (child_index < children->length) {
-		struct sway_container *child = children->items[child_index];
-		return child;
+	if (title_height > 0) {
+		int child_index = (ly - box.y) / title_height;
+		if (child_index < children->length) {
+			struct sway_container *child = children->items[child_index];
+			return child;
+		}
 	}
 
 	// Surfaces


### PR DESCRIPTION
Fixes #3618

It is possible to make the title bars have a zero pixel height while
stacked, by using a blank font and no padding. This causes a division by
zero when attempting to calculate the child index in
container_at_stacked, which then results in a segfault when attempting
to access the child at that bad index (INT_MIN). This just skips the
check to see if the cursor is over a title bar of a child of a stacked
container when the title bar height is zero since there will be no title
bars.