### PR TITLE
Fix a race condition when respawning swaybg

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -482,9 +482,11 @@ void free_output_config(struct output_config *oc) {
 
 static void handle_swaybg_client_destroy(struct wl_listener *listener,
 		void *data) {
-	wl_list_remove(&config->swaybg_client_destroy.link);
-	wl_list_init(&config->swaybg_client_destroy.link);
-	config->swaybg_client = NULL;
+	struct wl_client *client = data;
+	wl_list_remove(&listener->link);
+	if (client == config->swaybg_client) {
+		config->swaybg_client = NULL;
+	}
 }
 
 static bool _spawn_swaybg(char **command) {


### PR DESCRIPTION
The destroy handler is sometimes called after a new instance was spawned and config->swaybg_client is already assigned to a new value, so in some cases wl_client_destroy is not called for newly spawned swaybg instances after changing the wallpaper and the background image gets stuck (and a lot of useless swaybg instances are spawned and not terminated)