### PR TITLE
ci: enable all features

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -32,7 +32,7 @@ tasks:
       sudo ninja -C build install
   - setup: |
       cd sway
-      meson build
+      meson build -Dauto_features=enabled -Dtray=disabled
   - build: |
       cd sway
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -28,7 +28,7 @@ tasks:
       sudo ninja -C build install
   - setup: |
       cd sway
-      meson build
+      meson build -Dauto_features=enabled
   - build: |
       cd sway
       ninja -C build


### PR DESCRIPTION
If unspecified, feature options are set to "auto", which means enabled only if
the required dependencies are found. In CI we don't want to miss compilation
errors because a dependency hasn't been found and code isn't built.

Leave FreeBSD out for now because it uses a subproject (haven't found a way to
make auto_features=enabled only apply to the toplevel project).