### PR TITLE
Feature: Add 'visible' key to view json response

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -344,6 +344,9 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "app_id",
 			app_id ? json_object_new_string(app_id) : NULL);
 
+	bool visible = view_is_visible(c->view);
+	json_object_object_add(object, "visible", json_object_new_boolean(visible));
+
 	json_object *marks = json_object_new_array();
 	list_t *con_marks = c->marks;
 	for (int i = 0; i < con_marks->length; ++i) {


### PR DESCRIPTION
This greatly simplifies the `jq` query for https://github.com/emersion/slurp/pull/28.