### PR TITLE
ci: use scdoc-git because 1.9.1 is broken

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -12,7 +12,6 @@ packages:
   - meson
   - pango-dev
   - pixman-dev
-  - scdoc
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev
@@ -20,7 +19,12 @@ packages:
 sources:
   - https://github.com/swaywm/sway
   - https://github.com/swaywm/wlroots
+  - https://git.sr.ht/~sircmpwn/scdoc
 tasks:
+  - scdoc: |
+      cd scdoc
+      make PREFIX=/usr
+      sudo make install PREFIX=/usr
   - wlroots: |
       cd wlroots
       meson --prefix=/usr build -Drootston=false -Dexamples=false

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -8,7 +8,6 @@ packages:
   - libxkbcommon
   - meson
   - pango
-  - scdoc
   - wayland
   - wayland-protocols
   - xcb-util-image
@@ -16,7 +15,12 @@ packages:
 sources:
   - https://github.com/swaywm/sway
   - https://github.com/swaywm/wlroots
+  - https://git.sr.ht/~sircmpwn/scdoc
 tasks:
+  - scdoc: |
+      cd scdoc
+      make PREFIX=/usr
+      sudo make install PREFIX=/usr
   - wlroots: |
       cd wlroots
       meson --prefix=/usr build -Drootston=false -Dexamples=false

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -8,7 +8,6 @@ packages:
 - graphics/gdk-pixbuf2
 - graphics/wayland
 - graphics/wayland-protocols
-- textproc/scdoc
 - x11-toolkits/pango
 - x11/libxcb
 - x11/libxkbcommon
@@ -22,10 +21,17 @@ packages:
 - x11/libX11
 - x11/pixman
 - x11/xcb-util-wm
+# scdoc dependencies
+- devel/gmake
 sources:
 - https://github.com/swaywm/sway
 - https://github.com/swaywm/wlroots
+- https://git.sr.ht/~sircmpwn/scdoc
 tasks:
+- scdoc: |
+    cd scdoc
+    gmake PREFIX=/usr/local
+    sudo gmake install PREFIX=/usr/local
 - fixup_epoll: |
     cat << 'EOF' | sudo tee /usr/local/libdata/pkgconfig/epoll-shim.pc
     prefix=/usr/local


### PR DESCRIPTION
Follow-up issue: revert this patch when scdoc-1.9.2 is released and included in all the platforms we support.