### PR TITLE
Flush stdout in swaymsg when in subscribe mode

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -493,6 +493,7 @@ int main(int argc, char **argv) {
 					printf("%s\n", json_object_to_json_string_ext(obj,
 						JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
 				}
+				fflush(stdout);
 				json_object_put(obj);
 			}
 


### PR DESCRIPTION
When in subscribe mode **and** piping to a process, the notifications are only arriving when the stdout buffer is full.
An easy way to reproduce that is `swaymsg -m -t subscribe '["window"]' | cat`.

Flushing stdout after printing a message fixes that.