### PR TITLE
introduce hide_edge_borders lone_tab

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -465,6 +465,7 @@ struct sway_config {
 	int floating_border_thickness;
 	enum edge_border_types hide_edge_borders;
 	enum edge_border_types saved_edge_borders;
+	bool hide_lone_tab;
 
 	// border colors
 	struct {

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -5,8 +5,14 @@
 
 struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "hide_edge_borders", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "hide_edge_borders", EXPECTED_AT_LEAST, 1))) {
 		return error;
+	}
+
+	if (strcmp(*argv, "--i3") == 0) {
+		config->hide_lone_tab = true;
+		++argv;
+		--argc;
 	}
 
 	if (strcmp(argv[0], "none") == 0) {
@@ -23,7 +29,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		config->hide_edge_borders = E_SMART_NO_GAPS;
 	} else {
 		return cmd_results_new(CMD_INVALID, "Expected 'hide_edge_borders "
-				"<none|vertical|horizontal|both|smart|smart_no_gaps>'");
+				"[--i3] <none|vertical|horizontal|both|smart|smart_no_gaps>'");
 	}
 	config->saved_edge_borders = config->hide_edge_borders;
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -261,6 +261,7 @@ static void config_defaults(struct sway_config *config) {
 	config->floating_border_thickness = 2;
 	config->hide_edge_borders = E_NONE;
 	config->saved_edge_borders = E_NONE;
+	config->hide_lone_tab = false;
 
 	// border colors
 	set_color(config->border_colors.focused.border, 0x4C7899);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -841,6 +841,14 @@ static void render_containers_stacked(struct sway_output *output,
 
 static void render_containers(struct sway_output *output,
 		pixman_region32_t *damage, struct parent_data *parent) {
+	if (config->hide_lone_tab && parent->children->length == 1) {
+		struct sway_container *child = parent->children->items[0];
+		if (child->view) {
+			render_containers_linear(output,damage, parent);
+			return;
+		}
+	}
+
 	switch (parent->layout) {
 	case L_NONE:
 	case L_HORIZ:

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -493,8 +493,10 @@ The default colors are:
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps ...).
 
-*hide_edge_borders* none|vertical|horizontal|both|smart|smart_no_gaps
-	Hides window borders adjacent to the screen edges. Default is _none_.
+*hide_edge_borders* [--i3] none|vertical|horizontal|both|smart|smart_no_gaps
+	Hides window borders adjacent to the screen edges. Default is _none_. The
+	_--i3_ option enables i3-compatible behavior to hide the title bar on tabbed
+	and stacked containers with one child.
 
 *input* <input_device> <input-subcommands...>
 	For details on input subcommands, see *sway-input*(5).

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -246,14 +246,17 @@ void view_autoconfigure(struct sway_view *view) {
 	// In a tabbed or stacked container, the container's y is the top of the
 	// title area. We have to offset the surface y by the height of the title,
 	// bar, and disable any top border because we'll always have the title bar.
-	enum sway_container_layout layout = container_parent_layout(con);
-	if (layout == L_TABBED && !container_is_floating(con)) {
-		y_offset = container_titlebar_height();
-		con->border_top = false;
-	} else if (layout == L_STACKED && !container_is_floating(con)) {
-		list_t *siblings = container_get_siblings(con);
-		y_offset = container_titlebar_height() * siblings->length;
-		con->border_top = false;
+	list_t *siblings = container_get_siblings(con);
+	bool show_titlebar = siblings->length > 1 || !config->hide_lone_tab;
+	if (show_titlebar && !container_is_floating(con)) {
+		enum sway_container_layout layout = container_parent_layout(con);
+		if (layout == L_TABBED) {
+			y_offset = container_titlebar_height();
+			con->border_top = false;
+		} else if (layout == L_STACKED) {
+			y_offset = container_titlebar_height() * siblings->length;
+			con->border_top = false;
+		}
 	}
 
 	double x, y, width, height;


### PR DESCRIPTION
Behaves same as _both_ in i3wm with regards to tabbed/stacked containers. If
there is only one tabbed/stacked container child, title bar is hidden.

Related issues and merge requests: #3031, #3002, #2912, #2987.
Fixes #3663 