### PR TITLE
fix double free for mode toggle if bar was invisible

### DIFF
--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -11,7 +11,7 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 	if (strcasecmp("toggle", mode) == 0 && !config->reading) {
 		if (strcasecmp("dock", bar->mode) == 0) {
 			bar->mode = strdup("hide");
-		} else if (strcasecmp("hide", bar->mode) == 0) {
+		} else{
 			bar->mode = strdup("dock");
 		}
 	} else if (strcasecmp("dock", mode) == 0) {


### PR DESCRIPTION
If the bar was set to "invisible" and subsequently "toggle" was send twice, the
new mode was never set and the bar->mode was double freed.
Fix this by not requiring the bar->mode to be "hide" and instead show it
unconditionally, because it was either hidden or invisible.

Fixes #3637