### PR TITLE
Make sway-version overrideable again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,7 +128,10 @@ endif
 
 add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
 
-version = '"@0@"'.format(meson.project_version())
+version = get_option('sway-version')
+if version == ''
+	version = '"@0@"'.format(meson.project_version())
+endif
 if git.found()
 	git_commit_hash = run_command([git.path(), 'describe', '--always', '--tags'])
 	git_branch = run_command([git.path(), 'rev-parse', '--abbrev-ref', 'HEAD'])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('sway-version', type: 'string', description: 'The version string reported in `sway --version`.')
 option('default-wallpaper', type: 'boolean', value: true, description: 'Install the default wallpaper.')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')


### PR DESCRIPTION
It would be great if the version of sway could be set at compile time without having to patch the buildfile. This would let package maintainers override the version if there have been any changes.