### PR TITLE
Use parent get_root_coords in subsurfaces

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -192,8 +192,11 @@ struct sway_view_child_impl {
  */
 struct sway_view_child {
 	const struct sway_view_child_impl *impl;
+	struct wl_list link;
 
 	struct sway_view *view;
+	struct sway_view_child *parent;
+	struct wl_list children; // sway_view_child::link
 	struct wlr_surface *surface;
 	bool mapped;
 


### PR DESCRIPTION
Subsurfaces need access to the parent get_root_coords impl for positioning in
popups. To do this, we store a reference to the parent view_child where
applicable.

Fixes #4191.