### PR TITLE
seat_cmd_cursor: fix typo in expected syntax

### DIFF
--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -12,7 +12,7 @@ static struct cmd_results *press_or_release(struct sway_cursor *cursor,
 
 static const char expected_syntax[] = "Expected 'cursor <move> <x> <y>' or "
 					"'cursor <set> <x> <y>' or "
-					"'curor <press|release> <button[1-9]|event-name-or-code>'";
+					"'cursor <press|release> <button[1-9]|event-name-or-code>'";
 
 static struct cmd_results *handle_command(struct sway_cursor *cursor,
 		int argc, char **argv) {


### PR DESCRIPTION
This just fixes a typo in the expected syntax for seat_cmd_cursor