### PR TITLE
Handle seat_get_focused_workspace returning NULL

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -208,6 +208,11 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 				"There is no output with that name");
 		}
 		struct sway_workspace *ws = seat_get_focused_workspace(seat);
+		if (!ws) {
+			free(identifier);
+			return cmd_results_new(CMD_FAILURE,
+				"No focused workspace to base directions off of");
+		}
 		output = output_get_in_direction(ws->output, direction);
 
 		if (!output) {

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -12,6 +12,11 @@ static void scratchpad_toggle_auto(void) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_container *focus = seat_get_focused_container(seat);
 	struct sway_workspace *ws = seat_get_focused_workspace(seat);
+	if (!ws) {
+		sway_log(SWAY_DEBUG,
+				"No focused workspace to toggle scratchpad windows on");
+		return;
+	}
 
 	// If the focus is in a floating split container,
 	// operate on the split container instead of the child.

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -185,8 +185,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		struct sway_seat *seat = config->handler_context.seat;
 		struct sway_workspace *current = seat_get_focused_workspace(seat);
 		if (!current) {
-			return cmd_results_new(CMD_FAILURE, "workspace",
-				"No workspace to switch from");
+			return cmd_results_new(CMD_FAILURE, "No workspace to switch from");
 		}
 
 		struct sway_workspace *ws = NULL;
@@ -226,6 +225,9 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				ws = workspace_create(NULL, name);
 			}
 			free(name);
+		}
+		if (!ws) {
+			return cmd_results_new(CMD_FAILURE, "No workspace to switch to");
 		}
 		workspace_switch(ws, no_auto_back_and_forth);
 		seat_consider_warp_to_focus(seat);

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -373,7 +373,6 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 		struct sway_seat *seat = input_manager_get_default_seat();
 		if (seat) {
 			struct sway_workspace *ws = seat_get_focused_workspace(seat);
-
 			if (ws != NULL) {
 				output = ws->output;
 			}

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -96,6 +96,10 @@ void root_scratchpad_remove_container(struct sway_container *con) {
 void root_scratchpad_show(struct sway_container *con) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *new_ws = seat_get_focused_workspace(seat);
+	if (!new_ws) {
+		sway_log(SWAY_DEBUG, "No focused workspace to show scratchpad on");
+		return;
+	}
 	struct sway_workspace *old_ws = con->workspace;
 
 	// If the current con or any of its parents are in fullscreen mode, we

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -368,13 +368,13 @@ struct sway_workspace *workspace_by_name(const char *name) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *current = seat_get_focused_workspace(seat);
 
-	if (strcmp(name, "prev") == 0) {
+	if (current && strcmp(name, "prev") == 0) {
 		return workspace_prev(current);
-	} else if (strcmp(name, "prev_on_output") == 0) {
+	} else if (current && strcmp(name, "prev_on_output") == 0) {
 		return workspace_output_prev(current, false);
-	} else if (strcmp(name, "next") == 0) {
+	} else if (current && strcmp(name, "next") == 0) {
 		return workspace_next(current);
-	} else if (strcmp(name, "next_on_output") == 0) {
+	} else if (current && strcmp(name, "next_on_output") == 0) {
 		return workspace_output_next(current, false);
 	} else if (strcmp(name, "current") == 0) {
 		return current;
@@ -399,6 +399,11 @@ static struct sway_workspace *workspace_output_prev_next_impl(
 		struct sway_output *output, int dir, bool create) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *workspace = seat_get_focused_workspace(seat);
+	if (!workspace) {
+		sway_log(SWAY_DEBUG,
+				"No focused workspace to base prev/next on output off of");
+		return NULL;
+	}
 
 	int index = list_find(output->workspaces, workspace);
 	if (!workspace_is_empty(workspace) && create &&


### PR DESCRIPTION
Closes #3853 

This modifiers the callers of seat_get_focused_workspace to handle
getting NULL as the return value, if they did not already.