### PR TITLE
fullscreen: init floating on disable without size

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -984,6 +984,13 @@ void container_fullscreen_disable(struct sway_container *con) {
 		root->fullscreen_global = NULL;
 	}
 
+	// If the container was mapped as fullscreen and set as floating by
+	// criteria, it needs to be reinitialized as floating to get the proper
+	// size and location
+	if (container_is_floating(con) && (con->width == 0 || con->height == 0)) {
+		container_init_floating(con);
+	}
+
 	con->fullscreen_mode = FULLSCREEN_NONE;
 	container_end_mouse_operation(con);
 	ipc_event_window(con, "fullscreen_mode");


### PR DESCRIPTION
Fixes #3850 

If a container gets mapped as fullscreen and set to floating by
criteria, the size and location are never set for the floating
container. This adds a check in container_fullscreen_disable for a
width or height of 0 and calls container_init_floating

_Note that the content may be smaller than the container due to the
natural size being larger than the maximum floating size and the
client giving a smaller surface of the same aspect ratio. I think
this is related to #2176 (or at least the discussion in the issue)_