### PR TITLE
fix misc memory leaks

### DIFF
--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -50,5 +50,5 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 	}
 
 	config->handler_context.seat_config = NULL;
-	return cmd_results_new(CMD_SUCCESS, NULL);
+	return res ? res : cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -118,7 +118,7 @@ void free_config(struct sway_config *config) {
 	}
 	list_free(config->no_focus);
 	list_free(config->active_bar_modifiers);
-	list_free(config->config_chain);
+	list_free_items_and_destroy(config->config_chain);
 	list_free(config->command_policies);
 	list_free(config->feature_policies);
 	list_free(config->ipc_policies);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -46,6 +46,7 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->position);
 	free(bar->hidden_state);
 	free(bar->status_command);
+	free(bar->swaybar_command);
 	free(bar->font);
 	free(bar->separator_symbol);
 	for (int i = 0; i < bar->bindings->length; i++) {


### PR DESCRIPTION
This fixes a few misc memory leaks reported by asan:
- Items of `config->config_chain` are now freed instead of just the list
itself
- `bar->swaybar_command` is now freed
- The result returned by a seat subcommand is now returned instead of
leaked