### PR TITLE
Don't manipulate size/pos of fullscreen containers

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -85,8 +85,6 @@ struct sway_container {
 	// Includes borders
 	double x, y;
 	double width, height;
-	double saved_x, saved_y;
-	double saved_width, saved_height;
 
 	// These are in layout coordinates.
 	double content_x, content_y;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -206,7 +206,6 @@ static void container_move_to_workspace(struct sway_container *container,
 	} else {
 		container_detach(container);
 		container->width = container->height = 0;
-		container->saved_width = container->saved_height = 0;
 		workspace_add_tiling(workspace, container);
 		container_update_representation(container);
 	}
@@ -234,7 +233,6 @@ static void container_move_to_container(struct sway_container *container,
 	container_detach(container);
 	container_remove_gaps(container);
 	container->width = container->height = 0;
-	container->saved_width = container->saved_height = 0;
 
 	if (destination->view) {
 		container_add_sibling(destination, container, 1);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -881,6 +881,23 @@ static void render_container(struct sway_output *output,
 	render_containers(output, damage, &data);
 }
 
+static void render_container_fullscreen(struct sway_output *output,
+		pixman_region32_t *damage, struct sway_container *con, bool focused) {
+	struct parent_data data = {
+		.layout = con->current.layout,
+		.box = {
+			.x = output->lx,
+			.y = output->ly,
+			.width = output->width,
+			.height = output->height,
+		},
+		.children = con->current.children,
+		.focused = focused,
+		.active_child = con->current.focused_inactive_child,
+	};
+	render_containers(output, damage, &data);
+}
+
 static void render_workspace(struct sway_output *output,
 		pixman_region32_t *damage, struct sway_workspace *ws, bool focused) {
 	struct parent_data data = {
@@ -1019,7 +1036,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 						output, damage, 1.0f);
 			}
 		} else {
-			render_container(output, damage, fullscreen_con,
+			render_container_fullscreen(output, damage, fullscreen_con,
 					fullscreen_con->current.focused);
 		}
 

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -219,19 +219,11 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	node_set_dirty(&workspace->node);
 	sway_log(SWAY_DEBUG, "Arranging workspace '%s' at %f, %f", workspace->name,
 			workspace->x, workspace->y);
-	if (workspace->fullscreen) {
-		struct sway_container *fs = workspace->fullscreen;
-		fs->x = output->lx;
-		fs->y = output->ly;
-		fs->width = output->width;
-		fs->height = output->height;
-		arrange_container(fs);
-	} else {
-		struct wlr_box box;
-		workspace_get_box(workspace, &box);
-		arrange_children(workspace->tiling, workspace->layout, &box);
-		arrange_floating(workspace->floating);
-	}
+
+	struct wlr_box box;
+	workspace_get_box(workspace, &box);
+	arrange_children(workspace->tiling, workspace->layout, &box);
+	arrange_floating(workspace->floating);
 }
 
 void arrange_output(struct sway_output *output) {
@@ -262,18 +254,9 @@ void arrange_root(void) {
 	root->width = layout_box->width;
 	root->height = layout_box->height;
 
-	if (root->fullscreen_global) {
-		struct sway_container *fs = root->fullscreen_global;
-		fs->x = root->x;
-		fs->y = root->y;
-		fs->width = root->width;
-		fs->height = root->height;
-		arrange_container(fs);
-	} else {
-		for (int i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
-			arrange_output(output);
-		}
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		arrange_output(output);
 	}
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -960,11 +960,6 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 	set_fullscreen_iterator(con, &enable);
 	container_for_each_child(con, set_fullscreen_iterator, &enable);
 
-	con->saved_x = con->x;
-	con->saved_y = con->y;
-	con->saved_width = con->width;
-	con->saved_height = con->height;
-
 	if (con->workspace) {
 		con->workspace->fullscreen = con;
 		struct sway_seat *seat;
@@ -992,10 +987,6 @@ static void container_fullscreen_global(struct sway_container *con) {
 	container_for_each_child(con, set_fullscreen_iterator, &enable);
 
 	root->fullscreen_global = con;
-	con->saved_x = con->x;
-	con->saved_y = con->y;
-	con->saved_width = con->width;
-	con->saved_height = con->height;
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
@@ -1018,13 +1009,6 @@ void container_fullscreen_disable(struct sway_container *con) {
 	bool enable = false;
 	set_fullscreen_iterator(con, &enable);
 	container_for_each_child(con, set_fullscreen_iterator, &enable);
-
-	if (container_is_floating(con)) {
-		con->x = con->saved_x;
-		con->y = con->saved_y;
-	}
-	con->width = con->saved_width;
-	con->height = con->saved_height;
 
 	if (con->fullscreen_mode == FULLSCREEN_WORKSPACE) {
 		if (con->workspace) {


### PR DESCRIPTION
In fullscreen mode position/dimensions of the fullscreen container were being changed and then restored on unfullscreen. This would break things that manipulated those dimensions while the window was fullscreen.
Instead have the rendering code handle the positioning directly and leave the container information alone.

Fixes #3547