### PR TITLE
Use clang analyzer_noreturn on assertion handler

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -20,6 +20,15 @@ typedef enum {
 #define ATTRIB_PRINTF(start, end)
 #endif
 
+#if !defined(CLANG_ANALYZER_NORETURN) && defined(__has_feature)
+#if __has_feature(attribute_analyzer_noreturn)
+#define CLANG_ANALYZER_NORETURN __attribute__((analyzer_noreturn))
+#endif
+#endif
+#ifndef CLANG_ANALYZER_NORETURN
+#define CLANG_ANALYZER_NORETURN
+#endif
+
 void error_handler(int sig);
 
 typedef void (*terminate_callback_t)(int exit_code);
@@ -31,7 +40,7 @@ void sway_log_init(sway_log_importance_t verbosity, terminate_callback_t termina
 void _sway_log(sway_log_importance_t verbosity, const char *format, ...) ATTRIB_PRINTF(2, 3);
 void _sway_vlog(sway_log_importance_t verbosity, const char *format, va_list args) ATTRIB_PRINTF(2, 0);
 void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
-bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
+bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3) CLANG_ANALYZER_NORETURN;
 
 // TODO: get meson to precompute this, for better reproducibility/less overhead
 const char *_sway_strip_path(const char *filepath);


### PR DESCRIPTION
This patch allows the use of Clang static analyzer “scan-build” more easily, as discussed in #3657 some time ago.
If the assertion handler is not tagged, a lot of false positives are generated by Clang static analyzer.

> `_sway_assert` isn't really `noreturn`, we need to handle the case in which it returns.
>
> (Besides, there is a C11 way to mark functions as `noreturn`)

_Originally posted by @emersion in https://github.com/swaywm/sway/issues/3657#issuecomment-462631848_

Apparently, Clang is not bothered by that, and it does not impact code generation, but only helps with static analysis.

> The Clang-specific 'analyzer_noreturn' attribute is almost identical to 'noreturn' except that it is ignored by the compiler for the purposes of code generation.
>
> This attribute is useful for annotating assertion handlers that actually can return, but for the purpose of using the analyzer we want to pretend that such functions do not return.

_From https://clang-analyzer.llvm.org/annotations.html#custom_assertions_


To use scan-build:

    CC=clang CXX=clang++ meson setup buildclang
    cd buildclang
    ninja scan-build


I’m not sure that this patch should absolutely be merged, but it is useful. Clang finds 19 “bugs” on 416c6ec.


Thanks!