### PR TITLE
apply_output_config: dpms on before modeset

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -199,6 +199,11 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		return true;
 	}
 
+	if (oc && oc->dpms_state == DPMS_ON) {
+		sway_log(SWAY_DEBUG, "Turning on screen");
+		wlr_output_enable(wlr_output, true);
+	}
+
 	bool modeset_success;
 	if (oc && oc->width > 0 && oc->height > 0) {
 		sway_log(SWAY_DEBUG, "Set %s mode to %dx%d (%f GHz)", oc->name, oc->width,
@@ -263,19 +268,9 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		}
 	}
 
-	if (oc) {
-		switch (oc->dpms_state) {
-		case DPMS_ON:
-			sway_log(SWAY_DEBUG, "Turning on screen");
-			wlr_output_enable(wlr_output, true);
-			break;
-		case DPMS_OFF:
-			sway_log(SWAY_DEBUG, "Turning off screen");
-			wlr_output_enable(wlr_output, false);
-			break;
-		case DPMS_IGNORE:
-			break;
-		}
+	if (oc && oc->dpms_state == DPMS_OFF) {
+		sway_log(SWAY_DEBUG, "Turning off screen");
+		wlr_output_enable(wlr_output, false);
 	}
 
 	return true;
@@ -294,6 +289,7 @@ static void default_output_config(struct output_config *oc,
 	oc->x = oc->y = -1;
 	oc->scale = 1;
 	oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;
+	oc->dpms_state = DPMS_ON;
 }
 
 static struct output_config *get_output_config(char *identifier,


### PR DESCRIPTION
Fixes #3688 

On the DRM backend, if an output is dpms'd off and a different output is
hotplugged, the CRTC for the output is reclaimed. When modesetting an
output without a CRTC, a CRTC will not be given to an output that is not
desired to be enabled. This splits setting the dpms state in
apply_output_config. If the output should be dpms on, the it is enabled
before attempting to modeset. Otherwise, it is dpms'd off after setting
everything else.