### PR TITLE
Allow concurrent clicks

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -613,6 +613,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 		} else {
 			state_erase_button(cursor, button);
 		}
+		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;
 	}
 
@@ -681,6 +682,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	if (cont && resize_edge && button == BTN_LEFT &&
 			state == WLR_BUTTON_PRESSED && !is_floating) {
 		seat_set_focus_container(seat, cont);
+		seat_pointer_notify_button(seat, time_msec, button, state);
 		seatop_begin_resize_tiling(seat, cont, button, edge);
 		return;
 	}
@@ -711,6 +713,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			}
 			cursor_set_image(seat->cursor, image, NULL);
 			seat_set_focus_container(seat, cont);
+			seat_pointer_notify_button(seat, time_msec, button, state);
 			seatop_begin_resize_tiling(seat, cont, button, edge);
 			return;
 		}
@@ -726,6 +729,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 				cont = cont->parent;
 			}
 			seat_set_focus_container(seat, cont);
+			seat_pointer_notify_button(seat, time_msec, button, state);
 			seatop_begin_move_floating(seat, cont, button);
 			return;
 		}
@@ -736,6 +740,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 			state == WLR_BUTTON_PRESSED) {
 		// Via border
 		if (button == BTN_LEFT && resize_edge != WLR_EDGE_NONE) {
+			seat_pointer_notify_button(seat, time_msec, button, state);
 			seatop_begin_resize_floating(seat, cont, button, resize_edge);
 			return;
 		}
@@ -753,6 +758,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 				WLR_EDGE_RIGHT : WLR_EDGE_LEFT;
 			edge |= cursor->cursor->y > floater->y + floater->height / 2 ?
 				WLR_EDGE_BOTTOM : WLR_EDGE_TOP;
+			seat_pointer_notify_button(seat, time_msec, button, state);
 			seatop_begin_resize_floating(seat, floater, button, edge);
 			return;
 		}
@@ -784,6 +790,7 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 	if (surface && cont && state == WLR_BUTTON_PRESSED) {
 		seat_set_focus_container(seat, cont);
 		seatop_begin_down(seat, cont, time_msec, button, sx, sy);
+		seat_pointer_notify_button(seat, time_msec, button, WLR_BUTTON_PRESSED);
 		return;
 	}
 

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -40,8 +40,6 @@ static void handle_finish(struct sway_seat *seat, uint32_t time_msec) {
 				cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 		cursor_send_pointer_motion(cursor, 0, node, surface, sx, sy);
 	}
-	seat_pointer_notify_button(seat, time_msec,
-		seat->seatop_button, WLR_BUTTON_RELEASED);
 }
 
 static void handle_abort(struct sway_seat *seat) {
@@ -82,6 +80,5 @@ void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
 	seat->seatop_data = e;
 	seat->seatop_button = button;
 
-	seat_pointer_notify_button(seat, time_msec, button, WLR_BUTTON_PRESSED);
 	container_raise_floating(con);
 }


### PR DESCRIPTION
If two cursor buttons are pressed at the same time, the client will now be notified of the second button press.

The main reason for not sending the concurrent presses was due to an early return in `dispatch_cursor_button` if a seatop is in progress. This patch makes it call `seat_pointer_notify_button` prior to returning. But it also has to make sure there's not a mismatch in events such as a release without a press.

Prior to this patch, the `down` seatop would send press and release events in its begin and finish functions. No other seatops did this. A press event would be sent prior to starting tiling drag, but never an associated release.

After this patch, no seatops send their own press or release events. We send them prior to calling the seatop begin functions, then the first part of `dispatch_cursor_button` handles all presses during seatops and when releasing the seatop.

To test:

* Use DRM (you can't test this with the wayland backend, as the DRM sway won't send concurrent clicks to the nested sway)
* Run `weston-eventdemo`
* Press and hold left mouse button
* Press right mouse button - note event in the weston-eventdemo stdout

Fixes #3539.