### PR TITLE
Rebase cursor when a layer surface maps

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -72,6 +72,7 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat);
  * This chooses a cursor icon and sends a motion event to the surface.
  */
 void cursor_rebase(struct sway_cursor *cursor);
+void cursor_rebase_all(void);
 
 void cursor_handle_activity(struct sway_cursor *cursor);
 void cursor_unhide(struct sway_cursor *cursor);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -6,7 +6,9 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output.h>
+#include "log.h"
 #include "sway/desktop/transaction.h"
+#include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
 #include "sway/layers.h"
@@ -14,7 +16,6 @@
 #include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/workspace.h"
-#include "log.h"
 
 static void apply_exclusive(struct wlr_box *usable_area,
 		uint32_t anchor, int32_t exclusive,
@@ -302,6 +303,8 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 	if (seat->focused_layer == sway_layer->layer_surface) {
 		seat_set_focus_layer(seat, NULL);
 	}
+
+	cursor_rebase_all();
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -321,7 +324,6 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		struct sway_output *output = sway_layer->layer_surface->output->data;
 		if (output != NULL) {
 			arrange_layers(output);
-			arrange_output(output);
 			transaction_commit_dirty();
 		}
 		wl_list_remove(&sway_layer->output_destroy.link);
@@ -339,6 +341,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	// TODO: send enter to subsurfaces and popups
 	wlr_surface_send_enter(sway_layer->layer_surface->surface,
 		sway_layer->layer_surface->output);
+	cursor_rebase_all();
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -314,14 +314,7 @@ static void transaction_apply(struct sway_transaction *transaction) {
 		node->instruction = NULL;
 	}
 
-	if (root->outputs->length) {
-		struct sway_seat *seat;
-		wl_list_for_each(seat, &server.input->seats, link) {
-			if (!seat_doing_seatop(seat)) {
-				cursor_rebase(seat->cursor);
-			}
-		}
-	}
+	cursor_rebase_all();
 }
 
 static void transaction_commit(struct sway_transaction *transaction);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -283,6 +283,19 @@ void cursor_rebase(struct sway_cursor *cursor) {
 	cursor_do_rebase(cursor, time_msec, cursor->previous.node, surface, sx, sy);
 }
 
+void cursor_rebase_all(void) {
+	if (!root->outputs->length) {
+		return;
+	}
+
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		if (!seat_doing_seatop(seat)) {
+			cursor_rebase(seat->cursor);
+		}
+	}
+}
+
 static int hide_notify(void *data) {
 	struct sway_cursor *cursor = data;
 	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);


### PR DESCRIPTION
Also removes an extraneous arrange_outputs call, it's already called if
necessary in arrange_layers.

Updates https://github.com/swaywm/sway/issues/3080