### PR TITLE
arrange: use int not size_t for title offsets

### DIFF
--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -99,7 +99,7 @@ static void apply_tabbed_layout(list_t *children, struct wlr_box *parent) {
 	}
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
-		size_t parent_offset = child->view ? 0 : container_titlebar_height();
+		int parent_offset = child->view ? 0 : container_titlebar_height();
 		container_remove_gaps(child);
 		child->x = parent->x;
 		child->y = parent->y + parent_offset;
@@ -115,7 +115,7 @@ static void apply_stacked_layout(list_t *children, struct wlr_box *parent) {
 	}
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
-		size_t parent_offset = child->view ?  0 :
+		int parent_offset = child->view ?  0 :
 			container_titlebar_height() * children->length;
 		container_remove_gaps(child);
 		child->x = parent->x;


### PR DESCRIPTION
Fixes #3845 
Related to #3333

This changes `apply_tabbed_layout` and `apply_stacked_layout` to use
`int` instead of `size_t`. This is necessary for tabbed and stacked
containers to be positioned correctly when the y-location is negative.
The reasoning for this is signed plus unsigned is always an unsigned
value. This was causing the y-location of the container to be
positioned near `INT_MIN` due to an unsigned integer underflow

_`ssize_t` will also work, but I feel like `int` is better since `ssize_t`
makes it seem like the titlebar height can be negative_