### PR TITLE
use surface coordinates for damaging buffers

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -163,12 +163,12 @@ void output_view_for_each_surface(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.content_x - output->lx
+		.ox = view->container->surface_x - output->lx
 			- view->geometry.x,
-		.oy = view->container->current.content_y - output->ly
+		.oy = view->container->surface_y - output->ly
 			- view->geometry.y,
-		.width = view->container->current.content_width,
-		.height = view->container->current.content_height,
+		.width = view->container->surface_width,
+		.height = view->container->surface_height,
 		.rotation = 0, // TODO
 	};
 
@@ -182,12 +182,12 @@ void output_view_for_each_popup(struct sway_output *output,
 		.user_iterator = iterator,
 		.user_data = user_data,
 		.output = output,
-		.ox = view->container->current.content_x - output->lx
+		.ox = view->container->surface_x - output->lx
 			- view->geometry.x,
-		.oy = view->container->current.content_y - output->ly
+		.oy = view->container->surface_y - output->ly
 			- view->geometry.y,
-		.width = view->container->current.content_width,
-		.height = view->container->current.content_height,
+		.width = view->container->surface_width,
+		.height = view->container->surface_height,
 		.rotation = 0, // TODO
 	};
 


### PR DESCRIPTION
Using the content coordinates can go wrong if the surface inside the content is actually smaller than the content space.

You can see the effect if you run [havoc](https://github.com/ii8/havoc) and enter text on the very bottom line; if the content width/height is not an exact multiple of the cell width/height then the text will be cut off.

Somebody more familiar with the sway codebase can hopefully confirm that using pending coordinates instead of current ones has no bad side-effects.