### PR TITLE
Fix scratchpad fullscreen behavior and crash

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -143,6 +143,11 @@ struct sway_node *seat_get_focus(struct sway_seat *seat);
 
 struct sway_workspace *seat_get_focused_workspace(struct sway_seat *seat);
 
+// If a scratchpad container is fullscreen global, this can be used to try to
+// determine the last focused workspace. Otherwise, this should yield the same
+// results as seat_get_focused_workspace.
+struct sway_workspace *seat_get_last_known_workspace(struct sway_seat *seat);
+
 struct sway_container *seat_get_focused_container(struct sway_seat *seat);
 
 /**

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -32,6 +32,11 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 		seat_set_focus_container(config->handler_context.seat, container);
 	}
 
+	if (container_is_scratchpad_hidden(container)) {
+		return cmd_results_new(CMD_INVALID,
+				"Can't change floating on hidden scratchpad container");
+	}
+
 	// If the container is in a floating split container,
 	// operate on the split container instead of the child.
 	if (container_is_floating_or_child(container)) {

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -182,6 +182,10 @@ static struct sway_node *node_get_in_direction_floating(
 	double closest_distance = DBL_MAX;
 	struct sway_container *closest_con = NULL;
 
+	if (!con->workspace) {
+		return NULL;
+	}
+
 	for (int i = 0; i < con->workspace->floating->length; i++) {
 		struct sway_container *floater = con->workspace->floating->items[i];
 		if (floater == con) {

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -26,6 +26,13 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 				"Can't fullscreen an empty workspace");
 	}
 
+	// If in the scratchpad, operate on the highest container
+	if (container && !container->workspace) {
+		while (container->parent) {
+			container = container->parent;
+		}
+	}
+
 	bool is_fullscreen = container &&
 		container->fullscreen_mode != FULLSCREEN_NONE;
 	bool global = false;

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -147,7 +147,11 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 			workspace->layout = new_layout;
 			workspace_update_representation(workspace);
 		}
-		arrange_workspace(workspace);
+		if (root->fullscreen_global) {
+			arrange_root();
+		} else {
+			arrange_workspace(workspace);
+		}
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -395,6 +395,11 @@ static struct cmd_results *cmd_move_container(int argc, char **argv) {
 		container = workspace_wrap_children(workspace);
 	}
 
+	if (container->fullscreen_mode == FULLSCREEN_GLOBAL) {
+		return cmd_results_new(CMD_FAILURE,
+				"Can't move fullscreen global container");
+	}
+
 	bool no_auto_back_and_forth = false;
 	while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
 		no_auto_back_and_forth = true;
@@ -646,6 +651,10 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 	}
 
 	struct sway_workspace *workspace = config->handler_context.workspace;
+	if (!workspace) {
+		return cmd_results_new(CMD_FAILURE, "No workspace to move");
+	}
+
 	struct sway_output *old_output = workspace->output;
 	int center_x = workspace->width / 2 + workspace->x,
 		center_y = workspace->height / 2 + workspace->y;

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -13,7 +13,8 @@ static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (con) {
-		if (container_is_scratchpad_hidden(con)) {
+		if (container_is_scratchpad_hidden(con) &&
+				con->fullscreen_mode != FULLSCREEN_GLOBAL) {
 			return cmd_results_new(CMD_FAILURE,
 					"Cannot split a hidden scratchpad container");
 		}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -251,14 +251,11 @@ static void output_for_each_surface(struct sway_output *output,
 	};
 
 	struct sway_workspace *workspace = output_get_active_workspace(output);
-	if (!workspace) {
-		return;
-	}
 	struct sway_container *fullscreen_con = root->fullscreen_global;
-	if (fullscreen_con && container_is_scratchpad_hidden(fullscreen_con)) {
-		fullscreen_con = NULL;
-	}
 	if (!fullscreen_con) {
+		if (!workspace) {
+			return;
+		}
 		fullscreen_con = workspace->current.fullscreen;
 	}
 	if (fullscreen_con) {

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -997,9 +997,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 	}
 
 	struct sway_container *fullscreen_con = root->fullscreen_global;
-	if (fullscreen_con && container_is_scratchpad_hidden(fullscreen_con)) {
-		fullscreen_con = NULL;
-	}
 	if (!fullscreen_con) {
 		fullscreen_con = workspace->current.fullscreen;
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -95,6 +95,10 @@ void container_begin_destroy(struct sway_container *con) {
 	if (con->fullscreen_mode == FULLSCREEN_WORKSPACE && con->workspace) {
 		con->workspace->fullscreen = NULL;
 	}
+	if (con->scratchpad && con->fullscreen_mode == FULLSCREEN_GLOBAL) {
+		container_fullscreen_disable(con);
+	}
+
 	wl_signal_emit(&con->node.events.destroy, &con->node);
 
 	container_end_mouse_operation(con);
@@ -128,7 +132,9 @@ void container_reap_empty(struct sway_container *con) {
 		container_begin_destroy(con);
 		con = parent;
 	}
-	workspace_consider_destroy(ws);
+	if (ws) {
+		workspace_consider_destroy(ws);
+	}
 }
 
 struct sway_container *container_flatten(struct sway_container *container) {
@@ -954,18 +960,20 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 	set_fullscreen_iterator(con, &enable);
 	container_for_each_child(con, set_fullscreen_iterator, &enable);
 
-	con->workspace->fullscreen = con;
 	con->saved_x = con->x;
 	con->saved_y = con->y;
 	con->saved_width = con->width;
 	con->saved_height = con->height;
 
-	struct sway_seat *seat;
-	struct sway_workspace *focus_ws;
-	wl_list_for_each(seat, &server.input->seats, link) {
-		focus_ws = seat_get_focused_workspace(seat);
-		if (focus_ws == con->workspace) {
-			seat_set_focus_container(seat, con);
+	if (con->workspace) {
+		con->workspace->fullscreen = con;
+		struct sway_seat *seat;
+		struct sway_workspace *focus_ws;
+		wl_list_for_each(seat, &server.input->seats, link) {
+			focus_ws = seat_get_focused_workspace(seat);
+			if (focus_ws == con->workspace) {
+				seat_set_focus_container(seat, con);
+			}
 		}
 	}
 
@@ -1019,11 +1027,14 @@ void container_fullscreen_disable(struct sway_container *con) {
 	con->height = con->saved_height;
 
 	if (con->fullscreen_mode == FULLSCREEN_WORKSPACE) {
-		con->workspace->fullscreen = NULL;
-		if (container_is_floating(con)) {
-			struct sway_output *output = container_floating_find_output(con);
-			if (con->workspace->output != output) {
-				container_floating_move_to_center(con);
+		if (con->workspace) {
+			con->workspace->fullscreen = NULL;
+			if (container_is_floating(con)) {
+				struct sway_output *output =
+					container_floating_find_output(con);
+				if (con->workspace->output != output) {
+					container_floating_move_to_center(con);
+				}
 			}
 		}
 	} else {
@@ -1040,6 +1051,17 @@ void container_fullscreen_disable(struct sway_container *con) {
 	con->fullscreen_mode = FULLSCREEN_NONE;
 	container_end_mouse_operation(con);
 	ipc_event_window(con, "fullscreen_mode");
+
+	if (con->scratchpad) {
+		struct sway_seat *seat;
+		wl_list_for_each(seat, &server.input->seats, link) {
+			struct sway_container *focus = seat_get_focused_container(seat);
+			if (focus == con || container_has_ancestor(focus, con)) {
+				seat_set_focus(seat,
+						seat_get_focus_inactive(seat, &root->node));
+			}
+		}
+	}
 }
 
 void container_set_fullscreen(struct sway_container *con,
@@ -1056,7 +1078,7 @@ void container_set_fullscreen(struct sway_container *con,
 		if (root->fullscreen_global) {
 			container_fullscreen_disable(root->fullscreen_global);
 		}
-		if (con->workspace->fullscreen) {
+		if (con->workspace && con->workspace->fullscreen) {
 			container_fullscreen_disable(con->workspace->fullscreen);
 		}
 		container_fullscreen_workspace(con);
@@ -1171,6 +1193,11 @@ void container_add_gaps(struct sway_container *c) {
 			c->current_gaps.bottom > 0 || c->current_gaps.left > 0) {
 		return;
 	}
+	// Fullscreen global scratchpad containers cannot have gaps
+	struct sway_workspace *ws = c->workspace;
+	if (!ws) {
+		return;
+	}
 	// Linear containers don't have gaps because it'd create double gaps
 	if (!c->view && c->layout != L_TABBED && c->layout != L_STACKED) {
 		return;
@@ -1198,8 +1225,6 @@ void container_add_gaps(struct sway_container *c) {
 			return;
 		}
 	}
-
-	struct sway_workspace *ws = c->workspace;
 
 	c->current_gaps.top = c->y == ws->y ? ws->gaps_inner : 0;
 	c->current_gaps.right = ws->gaps_inner;
@@ -1308,6 +1333,10 @@ void container_add_child(struct sway_container *parent,
 	child->parent = parent;
 	child->workspace = parent->workspace;
 	container_for_each_child(child, set_workspace, NULL);
+	bool fullscreen = child->fullscreen_mode != FULLSCREEN_NONE ||
+		parent->fullscreen_mode != FULLSCREEN_NONE;
+	set_fullscreen_iterator(child, &fullscreen);
+	container_for_each_child(child, set_fullscreen_iterator, &fullscreen);
 	container_handle_fullscreen_reparent(child);
 	container_update_representation(parent);
 	node_set_dirty(&child->node);
@@ -1347,8 +1376,31 @@ void container_detach(struct sway_container *child) {
 
 void container_replace(struct sway_container *container,
 		struct sway_container *replacement) {
+	enum sway_fullscreen_mode fullscreen = container->fullscreen_mode;
+	bool scratchpad = container->scratchpad;
+	if (fullscreen != FULLSCREEN_NONE) {
+		container_fullscreen_disable(container);
+	}
+	if (scratchpad) {
+		root_scratchpad_show(container);
+		root_scratchpad_remove_container(container);
+	}
 	container_add_sibling(container, replacement, 1);
 	container_detach(container);
+	if (scratchpad) {
+		root_scratchpad_add_container(replacement);
+	}
+	switch (fullscreen) {
+	case FULLSCREEN_WORKSPACE:
+		container_fullscreen_workspace(replacement);
+		break;
+	case FULLSCREEN_GLOBAL:
+		container_fullscreen_global(replacement);
+		break;
+	case FULLSCREEN_NONE:
+		// noop
+		break;
+	}
 }
 
 struct sway_container *container_split(struct sway_container *child,
@@ -1369,7 +1421,11 @@ struct sway_container *container_split(struct sway_container *child,
 
 	if (set_focus) {
 		seat_set_raw_focus(seat, &cont->node);
-		seat_set_raw_focus(seat, &child->node);
+		if (cont->fullscreen_mode == FULLSCREEN_GLOBAL) {
+			seat_set_focus(seat, &child->node);
+		} else {
+			seat_set_raw_focus(seat, &child->node);
+		}
 	}
 
 	return cont;
@@ -1529,7 +1585,7 @@ void container_raise_floating(struct sway_container *con) {
 	while (floater->parent) {
 		floater = floater->parent;
 	}
-	if (container_is_floating(floater)) {
+	if (container_is_floating(floater) && floater->workspace) {
 		list_move_to_end(floater->workspace->floating, floater);
 		node_set_dirty(&floater->workspace->node);
 	}

--- a/sway/tree/node.c
+++ b/sway/tree/node.c
@@ -142,9 +142,17 @@ list_t *node_get_children(struct sway_node *node) {
 }
 
 bool node_has_ancestor(struct sway_node *node, struct sway_node *ancestor) {
+	if (ancestor->type == N_ROOT && node->type == N_CONTAINER &&
+			node->sway_container->fullscreen_mode == FULLSCREEN_GLOBAL) {
+		return true;
+	}
 	struct sway_node *parent = node_get_parent(node);
 	while (parent) {
 		if (parent == ancestor) {
+			return true;
+		}
+		if (ancestor->type == N_ROOT && parent->type == N_CONTAINER &&
+				parent->sway_container->fullscreen_mode == FULLSCREEN_GLOBAL) {
 			return true;
 		}
 		parent = node_get_parent(parent);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -62,6 +62,11 @@ void root_scratchpad_add_container(struct sway_container *con) {
 	struct sway_container *parent = con->parent;
 	struct sway_workspace *workspace = con->workspace;
 
+	// Clear the fullscreen mode when sending to the scratchpad
+	if (con->fullscreen_mode != FULLSCREEN_NONE) {
+		container_fullscreen_disable(con);
+	}
+
 	// When a tiled window is sent to scratchpad, center and resize it.
 	if (!container_is_floating(con)) {
 		container_set_floating(con, true);
@@ -143,6 +148,15 @@ void root_scratchpad_hide(struct sway_container *con) {
 	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
 	struct sway_workspace *ws = con->workspace;
 
+	if (con->fullscreen_mode == FULLSCREEN_GLOBAL && !con->workspace) {
+		// If the container was made fullscreen global while in the scratchpad,
+		// it should be shown until fullscreen has been disabled
+		return;
+	}
+
+	if (con->fullscreen_mode != FULLSCREEN_NONE) {
+		container_fullscreen_disable(con);
+	}
 	container_detach(con);
 	arrange_workspace(ws);
 	if (&con->node == focus || node_has_ancestor(focus, &con->node)) {


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/3972#issuecomment-476576069

When setting fullscreen on a hidden scratchpad container, there was a
check to see if there was an existing fullscreen container on the
workspace so it could be fullscreen disabled first. Since the workspace
is NULL, it would cause a SIGSEGV. This adds a NULL check to avoid the
crash.

This also changes the behavior of how fullscreen is handled when adding
a container to the scratchpad or changing visibility of a scratchpad
container to match i3's. The behavior is as follows:
- When adding a container to the scratchpad or hiding a container back
  into the scratchpad, there is an implicit fullscreen disable
- When setting fullscreen on a container that is hidden in the
  scratchpad, it will be fullscreen when shown (and fullscreen disabled
  when hidden as stated above)
- When setting fullscreen global on a container that is hidden in the
  scratchpad, it will be shown immediately as fullscreen global. The
  container is not moved to a workspace and remains in the
  scratchpad. The container will be visible until fullscreen disabled
  or killed. Since the container is in the scratchpad, running
  `scratchpad show` or `move container to scratchpad` will have no
  effect

This also changes `container_replace` to transfer fullscreen and
scratchpad status.