### PR TITLE
view: remove pointer constraints on unmap

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -664,6 +664,13 @@ void view_unmap(struct sway_view *view) {
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
 		seat->cursor->image_surface = NULL;
+		if (seat->cursor->active_constraint) {
+			struct wlr_surface *constrain_surface =
+				seat->cursor->active_constraint->surface;
+			if (view_from_wlr_surface(constrain_surface) == view) {
+				sway_cursor_constrain(seat->cursor, NULL);
+			}
+		}
 		seat_consider_warp_to_focus(seat);
 	}
 


### PR DESCRIPTION
Fixes #3599 

If the view has any pointer constraints, ensure they are removed
before the view is unmapped and the surface is no longer tied to the
view.