### PR TITLE
hide_edge_borders.c: add missing case for --i3

### DIFF
--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -13,6 +13,8 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		config->hide_lone_tab = true;
 		++argv;
 		--argc;
+	} else {
+		config->hide_lone_tab = false;
 	}
 
 	if (strcmp(argv[0], "none") == 0) {


### PR DESCRIPTION
Disable the i3-compatible behavior if the option '--i3' is not given.
Previously it was only possible to disable it by changing the config
file. Now it also works via swaymsg.