### PR TITLE
criteria: reset on semicolon separation

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -45,7 +45,8 @@ the bindsym command.
 Commands are split into several arguments using spaces. You can enclose
 arguments with quotation marks (*"..."* or *'...'*) to add spaces to a single
 argument. You may also run several commands in order by separating each with
-*,* or *;*.
+*,* or *;*. Criteria is retained across commands separated by *,*, but will be
+reset (and allow for new criteria, if desired) for commands separated by a *;*.
 
 Throughout the documentation, *|* is used to distinguish between arguments for
 which you may only select one. *[...]* is used for optional arguments, and
@@ -753,7 +754,9 @@ A criteria is a string in the form of, for example:
 
 The string contains one or more (space separated) attribute/value pairs. They
 are used by some commands to choose which views to execute actions on. All
-attributes must match for the criteria to match.
+attributes must match for the criteria to match. Criteria is retained across
+commands separated by a *,*, but will be reset (and allow for new criteria, if
+desired) for commands separated by a *;*.
 
 Criteria may be used with either the *for_window* or *assign* commands to
 specify operations to perform on new views. A criteria may also be used to


### PR DESCRIPTION
This matches i3's behavior of only retaining criteria across comma
separated commands. When separating commands with a semicolon, the
criteria is reset and allows for new criteria to be set, if desired.

Excerpt from [i3 user guide](https://i3wm.org/docs/userguide.html#command_criteria):
> When using multiple commands, separate them by using a , (a comma) instead of a semicolon. Criteria apply only until the next semicolon, so if you use a semicolon to separate commands, only the first one will be executed for the matched window(s).