### PR TITLE
Provide current DPMS state in GET_OUTPUTS

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -162,6 +162,8 @@ static void ipc_json_describe_output(struct sway_output *output,
 	struct wlr_output *wlr_output = output->wlr_output;
 	json_object_object_add(object, "type", json_object_new_string("output"));
 	json_object_object_add(object, "active", json_object_new_boolean(true));
+	json_object_object_add(object, "dpms",
+			json_object_new_boolean(output->wlr_output->enabled));
 	json_object_object_add(object, "primary", json_object_new_boolean(false));
 	json_object_object_add(object, "layout", json_object_new_string("output"));
 	json_object_object_add(object, "orientation",
@@ -233,6 +235,7 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	json_object_object_add(object, "name",
 			json_object_new_string(wlr_output->name));
 	json_object_object_add(object, "active", json_object_new_boolean(false));
+	json_object_object_add(object, "dpms", json_object_new_boolean(false));
 	json_object_object_add(object, "primary", json_object_new_boolean(false));
 	json_object_object_add(object, "make",
 			json_object_new_string(wlr_output->make));

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -205,6 +205,9 @@ following properties:
 |- active
 :  boolean
 :  Whether this output is active/enabled
+|- dpms
+:  boolean
+:  Whether this output is on/off (via DPMS)
 |- primary
 :  boolean
 :  For i3 compatibility, this will be false. It does not make sense in Wayland


### PR DESCRIPTION
This is useful for scripting dpms switching.