### PR TITLE
swaybar: fix loading of malformed icon theme

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -243,6 +243,10 @@ static struct icon_theme *read_theme_file(char *basedir, char *theme_name) {
 			free(group);
 			group = strdup(&line[1]);
 		} else { // key-value pair
+			if (!group) {
+				error = true;
+				break;
+			}
 			// check well-formed
 			int eok = 0;
 			for (; isalnum(line[eok]) || line[eok] == '-'; ++eok) {} // TODO locale?


### PR DESCRIPTION
If the icon index.theme contained a key-value pair without a preceding
group header, entry_handler() would be called with a zero pointer and
lead to a segfault.
Set the error flag and break on such malformed files.