### PR TITLE
seat: allow tree focus changes while layer focused

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -725,6 +725,10 @@ void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node) {
 
 void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 	if (seat->focused_layer) {
+		struct wlr_layer_surface_v1 *layer = seat->focused_layer;
+		seat_set_focus_layer(seat, NULL);
+		seat_set_focus(seat, node);
+		seat_set_focus_layer(seat, layer);
 		return;
 	}
 


### PR DESCRIPTION
Fixes #3615 

This allows the focused inactive tree node and visible workspaces to be
changed while a surface layer has focus. The layer temporarily loses
focus, the tree focus changes, and the layer gets refocused.