### PR TITLE
Add feature to revoke bindings

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -181,6 +181,8 @@ sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;
 sway_cmd cmd_titlebar_padding;
+sway_cmd cmd_unbindcode;
+sway_cmd cmd_unbindsym;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -182,6 +182,7 @@ sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;
 sway_cmd cmd_titlebar_padding;
 sway_cmd cmd_unbindcode;
+sway_cmd cmd_unbindswitch;
 sway_cmd cmd_unbindsym;
 sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -217,6 +217,8 @@ sway_cmd bar_cmd_tray_bindcode;
 sway_cmd bar_cmd_tray_bindsym;
 sway_cmd bar_cmd_tray_output;
 sway_cmd bar_cmd_tray_padding;
+sway_cmd bar_cmd_unbindcode;
+sway_cmd bar_cmd_unbindsym;
 sway_cmd bar_cmd_wrap_scroll;
 sway_cmd bar_cmd_workspace_buttons;
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -93,6 +93,7 @@ static struct cmd_handler handlers[] = {
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },
 	{ "unbindcode", cmd_unbindcode },
+	{ "unbindswitch", cmd_unbindswitch },
 	{ "unbindsym", cmd_unbindsym },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -92,6 +92,8 @@ static struct cmd_handler handlers[] = {
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },
+	{ "unbindcode", cmd_unbindcode },
+	{ "unbindsym", cmd_unbindsym },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -32,6 +32,8 @@ static struct cmd_handler bar_handlers[] = {
 	{ "tray_bindsym", bar_cmd_tray_bindsym },
 	{ "tray_output", bar_cmd_tray_output },
 	{ "tray_padding", bar_cmd_tray_padding },
+	{ "unbindcode", bar_cmd_unbindcode },
+	{ "unbindsym", bar_cmd_unbindsym },
 	{ "workspace_buttons", bar_cmd_workspace_buttons },
 	{ "wrap_scroll", bar_cmd_wrap_scroll },
 };

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -9,10 +9,70 @@
 #include "log.h"
 #include "stringop.h"
 
-static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
-	const char *command = code ? "bar bindcode" : "bar bindsym";
+static struct cmd_results *binding_add(struct bar_binding *binding,
+		list_t *mode_bindings) {
+	const char *name = get_mouse_button_name(binding->button);
+	bool overwritten = false;
+	for (int i = 0; i < mode_bindings->length; i++) {
+		struct bar_binding *other = mode_bindings->items[i];
+		if (other->button == binding->button &&
+				other->release == binding->release) {
+			overwritten = true;
+			mode_bindings->items[i] = binding;
+			free_bar_binding(other);
+			sway_log(SWAY_DEBUG, "[bar %s] Updated binding for %u (%s)%s",
+					config->current_bar->id, binding->button, name,
+					binding->release ? " - release" : "");
+			break;
+		}
+	}
+	if (!overwritten) {
+		list_add(mode_bindings, binding);
+		sway_log(SWAY_DEBUG, "[bar %s] Added binding for %u (%s)%s",
+				config->current_bar->id, binding->button, name,
+				binding->release ? " - release" : "");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+static struct cmd_results *binding_remove(struct bar_binding *binding,
+		list_t *mode_bindings) {
+	const char *name = get_mouse_button_name(binding->button);
+	for (int i = 0; i < mode_bindings->length; i++) {
+		struct bar_binding *other = mode_bindings->items[i];
+		if (other->button == binding->button &&
+				other->release == binding->release) {
+			sway_log(SWAY_DEBUG, "[bar %s] Unbound binding for %u (%s)%s",
+					config->current_bar->id, binding->button, name,
+					binding->release ? " - release" : "");
+			free_bar_binding(other);
+			free_bar_binding(binding);
+			list_del(mode_bindings, i);
+			return cmd_results_new(CMD_SUCCESS, NULL);
+		}
+	}
+
+	struct cmd_results *error = cmd_results_new(CMD_FAILURE, "Could not "
+			"find binding for [bar %s]" " Button %u (%s)%s",
+			config->current_bar->id, binding->button, name,
+			binding->release ? " - release" : "");
+	free_bar_binding(binding);
+	return error;
+}
+
+static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
+		bool unbind) {
+	int minargs = 2;
+	const char *command;
+	if (unbind) {
+		minargs--;
+		command = code ? "bar unbindcode" : "bar unbindsym";
+	} else {
+		command = code ? "bar bindcode" : "bar bindsym";
+	}
+
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, command, EXPECTED_AT_LEAST, 2))) {
+	if ((error = checkarg(argc, command, EXPECTED_AT_LEAST, minargs))) {
 		return error;
 	}
 	if (!config->current_bar) {
@@ -46,39 +106,27 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code) {
 		free_bar_binding(binding);
 		return cmd_results_new(CMD_INVALID, "Unknown button %s", argv[0]);
 	}
-	const char *name = get_mouse_button_name(binding->button);
+	list_t *bindings = config->current_bar->bindings;
+	if (unbind) {
+		return binding_remove(binding, bindings);
+	}
 
 	binding->command = join_args(argv + 1, argc - 1);
-
-	list_t *bindings = config->current_bar->bindings;
-	bool overwritten = false;
-	for (int i = 0; i < bindings->length; i++) {
-		struct bar_binding *other = bindings->items[i];
-		if (other->button == binding->button &&
-				other->release == binding->release) {
-			overwritten = true;
-			bindings->items[i] = binding;
-			free_bar_binding(other);
-			sway_log(SWAY_DEBUG, "[bar %s] Updated binding for %u (%s)%s",
-					config->current_bar->id, binding->button, name,
-					binding->release ? " - release" : "");
-			break;
-		}
-	}
-	if (!overwritten) {
-		list_add(bindings, binding);
-		sway_log(SWAY_DEBUG, "[bar %s] Added binding for %u (%s)%s",
-				config->current_bar->id, binding->button, name,
-				binding->release ? " - release" : "");
-	}
-
-	return cmd_results_new(CMD_SUCCESS, NULL);
+	return binding_add(binding, bindings);
 }
 
 struct cmd_results *bar_cmd_bindcode(int argc, char **argv) {
-	return bar_cmd_bind(argc, argv, true);
+	return bar_cmd_bind(argc, argv, true, false);
 }
 
 struct cmd_results *bar_cmd_bindsym(int argc, char **argv) {
-	return bar_cmd_bind(argc, argv, false);
+	return bar_cmd_bind(argc, argv, false, false);
+}
+
+struct cmd_results *bar_cmd_unbindcode(int argc, char **argv) {
+	return bar_cmd_bind(argc, argv, true, true);
+}
+
+struct cmd_results *bar_cmd_unbindsym(int argc, char **argv) {
+	return bar_cmd_bind(argc, argv, false, true);
 }

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -112,6 +112,12 @@ Sway allows configuring swaybar in the sway configuration file.
 	the bar. This value will be multiplied by the output scale. The default is
 	_3_.
 
+*unbindcode* [--release] <event-code>
+	Removes the binding with the given <event-code>.
+
+*unbindsym* [--release] button[1-9]|<event-name>
+	Removes the binding with the given <button> or <event-name>.
+
 ## TRAY
 
 Swaybar provides a system tray where third-party applications may place icons.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -641,6 +641,9 @@ The default colors are:
 	to _yes_, the marks will be shown on the _left_ side instead of the
 	_right_ side.
 
+*unbindswitch* <switch>:<state>
+	Removes a binding for when <switch> changes to <state>.
+
 *unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--input-device=<device>] <key combo>
 	Removes the binding for _key combo_ that was previously bound with the
 	given flags.  If _input-device_ is given, only the binding for that

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -641,6 +641,14 @@ The default colors are:
 	to _yes_, the marks will be shown on the _left_ side instead of the
 	_right_ side.
 
+*unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--input-device=<device>] <key combo>
+	Removes the binding for _key combo_ that was previously bound with the
+	given flags.  If _input-device_ is given, only the binding for that
+	input device will be unbound.
+
+	*unbindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] [input-device=<device>] <code>
+	is also available for unbinding with key/button codes instead of key/button names.
+
 *unmark* [<identifier>]
 	*unmark* will remove _identifier_ from the list of current marks on a
 	window. If _identifier_ is omitted, all marks are removed.


### PR DESCRIPTION
This PR implements the feature request #3971 that will allow a user to revoke key, mouse, or switch bindings both for sway and swaybar.

Status:
- [x] Add unbindsym/unbindcode commands for sway
- [x] Add unbindsym/unbindcode commands for swaybar
- [x] Add unbindswitch command
- [x] Cleanup

Closes #3971 