### PR TITLE
Set minimum wlroots version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,17 +60,19 @@ rt             = cc.find_library('rt')
 git            = find_program('git', required: false)
 
 # Try first to find wlroots as a subproject, then as a system dependency
+wlroots_version = '>=0.4.1'
 wlroots_proj = subproject(
 	'wlroots',
 	default_options: ['rootston=false', 'examples=false'],
 	required: false,
+	version: wlroots_version,
 )
 if wlroots_proj.found()
 	wlroots = wlroots_proj.get_variable('wlroots')
 	wlroots_conf = wlroots_proj.get_variable('conf_data')
 	wlroots_has_xwayland = wlroots_conf.get('WLR_HAS_XWAYLAND') == 1
 else
-	wlroots = dependency('wlroots')
+	wlroots = dependency('wlroots', version: wlroots_version)
 	wlroots_has_xwayland = cc.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
 endif
 


### PR DESCRIPTION
Makes it more obvious that building sway with an old copy of wlroots won't work.