### PR TITLE
cmd_split: fix toggle split for non-split layouts

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -26,19 +26,37 @@ static const char expected_syntax[] =
 	"'layout toggle [split|all]' or "
 	"'layout toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...'";
 
+static enum sway_container_layout toggle_split_layout(
+		enum sway_container_layout layout,
+		enum sway_container_layout prev_split_layout,
+		struct sway_output *output) {
+	if (layout == L_HORIZ) {
+		return L_VERT;
+	} else if (layout == L_VERT) {
+		return L_HORIZ;
+	} else if (prev_split_layout != L_NONE) {
+		return prev_split_layout;
+	} else if (config->default_orientation != L_NONE) {
+		return config->default_orientation;
+	} else if (output->height > output->width) {
+		return L_VERT;
+	}
+	return L_HORIZ;
+}
+
 static enum sway_container_layout get_layout_toggle(int argc, char **argv,
 		enum sway_container_layout layout,
 		enum sway_container_layout prev_split_layout,
 		struct sway_output *output) {
 	// "layout toggle"
 	if (argc == 1) {
-		return layout == L_HORIZ ? L_VERT : L_HORIZ;
+		return toggle_split_layout(layout, prev_split_layout, output);
 	}
 
 	if (argc == 2) {
 		// "layout toggle split" (same as "layout toggle")
 		if (strcasecmp(argv[1], "split") == 0) {
-			return layout == L_HORIZ ? L_VERT : L_HORIZ;
+			return toggle_split_layout(layout, prev_split_layout, output);
 		}
 		// "layout toggle all"
 		if (strcasecmp(argv[1], "all") == 0) {
@@ -68,18 +86,7 @@ static enum sway_container_layout get_layout_toggle(int argc, char **argv,
 			return parsed;
 		}
 		if (strcmp(argv[i], "split") == 0) {
-			if (layout == L_HORIZ) {
-				return L_VERT;
-			} else if (layout == L_VERT) {
-				return L_HORIZ;
-			} else if (prev_split_layout != L_NONE) {
-				return prev_split_layout;
-			} else if (config->default_orientation != L_NONE) {
-				return config->default_orientation;
-			} else if (output->height > output->width) {
-				return L_VERT;
-			}
-			return L_HORIZ;
+			return toggle_split_layout(layout, prev_split_layout, output);
 		}
 		// invalid layout strings are silently ignored
 	}


### PR DESCRIPTION
Fixes #4316 

Previously, `layout toggle` and `layout toggle split` would set L_VERT
when layout was L_HORIZ, otherwise it would set L_HORIZ. This meant
that when the layout was L_TABBED or L_STACKED, it would always be
L_HORIZ. This extends #4315 (which corrects the handling when multiple
layouts are given) to try prev_split_layout,
config->default_orientation, and then falling back to L_VERT when the
output is taller than wide and L_HORIZ when wider than tall.