### PR TITLE
Fix #3924 ( Stripping of escaped quotes in exec )

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -276,7 +276,6 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 			// Var replacement, for all but first argument of set
 			for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
 				argv[i] = do_var_replacement(argv[i]);
-				unescape_string(argv[i]);
 			}
 
 			if (!config->handler_context.using_criteria) {


### PR DESCRIPTION
From what i understand, 
do_var_replacement never adds escape characters.
if the variable's value contains an escaped characther, it should stay escaped after the replacement.

Thus, unescapping the string after calling do_var_replacement is unescessary and strips the escape characters before calling the exec_always.c
And exec_always.c removes the quotes because they are not escaped anymore