### PR TITLE
Fix xdg-decoration unconfigured if set before first commit

### DIFF
--- a/sway/xdg_decoration.c
+++ b/sway/xdg_decoration.c
@@ -47,6 +47,8 @@ void handle_xdg_decoration(struct wl_listener *listener, void *data) {
 	deco->request_mode.notify = xdg_decoration_handle_request_mode;
 
 	wl_list_insert(&server.xdg_decorations, &deco->link);
+
+	xdg_decoration_handle_request_mode(&deco->request_mode, wlr_deco);
 }
 
 struct sway_xdg_decoration *xdg_decoration_from_surface(


### PR DESCRIPTION
In case a set_mode/unset_mode request is sent before the first commit, we need
to handle the value and send our preference accordingly.

This fixes xdg-decoration support for Qt apps.