### PR TITLE
Minor fix of code duplication.

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -186,11 +186,7 @@ static void log_kernel(void) {
 
 static bool drop_permissions(void) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
-		if (setgid(getgid()) != 0) {
-			sway_log(SWAY_ERROR, "Unable to drop root, refusing to start");
-			return false;
-		}
-		if (setuid(getuid()) != 0) {
+		if (setuid(getuid()) != 0 || setgid(getgid()) != 0) {
 			sway_log(SWAY_ERROR, "Unable to drop root, refusing to start");
 			return false;
 		}


### PR DESCRIPTION
This change removes 3~ lines of code that didn't need to be restated. Doesn't modify functionality, except for reordering the checks in the nested if statement to mirror its parent aesthetically.