### PR TITLE
bindings: defer while initializing

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -559,6 +559,11 @@ bool read_config(FILE *file, struct sway_config *config,
 void run_deferred_commands(void);
 
 /**
+ * Run the binding commands that were deferred when initializing the inputs
+ */
+void run_deferred_bindings(void);
+
+/**
  * Adds a warning entry to the swaynag instance used for errors.
  */
 void config_add_swaynag_warning(char *fmt, ...);

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -78,6 +78,8 @@ struct sway_seat {
 
 	uint32_t last_button_serial;
 
+	list_t *deferred_bindings; // struct sway_binding
+
 	struct wl_listener focus_destroy;
 	struct wl_listener new_node;
 	struct wl_listener request_start_drag;

--- a/sway/config.c
+++ b/sway/config.c
@@ -644,7 +644,23 @@ void run_deferred_commands(void) {
 		list_free(res_list);
 		free(line);
 	}
-	transaction_commit_dirty();
+}
+
+void run_deferred_bindings(void) {
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &(server.input->seats), link) {
+		if (!seat->deferred_bindings->length) {
+			continue;
+		}
+		sway_log(SWAY_DEBUG, "Running deferred bindings for seat %s",
+				seat->wlr_seat->name);
+		while (seat->deferred_bindings->length) {
+			struct sway_binding *binding = seat->deferred_bindings->items[0];
+			seat_execute_command(seat, binding);
+			list_del(seat->deferred_bindings, 0);
+			free_sway_binding(binding);
+		}
+	}
 }
 
 // get line, with backslash continuation

--- a/sway/main.c
+++ b/sway/main.c
@@ -16,6 +16,7 @@
 #include "sway/config.h"
 #include "sway/server.h"
 #include "sway/swaynag.h"
+#include "sway/desktop/transaction.h"
 #include "sway/tree/root.h"
 #include "sway/ipc-server.h"
 #include "ipc-client.h"
@@ -389,6 +390,8 @@ int main(int argc, char **argv) {
 	config->active = true;
 	load_swaybars();
 	run_deferred_commands();
+	run_deferred_bindings();
+	transaction_commit_dirty();
 
 	if (config->swaynag_config_errors.client != NULL) {
 		swaynag_show(&config->swaynag_config_errors);


### PR DESCRIPTION
Fixes #4224 

This adds the logic to defer binding execution while sway is still
initializing. Without this, the binding command would be executed, but
the command handler would return CMD_DEFER, which was being treated as
a failure to run. To avoid partial executions, this will defer all
bindings while config->active is false.