### PR TITLE
cmd_seat: split action and config handlers

### DIFF
--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -7,14 +7,44 @@
 #include "stringop.h"
 
 // must be in order for the bsearch
+// these handlers perform actions on the seat
+static struct cmd_handler seat_action_handlers[] = {
+	{ "cursor", seat_cmd_cursor },
+};
+
+// must be in order for the bsearch
+// these handlers alter the seat config
 static struct cmd_handler seat_handlers[] = {
 	{ "attach", seat_cmd_attach },
-	{ "cursor", seat_cmd_cursor },
 	{ "fallback", seat_cmd_fallback },
 	{ "hide_cursor", seat_cmd_hide_cursor },
 	{ "pointer_constraint", seat_cmd_pointer_constraint },
 	{ "xcursor_theme", seat_cmd_xcursor_theme },
 };
+
+static struct cmd_results *action_handlers(int argc, char **argv) {
+	struct cmd_results *res = config_subcommand(argv, argc,
+			seat_action_handlers, sizeof(seat_action_handlers));
+	free_seat_config(config->handler_context.seat_config);
+	config->handler_context.seat_config = NULL;
+	return res;
+}
+
+static struct cmd_results *config_handlers(int argc, char **argv) {
+	struct cmd_results *res = config_subcommand(argv, argc,
+			seat_handlers, sizeof(seat_handlers));
+	if (res && res->status != CMD_SUCCESS) {
+		free_seat_config(config->handler_context.seat_config);
+	} else {
+		struct seat_config *sc =
+			store_seat_config(config->handler_context.seat_config);
+		if (!config->reading) {
+			input_manager_apply_seat_config(sc);
+		}
+	}
+	config->handler_context.seat_config = NULL;
+	return res;
+}
 
 struct cmd_results *cmd_seat(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -36,20 +66,12 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}
 
-	struct cmd_results *res = config_subcommand(argv + 1, argc - 1,
-			seat_handlers, sizeof(seat_handlers));
-	if (res && res->status != CMD_SUCCESS) {
-		free_seat_config(config->handler_context.seat_config);
-		config->handler_context.seat_config = NULL;
-		return res;
+	struct cmd_results *res = NULL;
+	if (find_handler(argv[1], seat_action_handlers,
+				sizeof(seat_action_handlers))) {
+		res = action_handlers(argc - 1, argv + 1);
+	} else {
+		res = config_handlers(argc - 1, argv + 1);
 	}
-
-	struct seat_config *sc =
-		store_seat_config(config->handler_context.seat_config);
-	if (!config->reading) {
-		input_manager_apply_seat_config(sc);
-	}
-
-	config->handler_context.seat_config = NULL;
 	return res ? res : cmd_results_new(CMD_SUCCESS, NULL);
 }


### PR DESCRIPTION
Fixes #4233 

This separates the logic for seat subcommand handlers that only perform
actions on the seat and handlers that alter the seat config. The former
group can immediately free the seat config after running the command as
it is only used by the subcommand to find the name of the seat to
operate on. The latter group alters the seat config so it will need to
go through the storage and application stage (assuming success).

_I chose the above solution rather than the proposed flag since this
constrains all of the logic to the seat command handler. Additionally,
a flag is useless for the remainder of the life of the seat config_