### PR TITLE
Add support for configurations per input device type

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -105,6 +105,7 @@ struct input_config_mapped_from_region {
  */
 struct input_config {
 	char *identifier;
+	const char *input_type;
 
 	int accel_profile;
 	int click_method;
@@ -418,6 +419,7 @@ struct sway_config {
 	list_t *workspace_configs;
 	list_t *output_configs;
 	list_t *input_configs;
+	list_t *input_type_configs;
 	list_t *seat_configs;
 	list_t *criteria;
 	list_t *no_focus;

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -62,4 +62,6 @@ struct input_config *input_device_get_config(struct sway_input_device *device);
 
 char *input_device_get_identifier(struct wlr_input_device *device);
 
+const char *input_device_get_type(struct sway_input_device *device);
+
 #endif

--- a/sway/config.c
+++ b/sway/config.c
@@ -113,6 +113,12 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->input_configs);
 	}
+	if (config->input_type_configs) {
+		for (int i = 0; i < config->input_type_configs->length; i++) {
+			free_input_config(config->input_type_configs->items[i]);
+		}
+		list_free(config->input_type_configs);
+	}
 	if (config->seat_configs) {
 		for (int i = 0; i < config->seat_configs->length; i++) {
 			free_seat_config(config->seat_configs->items[i]);
@@ -191,9 +197,11 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->workspace_configs = create_list())) goto cleanup;
 	if (!(config->criteria = create_list())) goto cleanup;
 	if (!(config->no_focus = create_list())) goto cleanup;
-	if (!(config->input_configs = create_list())) goto cleanup;
 	if (!(config->seat_configs = create_list())) goto cleanup;
 	if (!(config->output_configs = create_list())) goto cleanup;
+
+	if (!(config->input_type_configs = create_list())) goto cleanup;
+	if (!(config->input_configs = create_list())) goto cleanup;
 
 	if (!(config->cmd_queue = create_list())) goto cleanup;
 

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -18,6 +18,7 @@ struct input_config *new_input_config(const char* identifier) {
 		return NULL;
 	}
 
+	input->input_type = NULL;
 	input->tap = INT_MIN;
 	input->tap_button_map = INT_MIN;
 	input->drag = INT_MIN;
@@ -140,6 +141,30 @@ static void merge_wildcard_on_all(struct input_config *wildcard) {
 			merge_input_config(ic, wildcard);
 		}
 	}
+
+	for (int i = 0; i < config->input_type_configs->length; i++) {
+		struct input_config *ic = config->input_type_configs->items[i];
+		if (strcmp(wildcard->identifier, ic->identifier) != 0) {
+			sway_log(SWAY_DEBUG, "Merging input * config on %s", ic->identifier);
+			merge_input_config(ic, wildcard);
+		}
+	}
+}
+
+static void merge_type_on_existing(struct input_config *type_wildcard) {
+	for (int i = 0; i < config->input_configs->length; i++) {
+		struct input_config *ic = config->input_configs->items[i];
+		if (ic->input_type == NULL) {
+			continue;
+		}
+
+		if (strcmp(ic->input_type, type_wildcard->identifier + 5) == 0) {
+			sway_log(SWAY_DEBUG, "Merging %s top of %s",
+				type_wildcard->identifier,
+				ic->identifier);
+			merge_input_config(ic, type_wildcard);
+		}
+	}
 }
 
 struct input_config *store_input_config(struct input_config *ic) {
@@ -148,11 +173,19 @@ struct input_config *store_input_config(struct input_config *ic) {
 		merge_wildcard_on_all(ic);
 	}
 
-	int i = list_seq_find(config->input_configs, input_identifier_cmp,
+	list_t *config_list = NULL;
+	if (strncmp(ic->identifier, "type:", 5) == 0) {
+		config_list = config->input_type_configs;
+		merge_type_on_existing(ic);
+	} else {
+		config_list = config->input_configs;
+	}
+
+	int i = list_seq_find(config_list, input_identifier_cmp,
 			ic->identifier);
 	if (i >= 0) {
 		sway_log(SWAY_DEBUG, "Merging on top of existing input config");
-		struct input_config *current = config->input_configs->items[i];
+		struct input_config *current = config_list->items[i];
 		merge_input_config(current, ic);
 		free_input_config(ic);
 		ic = current;
@@ -167,7 +200,7 @@ struct input_config *store_input_config(struct input_config *ic) {
 			free_input_config(ic);
 			ic = current;
 		}
-		list_add(config->input_configs, ic);
+		list_add(config_list, ic);
 	} else {
 		// New wildcard config. Just add it
 		sway_log(SWAY_DEBUG, "Adding input * config");

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -71,6 +71,40 @@ char *input_device_get_identifier(struct wlr_input_device *device) {
 	return identifier;
 }
 
+static bool device_is_touchpad(struct sway_input_device *device) {
+	if (device->wlr_device->type != WLR_INPUT_DEVICE_POINTER ||
+			!wlr_input_device_is_libinput(device->wlr_device)) {
+		return false;
+	}
+
+	struct libinput_device *libinput_device =
+		wlr_libinput_get_device_handle(device->wlr_device);
+
+	return libinput_device_config_tap_get_finger_count(libinput_device) > 0;
+}
+
+const char *input_device_get_type(struct sway_input_device *device) {
+	switch (device->wlr_device->type) {
+	case WLR_INPUT_DEVICE_POINTER:
+		if (device_is_touchpad(device)) {
+			return "touchpad";
+		} else {
+			return "pointer";
+		}
+	case WLR_INPUT_DEVICE_KEYBOARD:
+		return "keyboard";
+	case WLR_INPUT_DEVICE_TOUCH:
+		return "touch";
+	case WLR_INPUT_DEVICE_TABLET_TOOL:
+		return "tablet_tool";
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		return "tablet_pad";
+	case WLR_INPUT_DEVICE_SWITCH:
+		return "switch";
+	}
+	return "unknown";
+}
+
 static struct sway_input_device *input_sway_device_from_wlr(
 		struct wlr_input_device *device) {
 	struct sway_input_device *input_device = NULL;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -85,24 +85,6 @@ static const char *ipc_json_output_transform_description(enum wl_output_transfor
 	return NULL;
 }
 
-static const char *ipc_json_device_type_description(struct sway_input_device *device) {
-	switch (device->wlr_device->type) {
-	case WLR_INPUT_DEVICE_POINTER:
-		return "pointer";
-	case WLR_INPUT_DEVICE_KEYBOARD:
-		return "keyboard";
-	case WLR_INPUT_DEVICE_SWITCH:
-		return "switch";
-	case WLR_INPUT_DEVICE_TOUCH:
-		return "touch";
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
-		return "tablet_tool";
-	case WLR_INPUT_DEVICE_TABLET_PAD:
-		return "tablet_pad";
-	}
-	return "unknown";
-}
-
 json_object *ipc_json_get_version(void) {
 	int major = 0, minor = 0, patch = 0;
 	json_object *version = json_object_new_object();
@@ -819,7 +801,7 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 		json_object_new_int(device->wlr_device->product));
 	json_object_object_add(object, "type",
 		json_object_new_string(
-			ipc_json_device_type_description(device)));
+			input_device_get_type(device)));
 
 	if (device->wlr_device->type == WLR_INPUT_DEVICE_KEYBOARD) {
 		struct wlr_keyboard *keyboard = device->wlr_device->keyboard;

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -9,12 +9,27 @@ sway-input - input configuration file and commands
 Sway allows for configuration of devices within the sway configuration file.
 To obtain a list of available device identifiers, run *swaymsg -t get_inputs*.
 Settings can also be applied to all input devices by using the wildcard, _\*_,
-in place of _\<identifier\>_ in the commands below.
+in place of _\<identifier\>_ in the commands below. In addition, the settings
+can be applied to a type of device, by using _type:\<input_type\>_ in place
+of _\<identifier\>_.
 
 Tip: If the configuration settings do not appear to be taking effect, you could
 try using _\*_ instead of _\<identifier\>_. If it works with the wildcard, try
 using a different identifier from *swaymsg -t get_inputs* until you find the
 correct input device.
+
+Current available input types are:
+
+- touchpad
+- pointer
+- keyboard
+- touch
+- tablet_tool
+- tablet_pad
+- switch
+
+Note: The type configurations are applied as the devices appear and get applied
+on top of the existing device configurations.
 
 # INPUT COMMANDS
 

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -98,6 +98,7 @@ static const char *pretty_type_name(const char *name) {
 	} type_names[] = {
 		{ "keyboard", "Keyboard" },
 		{ "pointer", "Mouse" },
+		{ "touchpad", "Touchpad" },
 		{ "tablet_pad", "Tablet pad" },
 		{ "tablet_tool", "Tablet tool" },
 		{ "touch", "Touch" },


### PR DESCRIPTION
This PR implements #3784.

The "touchpad-iness" of a pointer is determined through `libinput_device_config_tap_get_finger_count`, which is referenced from [clutter](https://gitlab.gnome.org/GNOME/mutter/blob/master/clutter/clutter/evdev/clutter-input-device-evdev.c#L1459). In the future, this may be updated to a more concrete method of determining whether an input device is a touchpad.

`swaymsg` is updated to reflect this change, outputting `Type: Touchpad` or `Type: Mouse` rather than only `Type: Pointer`. In addition, `sway` now logs the matching of a type wildcard.

The behaviour is as follows:
- If a device is added and has a configuration, it is applied on top of it's type config.
- If a device is added, does not have a configuration, and it has a matching type config, the device will use the type config.
- If a device is already existing when a type config is applied, the type config will be merged on top of the existing device config.
- As expected, wildcard configs apply on top both type configs and device-specific configs.