### PR TITLE
workspace_get_initial_output: handle focused layer

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -42,10 +42,16 @@ struct sway_output *workspace_get_initial_output(const char *name) {
 			}
 		}
 	}
-	// Otherwise put it on the focused output
+	// Otherwise try to put it on the focused output
 	struct sway_seat *seat = input_manager_current_seat();
-	struct sway_workspace *focus = seat_get_focused_workspace(seat);
-	return focus->output;
+	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
+	if (focus && focus->type == N_WORKSPACE) {
+		return focus->sway_workspace->output;
+	} else if (focus && focus->type == N_CONTAINER) {
+		return focus->sway_container->workspace->output;
+	}
+	// Fallback to the first output or noop output for headless
+	return root->outputs->length ? root->outputs->items[0] : root->noop_output;
 }
 
 static void prevent_invalid_outer_gaps(struct sway_workspace *ws) {


### PR DESCRIPTION
Fixes #3616 

When a layer surface is focused, `seat_get_focused_workspace` will be
NULL. This changes `workspace_get_initial_output` to use output of the
focus inactive. If the focus inactive is also NULL, then either the
first output or the noop output will be used as fallbacks.