### PR TITLE
Destroy swaybg client on reload

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -441,6 +441,10 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		config->reloading = true;
 		config->active = true;
 
+		if (old_config->swaybg_client != NULL) {
+			wl_client_destroy(old_config->swaybg_client);
+		}
+
 		if (old_config->swaynag_config_errors.client != NULL) {
 			wl_client_destroy(old_config->swaynag_config_errors.client);
 		}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -482,9 +482,11 @@ void free_output_config(struct output_config *oc) {
 
 static void handle_swaybg_client_destroy(struct wl_listener *listener,
 		void *data) {
-	wl_list_remove(&config->swaybg_client_destroy.link);
-	wl_list_init(&config->swaybg_client_destroy.link);
-	config->swaybg_client = NULL;
+	struct sway_config *sway_config =
+		wl_container_of(listener, sway_config, swaybg_client_destroy);
+	wl_list_remove(&sway_config->swaybg_client_destroy.link);
+	wl_list_init(&sway_config->swaybg_client_destroy.link);
+	sway_config->swaybg_client = NULL;
 }
 
 static bool _spawn_swaybg(char **command) {


### PR DESCRIPTION
Supersedes/Closes #4122  _(thanks @Hummer12007 for the initial PR)_

When reloading, this destroys the old config's swaybg client before
spawning the new config's swaybg. This fixes a race condition where the
old config's swaybg client's destroy was being called after the new
config's swaybg client was being spawned. This was causing the
reference to the new swaybg client to be removed and never destroyed.

This also modifies handle_swaybg_client_destroy to grab the config
reference using wl_container_of on the listener since the swaybg client
may be the old config swaybg client and should be used instead of the
global config instance