### PR TITLE
commands/bar: fix mode and hidden_state at runtime

### DIFF
--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -80,7 +80,8 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		}
 		config->current_bar = bar;
 		++argv; --argc;
-	} else if (!config->reading) {
+	} else if (!config->reading && strcmp(argv[0], "mode") != 0 &&
+			strcmp(argv[0], "hidden_state") != 0) {
 		if (is_subcommand(argv[0])) {
 			return cmd_results_new(CMD_INVALID, "No bar defined.");
 		} else {


### PR DESCRIPTION
This fixes a regression that I missed when reviewing #4160 

For compatibility with i3, `bar mode` and `bar hidden_state` do not
require bar-ids (in the normal location) at runtime since they follow
the alternative syntax: `bar mode|hidden_state <option> [<bar-id>]`

This removes the incorrect error that the bar-id is missing for those
two bar subcommands