### PR TITLE
Correctly reset the cursor image after a seatop

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -193,11 +193,9 @@ static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 		struct sway_node *node, struct wlr_surface *surface,
 		double sx, double sy) {
 	struct wlr_seat *wlr_seat = cursor->seat->wlr_seat;
-	// Handle cursor image
 	if (surface) {
 		if (seat_is_input_allowed(cursor->seat, surface)) {
 			wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
-			wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
 		}
 	} else if (node && node->type == N_CONTAINER) {
 		// Try a node's resize edge
@@ -462,6 +460,9 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
 	}
 
 	cursor_do_rebase(cursor, time_msec, node, surface, sx, sy);
+	if (surface && seat_is_input_allowed(cursor->seat, surface)) {
+		wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
+	}
 
 	struct sway_drag_icon *drag_icon;
 	wl_list_for_each(drag_icon, &root->drag_icons, link) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -192,12 +192,12 @@ static void state_add_button(struct seatop_default_event *e, uint32_t button) {
 static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 		struct sway_node *node, struct wlr_surface *surface,
 		double sx, double sy) {
+	struct wlr_seat *wlr_seat = cursor->seat->wlr_seat;
 	// Handle cursor image
 	if (surface) {
-		// Reset cursor if switching between clients
-		struct wl_client *client = wl_resource_get_client(surface->resource);
-		if (client != cursor->image_client) {
-			cursor_set_image(cursor, "left_ptr", client);
+		if (seat_is_input_allowed(cursor->seat, surface)) {
+			wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
+			wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
 		}
 	} else if (node && node->type == N_CONTAINER) {
 		// Try a node's resize edge
@@ -217,14 +217,7 @@ static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 		cursor_set_image(cursor, "left_ptr", NULL);
 	}
 
-	// Send pointer enter/leave
-	struct wlr_seat *wlr_seat = cursor->seat->wlr_seat;
-	if (surface) {
-		if (seat_is_input_allowed(cursor->seat, surface)) {
-			wlr_seat_pointer_notify_enter(wlr_seat, surface, sx, sy);
-			wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
-		}
-	} else {
+	if (surface == NULL) {
 		wlr_seat_pointer_clear_focus(wlr_seat);
 	}
 }

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -461,7 +461,7 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
 
 	cursor_do_rebase(cursor, time_msec, node, surface, sx, sy);
 	if (surface && seat_is_input_allowed(cursor->seat, surface)) {
-		wlr_seat_pointer_notify_motion(wlr_seat, time_msec, sx, sy);
+		wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
 	}
 
 	struct sway_drag_icon *drag_icon;

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -60,4 +60,5 @@ void seatop_begin_move_floating(struct sway_seat *seat,
 	container_raise_floating(con);
 
 	cursor_set_image(seat->cursor, "grab", NULL);
+	wlr_seat_pointer_clear_focus(seat->wlr_seat);
 }

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -327,6 +327,7 @@ void seatop_begin_move_tiling_threshold(struct sway_seat *seat,
 	seat->seatop_data = e;
 
 	container_raise_floating(con);
+	wlr_seat_pointer_clear_focus(seat->wlr_seat);
 }
 
 void seatop_begin_move_tiling(struct sway_seat *seat,

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -160,4 +160,5 @@ void seatop_begin_resize_floating(struct sway_seat *seat,
 	const char *image = edge == WLR_EDGE_NONE ?
 		"se-resize" : wlr_xcursor_get_resize_name(edge);
 	cursor_set_image(seat->cursor, image, NULL);
+	wlr_seat_pointer_clear_focus(seat->wlr_seat);
 }

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -105,4 +105,6 @@ void seatop_begin_resize_tiling(struct sway_seat *seat,
 
 	seat->seatop_impl = &seatop_impl;
 	seat->seatop_data = e;
+
+	wlr_seat_pointer_clear_focus(seat->wlr_seat);
 }


### PR DESCRIPTION
This fixes a minor annoyance when moving or resizing using the floating_modifier.  Currently, after finishing moving or resizing a window, the cursor is reset to "left_ptr", not the image requested by the client.  This PR saves said image and restores it correctly.