### PR TITLE
fix "directive argument is null" errors

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -624,8 +624,8 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 				in_quotes = false;
 			}
 			unescape(value);
+			sway_log(SWAY_DEBUG, "Found pair: %s=%s", name, value);
 		}
-		sway_log(SWAY_DEBUG, "Found pair: %s=%s", name, value);
 		if (!parse_token(criteria, name, value)) {
 			*error_arg = error;
 			goto cleanup;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -705,8 +705,7 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 		seat->cursor->xcursor_manager =
 			wlr_xcursor_manager_create(cursor_theme, 24);
 		if (sway_assert(seat->cursor->xcursor_manager,
-					"Cannot create XCursor manager for theme %s",
-					cursor_theme)) {
+					"Cannot create XCursor manager for theme")) {
 			return;
 		}
 	}


### PR DESCRIPTION
In sway/criteria.c - value was the offender. Moved the logging call up to where value is not guaranteed to e NULL.

In sway/input/seat.c - until cursor_theme is configurable, it shouldn't be passed to sway_assert. It's already marked with a TODO, so I'm sure the logging can be changed back later.

Full disclosure: I have not (yet) tested these changes.