### PR TITLE
config: Fix socket/wl_client leaks when executing child processes fails

### DIFF
--- a/include/sway/util.h
+++ b/include/sway/util.h
@@ -1,0 +1,14 @@
+#ifndef _SWAY_SWAY_UTIL_H
+#define _SWAY_SWAY_UTIL_H
+
+#include <spawn.h>
+
+/**
+ * Close fd and log theoretical case when close(2) failed
+ */
+void close_warn(int fd);
+
+struct wl_client *spawn_wl_client(char * const cmd[], struct wl_display *display);
+struct wl_client *spawn_wl_client_fa(char * const cmd[], struct wl_display *display, posix_spawn_file_actions_t *fa);
+
+#endif//_SWAY_SWAY_UTIL_H

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -13,6 +13,7 @@
 #include "sway/config.h"
 #include "sway/input/keyboard.h"
 #include "sway/output.h"
+#include "sway/util.h"
 #include "config.h"
 #include "list.h"
 #include "log.h"
@@ -187,79 +188,25 @@ static void handle_swaybar_client_destroy(struct wl_listener *listener,
 	bar->client = NULL;
 }
 
-static void invoke_swaybar(struct bar_config *bar) {
-	int sockets[2];
-	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
-		sway_log_errno(SWAY_ERROR, "socketpair failed");
-		return;
-	}
-	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
-		return;
-	}
-
-	bar->client = wl_client_create(server.wl_display, sockets[0]);
-	if (bar->client == NULL) {
-		sway_log_errno(SWAY_ERROR, "wl_client_create failed");
-		return;
-	}
-
-	bar->client_destroy.notify = handle_swaybar_client_destroy;
-	wl_client_add_destroy_listener(bar->client, &bar->client_destroy);
-
-	pid_t pid = fork();
-	if (pid < 0) {
-		sway_log(SWAY_ERROR, "Failed to create fork for swaybar");
-		return;
-	} else if (pid == 0) {
-		// Remove the SIGUSR1 handler that wlroots adds for xwayland
-		sigset_t set;
-		sigemptyset(&set);
-		sigprocmask(SIG_SETMASK, &set, NULL);
-
-		pid = fork();
-		if (pid < 0) {
-			sway_log_errno(SWAY_ERROR, "fork failed");
-			_exit(EXIT_FAILURE);
-		} else if (pid == 0) {
-			if (!set_cloexec(sockets[1], false)) {
-				_exit(EXIT_FAILURE);
-			}
-
-			char wayland_socket_str[16];
-			snprintf(wayland_socket_str, sizeof(wayland_socket_str),
-					"%d", sockets[1]);
-			setenv("WAYLAND_SOCKET", wayland_socket_str, true);
-
-			// run custom swaybar
-			char *const cmd[] = {
-					bar->swaybar_command ? bar->swaybar_command : "swaybar",
-					"-b", bar->id, NULL};
-			execvp(cmd[0], cmd);
-			_exit(EXIT_FAILURE);
-		}
-		_exit(EXIT_SUCCESS);
-	}
-
-	if (close(sockets[1]) != 0) {
-		sway_log_errno(SWAY_ERROR, "close failed");
-		return;
-	}
-
-	if (waitpid(pid, NULL, 0) < 0) {
-		sway_log_errno(SWAY_ERROR, "waitpid failed");
-		return;
-	}
-
-	sway_log(SWAY_DEBUG, "Spawned swaybar %s", bar->id);
-	return;
-}
-
 void load_swaybar(struct bar_config *bar) {
 	if (bar->client != NULL) {
 		wl_client_destroy(bar->client);
 	}
 	sway_log(SWAY_DEBUG, "Invoking swaybar for bar id '%s'", bar->id);
-	invoke_swaybar(bar);
+
+	char *const cmd[] = {
+			bar->swaybar_command ? bar->swaybar_command : "swaybar",
+			"-b", bar->id, NULL};
+	bar->client = spawn_wl_client(cmd, server.wl_display);
+
+	if (bar->client == NULL) {
+		sway_log(SWAY_ERROR, "Failed to spawn swaybar %s", bar->id);
+		return;
+	}
+
+	sway_log(SWAY_DEBUG, "Spawned swaybar %s", bar->id);
+	bar->client_destroy.notify = handle_swaybar_client_destroy;
+	wl_client_add_destroy_listener(bar->client, &bar->client_destroy);
 }
 
 void load_swaybars(void) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -9,6 +9,7 @@ sway_sources = files(
 	'security.c',
 	'server.c',
 	'swaynag.c',
+	'util.c',
 	'xdg_decoration.c',
 
 	'desktop/desktop.c',

--- a/sway/util.c
+++ b/sway/util.c
@@ -1,0 +1,96 @@
+#define _POSIX_C_SOURCE 200809L
+#include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <wayland-server.h>
+
+#include "log.h"
+#include "sway/util.h"
+#include "util.h"
+
+extern char **environ;
+
+void close_warn(int fd) {
+	if (close(fd) != 0) {
+		sway_log_errno(SWAY_ERROR, "close failed");
+	}
+}
+
+struct wl_client *spawn_wl_client(char * const cmd[], struct wl_display *display) {
+	return spawn_wl_client_fa(cmd, display, NULL);
+}
+
+struct wl_client *spawn_wl_client_fa(char * const cmd[], struct wl_display *display, posix_spawn_file_actions_t *fa) {
+	int sockets[2];
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+		sway_log_errno(SWAY_ERROR, "socketpair failed");
+		return NULL;
+	}
+
+	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
+		goto cleanup_sockets;
+	}
+
+	struct wl_client *client = wl_client_create(display, sockets[0]);
+	if (client == NULL) {
+		sway_log_errno(SWAY_ERROR, "wl_client_create failed");
+		goto cleanup_sockets;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		sway_log(SWAY_ERROR, "Failed to create fork for swaybar");
+		goto cleanup_client;
+	} else if (pid == 0) {
+		posix_spawnattr_t attr;
+		posix_spawnattr_init(&attr);
+
+		// Remove the SIGUSR1 handler that wlroots adds for xwayland
+		sigset_t set;
+		sigfillset(&set);
+		posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGDEF);
+		posix_spawnattr_setsigdefault(&attr, &set);
+
+		char wayland_socket_str[16];
+		snprintf(wayland_socket_str, sizeof(wayland_socket_str),
+				"%d", sockets[1]);
+		setenv("WAYLAND_SOCKET", wayland_socket_str, true);
+
+		if (!set_cloexec(sockets[1], false)) {
+			_exit(EXIT_FAILURE);
+		}
+
+		int r = posix_spawnp(&pid, cmd[0], fa, &attr, cmd, environ);
+		if (r) {
+			sway_log_errno(SWAY_ERROR, "posix_spawnp failed");
+			_exit(EXIT_FAILURE);
+		}
+
+		posix_spawnattr_destroy(&attr);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	if (waitpid(pid, NULL, 0) < 0) {
+		sway_log_errno(SWAY_ERROR, "waitpid failed");
+		goto cleanup_client;
+	}
+
+	close_warn(sockets[1]);
+
+	return client;
+
+cleanup_client:
+	wl_client_destroy(client);
+
+cleanup_sockets:
+	close(sockets[0]);
+	close(sockets[1]);
+
+	return NULL;
+}


### PR DESCRIPTION
Added spawn_wl_client helper function that is used for spawning both bar and
background processes

There are still unresolved issues so please don't merge until they are all solved.

Where to place this helper function? Config is not good place for it.

Failing on close(sockets[1]) is not wise in my opinion. It's cleanup stage and we can not do anything with it.

Also there is same code with same problems in sway/swaynag.c but it has pipe setup stage.
It can be generalized if posix_spawn is used instead of inner fork.