### PR TITLE
Repair swaynag crash reading message from stdin

### DIFF
--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -18,7 +18,7 @@ static char *read_from_stdin(void) {
 	size_t line_size = 0;
 	ssize_t nread;
 	while ((nread = getline(&line, &line_size, stdin)) != -1) {
-		buffer = realloc(buffer, buffer_len + nread);
+		buffer = realloc(buffer, buffer_len + nread + 1);
 		snprintf(&buffer[buffer_len], nread + 1, "%s", line);
 		buffer_len += nread;
 	}


### PR DESCRIPTION
When swaynag is run with the `-l/--detailed-message option`, a crash may
occur if the detailed message read from stdin is large enough. E.g.:

    swaynag -m hello -l < ~/.config/sway/config

The root cause is that the `read_from_stdin()` function under-allocates
memory for the destination buffer which causes that buffer to be overflowed
when copying line data to it with `snprintf()`.

The repair is to allocate one more byte for the terminating null byte.

N.B. although `getline()` returns the number of bytes read excluding a
terminating null byte, the line buffer is terminated with a null byte. Thus
we have a guarantee that the line buffer will be null terminated (which is
important when copying with `snprintf()`).