### PR TITLE
ws-output-priority: fix logic issue in find_output

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -514,7 +514,7 @@ bool workspace_is_empty(struct sway_workspace *ws) {
 }
 
 static int find_output(const void *id1, const void *id2) {
-	return strcmp(id1, id2) ? 0 : 1;
+	return strcmp(id1, id2);
 }
 
 void workspace_output_raise_priority(struct sway_workspace *ws,


### PR DESCRIPTION
Fixes #4278 

The function used for comparing two output names in the workspace
output priority lists was inverted. This was causing priority to not be
stored correctly resulting in workspaces not always being restored or
moved to the desired outputs