### PR TITLE
ipc: handle unnamed xkb_active_layout_name

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -597,7 +597,7 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 				const char *layout =
 					xkb_keymap_layout_get_name(keymap, layout_idx);
 				json_object_object_add(object, "xkb_active_layout_name",
-						json_object_new_string(layout));
+						layout ? json_object_new_string(layout) : NULL);
 				break;
 			}
 		}

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -135,8 +135,8 @@ static void pretty_print_input(json_object *i) {
 		json_object_get_int(vendor));
 
 	if (json_object_object_get_ex(i, "xkb_active_layout_name", &kbdlayout)) {
-		printf("  Active Keyboard Layout: %s\n",
-			json_object_get_string(kbdlayout));
+		const char *layout = json_object_get_string(kbdlayout);
+		printf("  Active Keyboard Layout: %s\n", layout ? layout : "(unnamed)");
 	}
 
 	if (json_object_object_get_ex(i, "libinput_send_events", &events)) {


### PR DESCRIPTION
Fixes #3639 

If the active xkb_layout does not have a name, use `NULL` instead of
`json_object_new_string(NULL)`. This also makes it so swaymsg will pretty
print this as `(unnamed)`.