### PR TITLE
Implement seat subcommand hide_cursor_while_typing

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -269,6 +269,7 @@ sway_cmd seat_cmd_attach;
 sway_cmd seat_cmd_cursor;
 sway_cmd seat_cmd_fallback;
 sway_cmd seat_cmd_hide_cursor;
+sway_cmd seat_cmd_hide_cursor_while_typing;
 sway_cmd seat_cmd_pointer_constraint;
 
 sway_cmd cmd_ipc_cmd;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -161,7 +161,8 @@ struct seat_config {
 	char *name;
 	int fallback; // -1 means not set
 	list_t *attachments; // list of seat_attachment configs
-	int hide_cursor_timeout;
+	int hide_cursor_timeout;  // idle timeout
+	int hide_cursor_typing_timeout;
 	enum seat_config_allow_constrain allow_constrain;
 };
 

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -12,6 +12,7 @@ static struct cmd_handler seat_handlers[] = {
 	{ "cursor", seat_cmd_cursor },
 	{ "fallback", seat_cmd_fallback },
 	{ "hide_cursor", seat_cmd_hide_cursor },
+	{ "hide_cursor_while_typing", seat_cmd_hide_cursor_while_typing },
 	{ "pointer_constraint", seat_cmd_pointer_constraint },
 };
 

--- a/sway/commands/seat/hide_cursor_while_typing.c
+++ b/sway/commands/seat/hide_cursor_while_typing.c
@@ -1,0 +1,29 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/seat.h"
+#include "stringop.h"
+
+struct cmd_results *seat_cmd_hide_cursor_while_typing(int argc, char **argv) {
+	struct cmd_results *error =
+		checkarg(argc, "hide_cursor_while_typing", EXPECTED_EQUAL_TO, 1);
+	if (error) {
+		return error;
+	}
+	if (!config->handler_context.seat_config) {
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
+	}
+
+	char *end;
+	int timeout = strtol(argv[0], &end, 10);
+	if (*end) {
+		return cmd_results_new(CMD_INVALID, "Expected an integer timeout");
+	}
+	if (timeout < 100 && timeout != 0) {
+		timeout = 100;
+	}
+	config->handler_context.seat_config->hide_cursor_typing_timeout = timeout;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -26,6 +26,7 @@ struct seat_config *new_seat_config(const char* name) {
 		return NULL;
 	}
 	seat->hide_cursor_timeout = -1;
+	seat->hide_cursor_typing_timeout = -1;
 	seat->allow_constrain = CONSTRAIN_DEFAULT;
 
 	return seat;
@@ -142,6 +143,10 @@ void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 
 	if (source->hide_cursor_timeout != -1) {
 		dest->hide_cursor_timeout = source->hide_cursor_timeout;
+	}
+
+	if (source->hide_cursor_typing_timeout != -1) {
+		dest->hide_cursor_typing_timeout = source->hide_cursor_typing_timeout;
 	}
 
 	if (source->allow_constrain != CONSTRAIN_DEFAULT) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -507,6 +507,7 @@ static void seat_reset_input_config(struct sway_seat *seat,
 		sway_device->input_device->identifier);
 	wlr_cursor_map_input_to_output(seat->cursor->cursor,
 		sway_device->input_device->wlr_device, NULL);
+	cursor_unhide(seat->cursor, CURSOR_VISIBLE);
 }
 
 static void seat_apply_input_config(struct sway_seat *seat,
@@ -1207,9 +1208,10 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	} else {
 		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
 	}
-	if (seat->cursor->hidden){
-		cursor_unhide(seat->cursor);
-		wl_event_source_timer_update(seat->cursor->hide_source, cursor_get_timeout(seat->cursor));
+	if (seat->cursor->hidden != CURSOR_VISIBLE) {
+		cursor_unhide(seat->cursor, CURSOR_VISIBLE);
+		wl_event_source_timer_update(seat->cursor->hide_source,
+				cursor_get_timeout(seat->cursor, CURSOR_HIDDEN_IDLE));
 	}
 }
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -86,6 +86,7 @@ sway_sources = files(
 	'commands/seat/cursor.c',
 	'commands/seat/fallback.c',
 	'commands/seat/hide_cursor.c',
+	'commands/seat/hide_cursor_while_typing.c',
 	'commands/seat/pointer_constraint.c',
 	'commands/set.c',
 	'commands/show_marks.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -184,7 +184,16 @@ correct seat.
 	Hides the cursor image after the specified _timeout_ (in milliseconds)
 	has elapsed with no activity on that cursor. A timeout of 0 (default)
 	disables hiding the cursor. The minimal timeout is 100 and any value less
-	than that (aside from 0), will be increased to 100.
+	than that (aside from 0), will be increased to 100. This may be used in
+	conjunction with _hide_cursor_while_typing_ to have complex cursor hiding
+	rules.
+
+*seat* <name> hide_cursor_while_typing <timeout>
+	Hides the cursor image while typing. The cursor image will be hidden until
+	the timeout expires after the last key is released. A timeout of 0
+	(default) disables hiding the cursor. The minimal timeout is 100 and any
+	value less than that (aside from 0), will be increased to 100. This may be
+	used in conjunction with _hide_cursor_ to have complex cursor hiding rules
 
 *seat* <name> pointer_constraint enable|disable|escape
 	Enables or disables the ability for clients to capture the cursor (enabled


### PR DESCRIPTION
Related to #1894

This implements the following seat subcommand:
  `hide_cursor_while_typing <timeout>`

If timeout is set to a positive value (of at least 100), the cursor
will be hidden when typing and will not be unhidden until the timeout
has expired after the last key has been released.

This also changes the way cursor hiding/unhiding is managed to allow
for both `hide_cursor` and `hide_cursor_while_typing` to be used in
conjunction with each other for complex cursor hiding rules.