### PR TITLE
cmd_move: respect workspace layout when inserting

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1385,8 +1385,10 @@ void container_replace(struct sway_container *container,
 		root_scratchpad_show(container);
 		root_scratchpad_remove_container(container);
 	}
-	container_add_sibling(container, replacement, 1);
-	container_detach(container);
+	if (container->parent || container->workspace) {
+		container_add_sibling(container, replacement, 1);
+		container_detach(container);
+	}
 	if (scratchpad) {
 		root_scratchpad_add_container(replacement);
 	}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -688,6 +688,9 @@ void workspace_insert_tiling(struct sway_workspace *workspace,
 	if (con->workspace) {
 		container_detach(con);
 	}
+	if (workspace->layout == L_STACKED || workspace->layout == L_TABBED) {
+		con = container_split(con, workspace->layout);
+	}
 	list_insert(workspace->tiling, index, con);
 	con->workspace = workspace;
 	container_for_each_child(con, set_workspace, NULL);


### PR DESCRIPTION
Fixes #4038 

When moving a container to become a direct child of the workspace and
the workspace's layout is tabbed or stacked, wrap it in a container
with the same layout. This allows for the following:
- Run `layout tabbed|stacked` on an empty workspace (or use
  `workspace_layout tabbed|stacked` in the config)
- Open some views
- Move one of the views in any direction
- Open another view
- The new container should also be `tabbed`/`stacked`