### PR TITLE
Unbreak -Werror on 32-bit platforms

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -621,7 +621,7 @@ bool spawn_swaybg(void) {
 	}
 
 	for (size_t k = 0; k < i; k++) {
-		sway_log(SWAY_DEBUG, "spawn_swaybg cmd[%ld] = %s", k, cmd[k]);
+		sway_log(SWAY_DEBUG, "spawn_swaybg cmd[%zd] = %s", k, cmd[k]);
 	}
 
 	bool result = _spawn_swaybg(cmd);


### PR DESCRIPTION
Same as https://github.com/swaywm/wlroots/pull/1650. See error logs: [armv7](https://github.com/swaywm/sway/files/3055931/sway-1.0.r1.221.log), [i386](https://github.com/swaywm/sway/files/3055930/sway-1.0.r1.221.log).