### PR TITLE
config/output: correctly set width/height in apply

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -308,9 +308,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_output_layout_get_box(root->output_layout, wlr_output);
 	output->lx = output_box->x;
 	output->ly = output_box->y;
-	wlr_output_transformed_resolution(wlr_output,
-		&output->width, &output->height);
-
+	output->width = output_box->width;
+	output->height = output_box->height;
 
 	if (oc && oc->dpms_state == DPMS_OFF) {
 		sway_log(SWAY_DEBUG, "Turning off screen");


### PR DESCRIPTION
Fixes #4198

In `apply_output_config`, this sets `output->{width,height}` using the
values in the output box. Previously, they were being set using
`wlr_output_transformed_resolution`, which takes the width and height
from the wlr_output and just checks whether they should be swapped
based on the transform. This did not take into account the output's
scale. `wlr_output_effective_resolution` could be used instead, which
handles both transform and scale. However, the values in the output box
have already been processed by `wlr_output_effective_resolution` so they
can just be used directly