### PR TITLE
subsurface_get_root_coords: break on NULL

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -708,6 +708,9 @@ static void subsurface_get_root_coords(struct sway_view_child *child,
 	while (surface && wlr_surface_is_subsurface(surface)) {
 		struct wlr_subsurface *subsurface =
 			wlr_subsurface_from_wlr_surface(surface);
+		if (subsurface == NULL) {
+			break;
+		}
 		*root_sx += subsurface->current.x;
 		*root_sy += subsurface->current.y;
 		surface = subsurface->parent;


### PR DESCRIPTION
Fixes #3671 

It is possible for `wlr_surface_is_subsurface` to return true, but
`wlr_surface_from_wlr_surface` to be NULL. This adds a NULL check to the
value returned by `wlr_surface_from_wlr_surface` and breaks out of the
while loop in `subsurface_get_root_coords`.