### PR TITLE
Fix "xwayland false"

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -751,10 +751,10 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 		}
 
 #if HAVE_XWAYLAND
-		if (!server.xwayland.xcursor_manager ||
+		if (config->xwayland && (!server.xwayland.xcursor_manager ||
 				!xcursor_manager_is_named(server.xwayland.xcursor_manager,
 					cursor_theme) ||
-				server.xwayland.xcursor_manager->size != cursor_size) {
+				server.xwayland.xcursor_manager->size != cursor_size)) {
 
 			wlr_xcursor_manager_destroy(server.xwayland.xcursor_manager);
 


### PR DESCRIPTION
Commit 190546fd315a24c04006fb1b177069933f4350da failed to consider the
edge case where xwayland is disabled via the sway config. This leads to
a SEGFAULT when setting the xwayland cursor since the xwayland server is
not running.