### PR TITLE
Rework the gaps code to make it simpler and correct

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -116,14 +116,6 @@ struct sway_container {
 	bool border_left;
 	bool border_right;
 
-	// The gaps currently applied to the container.
-	struct {
-		int top;
-		int right;
-		int bottom;
-		int left;
-	} current_gaps;
-
 	struct sway_workspace *workspace; // NULL when hidden in the scratchpad
 	struct sway_container *parent;    // NULL if container in root of workspace
 	list_t *children;                 // struct sway_container
@@ -295,10 +287,6 @@ bool container_is_fullscreen_or_child(struct sway_container *container);
 struct sway_output *container_get_effective_output(struct sway_container *con);
 
 void container_discover_outputs(struct sway_container *con);
-
-void container_remove_gaps(struct sway_container *container);
-
-void container_add_gaps(struct sway_container *container);
 
 enum sway_container_layout container_parent_layout(struct sway_container *con);
 

--- a/include/sway/tree/node.h
+++ b/include/sway/tree/node.h
@@ -3,6 +3,9 @@
 #include <stdbool.h>
 #include "list.h"
 
+#define MIN_SANE_W 100
+#define MIN_SANE_H 60
+
 struct sway_root;
 struct sway_output;
 struct sway_workspace;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -235,7 +235,6 @@ static void container_move_to_container(struct sway_container *container,
 	struct sway_workspace *old_workspace = container->workspace;
 
 	container_detach(container);
-	container_remove_gaps(container);
 	container->width = container->height = 0;
 	container->width_fraction = container->height_fraction = 0;
 

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -15,8 +15,6 @@
 #define AXIS_HORIZONTAL (WLR_EDGE_LEFT | WLR_EDGE_RIGHT)
 #define AXIS_VERTICAL   (WLR_EDGE_TOP | WLR_EDGE_BOTTOM)
 
-static const int MIN_SANE_W = 100, MIN_SANE_H = 60;
-
 enum resize_unit {
 	RESIZE_UNIT_PX,
 	RESIZE_UNIT_PPT,

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -68,7 +68,10 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 		}
 		temp = temp->parent;
 	}
-	double child_total_width = parent->width - inner_gap * (children->length - 1);
+	double total_gap = fmin(inner_gap * (children->length - 1),
+		fmax(0, parent->width - MIN_SANE_W * children->length));
+	double child_total_width = parent->width - total_gap;
+	inner_gap = total_gap / (children->length - 1);
 
 	// Resize windows
 	sway_log(SWAY_DEBUG, "Arranging %p horizontally", parent);
@@ -143,7 +146,10 @@ static void apply_vert_layout(list_t *children, struct wlr_box *parent) {
 		}
 		temp = temp->parent;
 	}
-	double child_total_height = parent->height - inner_gap * (children->length - 1);
+	double total_gap = fmin(inner_gap * (children->length - 1),
+		fmax(0, parent->height - MIN_SANE_H * children->length));
+	double child_total_height = parent->height - total_gap;
+	inner_gap = total_gap / (children->length - 1);
 
 	// Resize windows
 	sway_log(SWAY_DEBUG, "Arranging %p vertically", parent);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -183,14 +183,6 @@ bool view_is_only_visible(struct sway_view *view) {
 }
 
 static bool gaps_to_edge(struct sway_view *view) {
-	struct sway_container *con = view->container;
-	while (con) {
-		if (con->current_gaps.top > 0 || con->current_gaps.right > 0 ||
-				con->current_gaps.bottom > 0 || con->current_gaps.left > 0) {
-			return true;
-		}
-		con = con->parent;
-	}
 	struct side_gaps gaps = view->container->workspace->current_gaps;
 	return gaps.top > 0 || gaps.right > 0 || gaps.bottom > 0 || gaps.left > 0;
 }
@@ -232,14 +224,14 @@ void view_autoconfigure(struct sway_view *view) {
 
 		if (config->hide_edge_borders == E_BOTH
 				|| config->hide_edge_borders == E_VERTICAL || hide_smart) {
-			con->border_left = con->x - con->current_gaps.left != ws->x;
-			int right_x = con->x + con->width + con->current_gaps.right;
+			con->border_left = con->x != ws->x;
+			int right_x = con->x + con->width;
 			con->border_right = right_x != ws->x + ws->width;
 		}
 		if (config->hide_edge_borders == E_BOTH
 				|| config->hide_edge_borders == E_HORIZONTAL || hide_smart) {
-			con->border_top = con->y - con->current_gaps.top != ws->y;
-			int bottom_y = con->y + con->height + con->current_gaps.bottom;
+			con->border_top = con->y != ws->y;
+			int bottom_y = con->y + con->height;
 			con->border_bottom = bottom_y != ws->y + ws->height;
 		}
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -700,28 +700,7 @@ void workspace_insert_tiling(struct sway_workspace *workspace,
 	node_set_dirty(&con->node);
 }
 
-void workspace_remove_gaps(struct sway_workspace *ws) {
-	if (ws->current_gaps.top == 0 && ws->current_gaps.right == 0 &&
-			ws->current_gaps.bottom == 0 && ws->current_gaps.left == 0) {
-		return;
-	}
-
-	ws->width += ws->current_gaps.left + ws->current_gaps.right;
-	ws->height += ws->current_gaps.top + ws->current_gaps.bottom;
-	ws->x -= ws->current_gaps.left;
-	ws->y -= ws->current_gaps.top;
-
-	ws->current_gaps.top = 0;
-	ws->current_gaps.right = 0;
-	ws->current_gaps.bottom = 0;
-	ws->current_gaps.left = 0;
-}
-
 void workspace_add_gaps(struct sway_workspace *ws) {
-	if (ws->current_gaps.top > 0 || ws->current_gaps.right > 0 ||
-			ws->current_gaps.bottom > 0 || ws->current_gaps.left > 0) {
-		return;
-	}
 	if (config->smart_gaps) {
 		struct sway_seat *seat = input_manager_get_default_seat();
 		struct sway_container *focus =
@@ -730,20 +709,19 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 			focus = seat_get_focus_inactive_view(seat, &focus->node);
 		}
 		if (focus && focus->view && view_is_only_visible(focus->view)) {
+			ws->current_gaps.top = 0;
+			ws->current_gaps.right = 0;
+			ws->current_gaps.bottom = 0;
+			ws->current_gaps.left = 0;
 			return;
 		}
 	}
 
 	ws->current_gaps = ws->gaps_outer;
-	if (ws->layout == L_TABBED || ws->layout == L_STACKED) {
-		// We have to add inner gaps for this, because children of tabbed and
-		// stacked containers don't apply their own gaps - they assume the
-		// tabbed/stacked container is using gaps.
-		ws->current_gaps.top += ws->gaps_inner;
-		ws->current_gaps.right += ws->gaps_inner;
-		ws->current_gaps.bottom += ws->gaps_inner;
-		ws->current_gaps.left += ws->gaps_inner;
-	}
+	ws->current_gaps.top += ws->gaps_inner;
+	ws->current_gaps.right += ws->gaps_inner;
+	ws->current_gaps.bottom += ws->gaps_inner;
+	ws->current_gaps.left += ws->gaps_inner;
 
 	ws->x += ws->current_gaps.left;
 	ws->y += ws->current_gaps.top;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -706,6 +706,25 @@ void workspace_add_gaps(struct sway_workspace *ws) {
 	ws->current_gaps.bottom = fmax(0, ws->current_gaps.bottom + ws->gaps_inner);
 	ws->current_gaps.left = fmax(0, ws->current_gaps.left + ws->gaps_inner);
 
+	// Now that we have the total gaps calculated we may need to clamp them in
+	// case they've made the available area too small
+	if (ws->width - ws->current_gaps.left - ws->current_gaps.right < MIN_SANE_W
+			&& ws->current_gaps.left + ws->current_gaps.right > 0) {
+		int total_gap = fmax(0, ws->width - MIN_SANE_W);
+		double left_gap_frac = ((double)ws->current_gaps.left /
+			((double)ws->current_gaps.left + (double)ws->current_gaps.right));
+		ws->current_gaps.left = left_gap_frac * total_gap;
+		ws->current_gaps.right = total_gap - ws->current_gaps.left;
+	}
+	if (ws->height - ws->current_gaps.top - ws->current_gaps.bottom < MIN_SANE_H
+			&& ws->current_gaps.top + ws->current_gaps.bottom > 0) {
+		int total_gap = fmax(0, ws->height - MIN_SANE_H);
+		double top_gap_frac = ((double) ws->current_gaps.top /
+			((double)ws->current_gaps.top + (double)ws->current_gaps.bottom));
+		ws->current_gaps.top = top_gap_frac * total_gap;
+		ws->current_gaps.bottom = total_gap - ws->current_gaps.top;
+	}
+
 	ws->x += ws->current_gaps.left;
 	ws->y += ws->current_gaps.top;
 	ws->width -= ws->current_gaps.left + ws->current_gaps.right;


### PR DESCRIPTION
Rework the gaps code to fix a series of bugs. The general approach is:

1. In tiled containers apply only gaps between containers directly in the layout code. This ensures proper sizing of containers. Fixes #4296 and #4294
2. For the gaps around the outside of workspaces (both outer and inner), calculate them together and apply them in the workspace code. At the end make sure they are positive and leave enough usable space in the container. Fixes #4304 and #4308

Depends on the layout PR (#4293) as it currently builds on top of it in the parts it touches the same code. But it doesn't depend on it functionally, so it can be reworked to apply to master.