### PR TITLE
common/ipc-client: remove ipc recv timeout log

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -74,8 +74,6 @@ bool ipc_set_recv_timeout(int socketfd, struct timeval tv) {
 		sway_log_errno(SWAY_ERROR, "Failed to set ipc recv timeout");
 		return false;
 	}
-	sway_log(SWAY_DEBUG, "ipc recv timeout set to %ld.%06ld",
-			tv.tv_sec, tv.tv_usec);
 	return true;
 }
 


### PR DESCRIPTION
Supersedes/Closes #4092 
See #4092 for compilation logs showing the issue

This just removes the ipc recv timeout log statement in
`ipc_recv_set_timeout`. The `tv_sec` field of `struct timeval` has
varying types and/or sizes depending on the platform and architecture.
On some of these, the current format string will cause compilation
errors. Additionally, the log statement is not extremely useful and the
function is currently only used by swaymsg, which has a hardcoded log
level that will prevent it from even being shown, so there is no point
in even keeping it.