### PR TITLE
config: fix find_handler logic

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -47,7 +47,8 @@ struct cmd_results *checkarg(int argc, const char *name,
 		enum expected_args type, int val);
 
 struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
-		int handlers_size);
+		size_t handlers_size);
+
 /**
  * Parse and executes a command.
  *


### PR DESCRIPTION
Without this change, the handlers listed in the config_handlers or
command_handlers arrays (depending on reading or active) in commands.c
would be valid subcommands. To make matters worse, they would also take
precedence over the defined subcommand handlers.

This corrects find_handler to only work on the handler array given
instead of implicitly trying others.