### PR TITLE
Use -fmacro-prefix-map to strip build path, when available

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -93,20 +93,3 @@ void _sway_log(sway_log_importance_t verbosity, const char *fmt, ...) {
 	sway_log_stderr(verbosity, fmt, args);
 	va_end(args);
 }
-
-// strips the path prefix from filepath
-// will try to strip SWAY_SRC_DIR as well as a relative src dir
-// e.g. '/src/build/sway/util/log.c' and
-// '../util/log.c' will both be stripped to
-// 'util/log.c'
-const char *_sway_strip_path(const char *filepath) {
-	static int srclen = sizeof(SWAY_SRC_DIR);
-	if (strstr(filepath, SWAY_SRC_DIR) == filepath) {
-		filepath += srclen;
-	} else if (*filepath == '.') {
-		while (*filepath == '.' || *filepath == '/') {
-			++filepath;
-		}
-	}
-	return filepath;
-}

--- a/include/log.h
+++ b/include/log.h
@@ -33,22 +33,26 @@ void _sway_vlog(sway_log_importance_t verbosity, const char *format, va_list arg
 void _sway_abort(const char *filename, ...) ATTRIB_PRINTF(1, 2);
 bool _sway_assert(bool condition, const char* format, ...) ATTRIB_PRINTF(2, 3);
 
-// TODO: get meson to precompute this, for better reproducibility/less overhead
-const char *_sway_strip_path(const char *filepath);
+#ifdef SWAY_REL_SRC_DIR
+// strip prefix from __FILE__, leaving the path relative to the project root
+#define _SWAY_FILENAME ((const char *)__FILE__ + sizeof(SWAY_REL_SRC_DIR) - 1)
+#else
+#define _SWAY_FILENAME __FILE__
+#endif
 
 #define sway_log(verb, fmt, ...) \
-	_sway_log(verb, "[%s:%d] " fmt, _sway_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+	_sway_log(verb, "[%s:%d] " fmt, _SWAY_FILENAME, __LINE__, ##__VA_ARGS__)
 
 #define sway_vlog(verb, fmt, args) \
-	_sway_vlog(verb, "[%s:%d] " fmt, _sway_strip_path(__FILE__), __LINE__, args)
+	_sway_vlog(verb, "[%s:%d] " fmt, _SWAY_FILENAME, __LINE__, args)
 
 #define sway_log_errno(verb, fmt, ...) \
 	sway_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))
 
 #define sway_abort(FMT, ...) \
-	_sway_abort("[%s:%d] " FMT, _sway_strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
+	_sway_abort("[%s:%d] " FMT, _SWAY_FILENAME, __LINE__, ##__VA_ARGS__)
 
 #define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, "[%s:%d] %s:" FMT, _sway_strip_path(__FILE__), __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+	_sway_assert(COND, "[%s:%d] %s:" FMT, _SWAY_FILENAME, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,6 @@ project(
 
 add_project_arguments(
 	[
-		'-DSWAY_SRC_DIR="@0@"'.format(meson.current_source_dir()),
-
 		'-DWL_HIDE_DEPRECATED',
 		'-DWLR_USE_UNSTABLE',
 
@@ -141,6 +139,44 @@ if git.found()
 	endif
 endif
 add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
+
+# Compute the relative path used by compiler invocations.
+source_root = meson.current_source_dir().split('/')
+build_root = meson.build_root().split('/')
+relative_dir_parts = []
+i = 0
+in_prefix = true
+foreach p : build_root
+	if i >= source_root.length() or not in_prefix or p != source_root[i]
+		in_prefix = false
+		relative_dir_parts += '..'
+	endif
+	i += 1
+endforeach
+i = 0
+in_prefix = true
+foreach p : source_root
+	if i >= build_root.length() or not in_prefix or build_root[i] != p
+		in_prefix = false
+		relative_dir_parts += p
+	endif
+	i += 1
+endforeach
+relative_dir = join_paths(relative_dir_parts) + '/'
+
+# Strip relative path prefixes from the code if possible, otherwise hide them.
+if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
+	add_project_arguments(
+		'-fmacro-prefix-map=@0@='.format(relative_dir),
+		language: 'c',
+	)
+else
+	add_project_arguments(
+		'-DSWAY_REL_SRC_DIR="@0@"'.format(relative_dir),
+		language: 'c',
+	)
+endif
+
 
 sway_inc = include_directories('include')
 


### PR DESCRIPTION
Closes #3680. This uses `-fmacro-prefix-path` to make `__FILE__` strings independent of the filesystem location of the build directory. If the option is not available, it falls back to the second method described in https://github.com/swaywm/sway/issues/3680#issuecomment-463804964 .

The method used to identify the relative path prefix is ugly but straightforward. I am not aware of any simple ways to determine string lengths with Meson itself.

I've tested this change with gcc 9.1.0 (which supports `-fmacro-prefix-path`) and clang 8.0.0 (which does not yet support it, their patch depends on others which are not yet merged).