### PR TITLE
Fix quoting of commands passed to for_window

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -387,6 +387,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 				&& handler->handle != cmd_bindsym
 				&& handler->handle != cmd_bindcode
 				&& handler->handle != cmd_set
+				&& handler->handle != cmd_for_window
 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
 			strip_quotes(argv[i]);
 		}


### PR DESCRIPTION
E.g. `for_window [class="mpv"] move container to output "Dell Inc. ..."`
does not work because the executed move command only uses `Dell` as
output name.