### PR TITLE
cmd_move: add support for output current

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -28,6 +28,15 @@ static const char expected_syntax[] =
 
 static struct sway_output *output_in_direction(const char *direction_string,
 		struct sway_output *reference, int ref_lx, int ref_ly) {
+	if (strcasecmp(direction_string, "current") == 0) {
+		struct sway_workspace *active_ws =
+			seat_get_focused_workspace(config->handler_context.seat);
+		if (!active_ws) {
+			return NULL;
+		}
+		return active_ws->output;
+	}
+
 	struct {
 		char *name;
 		enum wlr_direction direction;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -206,7 +206,7 @@ set|plus|minus <amount>
 *move* [container|window] [to] workspace back_and_forth
 	Moves the focused container to previously focused workspace.
 
-*move* [container|window] [to] output <name-or-id>
+*move* [container|window] [to] output <name-or-id>|current
 	Moves the focused container to the specified output.
 
 *move* [container|window] [to] output up|right|down|left
@@ -216,10 +216,10 @@ set|plus|minus <amount>
 *move* [container|window] [to] scratchpad
 	Moves the focused container to the scratchpad.
 
-*move* workspace [to] output <name-or-id>
+*move* workspace [to] output <name-or-id>|current
 	Moves the focused workspace to the specified output.
 
-*move* workspace to [output] <name-or-id>
+*move* workspace to [output] <name-or-id>|current
 	Moves the focused workspace to the specified output.
 
 *move* workspace [to] output up|right|down|left


### PR DESCRIPTION
Related to https://github.com/swaywm/sway/issues/4108#issuecomment-488104938

This adds support for the following commands for i3 compatibility:
- `move [window|container] [to] output current`
- `move workspace to [output] current`
- `move workspace [to] output current`

The above commands are only useful when used with criteria.