### PR TITLE
Don't apply hide_edge_borders to floating windows 

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -221,8 +221,10 @@ void view_autoconfigure(struct sway_view *view) {
 
 	con->border_top = con->border_bottom = true;
 	con->border_left = con->border_right = true;
+	double y_offset = 0;
 
-	if (ws) {
+	if (!container_is_floating(con) && ws) {
+
 		bool smart = config->hide_edge_borders == E_SMART ||
 			(config->hide_edge_borders == E_SMART_NO_GAPS &&
 			!gaps_to_edge(view));
@@ -240,24 +242,22 @@ void view_autoconfigure(struct sway_view *view) {
 			int bottom_y = con->y + con->height + con->current_gaps.bottom;
 			con->border_bottom = bottom_y != ws->y + ws->height;
 		}
-	}
 
-	double y_offset = 0;
-
-	// In a tabbed or stacked container, the container's y is the top of the
-	// title area. We have to offset the surface y by the height of the title,
-	// bar, and disable any top border because we'll always have the title bar.
-	list_t *siblings = container_get_siblings(con);
-	bool show_titlebar = (siblings && siblings->length > 1)
-		|| !config->hide_lone_tab;
-	if (show_titlebar && !container_is_floating(con)) {
-		enum sway_container_layout layout = container_parent_layout(con);
-		if (layout == L_TABBED) {
-			y_offset = container_titlebar_height();
-			con->border_top = false;
-		} else if (layout == L_STACKED) {
-			y_offset = container_titlebar_height() * siblings->length;
-			con->border_top = false;
+		// In a tabbed or stacked container, the container's y is the top of the
+		// title area. We have to offset the surface y by the height of the title,
+		// bar, and disable any top border because we'll always have the title bar.
+		list_t *siblings = container_get_siblings(con);
+		bool show_titlebar = (siblings && siblings->length > 1)
+			|| !config->hide_lone_tab;
+		if (show_titlebar) {
+			enum sway_container_layout layout = container_parent_layout(con);
+			if (layout == L_TABBED) {
+				y_offset = container_titlebar_height();
+				con->border_top = false;
+			} else if (layout == L_STACKED) {
+				y_offset = container_titlebar_height() * siblings->length;
+				con->border_top = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
With the command `hide_edge_borders` it is possible to hide window borders adjacent to the screen edges and this was also applied to floating windows. This patch changes this behavior to match i3's (see https://github.com/i3/i3/blob/56bbc528d7de68100298c6ba85a6488778f3a64e/src/con.c#L1645).

The old behavior led to the following problem: If a floating window's border (adjacent to the screen edge)  was hidden by `hide_edge_borders`, the border stayed hidden when the window was moved away from the screen edge. To reproduce:

1. Open a floating terminal (with a size smaller than the screen).
2. In this terminal execute `swaymsg border normal 2, hide_edge_borders both, move window to workspace 1, workspace 1, move absolute position 0 0, workspace 1, move position center`
3. The terminal is centered and its left border is missing.

The first commit refactors view_auto_configure() to improve readability. The second commit contains the actual change:
