### PR TITLE
swaybar: hide mode visibility improvements

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -23,6 +23,7 @@ struct swaybar {
 	// only relevant when bar is in "hide" mode
 	bool visible_by_modifier;
 	bool visible_by_urgency;
+	bool visible_by_mode;
 	bool visible;
 
 	struct wl_display *display;

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -148,7 +148,8 @@ bool determine_bar_visibility(struct swaybar *bar, bool moving_layer) {
 	struct swaybar_config *config = bar->config;
 	bool visible = !(strcmp(config->mode, "invisible") == 0 ||
 		(strcmp(config->mode, config->hidden_state) == 0 // both "hide"
-			&& !bar->visible_by_modifier && !bar->visible_by_urgency));
+			&& !bar->visible_by_modifier && !bar->visible_by_urgency
+			&& !bar->visible_by_mode));
 
 	// Create/destroy layer surfaces as needed
 	struct swaybar_output *output;


### PR DESCRIPTION
Closes #3036

This allows swaybar to become visible when the mode changes (to any
mode other than the default). swaybar will be hidden again when the
modifier is pressed and released or when switching back to the default
mode.

This also applies the same logic to visible by urgency to hide swaybar
when the modifier is pressed and released.

These changes are to match i3's behavior.