### PR TITLE
handle_layer_shell_surface: do not use noop output

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -378,7 +378,7 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 				output = ws->output;
 			}
 		}
-		if (!output) {
+		if (!output || output == root->noop_output) {
 			if (!root->outputs->length) {
 				sway_log(SWAY_ERROR,
 						"no output to auto-assign layer surface '%s' to",


### PR DESCRIPTION
Fixes #3686 

If the noop output is focused (all other outputs disabled/disconnected),
do not auto assign a layer surface to it. The noop output is not enabled
and does not have the `output->layers` list initialized. It also does
not make sense to map the layer surfaces to something that is not
visible.

Easy way to reproduce:  `swaymsg output \* disable; swaynag -m test`