### PR TITLE
tree: set correct border value before creating floater

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -755,14 +755,14 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		struct sway_container *old_parent = container->parent;
 		container_detach(container);
 		workspace_add_floating(workspace, container);
-		container_floating_set_default_size(container);
-		container_floating_resize_and_center(container);
 		if (container->view) {
 			view_set_tiled(container->view, false);
 			if (container->view->using_csd) {
 				container->border = B_CSD;
 			}
 		}
+		container_floating_set_default_size(container);
+		container_floating_resize_and_center(container);
 		if (old_parent) {
 			container_reap_empty(old_parent);
 		}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -612,6 +612,10 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		&view->surface_new_subsurface);
 	view->surface_new_subsurface.notify = view_handle_surface_new_subsurface;
 
+	if (decoration) {
+		view_update_csd_from_client(view, decoration);
+	}
+
 	if (view->impl->wants_floating && view->impl->wants_floating(view)) {
 		view->container->border = config->floating_border;
 		view->container->border_thickness = config->floating_border_thickness;
@@ -634,10 +638,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	view_update_title(view, false);
 	container_update_representation(view->container);
-
-	if (decoration) {
-		view_update_csd_from_client(view, decoration);
-	}
 
 	if (fullscreen) {
 		container_set_fullscreen(view->container, true);


### PR DESCRIPTION
Currently, `border` is set to `B_CSD` after setting coordinates, messing up the `content_*` fields.