### PR TITLE
Fix sizing of floaters + scratchpad

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -217,6 +217,8 @@ void floating_calculate_constraints(int *min_width, int *max_width,
 
 void container_floating_resize_and_center(struct sway_container *con);
 
+void container_floating_set_default_size(struct sway_container *con);
+
 void container_set_floating(struct sway_container *container, bool enable);
 
 void container_set_geometry_from_content(struct sway_container *con);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -712,19 +712,28 @@ void container_floating_resize_and_center(struct sway_container *con) {
 	}
 }
 
-static void container_floating_set_default_size(struct sway_container *con) {
+void container_floating_set_default_size(struct sway_container *con) {
 	if (!sway_assert(con->workspace, "Expected a container on a workspace")) {
 		return;
 	}
+
 	int min_width, max_width, min_height, max_height;
 	floating_calculate_constraints(&min_width, &max_width,
 			&min_height, &max_height);
 	struct wlr_box *box = calloc(1, sizeof(struct wlr_box));
 	workspace_get_box(con->workspace, box);
+
+	double width = fmax(min_width, fmin(box->width * 0.5, max_width));
+	double height = fmax(min_height, fmin(box->height * 0.75, max_height));
 	if (!con->view) {
-		con->width = fmax(min_width, fmin(box->width * 0.5, max_width));
-		con->height = fmax(min_height, fmin(box->height * 0.75, max_height));
+		con->width = width;
+		con->height = height;
+	} else {
+		con->content_width = width;
+		con->content_height = height;
+		container_set_geometry_from_content(con);
 	}
+
 	free(box);
 }
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -62,6 +62,8 @@ void root_scratchpad_add_container(struct sway_container *con) {
 	struct sway_container *parent = con->parent;
 	struct sway_workspace *workspace = con->workspace;
 	container_set_floating(con, true);
+	container_floating_set_default_size(con);
+	container_floating_move_to_center(con);
 	container_detach(con);
 	con->scratchpad = true;
 	list_add(root->scratchpad, con);


### PR DESCRIPTION
Fixes #3991 
Fixes #3935 

This fixes the sizing of floating non-view containers. On master, the
floater will get set to the maximum width and height, which by default
is the entire output layout. When setting a non-view container to
floating, this will set a sane default size of 50% of the workspace
width and 75% of the workspace height, or whatever the closest is that
the minimum and maximum floating width/height values allow for. On all
future calls to `floating_natural_resize`, the width and height will be
kept unless they need to be changed to respect the min/max floating
width/height values.

This also matches i3's behavior of setting scratchpad containers to 50% of
the workspace's width and 75% of the workspace's height, bound by the
minimum and maximum floating width/height.