### PR TITLE
Stop using wlr_output->{lx,ly}

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -29,8 +29,8 @@ struct sway_output {
 	struct timespec last_frame;
 	struct wlr_output_damage *damage;
 
-	int lx, ly;
-	int width, height;
+	int lx, ly; // layout coords
+	int width, height; // transformed buffer size
 
 	bool enabled, configured;
 	list_t *workspaces;
@@ -144,7 +144,7 @@ void output_get_box(struct sway_output *output, struct wlr_box *box);
 enum sway_container_layout output_get_default_layout(
 		struct sway_output *output);
 
-void render_rect(struct wlr_output *wlr_output,
+void render_rect(struct sway_output *output,
 		pixman_region32_t *output_damage, const struct wlr_box *_box,
 		float color[static 4]);
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -319,6 +319,14 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_output_layout_add_auto(root->output_layout, wlr_output);
 	}
 
+	// Update output->{lx, ly, width, height}
+	struct wlr_box *output_box =
+		wlr_output_layout_get_box(root->output_layout, wlr_output);
+	output->lx = output_box->x;
+	output->ly = output_box->y;
+	wlr_output_transformed_resolution(wlr_output,
+		&output->width, &output->height);
+
 	if (output->swaybg_client != NULL) {
 		wl_client_destroy(output->swaybg_client);
 	}

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -6,8 +6,10 @@ void desktop_damage_surface(struct wlr_surface *surface, double lx, double ly,
 		bool whole) {
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		output_damage_surface(output, lx - output->wlr_output->lx,
-				ly - output->wlr_output->ly, surface, whole);
+		struct wlr_box *output_box = wlr_output_layout_get_box(
+			root->output_layout, output->wlr_output);
+		output_damage_surface(output, lx - output_box->x,
+			ly - output_box->y, surface, whole);
 	}
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -150,9 +150,9 @@ void output_view_for_each_surface(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.content_x - output->wlr_output->lx
+		.ox = view->container->current.content_x - output->lx
 			- view->geometry.x,
-		.oy = view->container->current.content_y - output->wlr_output->ly
+		.oy = view->container->current.content_y - output->ly
 			- view->geometry.y,
 		.width = view->container->current.content_width,
 		.height = view->container->current.content_height,
@@ -169,9 +169,9 @@ void output_view_for_each_popup(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.content_x - output->wlr_output->lx
+		.ox = view->container->current.content_x - output->lx
 			- view->geometry.x,
-		.oy = view->container->current.content_y - output->wlr_output->ly
+		.oy = view->container->current.content_y - output->ly
 			- view->geometry.y,
 		.width = view->container->current.content_width,
 		.height = view->container->current.content_height,
@@ -202,8 +202,8 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 	wl_list_for_each(unmanaged_surface, unmanaged, link) {
 		struct wlr_xwayland_surface *xsurface =
 			unmanaged_surface->wlr_xwayland_surface;
-		double ox = unmanaged_surface->lx - output->wlr_output->lx;
-		double oy = unmanaged_surface->ly - output->wlr_output->ly;
+		double ox = unmanaged_surface->lx - output->lx;
+		double oy = unmanaged_surface->ly - output->ly;
 
 		output_surface_for_each_surface(output, xsurface->surface, ox, oy,
 			iterator, user_data);
@@ -216,8 +216,8 @@ void output_drag_icons_for_each_surface(struct sway_output *output,
 		void *user_data) {
 	struct sway_drag_icon *drag_icon;
 	wl_list_for_each(drag_icon, drag_icons, link) {
-		double ox = drag_icon->x - output->wlr_output->lx;
-		double oy = drag_icon->y - output->wlr_output->ly;
+		double ox = drag_icon->x - output->lx;
+		double oy = drag_icon->y - output->ly;
 
 		if (drag_icon->wlr_drag_icon->mapped) {
 			output_surface_for_each_surface(output,
@@ -463,8 +463,8 @@ void output_damage_from_view(struct sway_output *output,
 void output_damage_box(struct sway_output *output, struct wlr_box *_box) {
 	struct wlr_box box;
 	memcpy(&box, _box, sizeof(struct wlr_box));
-	box.x -= output->wlr_output->lx;
-	box.y -= output->wlr_output->ly;
+	box.x -= output->lx;
+	box.y -= output->ly;
 	scale_box(&box, output->wlr_output->scale);
 	wlr_output_damage_add_box(output->damage, &box);
 }
@@ -484,8 +484,8 @@ void output_damage_whole_container(struct sway_output *output,
 		struct sway_container *con) {
 	// Pad the box by 1px, because the width is a double and might be a fraction
 	struct wlr_box box = {
-		.x = con->current.x - output->wlr_output->lx - 1,
-		.y = con->current.y - output->wlr_output->ly - 1,
+		.x = con->current.x - output->lx - 1,
+		.y = con->current.y - output->ly - 1,
 		.width = con->current.width + 2,
 		.height = con->current.height + 2,
 	};

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -37,7 +37,7 @@ static void handle_render(struct sway_seat *seat,
 		struct wlr_box box;
 		memcpy(&box, &e->drop_box, sizeof(struct wlr_box));
 		scale_box(&box, output->wlr_output->scale);
-		render_rect(output->wlr_output, damage, &box, color);
+		render_rect(output, damage, &box, color);
 	}
 }
 

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -195,8 +195,8 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	double prev_y = workspace->y;
 	workspace->width = area->width;
 	workspace->height = area->height;
-	workspace->x = output->wlr_output->lx + area->x;
-	workspace->y = output->wlr_output->ly + area->y;
+	workspace->x = output->lx + area->x;
+	workspace->y = output->ly + area->y;
 
 	// Adjust any floating containers
 	double diff_x = workspace->x - prev_x;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -101,11 +101,6 @@ void output_enable(struct sway_output *output, struct output_config *oc) {
 	output->configured = true;
 	list_add(root->outputs, output);
 
-	output->lx = wlr_output->lx;
-	output->ly = wlr_output->ly;
-	wlr_output_transformed_resolution(wlr_output,
-			&output->width, &output->height);
-
 	restore_workspaces(output);
 
 	struct sway_workspace *ws = NULL;
@@ -311,8 +306,10 @@ struct sway_output *output_get_in_direction(struct sway_output *reference,
 	if (!sway_assert(direction, "got invalid direction: %d", direction)) {
 		return NULL;
 	}
-	int lx = reference->wlr_output->lx + reference->width / 2;
-	int ly = reference->wlr_output->ly + reference->height / 2;
+	struct wlr_box *output_box =
+		wlr_output_layout_get_box(root->output_layout, reference->wlr_output);
+	int lx = output_box->x + output_box->width / 2;
+	int ly = output_box->y + output_box->height / 2;
 	struct wlr_output *wlr_adjacent = wlr_output_layout_adjacent_output(
 			root->output_layout, direction, reference->wlr_output, lx, ly);
 	if (!wlr_adjacent) {


### PR DESCRIPTION
This is an update for https://github.com/swaywm/wlroots/pull/1611. It doesn't depend on it though, and can be merged before.

Also fixes sway_output->{lx,ly,width,height} not being updated. Also fixes
output_get_in_direction adding buffer coords to layout coords.