### PR TITLE
meson: update scdoc requirement to >= 1.9.2

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -38,7 +38,7 @@ Instale las dependencias:
 * pango
 * cairo
 * gdk-pixbuf2 \*\*
-* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) >= 1.9.0 (optional: man pages) \*
+* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*
 * git \*
 
 _\*Compile-time dep_

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install dependencies:
 * pango
 * cairo
 * gdk-pixbuf2 \*\*
-* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) >= 1.9.0 (optional: man pages) \*
+* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*
 * git \*
 
 _\*Compile-time dep_

--- a/README.pl.md
+++ b/README.pl.md
@@ -39,7 +39,7 @@ Zainstaluj zależności:
 * pango
 * cairo
 * gdk-pixbuf2 \*\*
-* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) >= 1.9.0 (opcjonalnie: strony pomocy man) \*
+* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (opcjonalnie: strony pomocy man) \*
 * git \*
 
 _\*zależności kompilacji_

--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ conf_data.set10('HAVE_SYSTEMD', systemd.found())
 conf_data.set10('HAVE_ELOGIND', elogind.found())
 conf_data.set10('HAVE_TRAY', have_tray)
 
-scdoc = dependency('scdoc', version: '>=1.9', native: true, required: get_option('man-pages'))
+scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
 if scdoc.found()
 	scdoc_prog = find_program('scdoc')
 	sh = find_program('sh')


### PR DESCRIPTION
Since scdoc 1.9.1 is bugged, this updates the meson version check to
 \>= 1.9.2 and drops the version requirement from the README. This should
make it more obvious to users who have 1.9.1 that they need to update
scdoc to be able to compile man pages and hopefully cut down on the
duplicate issues