### PR TITLE
Set prev_workspace_name based off of focus

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -763,6 +763,18 @@ static void set_workspace(struct sway_seat *seat,
 	if (seat->workspace == new_ws) {
 		return;
 	}
+
+	if (seat->workspace) {
+		free(seat->prev_workspace_name);
+		seat->prev_workspace_name = malloc(strlen(seat->workspace->name) + 1);
+		if (!seat->prev_workspace_name) {
+			sway_log(SWAY_ERROR, "Unable to allocate previous workspace name");
+			seat->prev_workspace_name = NULL;
+		} else {
+			strcpy(seat->prev_workspace_name, seat->workspace->name);
+		}
+	}
+
 	ipc_event_workspace(seat->workspace, new_ws, "focus");
 	seat->workspace = new_ws;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -481,18 +481,6 @@ bool workspace_switch(struct sway_workspace *workspace,
 			workspace_create(NULL, seat->prev_workspace_name);
 	}
 
-	if (active_ws && (!seat->prev_workspace_name ||
-			(strcmp(seat->prev_workspace_name, active_ws->name)
-				&& active_ws != workspace))) {
-		free(seat->prev_workspace_name);
-		seat->prev_workspace_name = malloc(strlen(active_ws->name) + 1);
-		if (!seat->prev_workspace_name) {
-			sway_log(SWAY_ERROR, "Unable to allocate previous workspace name");
-			return false;
-		}
-		strcpy(seat->prev_workspace_name, active_ws->name);
-	}
-
 	sway_log(SWAY_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);
 	struct sway_node *next = seat_get_focus_inactive(seat, &workspace->node);


### PR DESCRIPTION
Fixes #3888

This moves setting `seat->prev_workspace_name` from `workspace_switch`
to `set_workspace`. `workspace_switch` is only called when using a
`workspace` command to change the workspace so any workspace change
based on criteria was not altering `seat->prev_workspace_name`. By
moving it to `set_workspace`, which is called by `seat_set_focus`, it
will change any time focus changes to a node on a different workspace