### PR TITLE
cmd_focus: raise floating for `<criteria> focus`

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -317,6 +317,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		}
 		seat_set_focus_container(seat, container);
 		seat_consider_warp_to_focus(seat);
+		container_raise_floating(container);
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 


### PR DESCRIPTION
Closes #4031 

Floaters are currently raised for `focus <direction>`. This extends the
same functionality to `<criteria> focus`.