### PR TITLE
handle_seat_node_destroy: update seat->workspace

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -146,6 +146,19 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 	struct sway_node *focus = seat_get_focus(seat);
 
 	if (node->type == N_WORKSPACE) {
+		// If an unmanaged or layer surface is focused when an output gets
+		// disabled and an empty workspace on the output was focused by the
+		// seat, the seat needs to refocus it's focus inactive to update the
+		// value of seat->workspace.
+		if (seat->workspace == node->sway_workspace) {
+			struct sway_node *node = seat_get_focus_inactive(seat, &root->node);
+			seat_set_focus(seat, NULL);
+			if (node) {
+				seat_set_focus(seat, node);
+			} else {
+				seat->workspace = NULL;
+			}
+		}
 		seat_node_destroy(seat_node);
 		return;
 	}


### PR DESCRIPTION
Fixes #3754

If an unmanaged or layer surface is focused when an output gets
disabled and an empty workspace on the output was focused by the seat,
the seat needs to refocus it's focus inactive to update the value of
`seat->workspace`.