### PR TITLE
seatop_move_tiling: do not move to descendant

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -164,7 +164,8 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 
 	// Use the hovered view - but we must be over the actual surface
 	con = node->sway_container;
-	if (!con->view->surface || node == &e->con->node) {
+	if (!con->view->surface || node == &e->con->node
+			|| node_has_ancestor(node, &e->con->node)) {
 		e->target_node = NULL;
 		e->target_edge = WLR_EDGE_NONE;
 		return;


### PR DESCRIPTION
In seatop_move_tiling, it is possible to cause a stack overflow by
dragging a container into one of its descendants. This disables the
ability to move into a descendant.