### PR TITLE
floating_maximum_size: change default behavior

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -212,6 +212,9 @@ void container_update_representation(struct sway_container *container);
  */
 size_t container_titlebar_height(void);
 
+void floating_calculate_constraints(int *min_width, int *max_width,
+		int *min_height, int *max_height);
+
 /**
  * Resize and center the container in its workspace.
  */

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -66,45 +66,6 @@ static int parse_resize_amount(int argc, char **argv,
 	return 2;
 }
 
-static void calculate_constraints(int *min_width, int *max_width,
-		int *min_height, int *max_height) {
-	struct sway_container *con = config->handler_context.container;
-
-	if (config->floating_minimum_width == -1) { // no minimum
-		*min_width = 0;
-	} else if (config->floating_minimum_width == 0) { // automatic
-		*min_width = 75;
-	} else {
-		*min_width = config->floating_minimum_width;
-	}
-
-	if (config->floating_minimum_height == -1) { // no minimum
-		*min_height = 0;
-	} else if (config->floating_minimum_height == 0) { // automatic
-		*min_height = 50;
-	} else {
-		*min_height = config->floating_minimum_height;
-	}
-
-	if (config->floating_maximum_width == -1 ||
-			container_is_scratchpad_hidden(con)) { // no max
-		*max_width = INT_MAX;
-	} else if (config->floating_maximum_width == 0) { // automatic
-		*max_width = con->workspace->width;
-	} else {
-		*max_width = config->floating_maximum_width;
-	}
-
-	if (config->floating_maximum_height == -1 ||
-			container_is_scratchpad_hidden(con)) { // no max
-		*max_height = INT_MAX;
-	} else if (config->floating_maximum_height == 0) { // automatic
-		*max_height = con->workspace->height;
-	} else {
-		*max_height = config->floating_maximum_height;
-	}
-}
-
 static uint32_t parse_resize_axis(const char *axis) {
 	if (strcasecmp(axis, "width") == 0 || strcasecmp(axis, "horizontal") == 0) {
 		return AXIS_HORIZONTAL;
@@ -258,7 +219,8 @@ static struct cmd_results *resize_adjust_floating(uint32_t axis,
 
 	// Make sure we're not adjusting beyond floating min/max size
 	int min_width, max_width, min_height, max_height;
-	calculate_constraints(&min_width, &max_width, &min_height, &max_height);
+	floating_calculate_constraints(&min_width, &max_width,
+			&min_height, &max_height);
 	if (con->width + grow_width < min_width) {
 		grow_width = min_width - con->width;
 	} else if (con->width + grow_width > max_width) {
@@ -383,7 +345,8 @@ static struct cmd_results *resize_set_tiled(struct sway_container *con,
 static struct cmd_results *resize_set_floating(struct sway_container *con,
 		struct resize_amount *width, struct resize_amount *height) {
 	int min_width, max_width, min_height, max_height, grow_width = 0, grow_height = 0;
-	calculate_constraints(&min_width, &max_width, &min_height, &max_height);
+	floating_calculate_constraints(&min_width, &max_width,
+			&min_height, &max_height);
 
 	if (width->amount) {
 		switch (width->unit) {

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -17,41 +17,6 @@ struct seatop_resize_floating_event {
 	double ref_con_lx, ref_con_ly; // container's x/y at start of op
 };
 
-static void calculate_floating_constraints(struct sway_container *con,
-		int *min_width, int *max_width, int *min_height, int *max_height) {
-	if (config->floating_minimum_width == -1) { // no minimum
-		*min_width = 0;
-	} else if (config->floating_minimum_width == 0) { // automatic
-		*min_width = 75;
-	} else {
-		*min_width = config->floating_minimum_width;
-	}
-
-	if (config->floating_minimum_height == -1) { // no minimum
-		*min_height = 0;
-	} else if (config->floating_minimum_height == 0) { // automatic
-		*min_height = 50;
-	} else {
-		*min_height = config->floating_minimum_height;
-	}
-
-	if (config->floating_maximum_width == -1) { // no maximum
-		*max_width = INT_MAX;
-	} else if (config->floating_maximum_width == 0) { // automatic
-		*max_width = con->workspace->width;
-	} else {
-		*max_width = config->floating_maximum_width;
-	}
-
-	if (config->floating_maximum_height == -1) { // no maximum
-		*max_height = INT_MAX;
-	} else if (config->floating_maximum_height == 0) { // automatic
-		*max_height = con->workspace->height;
-	} else {
-		*max_height = config->floating_maximum_height;
-	}
-}
-
 static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_resize_floating_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
@@ -85,7 +50,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec) {
 	double width = e->ref_width + grow_width;
 	double height = e->ref_height + grow_height;
 	int min_width, max_width, min_height, max_height;
-	calculate_floating_constraints(con, &min_width, &max_width,
+	floating_calculate_constraints(&min_width, &max_width,
 			&min_height, &max_height);
 	width = fmax(min_width, fmin(width, max_width));
 	height = fmax(min_height, fmin(height, max_height));

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -430,7 +430,8 @@ The default colors are:
 
 *floating_maximum_size* <width> x <height>
 	Specifies the maximum size of floating windows. -1 x -1 removes the upper
-	limit.
+	limit. The default is 0 x 0, which will use the width and height of the
+	entire output layout as the maximums
 
 *floating_minimum_size* <width> x <height>
 	Specifies the minimum size of floating windows. The default is 75 x 50.


### PR DESCRIPTION
Fixes #3718 
Fixes #3593 

This changes the way zero (which is the default) is interpreted for both
the width and height of `floating_maximum_size`. It now refers to the
width and height of the entire output layout, which matches i3's
behavior.

This also removes duplicated code to calculate the floating constraints
in three files. Before this, `container_init_floating` used two-thirds
of the workspace width/height as the max and the entire workspace
width/height was used everywhere else. Now, all callers use a single
function `floating_calculate_constraints`.