### PR TITLE
Allow rendering titlebar on bottom

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -190,6 +190,7 @@ sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;
 sway_cmd cmd_titlebar_padding;
+sway_cmd cmd_titlebar_position;
 sway_cmd cmd_unbindcode;
 sway_cmd cmd_unbindswitch;
 sway_cmd cmd_unbindgesture;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -473,6 +473,11 @@ enum xwayland_mode {
 	XWAYLAND_MODE_IMMEDIATE,
 };
 
+enum titlebar_position {
+	TITLEBAR_TOP,
+	TITLEBAR_BOTTOM
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -534,6 +539,7 @@ struct sway_config {
 	bool show_marks;
 	enum alignment title_align;
 	bool primary_selection;
+	enum titlebar_position titlebar_position;
 
 	bool tiling_drag;
 	int tiling_drag_threshold;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -93,6 +93,7 @@ static const struct cmd_handler handlers[] = {
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
 	{ "titlebar_padding", cmd_titlebar_padding },
+	{ "titlebar_position", cmd_titlebar_position },
 	{ "unbindcode", cmd_unbindcode },
 	{ "unbindgesture", cmd_unbindgesture },
 	{ "unbindswitch", cmd_unbindswitch },

--- a/sway/commands/titlebar_position.c
+++ b/sway/commands/titlebar_position.c
@@ -1,0 +1,30 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/root.h"
+
+struct cmd_results *cmd_titlebar_position(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "titlebar_position", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (strcmp(argv[0], "top") == 0) {
+		config->titlebar_position = TITLEBAR_TOP;
+	} else if (strcmp(argv[0], "bottom") == 0) {
+		config->titlebar_position = TITLEBAR_BOTTOM;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+				"Expected 'titlebar_position top|bottom'");
+	}
+
+	arrange_root();
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		output_damage_whole(output);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+

--- a/sway/config.c
+++ b/sway/config.c
@@ -271,6 +271,7 @@ static void config_defaults(struct sway_config *config) {
 	config->reading = false;
 	config->show_marks = true;
 	config->title_align = ALIGN_LEFT;
+	config->titlebar_position = TITLEBAR_TOP;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
 	config->primary_selection = true;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -733,8 +733,12 @@ static void render_containers_linear(struct render_context *ctx, struct parent_d
 			}
 
 			if (state->border == B_NORMAL) {
-				render_titlebar(ctx, child, floor(state->x),
-						floor(state->y), state->width, colors,
+				int y = state->y;
+				if (config->titlebar_position == TITLEBAR_BOTTOM) {
+					y += state->height - container_titlebar_height();
+				}
+				render_titlebar(ctx, child, floor(state->x), floor(y),
+						state->width, colors,
 						title_texture, marks_texture);
 			} else if (state->border == B_PIXEL) {
 				render_top_border(ctx, child, colors);
@@ -810,8 +814,11 @@ static void render_containers_tabbed(struct render_context *ctx, struct parent_d
 		if (i == parent->children->length - 1) {
 			tab_width = parent->box.width - tab_width * i;
 		}
-
-		render_titlebar(ctx, child, x, parent->box.y, tab_width,
+		int y = parent->box.y;
+		if (config->titlebar_position == TITLEBAR_BOTTOM) {
+			y += parent->box.height - container_titlebar_height();
+		}
+		render_titlebar(ctx, child, x, y, tab_width,
 				colors, title_texture, marks_texture);
 
 		if (child == current) {
@@ -843,6 +850,7 @@ static void render_containers_stacked(struct render_context *ctx, struct parent_
 	struct sway_container *current = parent->active_child;
 	struct border_colors *current_colors = &config->border_colors.unfocused;
 	size_t titlebar_height = container_titlebar_height();
+	bool titlebar_is_on_top = config->titlebar_position == TITLEBAR_TOP;
 
 	// Render titles
 	for (int i = 0; i < parent->children->length; ++i) {
@@ -877,9 +885,13 @@ static void render_containers_stacked(struct render_context *ctx, struct parent_
 			marks_texture = child->marks_unfocused;
 		}
 
-		int y = parent->box.y + titlebar_height * i;
-		render_titlebar(ctx, child, parent->box.x, y,
-				parent->box.width, colors, title_texture, marks_texture);
+		int titlebar_y = parent->box.y + titlebar_height * i;
+		if (!titlebar_is_on_top) {
+			titlebar_y = parent->box.height - titlebar_height * (parent->children->length - i) - (child->pending.border_thickness * child->pending.border_bottom);
+		}
+		render_titlebar(ctx, child, parent->box.x,
+				titlebar_y, parent->box.width, colors, title_texture,
+			   	marks_texture);
 
 		if (child == current) {
 			current_colors = colors;
@@ -981,8 +993,12 @@ static void render_floating_container(struct render_context *ctx,
 		}
 
 		if (con->current.border == B_NORMAL) {
+			int titlebar_y = con->current.y;
+			if (config->titlebar_position == TITLEBAR_BOTTOM) {
+				titlebar_y += con->current.height - container_titlebar_height();
+			}
 			render_titlebar(ctx, con, floor(con->current.x),
-					floor(con->current.y), con->current.width, colors,
+					floor(titlebar_y), con->current.width, colors,
 					title_texture, marks_texture);
 		} else if (con->current.border == B_PIXEL) {
 			render_top_border(ctx, con, colors);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -117,6 +117,7 @@ sway_sources = files(
 	'commands/title_format.c',
 	'commands/titlebar_border_thickness.c',
 	'commands/titlebar_padding.c',
+	'commands/titlebar_position.c',
 	'commands/unmark.c',
 	'commands/urgent.c',
 	'commands/workspace.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -849,6 +849,10 @@ The default colors are:
 	to _yes_, the marks will be shown on the _left_ side instead of the
 	_right_ side.
 
+
+*titlebar_position* top|bottom
+	Sets the titlebar position.
+
 *unbindswitch* <switch>:<state>
 	Removes a binding for when <switch> changes to <state>.
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -924,14 +924,19 @@ void container_set_geometry_from_content(struct sway_container *con) {
 
 	if (con->pending.border != B_CSD && !con->pending.fullscreen_mode) {
 		border_width = con->pending.border_thickness * (con->pending.border != B_NONE);
-		top = con->pending.border == B_NORMAL ?
-			container_titlebar_height() : border_width;
+		top = con->pending.border == B_NORMAL
+			&& (config->titlebar_position != TITLEBAR_BOTTOM)
+			? container_titlebar_height()
+			: border_width;
 	}
 
 	con->pending.x = con->pending.content_x - border_width;
 	con->pending.y = con->pending.content_y - top;
 	con->pending.width = con->pending.content_width + border_width * 2;
 	con->pending.height = top + con->pending.content_height + border_width;
+	if (config->titlebar_position == TITLEBAR_BOTTOM) {
+		con->pending.height += container_titlebar_height() - border_width;
+	}
 	node_set_dirty(&con->node);
 }
 


### PR DESCRIPTION
This implements part of #883 and similar issue on i3/i3/issues/2747 by adding a command `titlebar_position`. It accepts two options for now: top and bottom.

I've probably missed some edge cases but would like to know if there's any interest in adding this feature?