### PR TITLE
idle_inhibit: fix crash during view destruction

### DIFF
--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -93,7 +93,8 @@ static bool check_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 	switch (inhibitor->mode) {
 	case INHIBIT_IDLE_APPLICATION:
 		// If there is no view associated with the inhibitor, assume visible
-		return !inhibitor->view || view_is_visible(inhibitor->view);
+		return !inhibitor->view || !inhibitor->view->container ||
+			view_is_visible(inhibitor->view);
 	case INHIBIT_IDLE_FOCUS:;
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {


### PR DESCRIPTION
Fixes #4004

This fixes a crash for application set idle inhibitors when their
associated view is being destroyed. There is a call to
`view_is_visible` to determine is the view is visible and it assumes
that the view has an container, but it is possible for the container
to already have been destroyed at this point. There is a NULL check for
the view in `check_active` and this re-adds the NULL check for the
container that I accidentally dropped when refactoring during the
inhibit_idle command PR (#3962)