### PR TITLE
config/xwayland: retain xwayland status on reload

### DIFF
--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -11,7 +11,12 @@ struct cmd_results *cmd_xwayland(int argc, char **argv) {
 	}
 
 #ifdef HAVE_XWAYLAND
-	config->xwayland = parse_boolean(argv[0], config->xwayland);
+	bool xwayland = parse_boolean(argv[0], true);
+	if (config->reloading && config->xwayland != xwayland) {
+		return cmd_results_new(CMD_FAILURE,
+				"xwayland can only be enabled/disabled at launch");
+	}
+	config->xwayland = xwayland;
 #else
 	sway_log(SWAY_INFO, "Ignoring `xwayland` command, "
 		"sway hasn't been built with Xwayland support");

--- a/sway/config.c
+++ b/sway/config.c
@@ -441,6 +441,11 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		config->reloading = true;
 		config->active = true;
 
+		// xwayland can only be enabled/disabled at launch
+		sway_log(SWAY_DEBUG, "xwayland will remain %s",
+				old_config->xwayland ? "enabled" : "disabled");
+		config->xwayland = old_config->xwayland;
+
 		if (old_config->swaybg_client != NULL) {
 			wl_client_destroy(old_config->swaybg_client);
 		}


### PR DESCRIPTION
Fixes #4265 

Since xwayland can only be enabled/disabled at launch, the xwayland
status should be retained on reload. Having `xwayland enabled|disabled`
in the config, should not cause `config->xwayland` to be invalid on
reload. This also returns `CMD_FAILURE` with a message that xwayland
can only be enabled/disabled on launch when trying to set the invalid
status on reload. This allows swaynag to notify the user that the
change will not take effect until sway is restarted.