### PR TITLE
execute_command: do not strip qoutes for cmd_mode

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -255,7 +255,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			int argc;
 			char **argv = split_args(cmd, &argc);
 			if (strcmp(argv[0], "exec") != 0 &&
-					strcmp(argv[0], "exec_always") != 0) {
+					strcmp(argv[0], "exec_always") != 0 &&
+					strcmp(argv[0], "mode") != 0) {
 				int i;
 				for (i = 1; i < argc; ++i) {
 					if (*argv[i] == '\"' || *argv[i] == '\'') {


### PR DESCRIPTION
Fixes #3775 
Related to #3209 

`cmd_mode` performs its own quote stripping for the mode string to
avoid double stripping quotes for `cmd_bindcode` and `cmd_bindsym` in
`config_command` and `execute_command`. Stripping quotes in
`execute_command` for `cmd_mode` will also result in double stripping,
which will cause issues for any mode string with spaces, such as pango
markup.