### PR TITLE
bar: fix segfault with missing or invalid bar id

### DIFF
--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -82,26 +82,30 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		++argv; --argc;
 	}
 
-	if (!config->current_bar && config->reading) {
-		// Create new bar with default values
-		struct bar_config *bar = default_bar_config();
-		if (!bar) {
-			return cmd_results_new(CMD_FAILURE,
-					"Unable to allocate bar state");
-		}
+	if (!config->current_bar) {
+		if (config->reading) {
+			// Create new bar with default values
+			struct bar_config *bar = default_bar_config();
+			if (!bar) {
+				return cmd_results_new(CMD_FAILURE,
+						"Unable to allocate bar state");
+			}
 
-		// set bar id
-		const int len = snprintf(NULL, 0, "bar-%d", config->bars->length - 1) + 1;
-		bar->id = malloc(len * sizeof(char));
-		if (bar->id) {
-			snprintf(bar->id, len, "bar-%d", config->bars->length - 1);
+			// set bar id
+			int len = snprintf(NULL, 0, "bar-%d", config->bars->length - 1) + 1;
+			bar->id = malloc(len * sizeof(char));
+			if (bar->id) {
+				snprintf(bar->id, len, "bar-%d", config->bars->length - 1);
+			} else {
+				return cmd_results_new(CMD_FAILURE, "Unable to allocate bar ID");
+			}
+
+			// Set current bar
+			config->current_bar = bar;
+			sway_log(SWAY_DEBUG, "Creating bar %s", bar->id);
 		} else {
-			return cmd_results_new(CMD_FAILURE, "Unable to allocate bar ID");
+			return cmd_results_new(CMD_FAILURE, "No bar defined.");
 		}
-
-		// Set current bar
-		config->current_bar = bar;
-		sway_log(SWAY_DEBUG, "Creating bar %s", bar->id);
 	}
 
 	if (find_handler(argv[0], bar_config_handlers,

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -75,9 +75,6 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
 	if ((error = checkarg(argc, command, EXPECTED_AT_LEAST, minargs))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 
 	struct bar_binding *binding = calloc(1, sizeof(struct bar_binding));
 	if (!binding) {

--- a/sway/commands/bar/binding_mode_indicator.c
+++ b/sway/commands/bar/binding_mode_indicator.c
@@ -10,10 +10,7 @@ struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {
 			"binding_mode_indicator", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-	config->current_bar->binding_mode_indicator = 
+	config->current_bar->binding_mode_indicator =
 		parse_boolean(argv[0], config->current_bar->binding_mode_indicator);
 	if (config->current_bar->binding_mode_indicator) {
 		sway_log(SWAY_DEBUG, "Enabling binding mode indicator on bar: %s",

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -9,9 +9,6 @@ struct cmd_results *bar_cmd_font(int argc, char **argv) {
 	if ((error = checkarg(argc, "font", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	char *font = join_args(argv, argc);
 	free(config->current_bar->font);
 	config->current_bar->font = font;

--- a/sway/commands/bar/gaps.c
+++ b/sway/commands/bar/gaps.c
@@ -13,9 +13,6 @@ struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
 	if ((error = checkarg(argc, "gaps", EXPECTED_AT_MOST, 4))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 
 	int top = 0, right = 0, bottom = 0, left = 0;
 

--- a/sway/commands/bar/icon_theme.c
+++ b/sway/commands/bar/icon_theme.c
@@ -12,10 +12,6 @@ struct cmd_results *bar_cmd_icon_theme(int argc, char **argv) {
 		return error;
 	}
 
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-
 	sway_log(SWAY_DEBUG, "[Bar %s] Setting icon theme to %s",
 			config->current_bar->id, argv[0]);
 	free(config->current_bar->icon_theme);

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -10,10 +10,6 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 		return error;
 	}
 
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-
 	uint32_t mod = 0;
 	if (strcmp(argv[0], "none") != 0) {
 		list_t *split = split_string(argv[0], "+");

--- a/sway/commands/bar/output.c
+++ b/sway/commands/bar/output.c
@@ -10,9 +10,6 @@ struct cmd_results *bar_cmd_output(int argc, char **argv) {
 	if ((error = checkarg(argc, "output", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 
 	const char *output = argv[0];
 	list_t *outputs = config->current_bar->outputs;

--- a/sway/commands/bar/pango_markup.c
+++ b/sway/commands/bar/pango_markup.c
@@ -9,11 +9,8 @@ struct cmd_results *bar_cmd_pango_markup(int argc, char **argv) {
 	if ((error = checkarg(argc, "pango_markup", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-	config->current_bar->pango_markup 
-		= parse_boolean(argv[0], config->current_bar->pango_markup);
+	config->current_bar->pango_markup =
+		parse_boolean(argv[0], config->current_bar->pango_markup);
 	if (config->current_bar->pango_markup) {
 		sway_log(SWAY_DEBUG, "Enabling pango markup for bar: %s",
 				config->current_bar->id);

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -9,9 +9,6 @@ struct cmd_results *bar_cmd_position(int argc, char **argv) {
 	if ((error = checkarg(argc, "position", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	char *valid[] = { "top", "bottom" };
 	for (size_t i = 0; i < sizeof(valid) / sizeof(valid[0]); ++i) {
 		if (strcasecmp(valid[i], argv[0]) == 0) {

--- a/sway/commands/bar/separator_symbol.c
+++ b/sway/commands/bar/separator_symbol.c
@@ -8,9 +8,6 @@ struct cmd_results *bar_cmd_separator_symbol(int argc, char **argv) {
 	if ((error = checkarg(argc, "separator_symbol", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	free(config->current_bar->separator_symbol);
 	config->current_bar->separator_symbol = strdup(argv[0]);
 	sway_log(SWAY_DEBUG, "Settings separator_symbol '%s' for bar: %s",

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -8,9 +8,6 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 	if ((error = checkarg(argc, "status_command", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	free(config->current_bar->status_command);
 	config->current_bar->status_command = NULL;
 

--- a/sway/commands/bar/strip_workspace_name.c
+++ b/sway/commands/bar/strip_workspace_name.c
@@ -10,9 +10,6 @@ struct cmd_results *bar_cmd_strip_workspace_name(int argc, char **argv) {
 				"strip_workspace_name", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 
 	config->current_bar->strip_workspace_name =
 		parse_boolean(argv[0], config->current_bar->strip_workspace_name);

--- a/sway/commands/bar/strip_workspace_numbers.c
+++ b/sway/commands/bar/strip_workspace_numbers.c
@@ -10,10 +10,7 @@ struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv) {
 				"strip_workspace_numbers", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-	
+
 	config->current_bar->strip_workspace_numbers =
 		parse_boolean(argv[0], config->current_bar->strip_workspace_numbers);
 

--- a/sway/commands/bar/swaybar_command.c
+++ b/sway/commands/bar/swaybar_command.c
@@ -8,9 +8,6 @@ struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
 	if ((error = checkarg(argc, "swaybar_command", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	free(config->current_bar->swaybar_command);
 	config->current_bar->swaybar_command = join_args(argv, argc);
 	sway_log(SWAY_DEBUG, "Using custom swaybar command: %s",

--- a/sway/commands/bar/tray_bind.c
+++ b/sway/commands/bar/tray_bind.c
@@ -12,9 +12,6 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 	if ((error = checkarg(argc, command, EXPECTED_EQUAL_TO, 2))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 
 	struct tray_binding *binding = calloc(1, sizeof(struct tray_binding));
 	if (!binding) {

--- a/sway/commands/bar/tray_output.c
+++ b/sway/commands/bar/tray_output.c
@@ -13,10 +13,6 @@ struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
 		return error;
 	}
 
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-
 	list_t *outputs = config->current_bar->tray_outputs;
 	if (!outputs) {
 		config->current_bar->tray_outputs = outputs = create_list();

--- a/sway/commands/bar/tray_padding.c
+++ b/sway/commands/bar/tray_padding.c
@@ -15,9 +15,6 @@ struct cmd_results *bar_cmd_tray_padding(int argc, char **argv) {
 		return error;
 	}
 
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
 	struct bar_config *bar = config->current_bar;
 
 	char *end;

--- a/sway/commands/bar/workspace_buttons.c
+++ b/sway/commands/bar/workspace_buttons.c
@@ -9,10 +9,7 @@ struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
 	if ((error = checkarg(argc, "workspace_buttons", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-	config->current_bar->workspace_buttons = 
+	config->current_bar->workspace_buttons =
 		parse_boolean(argv[0], config->current_bar->workspace_buttons);
 	if (config->current_bar->workspace_buttons) {
 		sway_log(SWAY_DEBUG, "Enabling workspace buttons on bar: %s",

--- a/sway/commands/bar/wrap_scroll.c
+++ b/sway/commands/bar/wrap_scroll.c
@@ -9,10 +9,7 @@ struct cmd_results *bar_cmd_wrap_scroll(int argc, char **argv) {
 	if ((error = checkarg(argc, "wrap_scroll", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	if (!config->current_bar) {
-		return cmd_results_new(CMD_FAILURE, "No bar defined.");
-	}
-	config->current_bar->wrap_scroll = 
+	config->current_bar->wrap_scroll =
 			parse_boolean(argv[0], config->current_bar->wrap_scroll);
 	if (config->current_bar->wrap_scroll) {
 		sway_log(SWAY_DEBUG, "Enabling wrap scroll on bar: %s",


### PR DESCRIPTION
Prior to this patch, if I ran something like this, sway would crash:

    swaymsg bar height 50

or

    swaymsg bar not-a-bar-id color bg #ff0000

This was in contrast to other bar subcommands, like status_command, which would exit with a "No bar defined message".

The difference between the subcommands that crashed and the ones that exited was that some subcommands had a check to see if a bar was specified, while others just assumed that it had been and carried on until they segfaulted.

Because this check was identical in every subcommand it was present in, and I couldn't think of a case where it would be valid to run a bar subcommand without specifying which bar to apply it to, I moved this check from individual subcommands into the bar command, which is already responsible for actually setting the specified bar. This reduced code duplication, and fixed the crash for the subcommands that were missing this check.