### PR TITLE
input/cursor: allow whole-window bindings on ws

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -552,10 +552,11 @@ static void state_add_button(struct sway_cursor *cursor, uint32_t button) {
 static struct sway_binding* get_active_mouse_binding(
 		const struct sway_cursor *cursor, list_t *bindings, uint32_t modifiers,
 		bool release, bool on_titlebar, bool on_border, bool on_content,
-		const char *identifier) {
-	uint32_t click_region = (on_titlebar ? BINDING_TITLEBAR : 0) |
-			(on_border ? BINDING_BORDER : 0) |
-			(on_content ? BINDING_CONTENTS : 0);
+		bool on_workspace, const char *identifier) {
+	uint32_t click_region =
+			((on_titlebar || on_workspace) ? BINDING_TITLEBAR : 0) |
+			((on_border || on_workspace) ? BINDING_BORDER : 0) |
+			((on_content || on_workspace) ? BINDING_CONTENTS : 0);
 
 	struct sway_binding *current = NULL;
 	for (int i = 0; i < bindings->length; ++i) {
@@ -564,6 +565,8 @@ static struct sway_binding* get_active_mouse_binding(
 				cursor->pressed_button_count != (size_t)binding->keys->length ||
 				release != (binding->flags & BINDING_RELEASE) ||
 				!(click_region & binding->flags) ||
+				(on_workspace &&
+				 (click_region & binding->flags) != click_region) ||
 				(strcmp(binding->input, identifier) != 0 &&
 				 strcmp(binding->input, "*") != 0)) {
 			continue;
@@ -629,6 +632,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		find_resize_edge(cont, cursor) : WLR_EDGE_NONE;
 	bool on_border = edge != WLR_EDGE_NONE;
 	bool on_contents = cont && !on_border && surface;
+	bool on_workspace = node && node->type == N_WORKSPACE;
 	bool on_titlebar = cont && !on_border && !surface;
 
 	// Handle mouse bindings
@@ -642,11 +646,13 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		state_add_button(cursor, button);
 		binding = get_active_mouse_binding(cursor,
 			config->current_mode->mouse_bindings, modifiers, false,
-			on_titlebar, on_border, on_contents, device_identifier);
+			on_titlebar, on_border, on_contents, on_workspace,
+			device_identifier);
 	} else {
 		binding = get_active_mouse_binding(cursor,
 			config->current_mode->mouse_bindings, modifiers, true,
-			on_titlebar, on_border, on_contents, device_identifier);
+			on_titlebar, on_border, on_contents, on_workspace,
+			device_identifier);
 		state_erase_button(cursor, button);
 	}
 	free(device_identifier);
@@ -836,6 +842,7 @@ void dispatch_cursor_axis(struct sway_cursor *cursor,
 	bool on_titlebar_border = cont && on_border &&
 		cursor->cursor->y < cont->content_y;
 	bool on_contents = cont && !on_border && surface;
+	bool on_workspace = node && node->type == N_WORKSPACE;
 	float scroll_factor =
 		(ic == NULL || ic->scroll_factor == FLT_MIN) ? 1.0f : ic->scroll_factor;
 
@@ -854,7 +861,7 @@ void dispatch_cursor_axis(struct sway_cursor *cursor,
 	state_add_button(cursor, button);
 	binding = get_active_mouse_binding(cursor,
 		config->current_mode->mouse_bindings, modifiers, false,
-		on_titlebar, on_border, on_contents, dev_id);
+		on_titlebar, on_border, on_contents, on_workspace, dev_id);
 	if (binding) {
 		seat_execute_command(seat, binding);
 		handled = true;
@@ -895,7 +902,7 @@ void dispatch_cursor_axis(struct sway_cursor *cursor,
 	// Handle mouse bindings - x11 mouse buttons 4-7 - release event
 	binding = get_active_mouse_binding(cursor,
 		config->current_mode->mouse_bindings, modifiers, true,
-		on_titlebar, on_border, on_contents, dev_id);
+		on_titlebar, on_border, on_contents, on_workspace, dev_id);
 	state_erase_button(cursor, button);
 	if (binding) {
 		seat_execute_command(seat, binding);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -310,9 +310,9 @@ runtime.
 	conjunction with any other option to specify that the titlebar should be
 	excluded from the region of consideration.
 
-	There is currently, however, no way to execute a mouse binding over a layer
-	surface (which includes the background of an empty workspace). This behaviour
-	is carried over from i3.
+	If _--whole-window_ is given, the command can be triggered when the cursor
+	is over an empty workspace. Using a mouse binding over a layer surface's
+	exclusive region is not currently possible.
 
 	Example:
 ```


### PR DESCRIPTION
Fixes #3750 

To match i3's behavior, this allows mouse bindings to be triggered over
a workspace when `--whole-window` is given.