### PR TITLE
xwayland: handle floating configure request size

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -432,8 +432,16 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		return;
 	}
 	if (container_is_floating(view->container)) {
-		configure(view, view->container->current.content_x,
-				view->container->current.content_y, ev->width, ev->height);
+		// Respect minimum and maximum sizes
+		view->natural_width = ev->width;
+		view->natural_height = ev->height;
+		container_init_floating(view->container);
+
+		configure(view, view->container->content_x,
+				view->container->content_y,
+				view->container->content_width,
+				view->container->content_height);
+		node_set_dirty(&view->container->node);
 	} else {
 		configure(view, view->container->current.content_x,
 				view->container->current.content_y,


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/pull/3854#issuecomment-471356043

This makes it so the container gets resized by a configure request for
xwayland floating views. The minimum and maximum sizes are also
respected. Previously, the configure request was resizing the surface
to the size requested, but never changing the container size. This
caused the surface to be rendered outside of the container or to be
smaller than the container. The former is never ideal and the latter
makes no sense for floating views since the container itself can just
be shrunk.

Test:
- Add `for_window [class="mpv"] floating enable` to your config
- Run`mpv /path/to/image-smaller-than-output --no-config --gpu-context=x11 --fs=yes --image-display-duration=inf --force-window=immeadiate`
- Fullscreen disable
- Borders now match the mpv window size

Note: There is a single frame where the border is still 640x480 before
the configure request. I'm not sure if that can be fixed since
`--force-window=immeadiate` has the view map at 640x480 and there
is no known size change until the configure request.