### PR TITLE
commands/bar: always reload after config change

### DIFF
--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -125,10 +125,10 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 
 	struct cmd_results *res =
 		config_subcommand(argv, argc, bar_handlers, sizeof(bar_handlers));
+	if (res && config->active && !config->validating) {
+		load_swaybar(config->current_bar);
+	}
 	if (!config->reading) {
-		if (spawn) {
-			load_swaybar(config->current_bar);
-		}
 		config->current_bar = NULL;
 	}
 	return res;

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -23,9 +23,5 @@ struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 		free(new_command);
 	}
 
-	if (config->active && !config->validating) {
-		load_swaybar(config->current_bar);
-	}
-
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }


### PR DESCRIPTION
Prior to this patch, running a command like this wouldn't do anything:

    swaymsg bar bar-0 color background #ff0000

The only exception was the status_command subcommand, because it reloaded the bar after updating the configuration.

This patch makes every bar subcommand reload the bar after config changes, so bar config can be changed on the fly like the rest of sway's configuration.

Note that, if two bars are stacked, and the first bar's config is changed, it will be removed and readded, so the order of the bars will be stopped. I believe that, despite this shortcoming, this change is strictly better than the current behavior, in which config can't be changed live at all, especially in what must surely be the far most common case of having only a single bar. Since changing status_command already did this, I assume that this edge-case is acceptable.