### PR TITLE
Fix sway crashes for scratchpad layouts

### DIFF
--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -46,8 +46,12 @@ void root_destroy(struct sway_root *root);
 
 /**
  * Move a container to the scratchpad.
+ * If a workspace is passed, the container is assumed to have been in
+ * the scratchpad before and is shown on the workspace.
+ * The ws parameter can safely be NULL.
  */
-void root_scratchpad_add_container(struct sway_container *con);
+void root_scratchpad_add_container(struct sway_container *con,
+   struct sway_workspace *ws);
 
 /**
  * Remove a container from the scratchpad.

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -856,7 +856,7 @@ static struct cmd_results *cmd_move_to_scratchpad(void) {
 	}
 
 	if (!con->scratchpad) {
-		root_scratchpad_add_container(con);
+		root_scratchpad_add_container(con, NULL);
 	} else if (con->workspace) {
 		root_scratchpad_hide(con);
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1378,10 +1378,12 @@ void container_replace(struct sway_container *container,
 		struct sway_container *replacement) {
 	enum sway_fullscreen_mode fullscreen = container->fullscreen_mode;
 	bool scratchpad = container->scratchpad;
+	struct sway_workspace *ws = NULL;
 	if (fullscreen != FULLSCREEN_NONE) {
 		container_fullscreen_disable(container);
 	}
 	if (scratchpad) {
+		ws = container->workspace;
 		root_scratchpad_show(container);
 		root_scratchpad_remove_container(container);
 	}
@@ -1390,7 +1392,7 @@ void container_replace(struct sway_container *container,
 		container_detach(container);
 	}
 	if (scratchpad) {
-		root_scratchpad_add_container(replacement);
+		root_scratchpad_add_container(replacement, ws);
 	}
 	switch (fullscreen) {
 	case FULLSCREEN_WORKSPACE:


### PR DESCRIPTION
Currently container_replace removes the container from the scratchpad
and re-adds it afterwards. For the split commands this results in the
container being send to the scratchpad, which results in a NULL segfault
if the same container should be shown.
Pass an optional workspace to root_scratchpad_add_container, if the
workspace is passed the window will continue to show on the workspace.
If NULL is passed it is sent to the scratchpad.
This was an issue if no other window except the scratchpad container was
on the workspace.

Fixes #4240