### PR TITLE
Add inhibit_fullscreen command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -135,6 +135,7 @@ sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
 sway_cmd cmd_hide_edge_borders;
 sway_cmd cmd_include;
+sway_cmd cmd_inhibit_fullscreen;
 sway_cmd cmd_inhibit_idle;
 sway_cmd cmd_input;
 sway_cmd cmd_seat;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -108,6 +108,9 @@ struct sway_container {
 
 	enum sway_fullscreen_mode fullscreen_mode;
 
+	bool inhibit_fullscreen;
+	bool is_fullscreen;
+
 	enum sway_container_border border;
 
 	// Used when the view changes to CSD unexpectedly. This will be a non-B_CSD
@@ -268,6 +271,8 @@ void container_end_mouse_operation(struct sway_container *container);
 
 void container_set_fullscreen(struct sway_container *con,
 		enum sway_fullscreen_mode mode);
+
+void container_request_fullscreen(struct sway_container *con, bool enable);
 
 /**
  * Convenience function.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -114,6 +114,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "exit", cmd_exit },
 	{ "floating", cmd_floating },
 	{ "fullscreen", cmd_fullscreen },
+	{ "inhibit_fullscreen", cmd_inhibit_fullscreen },
 	{ "inhibit_idle", cmd_inhibit_idle },
 	{ "kill", cmd_kill },
 	{ "layout", cmd_layout },

--- a/sway/commands/inhibit_fullscreen.c
+++ b/sway/commands/inhibit_fullscreen.c
@@ -1,0 +1,45 @@
+#include <strings.h>
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
+#include "util.h"
+
+// inhibit_fullscreen [toggle|enable|disable]
+struct cmd_results *cmd_inhibit_fullscreen(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "inhibit_fullscreen", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	if (!root->outputs->length) {
+		return cmd_results_new(CMD_FAILURE,
+				"Can't run this command while there's no outputs connected.");
+	}
+	struct sway_node *node = config->handler_context.node;
+	struct sway_container *container = config->handler_context.container;
+	struct sway_workspace *workspace = config->handler_context.workspace;
+	if (node->type == N_WORKSPACE && workspace->tiling->length == 0) {
+		return cmd_results_new(CMD_FAILURE,
+				"Can't fullscreen an empty workspace");
+	}
+
+	// If in the scratchpad, operate on the highest container
+	if (container && !container->workspace) {
+		while (container->parent) {
+			container = container->parent;
+		}
+	}
+
+	bool enable = false;
+	if (strcasecmp(argv[0], "toggle") == 0) {
+		enable = !container->inhibit_fullscreen;
+	} else {
+		enable = strcasecmp(argv[0], "enable") == 0;
+	}
+
+	container->inhibit_fullscreen = enable;
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -363,7 +363,7 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		}
 	}
 
-	container_set_fullscreen(view->container, e->fullscreen);
+	container_request_fullscreen(view->container, e->fullscreen);
 
 	arrange_root();
 	transaction_commit_dirty();

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -65,6 +65,7 @@ sway_sources = files(
 	'commands/fullscreen.c',
 	'commands/gaps.c',
 	'commands/hide_edge_borders.c',
+	'commands/inhibit_fullscreen.c',
 	'commands/inhibit_idle.c',
 	'commands/kill.c',
 	'commands/mark.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -161,6 +161,12 @@ set|plus|minus <amount>
 	_right_, _bottom_, and _left_ or per direction with _horizontal_ and
 	_vertical_.
 
+*inhibit_fullscreen* toggle|enable|disable
+	Set/unset fullscreen inhibitor for for the container. If enabled, client
+	requests to fullscreen the container will be ignored. This can be used to
+	have clients transition to their fullscreen interface, while still
+	constraining them to their container.
+
 *inhibit_idle* focus|fullscreen|open|none|visible
 	Set/unset an idle inhibitor for the view. _focus_ will inhibit idle when
 	the view is focused by any seat. _fullscreen_ will inhibit idle when the


### PR DESCRIPTION
Some clients have special UIs in fullscreen mode, commonly optimized for no-fuss content delivery. Examples of such applications would be browsers playing videos. In such cases, the fullscreen UI is often only the video (potentially with overlays), making video consumption much more comfortable. Other applications may remove menu bars or other interfering elements.

However, one may simply wish to consume the fullscreen UI, not actually fullscreen the application. This is especially true for a tiling window manager, where one may have dedicated a fixed amount of screen real estate for the application. For a video, one could for example dedicate the area for the aspect ratio, leaving what would otherwise be black borders open to other work.

This PR implements a fullscreen inhibition feature in sway. When inhibited, sway will answer fullscreen requests correctly, but will not fullscreen the container.