### PR TITLE
root_scratchpad_hide: fix crash when layer focused

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -135,7 +135,7 @@ void root_scratchpad_show(struct sway_container *con) {
 
 void root_scratchpad_hide(struct sway_container *con) {
 	struct sway_seat *seat = input_manager_current_seat();
-	struct sway_node *focus = seat_get_focus(seat);
+	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
 	struct sway_workspace *ws = con->workspace;
 
 	container_detach(con);


### PR DESCRIPTION
Fixes #4008 

This fixes a crash in `root_scratchpad_hide` when a layer surface is
focused. Since `seat_get_focus` is NULL when a layer surface is
focused, the call to `node_has_ancestor` was causing a SIGSEGV since it
was attempting to access the parent of NULL. This changes the call to
`seat_get_focus_inactive`, which will return a node even when a layer
surface is focused and is also guaranteed to have something in the
focus stack if a scratchpad container is being hidden (otherwise there
would not be any containers yet).