### PR TITLE
input/keyboard: attempt default keymap on failure

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -65,6 +65,8 @@ struct sway_keyboard {
 	struct sway_binding *repeat_binding;
 };
 
+struct xkb_keymap *sway_keyboard_compile_keymap(struct input_config *ic);
+
 struct sway_keyboard *sway_keyboard_create(struct sway_seat *seat,
 		struct sway_seat_device *device);
 


### PR DESCRIPTION
Partial fix for #4148. The user facing error portion is still a WIP

This attempts to use the default keymap when the one defined in the
input config fails to compile. The goal is to make it so the keyboard
is always in a usable state, even if it is not the user's requested
settings as usability is more important.

This also removes the calls to `getenv` for the `XKB_DEFAULT_*` family
of environment variables. The reasoning is libxkbcommon will fallback
to using those (and then the system defaults) when any of the rule
names are `NULL` or an empty string anyway so there is no need for
sway to duplicate the efforts.