### PR TITLE
criteria: change workspace to support regex

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -35,7 +35,7 @@ struct criteria {
 	bool floating;
 	bool tiling;
 	char urgent; // 'l' for latest or 'o' for oldest
-	char *workspace;
+	pcre *workspace;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -208,7 +208,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 	if (criteria->workspace) {
 		struct sway_workspace *ws = view->container->workspace;
-		if (!ws || strcmp(ws->name, criteria->workspace) != 0) {
+		if (!ws || regex_cmp(ws->name, criteria->workspace) != 0) {
 			return false;
 		}
 	}
@@ -515,7 +515,7 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		}
 		break;
 	case T_WORKSPACE:
-		criteria->workspace = strdup(effective_value);
+		generate_regex(&criteria->workspace, effective_value);
 		break;
 	case T_INVALID:
 		break;


### PR DESCRIPTION
Fixes #3877 

This changes the workspace criteria to support regex instead of basic
strings. This matches i3's behavior.