### PR TITLE
Fix crash in cmd_workspace when layer surface has focus

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -184,6 +184,11 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		bool create = argc > 1 && strcasecmp(argv[1], "--create") == 0;
 		struct sway_seat *seat = config->handler_context.seat;
 		struct sway_workspace *current = seat_get_focused_workspace(seat);
+		if (!current) {
+			return cmd_results_new(CMD_FAILURE, "workspace",
+				"No workspace to switch from");
+		}
+
 		struct sway_workspace *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
 			if (argc < 2) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1101,7 +1101,7 @@ struct sway_node *seat_get_focus(struct sway_seat *seat) {
 }
 
 struct sway_workspace *seat_get_focused_workspace(struct sway_seat *seat) {
-	struct sway_node *focus = seat_get_focus(seat);
+	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
 	if (!focus) {
 		return NULL;
 	}
@@ -1111,7 +1111,7 @@ struct sway_workspace *seat_get_focused_workspace(struct sway_seat *seat) {
 	if (focus->type == N_WORKSPACE) {
 		return focus->sway_workspace;
 	}
-	return NULL; // unreachable
+	return NULL; // output doesn't have a workspace yet
 }
 
 struct sway_container *seat_get_focused_container(struct sway_seat *seat) {


### PR DESCRIPTION
This changes `seat_get_focused_workspace` to use `seat_get_focus_inactive` instead of `seat_get_focus`. This may break things, but I can't think of a situation in which it would.

We still need to check whether `seat_get_focused_workspace` is NULL.

Follow-up issue: check all other `seat_get_focused_workspace` calls.

Test plan: run `sleep 5; swaymsg workspace prev_on_output`, then run `slurp` in another terminal

Fixes https://github.com/swaywm/sway/issues/3795