### PR TITLE
Fix xwayland configure request scratchpad crash

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -215,10 +215,7 @@ size_t container_titlebar_height(void);
 void floating_calculate_constraints(int *min_width, int *max_width,
 		int *min_height, int *max_height);
 
-/**
- * Resize and center the container in its workspace.
- */
-void container_init_floating(struct sway_container *container);
+void container_floating_resize_and_center(struct sway_container *con);
 
 void container_set_floating(struct sway_container *container, bool enable);
 

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -435,7 +435,7 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		// Respect minimum and maximum sizes
 		view->natural_width = ev->width;
 		view->natural_height = ev->height;
-		container_init_floating(view->container);
+		container_floating_resize_and_center(view->container);
 
 		configure(view, view->container->content_x,
 				view->container->content_y,

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -77,7 +77,7 @@ static void restore_workspaces(struct sway_output *output) {
 					floater->y > output->ly + output->height ||
 					floater->x + floater->width < output->lx ||
 					floater->y + floater->height < output->ly) {
-				container_init_floating(floater);
+				container_floating_resize_and_center(floater);
 			}
 		}
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -124,15 +124,7 @@ void root_scratchpad_show(struct sway_container *con) {
 	struct wlr_box workspace_box;
 	workspace_get_box(new_ws, &workspace_box);
 	if (!wlr_box_contains_point(&workspace_box, center_lx, center_ly)) {
-		// Maybe resize it
-		if (con->width > new_ws->width || con->height > new_ws->height) {
-			container_init_floating(con);
-		}
-
-		// Center it
-		double new_lx = new_ws->x + (new_ws->width - con->width) / 2;
-		double new_ly = new_ws->y + (new_ws->height - con->height) / 2;
-		container_floating_move_to(con, new_lx, new_ly);
+		container_floating_resize_and_center(con);
 	}
 
 	arrange_workspace(new_ws);


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/3972#issue-425142958

This fixes a crash in `container_init_floating` when a xwayland view
sends a configure request while in the scratchpad.

`container_init_floating` gets called so the configured minimum and
maximum sizes gets respected when resizing to the requested size. Since
the workspace was NULL, it would SIGSEGV when attempting to get the
workspace's output for the output box retrieval.

This extracts the resizing portion of `container_init_floating` into a
separate function. If the container is in the scratchpad, it will just
be resized and skip the centering

Additionally, `container_init_floating` has been renamed to
`container_floating_resize_and_center` to more accurately describe what
it does.