### PR TITLE
ipc: add missing fields to disabled outputs

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -251,6 +251,7 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	json_object_object_add(object, "name",
 			json_object_new_string(wlr_output->name));
 	json_object_object_add(object, "active", json_object_new_boolean(false));
+	json_object_object_add(object, "primary", json_object_new_boolean(false));
 	json_object_object_add(object, "make",
 			json_object_new_string(wlr_output->make));
 	json_object_object_add(object, "model",
@@ -258,6 +259,15 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	json_object_object_add(object, "serial",
 			json_object_new_string(wlr_output->serial));
 	json_object_object_add(object, "modes", json_object_new_array());
+
+	json_object_object_add(object, "current_workspace", NULL);
+
+	json_object *rect_object = json_object_new_object();
+	json_object_object_add(rect_object, "x", json_object_new_int(0));
+	json_object_object_add(rect_object, "y", json_object_new_int(0));
+	json_object_object_add(rect_object, "width", json_object_new_int(0));
+	json_object_object_add(rect_object, "height", json_object_new_int(0));
+	json_object_object_add(object, "rect", rect_object);
 
 	json_object_object_add(object, "percent", NULL);
 


### PR DESCRIPTION
i3 requires all outputs to have certain fields, including 'primary', 'current_workspace', and 'rect' which were missing on disabled outputs.

https://i3wm.org/docs/ipc.html#_outputs_reply

Fixes a bug I was having with [i3ipc-rs](https://github.com/tmerr/i3ipc-rs) where my program would crash when calling get_outputs() because the fields were missing.