### PR TITLE
Layout correctly with several new windows

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -87,6 +87,7 @@ struct sway_container {
 	double width, height;
 	double saved_x, saved_y;
 	double saved_width, saved_height;
+	bool saved_dims;
 
 	// These are in layout coordinates.
 	double content_x, content_y;

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -39,7 +39,11 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 			}
 		}
 		container_remove_gaps(child);
-		total_width += child->width;
+		if (child->saved_dims) {
+			total_width += child->saved_width;
+		} else {
+			total_width += child->width;
+		}
 	}
 	double scale = parent->width / total_width;
 
@@ -51,12 +55,16 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 		child->x = child_x;
 		child->y = parent->y;
 		child->width = floor(child->width * scale);
+		child->saved_width = floor(child->saved_width * scale);
 		child->height = parent->height;
-		child_x += child->width;
-
+		if (child->saved_dims) {
+			child_x += child->saved_width;
+		} else {
+			child_x += child->width;
+		}
 		// Make last child use remaining width of parent
 		if (i == children->length - 1) {
-			child->width = parent->x + parent->width - child->x;
+			child->width = child->saved_width = parent->x + parent->width - child->x;
 		}
 		container_add_gaps(child);
 	}
@@ -88,7 +96,11 @@ static void apply_vert_layout(list_t *children, struct wlr_box *parent) {
 			}
 		}
 		container_remove_gaps(child);
-		total_height += child->height;
+		if (child->saved_dims) {
+			total_height += child->saved_height;
+		} else {
+			total_height += child->height;
+		}
 	}
 	double scale = parent->height / total_height;
 
@@ -101,11 +113,15 @@ static void apply_vert_layout(list_t *children, struct wlr_box *parent) {
 		child->y = child_y;
 		child->width = parent->width;
 		child->height = floor(child->height * scale);
-		child_y += child->height;
-
+		child->saved_height = floor(child->saved_height * scale);
+		if (child->saved_dims) {
+			child_y += child->saved_height;
+		} else {
+			child_y += child->height;
+		}
 		// Make last child use remaining height of parent
 		if (i == children->length - 1) {
-			child->height = parent->y + parent->height - child->y;
+			child->height = child->saved_height = parent->y + parent->height - child->y;
 		}
 		container_add_gaps(child);
 	}

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -18,13 +18,22 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 		return;
 	}
 
+	// Count the number of new windows we are resizing
+	int new_children = 0;
+	for (int i = 0; i < children->length; ++i) {
+		struct sway_container *child = children->items[i];
+		if (child->width <= 0) {
+			new_children += 1;
+		}
+	}
+
 	// Calculate total width of children
 	double total_width = 0;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
 		if (child->width <= 0) {
-			if (children->length > 1) {
-				child->width = parent->width / (children->length - 1);
+			if (children->length > new_children) {
+				child->width = parent->width / (children->length - new_children);
 			} else {
 				child->width = parent->width;
 			}
@@ -58,13 +67,22 @@ static void apply_vert_layout(list_t *children, struct wlr_box *parent) {
 		return;
 	}
 
+	// Count the number of new windows we are resizing
+	int new_children = 0;
+	for (int i = 0; i < children->length; ++i) {
+		struct sway_container *child = children->items[i];
+		if (child->height <= 0) {
+			new_children += 1;
+		}
+	}
+
 	// Calculate total height of children
 	double total_height = 0;
 	for (int i = 0; i < children->length; ++i) {
 		struct sway_container *child = children->items[i];
 		if (child->height <= 0) {
-			if (children->length > 1) {
-				child->height = parent->height / (children->length - 1);
+			if (children->length > new_children) {
+				child->height = parent->height / (children->length - new_children);
 			} else {
 				child->height = parent->height;
 			}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1182,9 +1182,13 @@ void container_remove_gaps(struct sway_container *c) {
 	}
 
 	c->width += c->current_gaps.left + c->current_gaps.right;
+	c->saved_width += c->current_gaps.left + c->current_gaps.right;
 	c->height += c->current_gaps.top + c->current_gaps.bottom;
+	c->saved_height += c->current_gaps.top + c->current_gaps.bottom;
 	c->x -= c->current_gaps.left;
+	c->saved_x -= c->current_gaps.left;
 	c->y -= c->current_gaps.top;
+	c->saved_y -= c->current_gaps.top;
 
 	c->current_gaps.top = 0;
 	c->current_gaps.right = 0;
@@ -1236,9 +1240,13 @@ void container_add_gaps(struct sway_container *c) {
 	c->current_gaps.left = c->x == ws->x ? ws->gaps_inner : 0;
 
 	c->x += c->current_gaps.left;
+	c->saved_x += c->current_gaps.left;
 	c->y += c->current_gaps.top;
+	c->saved_y += c->current_gaps.top;
 	c->width -= c->current_gaps.left + c->current_gaps.right;
+	c->saved_width -= c->current_gaps.left + c->current_gaps.right;
 	c->height -= c->current_gaps.top + c->current_gaps.bottom;
+	c->saved_height -= c->current_gaps.top + c->current_gaps.bottom;
 }
 
 enum sway_container_layout container_parent_layout(struct sway_container *con) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -35,6 +35,7 @@ struct sway_container *container_create(struct sway_view *view) {
 	c->layout = L_NONE;
 	c->view = view;
 	c->alpha = 1.0f;
+	c->saved_dims = false;
 
 	if (!view) {
 		c->children = create_list();
@@ -964,6 +965,7 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 	con->saved_y = con->y;
 	con->saved_width = con->width;
 	con->saved_height = con->height;
+	con->saved_dims = true;
 
 	if (con->workspace) {
 		con->workspace->fullscreen = con;
@@ -996,6 +998,7 @@ static void container_fullscreen_global(struct sway_container *con) {
 	con->saved_y = con->y;
 	con->saved_width = con->width;
 	con->saved_height = con->height;
+	con->saved_dims = true;
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
@@ -1025,6 +1028,7 @@ void container_fullscreen_disable(struct sway_container *con) {
 	}
 	con->width = con->saved_width;
 	con->height = con->saved_height;
+	con->saved_dims = false;
 
 	if (con->fullscreen_mode == FULLSCREEN_WORKSPACE) {
 		if (con->workspace) {


### PR DESCRIPTION
If there is more than one new window layout correctly by calculating the default size of the new windows using the information of how many of them there are in total.

This helps with issue #3547 but doesn't fix it in all situations. Things now work correctly if the first layout of new windows happens after leaving fullscreen. But if for some reason an `arrange_container()` gets called while we are fullscreen the windows will still be incorrectly sized after `saved_width`/`saved_height` get used to restore the first window's size before going fullscreen.