### PR TITLE
ipc: fix criteria for emitting bar_state_update

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -424,11 +424,18 @@ static int handle_keyboard_repeat(void *data) {
 static void determine_bar_visibility(uint32_t modifiers) {
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *bar = config->bars->items[i];
-		if (strcmp(bar->mode, bar->hidden_state) == 0) { // both are "hide"
-			bool should_be_visible = 
-				bar->modifier != 0 && (~modifiers & bar->modifier) == 0;
-			if (bar->visible_by_modifier != should_be_visible) {
-				bar->visible_by_modifier = should_be_visible;
+		if (bar->modifier == 0) {
+			continue;
+		}
+
+		bool vis_by_mod = (~modifiers & bar->modifier) == 0;
+		if (bar->visible_by_modifier != vis_by_mod) {
+			// If visible by modifier is set, send that it is no longer visible
+			// by modifier (regardless of bar mode and state). Otherwise, only
+			// send the visible by modifier status if mode and state are hide
+			if (bar->visible_by_modifier
+					|| strcmp(bar->mode, bar->hidden_state) == 0) {
+				bar->visible_by_modifier = vis_by_mod;
 				ipc_event_bar_state_update(bar);
 			}
 		}


### PR DESCRIPTION
Fixes #4066 

This fixes the criteria for emitting a `bar_state_update` event to
notify swaybar (and any other bars utilizing the event) on whether the
bar is visible by modifier. It is not enough to only emit the event
when both the bar mode and bar hidden state are `hide` since it is
possible to release the modifier while hidden state is `show` and then
change hidden state to `hide` without pressing the modifier. This also
emits the event whenever visible by modifier is set and should no
longer be regardless of the mode and state to ensure that it gets
properly cleared. If visible by modifier is not set and the bar is not
in `hide`/`hide`, then no events will be sent and visible by modifier
will not be set