### PR TITLE
damage: remove output_damage_view

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -450,17 +450,13 @@ void output_damage_surface(struct sway_output *output, double ox, double oy,
 		damage_surface_iterator, &whole);
 }
 
-static void output_damage_view(struct sway_output *output,
-		struct sway_view *view, bool whole) {
+void output_damage_from_view(struct sway_output *output,
+		struct sway_view *view) {
 	if (!view_is_visible(view)) {
 		return;
 	}
+	bool whole = false;
 	output_view_for_each_surface(output, view, damage_surface_iterator, &whole);
-}
-
-void output_damage_from_view(struct sway_output *output,
-		struct sway_view *view) {
-	output_damage_view(output, view, false);
 }
 
 // Expecting an unscaled box in layout coordinates


### PR DESCRIPTION
Closes #1883
Related #3822 

This removes `output_damage_view` since it is unnecessary. The logic
has been moved into its only caller `output_damage_from_view`. When
damaging the whole view, `output_damage_whole_container` should be used
instead