### PR TITLE
swaybg: one instance for all outputs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -424,7 +424,6 @@ struct sway_config {
 	list_t *active_bar_modifiers;
 	struct sway_mode *current_mode;
 	struct bar_config *current_bar;
-	char *swaybg_command;
 	uint32_t floating_mod;
 	bool floating_mod_inverse;
 	uint32_t dragging_key;
@@ -446,6 +445,11 @@ struct sway_config {
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;
 	bool xwayland;
+
+	// swaybg
+	char *swaybg_command;
+	struct wl_client *swaybg_client;
+	struct wl_listener swaybg_client_destroy;
 
 	// Flags
 	enum focus_follows_mouse_mode focus_follows_mouse;
@@ -607,6 +611,8 @@ void reset_outputs(void);
 
 void free_output_config(struct output_config *oc);
 
+bool spawn_swaybg(void);
+
 int workspace_output_cmp_workspace(const void *a, const void *b);
 
 int sway_binding_cmp(const void *a, const void *b);
@@ -624,8 +630,6 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding);
 void load_swaybar(struct bar_config *bar);
 
 void load_swaybars(void);
-
-void terminate_swaybg(pid_t pid);
 
 struct bar_config *default_bar_config(void);
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -38,8 +38,6 @@ struct sway_output {
 
 	struct sway_output_state current;
 
-	struct wl_client *swaybg_client;
-
 	struct wl_listener destroy;
 	struct wl_listener mode;
 	struct wl_listener transform;
@@ -47,7 +45,6 @@ struct sway_output {
 	struct wl_listener present;
 	struct wl_listener damage_destroy;
 	struct wl_listener damage_frame;
-	struct wl_listener swaybg_client_destroy;
 
 	struct {
 		struct wl_signal destroy;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -68,6 +68,8 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	config->handler_context.leftovers.argc = 0;
 	config->handler_context.leftovers.argv = NULL;
 
+	bool background = output->background;
+
 	output = store_output_config(output);
 
 	// If reloading, the output configs will be applied after reading the
@@ -75,6 +77,9 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	// workspace name is not given to re-enabled outputs.
 	if (!config->reloading) {
 		apply_output_config_to_outputs(output);
+		if (background) {
+			spawn_swaybg();
+		}
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/config.c
+++ b/sway/config.c
@@ -104,6 +104,9 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->output_configs);
 	}
+	if (config->swaybg_client != NULL) {
+		wl_client_destroy(config->swaybg_client);
+	}
 	if (config->input_configs) {
 		for (int i = 0; i < config->input_configs->length; i++) {
 			free_input_config(config->input_configs->items[i]);
@@ -480,6 +483,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 
 	if (is_active) {
 		reset_outputs();
+		spawn_swaybg();
 
 		config->reloading = false;
 		if (config->swaynag_config_errors.pid > 0) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -525,7 +525,6 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&output->present.link);
 	wl_list_remove(&output->damage_destroy.link);
 	wl_list_remove(&output->damage_frame.link);
-	wl_list_remove(&output->swaybg_client_destroy.link);
 
 	transaction_commit_dirty();
 }
@@ -632,7 +631,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->damage_frame.notify = damage_handle_frame;
 	wl_signal_add(&output->damage->events.destroy, &output->damage_destroy);
 	output->damage_destroy.notify = damage_handle_destroy;
-	wl_list_init(&output->swaybg_client_destroy.link);
 
 	struct output_config *oc = find_output_config(output);
 	if (!oc || oc->enabled) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -262,10 +262,6 @@ void output_disable(struct sway_output *output) {
 
 	root_for_each_container(untrack_output, output);
 
-	if (output->swaybg_client != NULL) {
-		wl_client_destroy(output->swaybg_client);
-	}
-
 	int index = list_find(root->outputs, output);
 	list_del(root->outputs, index);
 


### PR DESCRIPTION
Closes #2051 
Fixes #3892

This makes it so there will only be one swaybg instance running
instead of one per output. swaybg's cli has been changed to a xrandr
like interface, where you select an output and then change properties
for that output and then select another output and repeat. This also
makes it so swaybg is only killed and respawned when a background
changes or when reloading.