### PR TITLE
Fix null pointer crash when doing tiling drag

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -108,7 +108,7 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 	}
 
 	if (node->type == N_WORKSPACE) {
-		// Emtpy workspace
+		// Empty workspace
 		e->target_node = node;
 		e->target_edge = WLR_EDGE_NONE;
 		workspace_get_box(node->sway_workspace, &e->drop_box);
@@ -164,7 +164,7 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 
 	// Use the hovered view - but we must be over the actual surface
 	con = node->sway_container;
-	if (!con->view->surface || node == &e->con->node
+	if (!con->view || !con->view->surface || node == &e->con->node
 			|| node_has_ancestor(node, &e->con->node)) {
 		e->target_node = NULL;
 		e->target_edge = WLR_EDGE_NONE;


### PR DESCRIPTION
* Create layout `S[V[view view] view]`
* Drag bottom view to the top
* Sway would crash when the cursor hovers the `V[view view]` title while dragging

Also fixes a typo in a comment.

Fixes #3985.