### PR TITLE
Add -p/--pretty option to swaymsg

### DIFF
--- a/completions/bash/swaymsg
+++ b/completions/bash/swaymsg
@@ -21,6 +21,7 @@ _swaymsg()
 
   short=(
     -h
+    -p
     -q
     -r
     -s
@@ -30,6 +31,7 @@ _swaymsg()
 
   long=(
     --help
+    --pretty
     --quiet
     --raw
     --socket

--- a/completions/fish/swaymsg.fish
+++ b/completions/fish/swaymsg.fish
@@ -2,10 +2,11 @@
 
 complete -f -c swaymsg
 complete -c swaymsg -s h -l help --description "Show help message and quit."
+complete -c swaymsg -s p -l pretty --description "Use pretty output even when not using a tty."
 complete -c swaymsg -s q -l quiet --description "Sends the IPC message but does not print the response from sway."
-complete -c swaymsg -s v -l version --description "Print the version (of swaymsg) and quit."
 complete -c swaymsg -s r -l raw --description "Use raw output even if using tty."
 complete -c swaymsg -s s -l socket -r --description "Use the specified socket path. Otherwise, swaymsg will ask where the socket is (which is the value of $SWAYSOCK, then of $I3SOCK)."
+complete -c swaymsg -s v -l version --description "Print the version (of swaymsg) and quit."
 
 complete -c swaymsg -s t -l type -fr --description "Specify the type of IPC message."
 complete -c swaymsg -s t -l type -fra 'get_workspaces' --description "Gets a JSON-encoded list of workspaces and their status."

--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -28,10 +28,11 @@ types=(
 )
 
 _arguments -s \
-	'(-v --version)'{-v,--version}'[Show the version number and quit]' \
-	'(-m --monitor)'{-m,--monitor}'[Monitor until killed (-t SUBSCRIBE only)]' \
 	'(-h --help)'{-h,--help}'[Show help message and quit]' \
+	'(-m --monitor)'{-m,--monitor}'[Monitor until killed (-t SUBSCRIBE only)]' \
+	'(-p --pretty)'{-p,--pretty}'[Use pretty output even when not using a tty]' \
 	'(-q --quiet)'{-q,--quiet}'[Be quiet]' \
 	'(-r --raw)'{-r,--raw}'[Use raw output even if using a tty]' \
 	'(-s --socket)'{-s,--socket}'[Use the specified socket path]:files:_files' \
-	'(-t --type)'{-t,--type}'[Specify the message type]:type:{_describe "type" types}'
+	'(-t --type)'{-t,--type}'[Specify the message type]:type:{_describe "type" types}' \
+	'(-v --version)'{-v,--version}'[Show the version number and quit]'

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -326,6 +326,7 @@ int main(int argc, char **argv) {
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"monitor", no_argument, NULL, 'm'},
+		{"pretty", no_argument, NULL, 'p'},
 		{"quiet", no_argument, NULL, 'q'},
 		{"raw", no_argument, NULL, 'r'},
 		{"socket", required_argument, NULL, 's'},
@@ -339,6 +340,7 @@ int main(int argc, char **argv) {
 		"\n"
 		"  -h, --help             Show help message and quit.\n"
 		"  -m, --monitor          Monitor until killed (-t SUBSCRIBE only)\n"
+		"  -p, --pretty           Use pretty output even when not using a tty\n"
 		"  -q, --quiet            Be quiet.\n"
 		"  -r, --raw              Use raw output even if using a tty\n"
 		"  -s, --socket <socket>  Use the specified socket.\n"
@@ -350,13 +352,16 @@ int main(int argc, char **argv) {
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hmqrs:t:v", long_options, &option_index);
+		c = getopt_long(argc, argv, "hmpqrs:t:v", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 'm': // Monitor
 			monitor = true;
+			break;
+		case 'p': // Pretty
+			raw = false;
 			break;
 		case 'q': // Quiet
 			quiet = true;

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -19,6 +19,9 @@ _swaymsg_ [options...] [message]
 	there is a malformed response or an invalid event type was requested,
 	swaymsg will stop monitoring and exit.
 
+*-p, --pretty*
+	Use raw output even when not using a tty.
+
 *-q, --quiet*
 	Sends the IPC message but does not print the response from sway.
 


### PR DESCRIPTION
This new option forces pretty (non-raw/non-JSON) output. By default, when
not using a tty, swaymsg outputs using the "raw" format. This makes it
impossible to, for example, pipe the pretty output to a pager such as
`less` since piping does not use a tty.

The new -p/--pretty option gives the user explicit control over the output
format while retaining the default tty-dependent behavior.

Signed-off-by: Peter Grayson <pete@jpgrayson.net>