### PR TITLE
Fix reload freeze when not modsetting current mode

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -586,6 +586,8 @@ struct output_config *store_output_config(struct output_config *oc);
 
 void apply_output_config_to_outputs(struct output_config *oc);
 
+void reset_outputs(void);
+
 void free_output_config(struct output_config *oc);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);

--- a/sway/config.c
+++ b/sway/config.c
@@ -471,9 +471,8 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	}
 
 	if (is_active) {
-		for (int i = 0; i < config->output_configs->length; i++) {
-			apply_output_config_to_outputs(config->output_configs->items[i]);
-		}
+		reset_outputs();
+
 		config->reloading = false;
 		if (config->swaynag_config_errors.pid > 0) {
 			swaynag_show(&config->swaynag_config_errors);

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -391,6 +391,17 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 	}
 }
 
+void reset_outputs(void) {
+	struct output_config *oc = NULL;
+	int i = list_seq_find(config->output_configs, output_name_cmp, "*");
+	if (i >= 0) {
+		oc = config->output_configs->items[i];
+	} else {
+		oc = store_output_config(new_output_config("*"));
+	}
+	apply_output_config_to_outputs(oc);
+}
+
 void free_output_config(struct output_config *oc) {
 	if (!oc) {
 		return;


### PR DESCRIPTION
Fixes #3685 with swaywm/wlroots#1545 -- which was
reverted in swaywm/wlroots#1550 due to #3685

On master, all output configs are applied on reload. This may cause an
output to have its config applied up to three times, instead of just
once. The three cases are: output name, output identifier, and wildcard.
Not only is this inefficient, but it can cause swaybg to be spawned and
immediately killed.

However, swaybg requires two roundtrips of wl_display (to obtain needed
globals) before it enters its normal event loop. Modesetting will
roundtrip the wl_display. Without modesetting, waitpid for killing
swaybg could block infinitely due to swaybg being blocked by
wl_display_roundtrip.

This only configured an output once. It either uses the wildcard config
or creates an empty wildcard config and applies that. This also fixes a
bug where an output would not be reset when there is no output config to
apply to it.