### PR TITLE
Remove extra inclusion of stdio.h

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -5,7 +5,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
The header file `stdio.h` was included twice in `main.c`.