### PR TITLE
ipc: fix rect for stacked children

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -535,8 +535,12 @@ json_object *ipc_json_describe_node(struct sway_node *node) {
 	if (node->type == N_CONTAINER) {
 		struct wlr_box deco_rect = {0, 0, 0, 0};
 		get_deco_rect(node->sway_container, &deco_rect);
-		box.y += deco_rect.height;
-		box.height -= deco_rect.height;
+		size_t count = 1;
+		if (container_parent_layout(node->sway_container) == L_STACKED) {
+			count = container_get_siblings(node->sway_container)->length;
+		}
+		box.y += deco_rect.height * count;
+		box.height -= deco_rect.height * count;
 	}
 
 	json_object *focus = json_object_new_array();


### PR DESCRIPTION
Related to #3821 

This now takes all titlebars for stacked children into account for the
ipc property `rect`