### PR TITLE
swaybar/nag: use xcursor theme defined by XCURSOR_THEME/SIZE

### DIFF
--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -67,9 +67,19 @@ void update_cursor(struct swaybar_seat *seat) {
 	if (pointer->cursor_theme) {
 		wl_cursor_theme_destroy(pointer->cursor_theme);
 	}
+	const char *cursor_theme = getenv("XCURSOR_THEME");
+	unsigned cursor_size = 24;
+	const char *env_cursor_size = getenv("XCURSOR_SIZE");
+	if (env_cursor_size) {
+		char *end;
+		unsigned size = strtoul(env_cursor_size, &end, 10);
+		if (!*end) {
+			cursor_size = size;
+		}
+	}
 	int scale = pointer->current ? pointer->current->scale : 1;
-	pointer->cursor_theme = wl_cursor_theme_load(NULL, 24 * scale,
-			seat->bar->shm);
+	pointer->cursor_theme = wl_cursor_theme_load(
+		cursor_theme, cursor_size * scale, seat->bar->shm);
 	struct wl_cursor *cursor;
 	cursor = wl_cursor_theme_get_cursor(pointer->cursor_theme, "left_ptr");
 	pointer->cursor_image = cursor->images[0];

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -70,10 +70,11 @@ void update_cursor(struct swaybar_seat *seat) {
 	const char *cursor_theme = getenv("XCURSOR_THEME");
 	unsigned cursor_size = 24;
 	const char *env_cursor_size = getenv("XCURSOR_SIZE");
-	if (env_cursor_size) {
+	if (env_cursor_size && strlen(env_cursor_size) > 0) {
+		errno = 0;
 		char *end;
 		unsigned size = strtoul(env_cursor_size, &end, 10);
-		if (!*end) {
+		if (!*end && errno == 0) {
 			cursor_size = size;
 		}
 	}

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -132,10 +132,11 @@ static void update_cursor(struct swaynag *swaynag) {
 	const char *cursor_theme = getenv("XCURSOR_THEME");
 	unsigned cursor_size = 24;
 	const char *env_cursor_size = getenv("XCURSOR_SIZE");
-	if (env_cursor_size) {
+	if (env_cursor_size && strlen(env_cursor_size) > 0) {
+		errno = 0;
 		char *end;
 		unsigned size = strtoul(env_cursor_size, &end, 10);
-		if (!*end) {
+		if (!*end && errno == 0) {
 			cursor_size = size;
 		}
 	}

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -129,8 +129,18 @@ static void update_cursor(struct swaynag *swaynag) {
 	if (swaynag->pointer.cursor_theme) {
 		wl_cursor_theme_destroy(swaynag->pointer.cursor_theme);
 	}
-	pointer->cursor_theme = wl_cursor_theme_load(NULL, 24 * swaynag->scale,
-			swaynag->shm);
+	const char *cursor_theme = getenv("XCURSOR_THEME");
+	unsigned cursor_size = 24;
+	const char *env_cursor_size = getenv("XCURSOR_SIZE");
+	if (env_cursor_size) {
+		char *end;
+		unsigned size = strtoul(env_cursor_size, &end, 10);
+		if (!*end) {
+			cursor_size = size;
+		}
+	}
+	pointer->cursor_theme = wl_cursor_theme_load(
+		cursor_theme, cursor_size * swaynag->scale, swaynag->shm);
 	struct wl_cursor *cursor =
 		wl_cursor_theme_get_cursor(pointer->cursor_theme, "left_ptr");
 	pointer->cursor_image = cursor->images[0];


### PR DESCRIPTION
If the `XCURSOR_THEME` and/or `XCURSOR_SIZE` environment variables are
set, use the theme and size they define.

If they're not set, use the same defaults as before (system default
theme, size=24).

Note: this builds upon https://github.com/swaywm/sway/pull/4202, and was suggested here: https://github.com/swaywm/sway/pull/4202#issuecomment-497972719