### PR TITLE
move scratchpad: hide visible scratchpad container

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -854,11 +854,11 @@ static struct cmd_results *cmd_move_to_scratchpad(void) {
 		}
 	}
 
-	if (con->scratchpad) {
-		return cmd_results_new(CMD_INVALID,
-				"Container is already in the scratchpad");
+	if (!con->scratchpad) {
+		root_scratchpad_add_container(con);
+	} else if (con->workspace) {
+		root_scratchpad_hide(con);
 	}
-	root_scratchpad_add_container(con);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 


### PR DESCRIPTION
Fixes #3748

This makes it so running `move [to] scratchpad` on a container already
in the scratchpad does not return an error. To match i3's behavior, a
visible scratchpad container will be hidden and a hidden scratchpad
container will be treated as a noop.