### PR TITLE
Add the missing constant for the switch input type

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -103,6 +103,7 @@ static const char *pretty_type_name(const char *name) {
 		{ "tablet_pad", "Tablet pad" },
 		{ "tablet_tool", "Tablet tool" },
 		{ "touch", "Touch" },
+		{ "switch", "Switch" },
 	};
 
 	for (size_t i = 0; i < sizeof(type_names) / sizeof(type_names[0]); ++i) {


### PR DESCRIPTION
Very minor edit.

On another note, I saw the TODO but couldn't figure a proper location for the constants in `common/`.