### PR TITLE
Fix crash exiting fullscreened floating container

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -847,16 +847,9 @@ void container_floating_move_to_center(struct sway_container *con) {
 		return;
 	}
 	struct sway_workspace *ws = con->workspace;
-	enum sway_fullscreen_mode fullscreen_mode = con->fullscreen_mode;
-	if (fullscreen_mode) {
-		container_fullscreen_disable(con);
-	}
 	double new_lx = ws->x + (ws->width - con->width) / 2;
 	double new_ly = ws->y + (ws->height - con->height) / 2;
 	container_floating_translate(con, new_lx - con->x, new_ly - con->y);
-	if (fullscreen_mode) {
-		container_set_fullscreen(con, fullscreen_mode);
-	}
 }
 
 static bool find_urgent_iterator(struct sway_container *con, void *data) {


### PR DESCRIPTION
container_floating_move_to_center and container_fullscreen_disable were
calling recursively when the container spawned as a fullscreen floating
container (via for_window). Such a window now doesn't crash sway anymore
but is still configured with a wrong, zero size, making it not directly
usable.

I didn't see this patch break anything that wasn't already broken.