### PR TITLE
commands/move: reintroduce wrongly removed NULL check

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -552,7 +552,7 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE,
 				"Expected output to have a workspace");
 	}
-	if (new_output_last_ws != new_workspace) {
+	if (new_output_last_ws && new_output_last_ws != new_workspace) {
 		struct sway_node *new_output_last_focus =
 			seat_get_focus_inactive(seat, &new_output_last_ws->node);
 		seat_set_raw_focus(seat, new_output_last_focus);


### PR DESCRIPTION
Commit d3d7956576341bbbfb60d045175b0e8a44752e0b removed this NULL check, which
leads to the following backtrace:
```
  #0  0x0000557bd201df46 in node_is_view (node=0x0) at ../sway/sway/tree/node.c:41
  #1  0x0000557bd1ff5d4e in seat_get_focus_inactive (seat=0x557bd3fc7580, node=0x0) at ../sway/sway/input/seat.c:968
          current = 0x557bd2033485
  #2  0x0000557bd2009f24 in cmd_move_container (argc=3, argv=0x557bd46b19c0) at ../sway/sway/commands/move.c:557
          new_output_last_focus = 0x0
          error = 0x0
          node = 0x557bd469f360
          workspace = 0x557bd4572ee0
          container = 0x557bd469f360
          no_auto_back_and_forth = false
          seat = 0x557bd3fc7580
          old_parent = 0x0
          old_ws = 0x557bd4572ee0
          old_output = 0x557bd411f740
          destination = 0x557bd46a0cc0
          new_output = 0x557bd411f740
          new_output_last_ws = 0x0
          focus = 0x557bd469f360
          __PRETTY_FUNCTION__ = "cmd_move_container"
          new_workspace = 0x557bd4572ee0
  […]
```
Reintroduce the NULL check to fix the bug.

Fixes #3746