### PR TITLE
Spawn swaynag as a wayland client

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <float.h>
+#include <fcntl.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -74,4 +75,22 @@ const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel) 
 	}
 	sway_assert(false, "Unknown value for wl_output_subpixel.");
 	return NULL;
+}
+
+bool set_cloexec(int fd, bool cloexec) {
+	int flags = fcntl(fd, F_GETFD);
+	if (flags == -1) {
+		sway_log_errno(SWAY_ERROR, "fcntl failed");
+		return false;
+	}
+	if (cloexec) {
+		flags = flags | FD_CLOEXEC;
+	} else {
+		flags = flags & ~FD_CLOEXEC;
+	}
+	if (fcntl(fd, F_SETFD, flags) == -1) {
+		sway_log_errno(SWAY_ERROR, "fcntl failed");
+		return false;
+	}
+	return true;
 }

--- a/include/sway/swaynag.h
+++ b/include/sway/swaynag.h
@@ -1,9 +1,12 @@
 #ifndef _SWAY_SWAYNAG_H
 #define _SWAY_SWAYNAG_H
+#include <wayland-server-core.h>
 
 struct swaynag_instance {
+	struct wl_client *client;
+	struct wl_listener client_destroy;
+
 	const char *args;
-	pid_t pid;
 	int fd[2];
 	bool detailed;
 };
@@ -14,9 +17,6 @@ struct swaynag_instance {
 // swaynag->detailed is true.
 bool swaynag_spawn(const char *swaynag_command,
 		struct swaynag_instance *swaynag);
-
-// Kill the swaynag instance
-void swaynag_kill(struct swaynag_instance *swaynag);
 
 // Write a log message to swaynag->fd[1]. This will fail when swaynag->detailed
 // is false.

--- a/include/util.h
+++ b/include/util.h
@@ -32,4 +32,6 @@ float parse_float(const char *value);
 
 const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel);
 
+bool set_cloexec(int fd, bool cloexec);
+
 #endif

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1,6 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
-#include <fcntl.h>
 #include <stdbool.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -486,24 +485,6 @@ static void handle_swaybg_client_destroy(struct wl_listener *listener,
 	wl_list_remove(&config->swaybg_client_destroy.link);
 	wl_list_init(&config->swaybg_client_destroy.link);
 	config->swaybg_client = NULL;
-}
-
-static bool set_cloexec(int fd, bool cloexec) {
-	int flags = fcntl(fd, F_GETFD);
-	if (flags == -1) {
-		sway_log_errno(SWAY_ERROR, "fcntl failed");
-		return false;
-	}
-	if (cloexec) {
-		flags = flags | FD_CLOEXEC;
-	} else {
-		flags = flags & ~FD_CLOEXEC;
-	}
-	if (fcntl(fd, F_SETFD, flags) == -1) {
-		sway_log_errno(SWAY_ERROR, "fcntl failed");
-		return false;
-	}
-	return true;
 }
 
 static bool _spawn_swaybg(char **command) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -391,7 +391,7 @@ int main(int argc, char **argv) {
 	load_swaybars();
 	run_deferred_commands();
 
-	if (config->swaynag_config_errors.pid > 0) {
+	if (config->swaynag_config_errors.client != NULL) {
 		swaynag_show(&config->swaynag_config_errors);
 	}
 

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -45,17 +45,24 @@ static void swaynag_button_execute(struct swaynag *swaynag,
 		swaynag->details.visible = !swaynag->details.visible;
 		render_frame(swaynag);
 	} else {
-		if (fork() == 0) {
+		pid_t pid = fork();
+		if (pid < 0) {
+			sway_log_errno(SWAY_DEBUG, "Failed to fork");
+			return;
+		} else if (pid == 0) {
 			// Child process. Will be used to prevent zombie processes
-			setsid();
-			if (fork() == 0) {
+			pid = fork();
+			if (pid < 0) {
+				sway_log_errno(SWAY_DEBUG, "Failed to fork");
+				return;
+			} else if (pid == 0) {
 				// Child of the child. Will be reparented to the init process
 				char *terminal = getenv("TERMINAL");
 				if (button->terminal && terminal && strlen(terminal)) {
 					sway_log(SWAY_DEBUG, "Found $TERMINAL: %s", terminal);
 					if (!terminal_execute(terminal, button->action)) {
 						swaynag_destroy(swaynag);
-						exit(EXIT_FAILURE);
+						_exit(EXIT_FAILURE);
 					}
 				} else {
 					if (button->terminal) {
@@ -63,12 +70,16 @@ static void swaynag_button_execute(struct swaynag *swaynag,
 								"$TERMINAL not found. Running directly");
 					}
 					execl("/bin/sh", "/bin/sh", "-c", button->action, NULL);
+					sway_log_errno(SWAY_DEBUG, "execl failed");
+					_exit(EXIT_FAILURE);
 				}
 			}
-			exit(EXIT_SUCCESS);
+			_exit(EXIT_SUCCESS);
+		}
+		if (waitpid(pid, NULL, 0) < 0) {
+			sway_log_errno(SWAY_DEBUG, "waitpid failed");
 		}
 	}
-	wait(0);
 }
 
 static void layer_surface_configure(void *data,


### PR DESCRIPTION
**Until #4051 is merged, I would recommend rebasing this on top of it for testing. Otherwise, pressing the "Reload sway" button may result in sway reloading multiple times causing a noticeable delay/unresponsive period. Reloading via a binding or command line is not affected by the multiple reloads issue**

Fixes #4047 

This spawns swaynag as a wayland client similar to how swaybar and
swaybg are already done