### PR TITLE
seat: don't send button release when not pressed

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -10,7 +10,7 @@ struct sway_seat;
 
 struct sway_seatop_impl {
 	void (*motion)(struct sway_seat *seat, uint32_t time_msec);
-	void (*finish)(struct sway_seat *seat);
+	void (*finish)(struct sway_seat *seat, uint32_t time_msec);
 	void (*abort)(struct sway_seat *seat);
 	void (*unref)(struct sway_seat *seat, struct sway_container *con);
 	void (*render)(struct sway_seat *seat, struct sway_output *output,
@@ -185,8 +185,8 @@ bool seat_is_input_allowed(struct sway_seat *seat, struct wlr_surface *surface);
 
 void drag_icon_update_position(struct sway_drag_icon *icon);
 
-void seatop_begin_down(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button, int sx, int sy);
+void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
+		uint32_t time_msec, uint32_t button, int sx, int sy);
 
 void seatop_begin_move_floating(struct sway_seat *seat,
 		struct sway_container *con, uint32_t button);
@@ -218,7 +218,7 @@ void seatop_motion(struct sway_seat *seat, uint32_t time_msec);
 /**
  * End a seatop and apply the affects.
  */
-void seatop_finish(struct sway_seat *seat);
+void seatop_finish(struct sway_seat *seat, uint32_t time_msec);
 
 /**
  * End a seatop without applying the affects.
@@ -238,6 +238,5 @@ void seatop_unref(struct sway_seat *seat, struct sway_container *con);
  */
 void seatop_render(struct sway_seat *seat, struct sway_output *output,
 		pixman_region32_t *damage);
-
 
 #endif

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -606,8 +606,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle existing seat operation
 	if (seat_doing_seatop(seat)) {
 		if (button == seat->seatop_button && state == WLR_BUTTON_RELEASED) {
-			seatop_finish(seat);
-			seat_pointer_notify_button(seat, time_msec, button, state);
+			seatop_finish(seat, time_msec);
 		}
 		if (state == WLR_BUTTON_PRESSED) {
 			state_add_button(cursor, button);
@@ -784,8 +783,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	// Handle mousedown on a container surface
 	if (surface && cont && state == WLR_BUTTON_PRESSED) {
 		seat_set_focus_container(seat, cont);
-		seat_pointer_notify_button(seat, time_msec, button, state);
-		seatop_begin_down(seat, cont, button, sx, sy);
+		seatop_begin_down(seat, cont, time_msec, button, sx, sy);
 		return;
 	}
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1211,9 +1211,9 @@ void seatop_motion(struct sway_seat *seat, uint32_t time_msec) {
 	}
 }
 
-void seatop_finish(struct sway_seat *seat) {
+void seatop_finish(struct sway_seat *seat, uint32_t time_msec) {
 	if (seat->seatop_impl && seat->seatop_impl->finish) {
-		seat->seatop_impl->finish(seat);
+		seat->seatop_impl->finish(seat, time_msec);
 	}
 	free(seat->seatop_data);
 	seat->seatop_data = NULL;

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -24,7 +24,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	e->moved = true;
 }
 
-static void handle_finish(struct sway_seat *seat) {
+static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_down_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 	// Set the cursor's previous coords to the x/y at the start of the
@@ -40,6 +40,8 @@ static void handle_finish(struct sway_seat *seat) {
 				cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 		cursor_send_pointer_motion(cursor, 0, node, surface, sx, sy);
 	}
+	seat_pointer_notify_button(seat, time_msec,
+		seat->seatop_button, WLR_BUTTON_RELEASED);
 }
 
 static void handle_abort(struct sway_seat *seat) {
@@ -60,8 +62,8 @@ static const struct sway_seatop_impl seatop_impl = {
 	.unref = handle_unref,
 };
 
-void seatop_begin_down(struct sway_seat *seat,
-		struct sway_container *con, uint32_t button, int sx, int sy) {
+void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
+		uint32_t time_msec, uint32_t button, int sx, int sy) {
 	seatop_abort(seat);
 
 	struct seatop_down_event *e =
@@ -80,5 +82,6 @@ void seatop_begin_down(struct sway_seat *seat,
 	seat->seatop_data = e;
 	seat->seatop_button = button;
 
+	seat_pointer_notify_button(seat, time_msec, button, WLR_BUTTON_PRESSED);
 	container_raise_floating(con);
 }

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -17,7 +17,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	desktop_damage_whole_container(e->con);
 }
 
-static void handle_finish(struct sway_seat *seat) {
+static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_move_floating_event *e = seat->seatop_data;
 
 	// We "move" the container to its own location

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -226,7 +226,7 @@ static bool is_parallel(enum sway_container_layout layout,
 	return layout_is_horiz == edge_is_horiz;
 }
 
-static void handle_finish(struct sway_seat *seat) {
+static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_move_tiling_event *e = seat->seatop_data;
 
 	if (!e->target_node) {

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -142,7 +142,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	arrange_container(con);
 }
 
-static void handle_finish(struct sway_seat *seat) {
+static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 	cursor_set_image(seat->cursor, "left_ptr", NULL);
 }
 

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -49,7 +49,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	}
 }
 
-static void handle_finish(struct sway_seat *seat) {
+static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 	cursor_set_image(seat->cursor, "left_ptr", NULL);
 }
 


### PR DESCRIPTION
All seat operations except "down" eat the button pressed event and don't send
it to clients. Thus, when ending such seat operations we shouldn't send the
button released event.

This commit moves the logic used to send pressed/released into the "down"
operation.

Related to https://github.com/swaywm/wlroots/pull/1586