### PR TITLE
Fix segfaults caused by faulty command parsing

### DIFF
--- a/include/stringop.h
+++ b/include/stringop.h
@@ -24,6 +24,6 @@ int unescape_string(char *string);
 char *join_args(char **argv, int argc);
 
 // Split string into 2 by delim, handle quotes
-char *argsep(char **stringp, const char *delim);
+char *argsep(char **stringp, const char *delim, char *matched_delim);
 
 #endif

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -212,9 +212,9 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 	char *name = NULL;
 
 	// workspace n
-	char *cmd = argsep(&cmdlist, " ");
+	char *cmd = argsep(&cmdlist, " ", NULL);
 	if (cmdlist) {
-		name = argsep(&cmdlist, ",;");
+		name = argsep(&cmdlist, ",;", NULL);
 	}
 
 	// TODO: support "move container to workspace" bindings as well


### PR DESCRIPTION
This fixes faulty command parsing introduced by
f0f5de9a9e87ca1f0d74e7cbf82ffceba51ffbe6. When that commit allowed
criteria reset on ';' delimeters in commands lists, it failed to account
for its inner ','-parsing loop eating threw the entire rest of the
string.

This refactors argsep to use a list of multiple separators, and
(optionally) return the separator that it matched against in this
iteration via a pointer. This allows it to hint at the command parser
which separator was used at the end of the last command, allowing it to
trigger a potential secondary read of the criteria.

Fixes #4239