### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1,4 +1,8 @@
 #define _POSIX_C_SOURCE 200809L
+#ifdef __FreeBSD__
+// for SOCK_CLOEXEC
+#define __BSD_VISIBLE 1
+#endif
 #include <assert.h>
 #include <fcntl.h>
 #include <stdbool.h>


### PR DESCRIPTION
Regressed by #3708. FreeBSD (even 13.0-CURRENT) still defines `SOCK_CLOEXEC` only when `_POSIX_C_SOURCE` is **not** defined.
