### PR TITLE
render_floating: skip fullscreen floaters

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -944,6 +944,9 @@ static void render_floating(struct sway_output *soutput,
 			}
 			for (int k = 0; k < ws->current.floating->length; ++k) {
 				struct sway_container *floater = ws->current.floating->items[k];
+				if (floater->fullscreen_mode != FULLSCREEN_NONE) {
+					continue;
+				}
 				render_floating_container(soutput, damage, floater);
 			}
 		}


### PR DESCRIPTION
Fixes #3808 

If a floater is fullscreen either on a workspace or globally, it
should not be rendered on any output is is not fullscreened on. When
rendering it on an output it should not be rendered on, there will be
an extraneous border along the adjacent side of the output. This adds
a check in render_floating to skip all fullscreened floaters