### PR TITLE
Fix size_t temporary underflow in log_loaded_themes

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -307,16 +307,16 @@ static void log_loaded_themes(list_t *themes) {
 		return;
 	}
 
-	const char *sep = ", ";
+	const char sep[] = ", ";
 	size_t sep_len = strlen(sep);
 
-	size_t len = 1 - sep_len;
+	size_t len = 0;
 	for (int i = 0; i < themes->length; ++i) {
 		struct icon_theme *theme = themes->items[i];
 		len += strlen(theme->name) + sep_len;
 	}
 
-	char *str = malloc(len);
+	char *str = malloc(len + 1);
 	if (!str) {
 		return;
 	}


### PR DESCRIPTION
`len` will underflow but will overflow right after, so it's not as bad as it
may appear. Still better not to under/overflow at all.

Fixes https://github.com/swaywm/sway/issues/3862