### PR TITLE
Generate wayland protocol header/data code with custom_target

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,85 +1,79 @@
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner = find_program('wayland-scanner')
-
-# should check wayland_scanner's version, but it is hard to get
-if wayland_server.version().version_compare('>=1.14.91')
-	code_type = 'private-code'
+wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+if wayland_scanner_dep.found()
+	wayland_scanner = find_program(
+		wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+		native: true,
+	)
 else
-	code_type = 'code'
+	wayland_scanner = find_program('wayland-scanner', native: true)
 endif
 
-wayland_scanner_code = generator(
-	wayland_scanner,
-	output: '@BASENAME@-protocol.c',
-	arguments: [code_type, '@INPUT@', '@OUTPUT@'],
-)
-
-wayland_scanner_client = generator(
-	wayland_scanner,
-	output: '@BASENAME@-client-protocol.h',
-	arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
-)
-
-wayland_scanner_server = generator(
-	wayland_scanner,
-	output: '@BASENAME@-protocol.h',
-	arguments: ['server-header', '@INPUT@', '@OUTPUT@'],
-)
-
-client_protocols = [
-	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
-	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
-	['wlr-layer-shell-unstable-v1.xml'],
-	['idle.xml'],
-	['wlr-input-inhibitor-unstable-v1.xml'],
-]
-
-server_protocols = [
+protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
 	[wl_protocol_dir, 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
+	['idle.xml'],
 	['wlr-input-inhibitor-unstable-v1.xml'],
 ]
 
-client_protos_src = []
-client_protos_headers = []
+client_protocols = [
+	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
+	['wlr-layer-shell-unstable-v1.xml'],
+	['wlr-input-inhibitor-unstable-v1.xml'],
+]
 
-server_protos_src = []
-server_protos_headers = []
+wl_protos_src = []
+wl_protos_headers = []
+
+foreach p : protocols
+	xml = join_paths(p)
+	wl_protos_src += custom_target(
+		xml.underscorify() + '_server_c',
+		input: xml,
+		output: '@BASENAME@-protocol.c',
+		command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+	)
+	wl_protos_headers += custom_target(
+		xml.underscorify() + '_server_h',
+		input: xml,
+		output: '@BASENAME@-protocol.h',
+		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+	)
+endforeach
 
 foreach p : client_protocols
 	xml = join_paths(p)
-	client_protos_src += wayland_scanner_code.process(xml)
-	client_protos_headers += wayland_scanner_client.process(xml)
-endforeach
-
-foreach p : server_protocols
-	xml = join_paths(p)
-	server_protos_src += wayland_scanner_code.process(xml)
-	server_protos_headers += wayland_scanner_server.process(xml)
+	wl_protos_headers += custom_target(
+		xml.underscorify() + '_client_h',
+		input: xml,
+		output: '@BASENAME@-client-protocol.h',
+		command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+	)
 endforeach
 
 lib_client_protos = static_library(
 	'client_protos',
-	client_protos_src + client_protos_headers,
-	dependencies: [wayland_client]
-) # for the include directory
+	wl_protos_src + wl_protos_headers,
+	dependencies: wayland_client.partial_dependency(compile_args: true),
+)
 
 client_protos = declare_dependency(
 	link_with: lib_client_protos,
-	sources: client_protos_headers,
+	sources: wl_protos_headers,
 )
 
 lib_server_protos = static_library(
 	'server_protos',
-	server_protos_src + server_protos_headers,
-	dependencies: [wayland_client]
-) # for the include directory
+	wl_protos_src + wl_protos_headers,
+	dependencies: wayland_server.partial_dependency(compile_args: true),
+)
 
 server_protos = declare_dependency(
 	link_with: lib_server_protos,
-	sources: server_protos_headers,
+	sources: wl_protos_headers,
 )


### PR DESCRIPTION
Closes  #4209. This change replaces the meson `generator` used to generate protocol source files and headers with a set of `custom_target`s. Each distinct file is now generated only once.

I've also added a fix for the dependency for `lib_server_protos`, which should depend on `wayland_server` instead of `wayland_client`; this doesn't change the dependency list for the `sway` binary, because `libwlroots.so` links both client and server libraries.