### PR TITLE
ipc: change {,deco_}rect to match i3

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -314,14 +314,15 @@ node and will have the following properties:
    and other special nodes such as the scratchpad
 |- rect
 :  object
-:  The absolute geometry of the node
+:  The absolute geometry of the node. The window decorations are excluded from
+   this, but borders are included.
 |- window_rect
 :  object
 :  The geometry of the contents inside the node. The window decorations are
    excluded from this calculation, but borders are included.
 |- deco_rect
 :  object
-:  The geometry of the decorations inside the node
+:  The geometry of the decorations for the node relative to the parent node
 |- geometry
 :  object
 :  The natural geometry of the contents if it were to size itself


### PR DESCRIPTION
Related to #3821 

This fixes the `deco_rect` and `rect` properties in the IPC responses
to match i3's behavior.

`deco_rect` should be relative to the parent node, not the current
node. This also takes tabbed and stacked decorations into account and
will calculate `deco_rect` for all containers since tabbed and stacked
child containers will have decorations.

`rect` should exclude the window decorations.