### PR TITLE
Add calibration_matrix config option

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -236,6 +236,7 @@ sway_cmd bar_colors_cmd_urgent_workspace;
 
 sway_cmd input_cmd_seat;
 sway_cmd input_cmd_accel_profile;
+sway_cmd input_cmd_calibration_matrix;
 sway_cmd input_cmd_click_method;
 sway_cmd input_cmd_drag;
 sway_cmd input_cmd_drag_lock;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -101,6 +101,11 @@ struct input_config_mapped_from_region {
 	bool mm;
 };
 
+struct calibration_matrix {
+	bool configured;
+	float matrix[6];
+};
+
 /**
  * options for input devices
  */
@@ -109,6 +114,7 @@ struct input_config {
 	const char *input_type;
 
 	int accel_profile;
+	struct calibration_matrix calibration_matrix;
 	int click_method;
 	int drag;
 	int drag_lock;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -9,6 +9,7 @@
 // must be in order for the bsearch
 static struct cmd_handler input_handlers[] = {
 	{ "accel_profile", input_cmd_accel_profile },
+	{ "calibration_matrix", input_cmd_calibration_matrix },
 	{ "click_method", input_cmd_click_method },
 	{ "drag", input_cmd_drag },
 	{ "drag_lock", input_cmd_drag_lock },

--- a/sway/commands/input/calibration_matrix.c
+++ b/sway/commands/input/calibration_matrix.c
@@ -27,7 +27,7 @@ struct cmd_results *input_cmd_calibration_matrix(int argc, char **argv) {
 	for (int i = 0; i < split->length; ++i) {
 		char *item = split->items[i];
 		float x = parse_float(item);
-		if (x != x) {
+		if (isnan(x)) {
 			return cmd_results_new(CMD_FAILURE, "calibration_matrix: unable to parse float: %s", item);
 		}
 		parsed[i] = x;

--- a/sway/commands/input/calibration_matrix.c
+++ b/sway/commands/input/calibration_matrix.c
@@ -10,7 +10,7 @@
 
 struct cmd_results *input_cmd_calibration_matrix(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "calibration_matrix", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "calibration_matrix", EXPECTED_EQUAL_TO, 6))) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;
@@ -18,14 +18,9 @@ struct cmd_results *input_cmd_calibration_matrix(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "No input device defined.");
 	}
 
-	list_t *split = split_string(argv[0], " ");
-	if (split->length != 6) {
-		return cmd_results_new(CMD_FAILURE, "calibration_matrix should be a space-separated list of length 6");
-	}
-
 	float parsed[6];
-	for (int i = 0; i < split->length; ++i) {
-		char *item = split->items[i];
+	for (int i = 0; i < argc; ++i) {
+		char *item = argv[i];
 		float x = parse_float(item);
 		if (isnan(x)) {
 			return cmd_results_new(CMD_FAILURE, "calibration_matrix: unable to parse float: %s", item);

--- a/sway/commands/input/calibration_matrix.c
+++ b/sway/commands/input/calibration_matrix.c
@@ -1,0 +1,40 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "log.h"
+#include "stringop.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_calibration_matrix(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "calibration_matrix", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	list_t *split = split_string(argv[0], " ");
+	if (split->length != 6) {
+		return cmd_results_new(CMD_FAILURE, "calibration_matrix should be a space-separated list of length 6");
+	}
+
+	float parsed[6];
+	for (int i = 0; i < split->length; ++i) {
+		char *item = split->items[i];
+		float x = parse_float(item);
+		if (x != x) {
+			return cmd_results_new(CMD_FAILURE, "calibration_matrix: unable to parse float: %s", item);
+		}
+		parsed[i] = x;
+	}
+
+	ic->calibration_matrix.configured = true;
+	memcpy(ic->calibration_matrix.matrix, parsed, sizeof(ic->calibration_matrix.matrix));
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -132,6 +132,11 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 		free(dst->mapped_to_output);
 		dst->mapped_to_output = strdup(src->mapped_to_output);
 	}
+	if (src->calibration_matrix.configured) {
+		dst->calibration_matrix.configured = src->calibration_matrix.configured;
+		memcpy(dst->calibration_matrix.matrix, src->calibration_matrix.matrix,
+			sizeof(src->calibration_matrix.matrix));
+	}
 }
 
 static bool validate_xkb_merge(struct input_config *dest,

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -281,6 +281,13 @@ static void input_manager_libinput_config_touch(
 		log_libinput_config_status(libinput_device_config_send_events_set_mode(
 					libinput_device, ic->send_events));
 	}
+	float *m = ic->calibration_matrix.matrix;
+	if (ic->calibration_matrix.configured) {
+		sway_log(SWAY_DEBUG, "libinput_config_touch(%s) calibration_set_matrix(%f %f %f %f %f %f)",
+			ic->identifier, m[0], m[1], m[2], m[3], m[4], m[5]);
+		log_libinput_config_status(libinput_device_config_calibration_set_matrix(
+					libinput_device, ic->calibration_matrix.matrix));
+	}
 }
 
 static void input_manager_libinput_reset_touch(
@@ -300,6 +307,12 @@ static void input_manager_libinput_reset_touch(
 		input_device->identifier, send_events);
 	log_libinput_config_status(libinput_device_config_send_events_set_mode(
 				libinput_device, send_events));
+	float m[6];
+	libinput_device_config_calibration_get_default_matrix(libinput_device, m);
+	sway_log(SWAY_DEBUG, "libinput_reset_touch(%s) calibration_set_matrix(%f %f %f %f %f %f)",
+		input_device->identifier, m[0], m[1], m[2], m[3], m[4], m[5]);
+	log_libinput_config_status(libinput_device_config_calibration_set_matrix(
+				libinput_device, m));
 }
 
 static void input_manager_libinput_config_pointer(

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -798,6 +798,18 @@ static json_object *describe_libinput_device(struct libinput_device *device) {
 		json_object_object_add(object, "dwt", json_object_new_string(dwt));
 	}
 
+	if (libinput_device_config_calibration_has_matrix(device)) {
+		float matrix[6];
+		libinput_device_config_calibration_get_matrix(device, matrix);
+		struct json_object* array = json_object_new_array();
+		struct json_object* x;
+		for (int i = 0; i < 6; i++) {
+			x = json_object_new_double(matrix[i]);
+			json_object_array_add(array, x);
+		}
+		json_object_object_add(object, "calibration_matrix", array);
+	}
+
 	return object;
 }
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -140,6 +140,7 @@ sway_sources = files(
 	'commands/bar/wrap_scroll.c',
 
 	'commands/input/accel_profile.c',
+	'commands/input/calibration_matrix.c',
 	'commands/input/click_method.c',
 	'commands/input/drag.c',
 	'commands/input/drag_lock.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -97,6 +97,9 @@ The following commands may only be used in the configuration file.
 *input* <identifier> accel_profile adaptive|flat
 	Sets the pointer acceleration profile for the specified input device.
 
+*input* <identifier> calibration_matrix <6 space-separated floating point values>
+	Sets the calibtration matrix.
+
 *input* <identifier> click_method none|button_areas|clickfinger
 	Changes the click method for the specified device.
 

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1107,6 +1107,10 @@ following properties will be included for devices that support them:
 |- dwt
 :  string
 :  Whether disable-while-typing is enabled. It can be _enabled_ or _disabled_
+|- calibration_matrix
+:  array
+:  An array of 6 floats representing the calibration matrix for absolute
+   devices such as touchscreens
 
 
 *Example Reply:*


### PR DESCRIPTION
Can be used to change the orientation of a touchscreen.

Example usage with swaymsg:

    # identity
    swaymsg input type:touch calibration_matrix '"1 0 0 0 1 0"'

    # 90 degree clockwise
    swaymsg input type:touch calibration_matrix '"0 -1 1 1 0 0"'

    # 180 degree clockwise
    swaymsg input type:touch calibration_matrix '"-1 0 1 0 -1 1"'

    # 270 degree clockwise
    swaymsg input type:touch calibration_matrix '"0 1 0 -1 0 1"'

Documentation:

    https://wayland.freedesktop.org/libinput/doc/latest/absolute-axes.html#calibration-of-absolute-devices

I have never really written any C, so please don't hesitate to tell me if I did anything horrible C-wise.

Personally I'm unsure about a few things:

1) The struct I chose to represent the calibration matrix in `config.h`. I also tried using:
- A plain `float matrix[6]`, but there was no good way to represent the non-configured state.
- A `float *matrix`, with `NULL` for the non-configured state. Allocating the arrays felt messy and less safe in this case. The commit for this attempt is here: https://github.com/mebubo/sway/commit/ea7c76514d6b218d0aa53af80f07a691eb587fc0

2) I was not sure whether it was safe to pass the reference to a local array to `libinput_device_config_calibration_set_matrix`. I had to go and look at libinput sources to confirm that it does not store the reference. Checking for things like this - is it something one has to do systematically?

3) Should I have used a loop to print the array contents instead of referencing the elements one-by-one?