### PR TITLE
Implement XCursor theme configuration

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -278,6 +278,7 @@ sway_cmd seat_cmd_cursor;
 sway_cmd seat_cmd_fallback;
 sway_cmd seat_cmd_hide_cursor;
 sway_cmd seat_cmd_pointer_constraint;
+sway_cmd seat_cmd_xcursor_theme;
 
 sway_cmd cmd_ipc_cmd;
 sway_cmd cmd_ipc_events;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -165,6 +165,10 @@ struct seat_config {
 	list_t *attachments; // list of seat_attachment configs
 	int hide_cursor_timeout;
 	enum seat_config_allow_constrain allow_constrain;
+	struct {
+		char *name;
+		int size;
+	} xcursor_theme;
 };
 
 enum config_dpms {

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -13,6 +13,7 @@ static struct cmd_handler seat_handlers[] = {
 	{ "fallback", seat_cmd_fallback },
 	{ "hide_cursor", seat_cmd_hide_cursor },
 	{ "pointer_constraint", seat_cmd_pointer_constraint },
+	{ "xcursor_theme", seat_cmd_xcursor_theme },
 };
 
 struct cmd_results *cmd_seat(int argc, char **argv) {

--- a/sway/commands/seat/xcursor_theme.c
+++ b/sway/commands/seat/xcursor_theme.c
@@ -1,0 +1,33 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+struct cmd_results *seat_cmd_xcursor_theme(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "xcursor_theme", EXPECTED_AT_LEAST, 1)) ||
+		(error = checkarg(argc, "xcursor_theme", EXPECTED_AT_MOST, 2))) {
+		return error;
+	}
+	if (!config->handler_context.seat_config) {
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
+	}
+
+	const char *theme_name = argv[0];
+	unsigned size = 24;
+
+	if (argc == 2) {
+		char *end;
+		size = strtoul(argv[1], &end, 10);
+		if (*end) {
+			return cmd_results_new(
+				CMD_INVALID, "Expected a positive integer size");
+		}
+	}
+
+	free(config->handler_context.seat_config->xcursor_theme.name);
+	config->handler_context.seat_config->xcursor_theme.name = strdup(theme_name);
+	config->handler_context.seat_config->xcursor_theme.size = size;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -27,6 +27,8 @@ struct seat_config *new_seat_config(const char* name) {
 	}
 	seat->hide_cursor_timeout = -1;
 	seat->allow_constrain = CONSTRAIN_DEFAULT;
+	seat->xcursor_theme.name = NULL;
+	seat->xcursor_theme.size = 24;
 
 	return seat;
 }
@@ -147,6 +149,12 @@ void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 	if (source->allow_constrain != CONSTRAIN_DEFAULT) {
 		dest->allow_constrain = source->allow_constrain;
 	}
+
+	if (source->xcursor_theme.name != NULL) {
+		free(dest->xcursor_theme.name);
+		dest->xcursor_theme.name = strdup(source->xcursor_theme.name);
+		dest->xcursor_theme.size = source->xcursor_theme.size;
+	}
 }
 
 struct seat_config *copy_seat_config(struct seat_config *seat) {
@@ -170,6 +178,7 @@ void free_seat_config(struct seat_config *seat) {
 		seat_attachment_config_free(seat->attachments->items[i]);
 	}
 	list_free(seat->attachments);
+	free(seat->xcursor_theme.name);
 	free(seat);
 }
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -89,6 +89,7 @@ sway_sources = files(
 	'commands/seat/fallback.c',
 	'commands/seat/hide_cursor.c',
 	'commands/seat/pointer_constraint.c',
+	'commands/seat/xcursor_theme.c',
 	'commands/set.c',
 	'commands/show_marks.c',
 	'commands/smart_borders.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -168,17 +168,6 @@ void server_fini(struct sway_server *server) {
 }
 
 bool server_start(struct sway_server *server) {
-	// TODO: configurable cursor theme and size
-	int cursor_size = 24;
-	const char *cursor_theme = NULL;
-
-	char cursor_size_fmt[16];
-	snprintf(cursor_size_fmt, sizeof(cursor_size_fmt), "%d", cursor_size);
-	setenv("XCURSOR_SIZE", cursor_size_fmt, 1);
-	if (cursor_theme != NULL) {
-		setenv("XCURSOR_THEME", cursor_theme, 1);
-	}
-
 #if HAVE_XWAYLAND
 	if (config->xwayland) {
 		sway_log(SWAY_DEBUG, "Initializing Xwayland");
@@ -193,17 +182,7 @@ bool server_start(struct sway_server *server) {
 
 		setenv("DISPLAY", server->xwayland.wlr_xwayland->display_name, true);
 
-		server->xwayland.xcursor_manager =
-			wlr_xcursor_manager_create(cursor_theme, cursor_size);
-		wlr_xcursor_manager_load(server->xwayland.xcursor_manager, 1);
-		struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(
-			server->xwayland.xcursor_manager, "left_ptr", 1);
-		if (xcursor != NULL) {
-			struct wlr_xcursor_image *image = xcursor->images[0];
-			wlr_xwayland_set_cursor(server->xwayland.wlr_xwayland, image->buffer,
-				image->width * 4, image->width, image->height, image->hotspot_x,
-				image->hotspot_y);
-		}
+		/* xcursor configured by the default seat */
 	}
 #endif
 

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -206,6 +206,12 @@ correct seat.
 	by default) for the seat. This is primarily useful for video games. The
 	"escape" command can be used at runtime to escape from a captured client.
 
+*seat* <name> xcursor_theme <theme> [<size>]
+	Override the system default XCursor theme. The default seat's
+	(_seat0_) theme is also used as the default cursor theme in
+	XWayland, and exported through the _XCURSOR_THEME_ and
+	_XCURSOR_SIZE_ environment variables.
+
 # SEE ALSO
 
 *sway*(5) *sway-output*(5) *xkeyboard-config*(7)


### PR DESCRIPTION
This adds configuration commands that configures the XCursor theme and
size. Configuration is done through a new seat command (the size is optional and defaults to 24):
```
seat * xcursor_theme Adwaita [48]
```
The configured theme name and size is used as the default pointer
theme (set in `input/seat.c`), and exported through the `XCURSOR_THEME` and `XCURSOR_SIZE`
environment variables, and used as the default XWayland xcursor theme.

Marked as WIP since it's missing, at the very least, documentation updates. I would like to get some feedback first though, before I get to that.

## Major Changes
The biggest changes (in addition to the new feature in itself) are:
* `XCURSOR_THEME` and `XCURSOR_SIZE` are now exported by the default seat, every time its xcursor configuration is changed. Thus all applications (re)started after a runtime change will see the new settings.
* The XWayland xcursor theme manager is no longer instantiated in `server_start()`. This is instead done by the default seat (and re-created when the theme is changed).

## Questions:
1) is a global configuration command the preferred option? Or should it be somewhere else?
2) I know that we're still missing the protocols needed to correctly propagate the theme/size to clients, but in the mean time, should swaybar/nag etc be updated to check the `XCURSOR_*` environment variables?