### PR TITLE
Make mouse drag in tiled mode swap containers if no edge is selected

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -326,6 +326,8 @@ void container_detach(struct sway_container *child);
 void container_replace(struct sway_container *container,
 		struct sway_container *replacement);
 
+void container_swap(struct sway_container *con1, struct sway_container *con2);
+
 struct sway_container *container_split(struct sway_container *child,
 		enum sway_container_layout layout);
 

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -84,8 +84,7 @@ static void swap_focus(struct sway_container *con1,
 	}
 }
 
-static void container_swap(struct sway_container *con1,
-		struct sway_container *con2) {
+void container_swap(struct sway_container *con1, struct sway_container *con2) {
 	if (!sway_assert(con1 && con2, "Cannot swap with nothing")) {
 		return;
 	}


### PR DESCRIPTION
I've always had the idea that the highlighted middle area would swap the current container, so I've implemented a quick solution for this.

This will also make it so that all 5 highlightable areas have unique actions. Previously, I've run into cases where the middle area would just perform the same action as one of the others.

I'm guessing we could add a config option for this if anyone feels strongly about using the middle area for swapping.

Now, I've added some code to see if the action should trigger a swap action and then just copied the swap function from `sway/commands/swap.c`. I don't know how the right way to solve this would be. Should we move in the swap function from `swap.c` into a central place or make the swap function a public function?

This is my first patch to sway, so I'm sure this patch might be missing other things than just code de-duplication.