### PR TITLE
Unbreak -Werror on 32-bit platforms

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -75,7 +75,7 @@ bool ipc_set_recv_timeout(int socketfd, struct timeval tv) {
 		return false;
 	}
 	sway_log(SWAY_DEBUG, "ipc recv timeout set to %ld.%06ld",
-			tv.tv_sec, tv.tv_usec);
+			(long)tv.tv_sec, (long)tv.tv_usec);
 	return true;
 }
 


### PR DESCRIPTION
Regressed by #4062. See error logs: [i386](https://github.com/swaywm/sway/files/3121838/sway-1.0.r1.257.log), [armv7](https://github.com/swaywm/sway/files/3121842/sway-1.0.r1.257.log).
