### PR TITLE
Fix output config retrieval for new outputs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -585,6 +585,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output);
 
 struct output_config *store_output_config(struct output_config *oc);
 
+struct output_config *find_output_config(struct sway_output *output);
+
 void apply_output_config_to_outputs(struct output_config *oc);
 
 void reset_outputs(void);

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -88,8 +88,6 @@ struct sway_output *output_by_name_or_id(const char *name_or_id);
 
 void output_sort_workspaces(struct sway_output *output);
 
-struct output_config *output_find_config(struct sway_output *output);
-
 void output_enable(struct sway_output *output, struct output_config *oc);
 
 void output_disable(struct sway_output *output);

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -438,6 +438,12 @@ static struct output_config *get_output_config(char *identifier,
 	return result;
 }
 
+struct output_config *find_output_config(struct sway_output *output) {
+	char id[128];
+	output_get_identifier(id, sizeof(id), output);
+	return get_output_config(id, output);
+}
+
 void apply_output_config_to_outputs(struct output_config *oc) {
 	// Try to find the output container and apply configuration now. If
 	// this is during startup then there will be no container and config

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -533,7 +533,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
 	if (!output->configured && !output->enabled) {
-		struct output_config *oc = output_find_config(output);
+		struct output_config *oc = find_output_config(output);
 		if (output->wlr_output->current_mode != NULL &&
 				(!oc || oc->enabled)) {
 			// We want to enable this output, but it didn't work last time,
@@ -634,7 +634,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->damage_destroy.notify = damage_handle_destroy;
 	wl_list_init(&output->swaybg_client_destroy.link);
 
-	struct output_config *oc = output_find_config(output);
+	struct output_config *oc = find_output_config(output);
 	if (!oc || oc->enabled) {
 		output_enable(output, oc);
 	} else {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -267,36 +267,6 @@ void output_begin_destroy(struct sway_output *output) {
 	output->wlr_output = NULL;
 }
 
-struct output_config *output_find_config(struct sway_output *output) {
-	const char *name = output->wlr_output->name;
-	char identifier[128];
-	output_get_identifier(identifier, sizeof(identifier), output);
-
-	struct output_config *oc = NULL, *all = NULL;
-	for (int i = 0; i < config->output_configs->length; ++i) {
-		struct output_config *cur = config->output_configs->items[i];
-
-		if (strcasecmp(name, cur->name) == 0 ||
-				strcasecmp(identifier, cur->name) == 0) {
-			sway_log(SWAY_DEBUG, "Matched output config for %s", name);
-			oc = cur;
-		}
-		if (strcasecmp("*", cur->name) == 0) {
-			sway_log(SWAY_DEBUG, "Matched wildcard output config for %s", name);
-			all = cur;
-		}
-
-		if (oc && all) {
-			break;
-		}
-	}
-	if (!oc) {
-		oc = all;
-	}
-
-	return oc;
-}
-
 struct sway_output *output_from_wlr_output(struct wlr_output *output) {
 	return output->data;
 }


### PR DESCRIPTION
This removes `output_find_config`, which would take the first matching
output config it found. This is fine if only a name output config,
identifier output config, or even just wildcard exist, but if there is
a name output config and identifier output config, they are not merged.
Instead, this introduces find_output_config, which is just a wrapper
for `get_output_config`. This ensures that both the name and identifier
output configs are respected.

This fixes the following case:
- For simplicity in this example, remove all output configs from config
- Run `swaymsg output <name> bg #ff0000 solid_color`
- Run `swaymsg output <identifier> scale 2`
- (Note the bg will be removed here. That will be fixed by #3905)
- Disconnect and reconnect output

Without this, the output will have the background, but not the scale.
With this, the output will have both the background and scale