### PR TITLE
Handle NULL from output_get_active_workspace

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -37,6 +37,9 @@ static struct sway_node *get_node_in_output_direction(
 		struct sway_output *output, enum wlr_direction dir) {
 	struct sway_seat *seat = config->handler_context.seat;
 	struct sway_workspace *ws = output_get_active_workspace(output);
+	if (!sway_assert(ws, "Expected output to have a workspace")) {
+		return NULL;
+	}
 	if (ws->fullscreen) {
 		return seat_get_focus_inactive(seat, &ws->fullscreen->node);
 	}

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -283,6 +283,9 @@ static bool container_move_in_direction(struct sway_container *container,
 			return false;
 		}
 		struct sway_workspace *ws = output_get_active_workspace(new_output);
+		if (!sway_assert(ws, "Expected output to have a workspace")) {
+			return false;
+		}
 		container_move_to_workspace(container, ws);
 		return true;
 	}
@@ -360,6 +363,9 @@ static bool container_move_in_direction(struct sway_container *container,
 		output_get_in_direction(container->workspace->output, move_dir);
 	if (output) {
 		struct sway_workspace *ws = output_get_active_workspace(output);
+		if (!sway_assert(ws, "Expected output to have a workspace")) {
+			return false;
+		}
 		container_move_to_workspace_from_direction(container, ws, move_dir);
 		return true;
 	}
@@ -525,6 +531,10 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	case N_OUTPUT: {
 			struct sway_output *output = destination->sway_output;
 			struct sway_workspace *ws = output_get_active_workspace(output);
+			if (!sway_assert(ws, "Expected output to have a workspace")) {
+				return cmd_results_new(CMD_FAILURE,
+						"Expected output to have a workspace");
+			}
 			container_move_to_workspace(container, ws);
 		}
 		break;
@@ -538,7 +548,11 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 	// restore focus on destination output back to its last active workspace
 	struct sway_workspace *new_workspace =
 		output_get_active_workspace(new_output);
-	if (new_output_last_ws && new_output_last_ws != new_workspace) {
+	if (!sway_assert(new_workspace, "Expected output to have a workspace")) {
+		return cmd_results_new(CMD_FAILURE,
+				"Expected output to have a workspace");
+	}
+	if (new_output_last_ws != new_workspace) {
 		struct sway_node *new_output_last_focus =
 			seat_get_focus_inactive(seat, &new_output_last_ws->node);
 		seat_set_raw_focus(seat, new_output_last_focus);
@@ -585,6 +599,9 @@ static void workspace_move_to_output(struct sway_workspace *workspace,
 	workspace_detach(workspace);
 	struct sway_workspace *new_output_old_ws =
 		output_get_active_workspace(output);
+	if (!sway_assert(new_output_old_ws, "Expected output to have a workspace")) {
+		return;
+	}
 
 	output_add_workspace(output, workspace);
 

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -9,6 +9,7 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "list.h"
+#include "log.h"
 #include "util.h"
 
 struct cmd_results *cmd_sticky(int argc, char **argv) {
@@ -29,6 +30,11 @@ struct cmd_results *cmd_sticky(int argc, char **argv) {
 		// move container to active workspace
 		struct sway_workspace *active_workspace =
 			output_get_active_workspace(container->workspace->output);
+		if (!sway_assert(active_workspace,
+					"Expected output to have a workspace")) {
+			return cmd_results_new(CMD_FAILURE,
+					"Expected output to have a workspace");
+		}
 		if (container->workspace != active_workspace) {
 			struct sway_workspace *old_workspace = container->workspace;
 			container_detach(container);

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -118,6 +118,10 @@ static void container_swap(struct sway_container *con1,
 		output_get_active_workspace(con1->workspace->output);
 	struct sway_workspace *vis2 =
 		output_get_active_workspace(con2->workspace->output);
+	if (!sway_assert(vis1 && vis2, "con1 or con2 are on an output without a"
+				"workspace. This should not happen")) {
+		return;
+	}
 
 	char *stored_prev_name = NULL;
 	if (seat->prev_workspace_name) {

--- a/sway/commands/titlebar_border_thickness.c
+++ b/sway/commands/titlebar_border_thickness.c
@@ -21,7 +21,12 @@ struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
 
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		arrange_workspace(output_get_active_workspace(output));
+		struct sway_workspace *ws = output_get_active_workspace(output);
+		if (!sway_assert(ws, "Expected output to have a workspace")) {
+			return cmd_results_new(CMD_FAILURE,
+					"Expected output to have a workspace");
+		}
+		arrange_workspace(ws);
 		output_damage_whole(output);
 	}
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -251,6 +251,9 @@ static void output_for_each_surface(struct sway_output *output,
 	};
 
 	struct sway_workspace *workspace = output_get_active_workspace(output);
+	if (!workspace) {
+		return;
+	}
 	struct sway_container *fullscreen_con = root->fullscreen_global;
 	if (fullscreen_con && container_is_scratchpad_hidden(fullscreen_con)) {
 		fullscreen_con = NULL;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -104,6 +104,9 @@ struct sway_node *node_at_coords(
 
 	// find the focused workspace on the output for this seat
 	struct sway_workspace *ws = output_get_active_workspace(output);
+	if (!ws) {
+		return NULL;
+	}
 
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -198,6 +198,9 @@ static void ipc_json_describe_output(struct sway_output *output,
 			ipc_json_output_transform_description(wlr_output->transform)));
 
 	struct sway_workspace *ws = output_get_active_workspace(output);
+	if (!sway_assert(ws, "Expected output to have a workspace")) {
+		return;
+	}
 	json_object_object_add(object, "current_workspace",
 			json_object_new_string(ws->name));
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -831,7 +831,7 @@ void container_floating_move_to(struct sway_container *con,
 	}
 	struct sway_workspace *new_workspace =
 		output_get_active_workspace(new_output);
-	if (old_workspace != new_workspace) {
+	if (new_workspace && old_workspace != new_workspace) {
 		container_detach(con);
 		workspace_add_floating(new_workspace, con);
 		arrange_workspace(old_workspace);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -143,6 +143,9 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 static void evacuate_sticky(struct sway_workspace *old_ws,
 		struct sway_output *new_output) {
 	struct sway_workspace *new_ws = output_get_active_workspace(new_output);
+	if (!sway_assert(new_ws, "New output does not have a workspace")) {
+		return;
+	}
 	while (old_ws->floating->length) {
 		struct sway_container *sticky = old_ws->floating->items[0];
 		container_detach(sticky);


### PR DESCRIPTION
Follow-up for #3743 

This modifies the places where output_get_active_workspace is called to
handle a NULL result. Some places already handled it and did not need a
change, some just have guard off code blocks, others return errors, and
some have sway_asserts since the case should never happen. A lot of this
is probably just safety precautions since they probably will never be
called when `output_get_active_workspace` is not fully configured with a
workspace.