### PR TITLE
cmd_hide_edge_borders: add missing arg count check

### DIFF
--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -4,17 +4,23 @@
 #include "sway/tree/view.h"
 
 struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
+	const char *expected_syntax = "Expected 'hide_edge_borders [--i3] "
+		"none|vertical|horizontal|both|smart|smart_no_gaps";
+
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "hide_edge_borders", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
+	bool hide_lone_tab = false;
 	if (strcmp(*argv, "--i3") == 0) {
-		config->hide_lone_tab = true;
+		hide_lone_tab = true;
 		++argv;
 		--argc;
-	} else {
-		config->hide_lone_tab = false;
+	}
+
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
 
 	if (strcmp(argv[0], "none") == 0) {
@@ -30,9 +36,9 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	} else if (strcmp(argv[0], "smart_no_gaps") == 0) {
 		config->hide_edge_borders = E_SMART_NO_GAPS;
 	} else {
-		return cmd_results_new(CMD_INVALID, "Expected 'hide_edge_borders "
-				"[--i3] <none|vertical|horizontal|both|smart|smart_no_gaps>'");
+		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
+	config->hide_lone_tab = hide_lone_tab;
 	config->saved_edge_borders = config->hide_edge_borders;
 
 	arrange_root();


### PR DESCRIPTION
This adds the missing argument count check after the --i3 flag
processing in cmd_hide_edge_borders. Without the check,
`hide_edge_borders --i3` would result in a SIGSEGV instead of a syntax
error. There are some minor adjustments to make it so nothing gets
altered if this check fails