### PR TITLE
Fix scratchpad logic for floating windows 

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -61,9 +61,14 @@ void root_scratchpad_add_container(struct sway_container *con) {
 
 	struct sway_container *parent = con->parent;
 	struct sway_workspace *workspace = con->workspace;
-	container_set_floating(con, true);
-	container_floating_set_default_size(con);
-	container_floating_move_to_center(con);
+
+	// When a tiled window is sent to scratchpad, center and resize it.
+	if (!container_is_floating(con)) {
+		container_set_floating(con, true);
+		container_floating_set_default_size(con);
+		container_floating_move_to_center(con);
+	}
+
 	container_detach(con);
 	con->scratchpad = true;
 	list_add(root->scratchpad, con);


### PR DESCRIPTION
Only sets an initial size if the container does *not* have a view. This
allows initial sizing geometry to be respected.

This is a follow up to https://github.com/swaywm/sway/pull/3992, wherein I believe the original intent was to only set a default size for containers without a view:

> When setting a non-view container to
floating, this will set a sane default size of 50% of the workspace
width and 75% of the workspace height, or whatever the closest is that
the minimum and maximum floating width/height values allow for.