### PR TITLE
cmd_mode: allow cmd_set to be a subcommand

### DIFF
--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -13,7 +13,8 @@
 static struct cmd_handler mode_handlers[] = {
 	{ "bindcode", cmd_bindcode },
 	{ "bindswitch", cmd_bindswitch },
-	{ "bindsym", cmd_bindsym }
+	{ "bindsym", cmd_bindsym },
+	{ "set", cmd_set },
 };
 
 struct cmd_results *cmd_mode(int argc, char **argv) {

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -573,9 +573,9 @@ The default colors are:
 	Switches to the specified mode. The default mode _default_.
 
 *mode* [--pango_markup] <mode> <mode-subcommands...>
-	The only valid _mode-subcommands..._ are *bindsym*, *bindcode* and
-	*bindswitch*. If _--pango_markup_ is given, then _mode_ will be interpreted
-	as pango markup.
+	The only valid _mode-subcommands..._ are *bindsym*, *bindcode*,
+	*bindswitch*, and *set*. If _--pango_markup_ is given, then _mode_ will be
+	interpreted as pango markup.
 
 *mouse_warping* output|container|none
 	If _output_ is specified, the mouse will be moved to new outputs as you


### PR DESCRIPTION
Related https://github.com/swaywm/sway/issues/2336#issuecomment-474661290

This allows set to be used in mode blocks