### PR TITLE
Update README - append hint to keep xwayland installed when running sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ Run `man 5 sway` for information on the configuration.
 ## Running
 
 Run `sway` from a TTY. Some display managers may work but are not supported by
-sway (gdm is known to work fairly well).
+sway (gdm is known to work fairly well). You will probably want to have xwayland
+installed, since most wayland applications (including dmenu and sway) will not
+start without it.


### PR DESCRIPTION
as discussed in #3907, many wayland-native apps refuse to run (unless
configured as such) without having xwayland installed. This can confuse
new users who might be tempted to remove anything xorg related - only to
end up with a broken wayland setup