### PR TITLE
sway-input.5: add xkeyboard-config(7) to "see also"

### DIFF
--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -193,4 +193,4 @@ correct seat.
 
 # SEE ALSO
 
-*sway*(5) *sway-output*(5)
+*sway*(5) *sway-output*(5) *xkeyboard-config*(7)


### PR DESCRIPTION
Since xkeyboard-config(7) is mentioned in the man page, add a reference
to the "see also" section.