### PR TITLE
config.in: allow launch apps with args via dmenu

### DIFF
--- a/config.in
+++ b/config.in
@@ -17,7 +17,7 @@ set $right l
 set $term urxvt
 # Your preferred application launcher
 # Note: it's recommended that you pass the final command to sway
-set $menu dmenu_path | dmenu | xargs swaymsg exec
+set $menu dmenu_path | dmenu | xargs swaymsg exec --
 
 ### Output configuration
 #


### PR DESCRIPTION
Without this change you can't execute apps with command line arguments (e.g. firefox -P profile) because -P will be parsed as argument for "swaymsg exec".