### PR TITLE
Allow for workspace renaming during exec handling

### DIFF
--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -85,4 +85,6 @@ struct sway_container *root_find_container(
 
 void root_get_box(struct sway_root *root, struct wlr_box *box);
 
+void root_rename_pid_workspaces(const char *old_name, const char *new_name);
+
 #endif

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -9,6 +9,7 @@
 #include "sway/output.h"
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"
+#include "sway/tree/root.h"
 
 static const char expected_syntax[] =
 	"Expected 'rename workspace <old_name> to <new_name>' or "
@@ -89,6 +90,9 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	}
 
 	sway_log(SWAY_DEBUG, "renaming workspace '%s' to '%s'", workspace->name, new_name);
+
+	root_rename_pid_workspaces(workspace->name, new_name);
+
 	free(workspace->name);
 	workspace->name = new_name;
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -390,3 +390,17 @@ void root_get_box(struct sway_root *root, struct wlr_box *box) {
 	box->width = root->width;
 	box->height = root->height;
 }
+
+void root_rename_pid_workspaces(const char *old_name, const char *new_name) {
+	if (!pid_workspaces.prev && !pid_workspaces.next) {
+		wl_list_init(&pid_workspaces);
+	}
+
+	struct pid_workspace *pw = NULL;
+	wl_list_for_each(pw, &pid_workspaces, link) {
+		if (strcmp(pw->workspace, old_name) == 0) {
+			free(pw->workspace);
+			pw->workspace = strdup(new_name);
+		}
+	}
+}


### PR DESCRIPTION
This change adds support for renaming workspace (without changing
workspace number) when `exec` command is being processed. If focused
workspace is renamed  after receiving `exec` command but before
the application is launched, sway will assign the application to
a workspace basing on matching number.

The change can be verified by running following command:

swaymsg exec <application>; swaymsg rename workspace number 1 to '1: new'

Fixes: #3952