### PR TITLE
output_get_active_workspace: check workspaces length

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -320,6 +320,9 @@ struct sway_workspace *output_get_active_workspace(struct sway_output *output) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_node *focus = seat_get_active_tiling_child(seat, &output->node);
 	if (!focus) {
+		if (!output->workspaces->length) {
+			return NULL;
+		}
 		return output->workspaces->items[0];
 	}
 	return focus->sway_workspace;


### PR DESCRIPTION
Fixes #3658 
Fixes #3654 
Fixes #3043 

If an output's node was dirty and the transaction was committed before a
workspace was moved to or created for the output, the instruction would
have a bad value for `state->active_workspace` due to a missing
length check in `output_get_active_workspace`. If there was no focus on
the output, the first workspace was being returned. If the workspace
list was currently empty, the value was either garbage, or in the case of
an output being disabled and re-enabled, a workspace that may have been
previously freed. This just adds the length check to avoid returning out
of bounds value.