### PR TITLE
Add swaybar overlay mode

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -58,6 +58,7 @@ struct swaybar_output {
 	struct zxdg_output_v1 *xdg_output;
 	struct wl_surface *surface;
 	struct zwlr_layer_surface_v1 *layer_surface;
+	struct wl_region *input_region;
 	uint32_t wl_name;
 
 	struct wl_list workspaces; // swaybar_workspace::link

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -20,6 +20,8 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 		bar->mode = strdup("hide");
 	} else if (strcasecmp("invisible", mode) == 0) {
 		bar->mode = strdup("invisible");
+	} else if (strcasecmp("overlay", mode) == 0) {
+		bar->mode = strdup("overlay");
 	} else {
 		return cmd_results_new(CMD_INVALID, "Invalid value %s", mode);
 	}

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -84,11 +84,13 @@ Sway allows configuring swaybar in the sway configuration file.
 	debug-events`. To disable the default behavior for a button, use the
 	command _nop_.
 
-*mode* dock|hide|invisible
+*mode* dock|hide|invisible|overlay
 	Specifies the visibility of the bar. In _dock_ mode, it is permanently
 	visible at one edge of the screen. In _hide_ mode, it is hidden unless the
 	modifier key is pressed, though this behaviour depends on the hidden state.
-	In _invisible_ mode, it is permanently hidden. Default is _dock_.
+	In _invisible_ mode, it is permanently hidden. In _overlay_ mode, it is
+	permanently visible on top of other windows. (In _overlay_ mode the bar is
+	transparent to input events.) Default is _dock_.
 
 *hidden_state* hide|show
 	Specifies the behaviour of the bar when it is in _hide_ mode. When the


### PR DESCRIPTION
Fixes #1620. Overlay mode puts swaybar above normal windows (in the overlay layer) and ignores input events. In my case I'm using it to always have the time in the corner of the screen. It probably works best with a theme/color scheme like mine, where the swaybar background color is transparent.