### PR TITLE
cmd_bindswitch: add option to execute on reload

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -39,6 +39,7 @@ enum binding_flags {
 	BINDING_CONTENTS=8,  // mouse only; trigger on container contents
 	BINDING_TITLEBAR=16, // mouse only; trigger on container titlebar
 	BINDING_CODE=32,     // keyboard only; convert keysyms into keycodes
+	BINDING_RELOAD=62,   // switch only; (re)trigger binding on reload
 };
 
 /**

--- a/include/sway/input/switch.h
+++ b/include/sway/input/switch.h
@@ -4,16 +4,20 @@
 #include "sway/input/seat.h"
 
 struct sway_switch {
-    struct sway_seat_device *seat_device;
+	struct sway_seat_device *seat_device;
+	enum wlr_switch_state state;
+	enum wlr_switch_type type;
 
-    struct wl_listener switch_toggle;
+	struct wl_listener switch_toggle;
 };
 
 struct sway_switch *sway_switch_create(struct sway_seat *seat,
-        struct sway_seat_device *device);
+		struct sway_seat_device *device);
 
 void sway_switch_configure(struct sway_switch *sway_switch);
 
 void sway_switch_destroy(struct sway_switch *sway_switch);
+
+void sway_switch_retrigger_bindings_for_all(void);
 
 #endif

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -478,6 +478,8 @@ struct cmd_results *cmd_bind_or_unbind_switch(int argc, char **argv,
 			binding->flags |= BINDING_LOCKED;
 		} else if (strcmp("--no-warn", argv[0]) == 0) {
 			warn = false;
+		} else if (strcmp("--reload", argv[0]) == 0) {
+			binding->flags |= BINDING_RELOAD;
 		} else {
 			break;
 		}

--- a/sway/config.c
+++ b/sway/config.c
@@ -17,6 +17,7 @@
 #include <wlr/types/wlr_output.h>
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/input/switch.h"
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/criteria.h"
@@ -520,17 +521,18 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	}
 
 	if (is_active) {
+		input_manager_verify_fallback_seat();
+		for (int i = 0; i < config->seat_configs->length; i++) {
+			input_manager_apply_seat_config(config->seat_configs->items[i]);
+		}
+		sway_switch_retrigger_bindings_for_all();
+
 		reset_outputs();
 		spawn_swaybg();
 
 		config->reloading = false;
 		if (config->swaynag_config_errors.client != NULL) {
 			swaynag_show(&config->swaynag_config_errors);
-		}
-
-		input_manager_verify_fallback_seat();
-		for (int i = 0; i < config->seat_configs->length; i++) {
-			input_manager_apply_seat_config(config->seat_configs->items[i]);
 		}
 	}
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -378,7 +378,7 @@ runtime.
 	*bindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] [--input-device=<device>] [--no-warn] <code> <command>
 	is also available for binding with key/button codes instead of key/button names.
 
-*bindswitch* [--locked] [--no-warn] <switch>:<state> <command>
+*bindswitch* [--locked] [--no-warn] [--reload] <switch>:<state> <command>
 	Binds <switch> to execute the sway command _command_ on state changes.
 	Supported switches are _lid_ (laptop lid) and _tablet_ (tablet mode)
 	switches. Valid values for _state_ are _on_, _off_ and _toggle_. These
@@ -390,6 +390,11 @@ runtime.
 	screen locking program is active. If there is a matching binding with
 	and without _--locked_, the one with will be preferred when locked and the
 	one without will be preferred when unlocked.
+
+	If the _--reload_ flag is given, the binding will also be executed when
+	the config is reloaded. _toggle_ bindings will not be executed on reload.
+	The _--locked_ flag will operate as normal so if the config is reloaded
+	while locked and _--locked_ is not given, the binding will not be executed.
 
 	By default, if you overwrite a binding, swaynag will give you a warning. To
 	silence this, use the _--no-warn_ flag.


### PR DESCRIPTION
Closes #4305

This adds a --reload flag to cmd_bindswitch that allows for the binding
to be executed on reload. One possible use case for this is to  allow
users to disable outputs when the lid closes and enable them when the
lid opens without having to open and re-close the lid after a reload.