### PR TITLE
criteria: fix __focused__ when no focus or unset

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -20,6 +20,7 @@ struct criteria {
 	char *cmdlist;
 	char *target; // workspace or output name for `assign` criteria
 
+	bool autofail; // __focused__ while no focus or n/a for focused view
 	pcre *title;
 	pcre *shell;
 	pcre *app_id;


### PR DESCRIPTION
Fixes #3953 

This fixes the behavior of `__focused__` when there is no focused view
to match i3's behavior of successfully matching no views instead of
returning an error of a missing value. It also applies the same logic
when a token is not applicable (or unset) for a view such as `app_id`
for a focused xwayland view or `class` for a focused xdg-shell view.

This adds an `autofail` boolean to `struct criteria`. If it is set to
`true`, then `criteria_matches_view` will immediately bail out as a
no match. If `autofail` is set, the criteria will also not be
considered empty by `criteria_is_empty`.

To set this new `autofail` property, `get_focused_prop` will now take
in a boolean pointer of the same name. If `__focused__` is supported
for the token and there is no focused view or the focused view does not
have a value for the token, then the boolean will be set to true. In
`parse_token`, the boolean value will be checked and if set to true,
then `criteria->autofail` will be set to true and `parse_token` will
bail successfully. Tokens will still be parsed to make sure the whole
criteria is syntactically valid, which is also why
`&criteria->autofail` is not passed to `get_focused_prop` and a local
boolean is declared in `parse_token`.