### PR TITLE
Fix a crash in swaybar when an icon dir is not readable

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -348,6 +348,9 @@ void init_themes(list_t **themes, list_t **basedirs) {
 	*themes = create_list();
 	for (int i = 0; i < (*basedirs)->length; ++i) {
 		list_t *dir_themes = load_themes_in_dir((*basedirs)->items[i]);
+		if (dir_themes == NULL) {
+			continue;
+		}
 		list_cat(*themes, dir_themes);
 		list_free(dir_themes);
 	}


### PR DESCRIPTION
Fixes #3981.