### PR TITLE
Implement DRM leasing for non-desktop outputs

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_input_method_v2.h>
+#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>
@@ -68,6 +69,9 @@ struct sway_server {
 	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager;
 	struct wl_listener xdg_decoration;
 	struct wl_list xdg_decorations; // sway_xdg_decoration::link
+
+	struct wlr_drm_lease_manager_v1 *drm_lease_manager;
+	struct wl_listener drm_lease_requested;
 
 	struct wlr_presentation *presentation;
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -4,9 +4,11 @@
 #include <strings.h>
 #include <time.h>
 #include <wayland-server-core.h>
+#include <wlr/backend/drm.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_buffer.h>
+#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -920,7 +922,17 @@ static void handle_present(struct wl_listener *listener, void *data) {
 void handle_new_output(struct wl_listener *listener, void *data) {
 	struct sway_server *server = wl_container_of(listener, server, new_output);
 	struct wlr_output *wlr_output = data;
-	sway_log(SWAY_DEBUG, "New output %p: %s", wlr_output, wlr_output->name);
+	sway_log(SWAY_DEBUG, "New output %p: %s (non-desktop: %d)",
+			wlr_output, wlr_output->name, wlr_output->non_desktop);
+
+	if (wlr_output->non_desktop) {
+		sway_log(SWAY_DEBUG, "Not configuring non-desktop output");
+		if (server->drm_lease_manager && wlr_output_is_drm(wlr_output)) {
+			wlr_drm_lease_manager_v1_offer_output(
+					server->drm_lease_manager, wlr_output);
+		}
+		return;
+	}
 
 	struct sway_output *output = output_create(wlr_output);
 	if (!output) {

--- a/sway/server.c
+++ b/sway/server.c
@@ -11,6 +11,7 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
@@ -49,6 +50,14 @@ bool server_privileged_prepare(struct sway_server *server) {
 		return false;
 	}
 	return true;
+}
+
+static void handle_drm_lease_requested(
+		struct wl_listener *listener, void *data) {
+	/* We only offer non-desktop outputs, but in the future we might want to do
+	 * more logic here. */
+	struct wlr_drm_lease_request_v1 *req = data;
+	wlr_drm_lease_manager_v1_grant_lease_request(req->manager, req);
 }
 
 bool server_init(struct sway_server *server) {
@@ -141,6 +150,14 @@ bool server_init(struct sway_server *server) {
 		&server->output_power_manager_set_mode);
 	server->input_method = wlr_input_method_manager_v2_create(server->wl_display);
 	server->text_input = wlr_text_input_manager_v3_create(server->wl_display);
+
+	server->drm_lease_manager =
+		wlr_drm_lease_manager_v1_create(server->wl_display, server->backend);
+	if (server->drm_lease_manager) {
+		server->drm_lease_requested.notify = handle_drm_lease_requested;
+		wl_signal_add(&server->drm_lease_manager->events.lease_requested,
+				&server->drm_lease_requested);
+	}
 
 	wlr_export_dmabuf_manager_v1_create(server->wl_display);
 	wlr_screencopy_manager_v1_create(server->wl_display);


### PR DESCRIPTION
This prevents sway from extending the desktop to i.e. VR headsets, and
makes them available for DRM leasing.

Depends on swaywm/wlroots#1730