### PR TITLE
Honor output for xdg_toplevel_set_fullscreen

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -314,7 +314,7 @@ void view_destroy(struct sway_view *view);
 void view_begin_destroy(struct sway_view *view);
 
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
-	bool fullscreen, bool decoration);
+	bool fullscreen, struct wlr_output *fullscreen_output, bool decoration);
 
 void view_unmap(struct sway_view *view);
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -339,6 +339,18 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		return;
 	}
 
+	if (e->fullscreen && e->output && e->output->data) {
+		struct sway_output *output = e->output->data;
+		struct sway_workspace *ws = output_get_active_workspace(output);
+		if (ws && !container_is_scratchpad_hidden(view->container)) {
+			if (container_is_floating(view->container)) {
+				workspace_add_floating(ws, view->container);
+			} else {
+				workspace_add_tiling(ws, view->container);
+			}
+		}
+	}
+
 	container_set_fullscreen(view->container, e->fullscreen);
 
 	arrange_root();
@@ -417,7 +429,9 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	}
 
 	view_map(view, view->wlr_xdg_surface->surface,
-		xdg_surface->toplevel->client_pending.fullscreen, csd);
+		xdg_surface->toplevel->client_pending.fullscreen,
+		xdg_surface->toplevel->client_pending.fullscreen_output,
+		csd);
 
 	transaction_commit_dirty();
 

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -339,6 +339,18 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		return;
 	}
 
+	if (e->fullscreen && e->output && e->output->data) {
+		struct sway_output *output = e->output->data;
+		struct sway_workspace *ws = output_get_active_workspace(output);
+		if (ws && !container_is_scratchpad_hidden(view->container)) {
+			if (container_is_floating(view->container)) {
+				workspace_add_floating(ws, view->container);
+			} else {
+				workspace_add_tiling(ws, view->container);
+			}
+		}
+	}
+
 	container_set_fullscreen(view->container, e->fullscreen);
 
 	arrange_root();
@@ -411,7 +423,9 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		== WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
 
 	view_map(view, view->wlr_xdg_surface_v6->surface,
-		xdg_surface->toplevel->client_pending.fullscreen, csd);
+		xdg_surface->toplevel->client_pending.fullscreen,
+		xdg_surface->toplevel->client_pending.fullscreen_output,
+		csd);
 
 	transaction_commit_dirty();
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -415,7 +415,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xwayland_view->commit.notify = handle_commit;
 
 	// Put it back into the tree
-	view_map(view, xsurface->surface, xsurface->fullscreen, false);
+	view_map(view, xsurface->surface, xsurface->fullscreen, NULL, false);
 
 	transaction_commit_dirty();
 }


### PR DESCRIPTION
Fixes #1813 
Requires swaywm/wlroots#1638

This honors the fullscreen output request for
`xdg_toplevel_set_fullscreen` and `zxdg_toplevel_v6_set_fullscreen`.

If the request was sent before mapping, the fullscreen output request
will be retrieved from the client_pending state for the toplevel. The
output will be passed to `view_map` and if there is a workspace on the
output, the view will be placed on that workspace.

If the request comes in after being mapped, the view will be moved to
the workspace on the output (if there is one) before becoming
fullscreen.