### PR TITLE
Clean up focus follows mouse logic

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -439,18 +439,17 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 		return;
 	}
 
-	if (node_is_view(hovered_node)) {
+	// This is where we handle the common case. We don't want to focus inactive
+	// tabs, hence the view_is_visible check.
+	if (node_is_view(hovered_node) &&
+			view_is_visible(hovered_node->sway_container->view)) {
+		// e->previous_node is the node which the cursor was over previously.
+		// If focus_follows_mouse is yes and the cursor got over the view due
+		// to, say, a workspace switch, we don't want to set the focus.
+		// But if focus_follows_mouse is "always", we do.
 		if (hovered_node != e->previous_node ||
 				config->focus_follows_mouse == FOLLOWS_ALWAYS) {
 			seat_set_focus(seat, hovered_node);
-		} else {
-			// Focusing a tab which contains a split child
-			struct sway_node *next_focus =
-				seat_get_focus_inactive(seat, &root->node);
-			if (next_focus && node_is_view(next_focus) &&
-					view_is_visible(next_focus->sway_container->view)) {
-				seat_set_focus(seat, next_focus);
-			}
 		}
 	}
 }


### PR DESCRIPTION
Firstly, this fixes a recent regression where having `focus_follows_mouse yes` and hovering an inactive tab caused it to gain focus. The code was missing a `view_is_visible` check.

The code is handling the logic for both `focus_follows_mouse yes` and `focus_follows_mouse always`, where the latter will apply when nudging the mouse after a workspace switch. However, the `view_is_visible` check didn't apply when using `focus_follows_mouse always`, so hovering a tab
with that configuration would cause is to focus. This was a bug. When adding the `view_is_visible` check, it now applies to both `yes` and `always`.

Note that the comment about the split container was wrong. At this point the hovered node cannot be a split container because it passed the `node_is_view` check. The comment has been removed.

Lastly, the else condition is completely removed. This didn't appear to have any practical use. Setting focus to the result of `seat_get_focus_inactive` is very likely going to be a no op. There is a slim chance that this will break something, and if so I'd like to find out what so it can be properly documented in the code.

Fixes #3925.