### PR TITLE
swaymsg: add timeout and type checks

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -69,6 +69,16 @@ int ipc_open_socket(const char *socket_path) {
 	return socketfd;
 }
 
+bool ipc_set_recv_timeout(int socketfd, struct timeval tv) {
+	if (setsockopt(socketfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == -1) {
+		sway_log_errno(SWAY_ERROR, "Failed to set ipc recv timeout");
+		return false;
+	}
+	sway_log(SWAY_DEBUG, "ipc recv timeout set to %ld.%06ld",
+			tv.tv_sec, tv.tv_usec);
+	return true;
+}
+
 struct ipc_response *ipc_recv_response(int socketfd) {
 	char data[IPC_HEADER_SIZE];
 	uint32_t *data32 = (uint32_t *)(data + sizeof(ipc_magic));

--- a/include/ipc-client.h
+++ b/include/ipc-client.h
@@ -1,7 +1,9 @@
 #ifndef _SWAY_IPC_CLIENT_H
 #define _SWAY_IPC_CLIENT_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <sys/time.h>
 
 #include "ipc.h"
 
@@ -36,5 +38,9 @@ struct ipc_response *ipc_recv_response(int socketfd);
  * Free ipc_response struct
  */
 void free_ipc_response(struct ipc_response *response);
+/**
+ * Sets the receive timeout for the IPC socket
+ */
+bool ipc_set_recv_timeout(int socketfd, struct timeval tv);
 
 #endif


### PR DESCRIPTION
*Disclaimer: I'm not really sure of the value of this, but it's not that large*

Closes #4046 

This adds a 3 second timeout to the initial reply in swaymsg. This
prevents swaymsg from hanging when `swaymsg -t get_{inputs,seats}` is
used in i3. The timeout is removed when waiting for a subscribed event
or monitoring for subscribed events.

This also adds type checks to commands where i3 does not reply with all
of the properties that sway does (such as `modes` in `get_outputs`).

This is mostly just a behavioral adjustment since swaymsg should run on
i3. When running under i3, some command reply's (such as the one for
`get_outputs) may have more useful information in the raw json than the
pretty printed version.