### PR TITLE
cmd_exec{,_always}: close standard in for child

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -61,6 +61,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 		close(fd[0]);
 		if ((child = fork()) == 0) {
 			close(fd[1]);
+			close(STDIN_FILENO);
 			execl("/bin/sh", "/bin/sh", "-c", cmd, (void *)NULL);
 			_exit(0);
 		}


### PR DESCRIPTION
Fixes #4214 

This just closes the standard input for processes started with the exec
and exec_always commands. This prevents interactive programs like vi(m)
from taking over input on the getty. Standard output and standard error
are kept open, which allows for the output/errors to be captured along
with the sway log.