### PR TITLE
Use container under cursor for mouse bindings

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -293,12 +293,13 @@ runtime.
 	overwrite a binding, swaynag will give you a warning. To silence this, use
 	the _--no-warn_ flag.
 
-	Mouse buttons can either be specified in the form _button[1-9]_ or by using
-	the name of the event code (ex _BTN\_LEFT_ or _BTN\_RIGHT_). For the former
-	option, the buttons will be mapped to their values in X11 (1=left, 2=middle,
-	3=right, 4=scroll up, 5=scroll down, 6=scroll left, 7=scroll right, 8=back,
-	9=forward). For the latter option, you can find the event names using
-	_libinput debug-events_.
+	Mouse bindings operate on the container under the cursor instead of the
+	container that has focus. Mouse buttons can either be specified in the form
+	_button[1-9]_ or by using the name of the event code (ex _BTN\_LEFT_ or
+	_BTN\_RIGHT_). For the former option, the buttons will be mapped to their
+	values in X11 (1=left, 2=middle, 3=right, 4=scroll up, 5=scroll down,
+	6=scroll left, 7=scroll right, 8=back, 9=forward). For the latter option,
+	you can find the event names using _libinput debug-events_.
 	
 	_--whole-window_, _--border_, and _--exclude-titlebar_ are mouse-only options
 	which affect the region in which the mouse bindings can be triggered.  By


### PR DESCRIPTION
This matches i3's behavior of executing mouse bindings in regards to the
container under the cursor instead of what is focused.

[i3 User Guide 4.4](https://i3wm.org/docs/userguide.html#mousebindings): A mouse binding makes i3 execute a command upon pressing a specific mouse button **in the scope of the clicked container**