### PR TITLE
Rework the gaps code so sizes are correct and to prevent broken layouts

### DIFF
--- a/include/sway/tree/node.h
+++ b/include/sway/tree/node.h
@@ -3,6 +3,9 @@
 #include <stdbool.h>
 #include "list.h"
 
+#define MIN_SANE_W 100
+#define MIN_SANE_H 60
+
 struct sway_root;
 struct sway_output;
 struct sway_workspace;

--- a/include/util.h
+++ b/include/util.h
@@ -34,4 +34,9 @@ const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel);
 
 bool set_cloexec(int fd, bool cloexec);
 
+#undef MAX
+#define MAX(a, b)  (((a) > (b)) ? (a) : (b))
+#undef MIN
+#define MIN(a, b)  (((a) < (b)) ? (a) : (b))
+
 #endif

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -15,8 +15,6 @@
 #define AXIS_HORIZONTAL (WLR_EDGE_LEFT | WLR_EDGE_RIGHT)
 #define AXIS_VERTICAL   (WLR_EDGE_TOP | WLR_EDGE_BOTTOM)
 
-static const int MIN_SANE_W = 100, MIN_SANE_H = 60;
-
 enum resize_unit {
 	RESIZE_UNIT_PX,
 	RESIZE_UNIT_PPT,

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -568,6 +568,9 @@ The default colors are:
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps ...).
 
+	If the gaps are too large and would make a view too narrow or short they
+	are adjusted to be smaller or even removed for that specific view.
+
 *hide_edge_borders* [--i3] none|vertical|horizontal|both|smart|smart_no_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_. The
 	_--i3_ option enables i3-compatible behavior to hide the title bar on tabbed

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1226,13 +1226,17 @@ void container_add_gaps(struct sway_container *c) {
 		}
 	}
 
-	int gaps1 = ws->gaps_inner / 2;
-	int gaps2 = ws->gaps_inner - gaps1;
+	int gaps_horizontal = MAX(0, MIN(ws->gaps_inner, c->width - MIN_SANE_W));
+	int gaps_horizontal1 = gaps_horizontal / 2;
+	int gaps_horizontal2 = gaps_horizontal - gaps_horizontal1;
+	c->current_gaps.left = gaps_horizontal1;
+	c->current_gaps.right = gaps_horizontal2;
 
-	c->current_gaps.top = gaps1;
-	c->current_gaps.bottom = gaps2;
-	c->current_gaps.left = gaps1;
-	c->current_gaps.right = gaps2;
+	int gaps_vertical = MAX(0, MIN(ws->gaps_inner, c->height - MIN_SANE_H));
+	int gaps_vertical1 = gaps_vertical / 2;
+	int gaps_vertical2 = gaps_vertical - gaps_vertical1;
+	c->current_gaps.top = gaps_vertical1;
+	c->current_gaps.bottom = gaps_vertical2;
 
 	c->x += c->current_gaps.left;
 	c->y += c->current_gaps.top;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1226,10 +1226,13 @@ void container_add_gaps(struct sway_container *c) {
 		}
 	}
 
-	c->current_gaps.top = c->y == ws->y ? ws->gaps_inner : 0;
-	c->current_gaps.right = ws->gaps_inner;
-	c->current_gaps.bottom = ws->gaps_inner;
-	c->current_gaps.left = c->x == ws->x ? ws->gaps_inner : 0;
+	int gaps1 = ws->gaps_inner / 2;
+	int gaps2 = ws->gaps_inner - gaps1;
+
+	c->current_gaps.top = gaps1;
+	c->current_gaps.bottom = gaps2;
+	c->current_gaps.left = gaps1;
+	c->current_gaps.right = gaps2;
 
 	c->x += c->current_gaps.left;
 	c->y += c->current_gaps.top;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -746,15 +746,19 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 	} else {
 		// For tiled containers we need to add the half-gap all around the edge
 		// to match the half gaps that the children have all already added around
-		// themselves. We use the opposite gaps1/gaps2 order so that the sum adds
-		// up to the correct total gap size in all circumstances.
-		int gaps1 = ws->gaps_inner / 2;
-		int gaps2 = ws->gaps_inner - gaps1;
+		// themselves. We use the opposite order for the two halves so that the
+		// sum adds up to the correct total gap size in all circumstances.
+		int gaps_horizontal = MAX(0, MIN(ws->gaps_inner, ws->width - MIN_SANE_W));
+		int gaps_horizontal1 = gaps_horizontal / 2;
+		int gaps_horizontal2 = gaps_horizontal - gaps_horizontal1;
+		ws->current_gaps.left += gaps_horizontal2;
+		ws->current_gaps.right += gaps_horizontal1;
 
-		ws->current_gaps.top += gaps2;
-		ws->current_gaps.bottom += gaps1;
-		ws->current_gaps.left += gaps2;
-		ws->current_gaps.right += gaps1;
+		int gaps_vertical = MAX(0, MIN(ws->gaps_inner, ws->height - MIN_SANE_H));
+		int gaps_vertical1 = gaps_vertical / 2;
+		int gaps_vertical2 = gaps_vertical - gaps_vertical1;
+		ws->current_gaps.top += gaps_vertical2;
+		ws->current_gaps.bottom += gaps_vertical1;
 	}
 
 	ws->x += ws->current_gaps.left;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -743,6 +743,18 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 		ws->current_gaps.right += ws->gaps_inner;
 		ws->current_gaps.bottom += ws->gaps_inner;
 		ws->current_gaps.left += ws->gaps_inner;
+	} else {
+		// For tiled containers we need to add the half-gap all around the edge
+		// to match the half gaps that the children have all already added around
+		// themselves. We use the opposite gaps1/gaps2 order so that the sum adds
+		// up to the correct total gap size in all circumstances.
+		int gaps1 = ws->gaps_inner / 2;
+		int gaps2 = ws->gaps_inner - gaps1;
+
+		ws->current_gaps.top += gaps2;
+		ws->current_gaps.bottom += gaps1;
+		ws->current_gaps.left += gaps2;
+		ws->current_gaps.right += gaps1;
 	}
 
 	ws->x += ws->current_gaps.left;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -748,17 +748,34 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 		// to match the half gaps that the children have all already added around
 		// themselves. We use the opposite order for the two halves so that the
 		// sum adds up to the correct total gap size in all circumstances.
-		int gaps_horizontal = MAX(0, MIN(ws->gaps_inner, ws->width - MIN_SANE_W));
-		int gaps_horizontal1 = gaps_horizontal / 2;
-		int gaps_horizontal2 = gaps_horizontal - gaps_horizontal1;
+		int gaps_horizontal1 = ws->gaps_inner / 2;
+		int gaps_horizontal2 = ws->gaps_inner - gaps_horizontal1;
 		ws->current_gaps.left += gaps_horizontal2;
 		ws->current_gaps.right += gaps_horizontal1;
 
-		int gaps_vertical = MAX(0, MIN(ws->gaps_inner, ws->height - MIN_SANE_H));
-		int gaps_vertical1 = gaps_vertical / 2;
-		int gaps_vertical2 = gaps_vertical - gaps_vertical1;
+		int gaps_vertical1 = ws->gaps_inner / 2;
+		int gaps_vertical2 = ws->gaps_inner - gaps_vertical1;
 		ws->current_gaps.top += gaps_vertical2;
 		ws->current_gaps.bottom += gaps_vertical1;
+	}
+
+	// Now that we have the total gaps calculated we may need to clamp them in
+	// case they've made the available area too small
+	if (ws->width - ws->current_gaps.left - ws->current_gaps.right < MIN_SANE_W &&
+			ws->current_gaps.left + ws->current_gaps.right > 0) {
+		int total_gap = MAX(0, ws->width - MIN_SANE_W);
+		double left_gap_frac = ((float) ws->current_gaps.left /
+			((float) ws->current_gaps.left + (float) ws->current_gaps.right));
+		ws->current_gaps.left = left_gap_frac * total_gap;
+		ws->current_gaps.right = total_gap - ws->current_gaps.left;
+	}
+	if (ws->height - ws->current_gaps.top - ws->current_gaps.bottom < MIN_SANE_H &&
+			ws->current_gaps.top + ws->current_gaps.bottom > 0) {
+		int total_gap = MAX(0, ws->height - MIN_SANE_H);
+		double top_gap_frac = ((float) ws->current_gaps.top /
+			((float) ws->current_gaps.top + (float) ws->current_gaps.bottom));
+		ws->current_gaps.top = top_gap_frac * total_gap;
+		ws->current_gaps.bottom = total_gap - ws->current_gaps.top;
 	}
 
 	ws->x += ws->current_gaps.left;


### PR DESCRIPTION
Fixes for issues #4296 and #4294. They're built on top of each other because they're touching the same code and the reworking of the calculation to make the gaps even makes it easier to then write the code to cap the gaps.

The weird addition of `#include "pango.h"` in ` sway/tree/workspace.c` was just to get `MIN()` and `MAX()`. This is probably not ok and sway should instead include its own definitions of these macros.

--
Fixes #4294  
Fixes #4296
Fixes #4304 