### PR TITLE
seatop_move_tiling: use tab/stack parent not self

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -150,6 +150,9 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 		}
 		if (edge) {
 			e->target_node = node_get_parent(&con->node);
+			if (e->target_node == &e->con->node) {
+				e->target_node = node_get_parent(e->target_node);
+			}
 			e->target_edge = edge;
 			node_get_box(e->target_node, &e->drop_box);
 			resize_box(&e->drop_box, edge, DROP_LAYOUT_BORDER);


### PR DESCRIPTION
When moving a descendant of a tabbed or stacked container, it is possible
for the target node to be the node being moved. This causes a segfault in
`handle_finish` since the node will be detached and then attempted to be
attached to it own parent, which is NULL due to the detach. In this
case, the target node should not be set to the node being moved, but the
parent of the node. This also allows for a descendant of a tabbed or
stacked container to be dragged out of the tabs/stacks and to be a
sibling of the tabbbed/stacked container, which was not previously
possible.

Create `T[viewa V[viewb]]` with only one output and focus viewb. Attempt to
drag it to the left or right side of the monitor. On the current master, this will
segfault. With this PR, it should create `H[T[viewa] viewb]`.