### PR TITLE
swaybar: do not retry search for tray icons

### DIFF
--- a/include/swaybar/tray/item.h
+++ b/include/swaybar/tray/item.h
@@ -20,6 +20,7 @@ struct swaybar_sni {
 	cairo_surface_t *icon;
 	int min_size;
 	int max_size;
+	int target_size;
 
 	// dbus properties
 	char *watcher_id;

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -124,7 +124,9 @@ uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 	struct swaybar_tray *tray = output->bar->tray;
 	for (int i = 0; i < tray->items->length; ++i) {
 		uint32_t h = render_sni(cairo, output, x, tray->items->items[i]);
-		max_height = h > max_height ? h : max_height;
+		if (h > max_height) {
+			max_height = h;
+		}
 	}
 
 	return max_height;


### PR DESCRIPTION
In case a tray icon cannot be found or does not have a desirable size, swaybar retries the search again and again, which increases load on disk and CPU.

This commit solves it by storing `target_size` for each icon, so that swaybar does not search for an icon of some size if it already tried to.

Fixes #3789.