### PR TITLE
sway-ipc.7: clarify window_rect omits decorations

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -317,7 +317,8 @@ node and will have the following properties:
 :  The absolute geometry of the node
 |- window_rect
 :  object
-:  The geometry of the contents inside the node
+:  The geometry of the contents inside the node. The window decorations are
+   excluded from this calculation, but borders are included.
 |- deco_rect
 :  object
 :  The geometry of the decorations inside the node


### PR DESCRIPTION
Closes #3785 

According to the i3 ipc documentation, `window_rect` excludes the window
decorations from the calculation. This just clarifies that in
`sway-ipc.7.scd`