### PR TITLE
Implement input_cmd_xkb_file (#3999)

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -257,6 +257,7 @@ sway_cmd input_cmd_scroll_method;
 sway_cmd input_cmd_tap;
 sway_cmd input_cmd_tap_button_map;
 sway_cmd input_cmd_xkb_capslock;
+sway_cmd input_cmd_xkb_file;
 sway_cmd input_cmd_xkb_layout;
 sway_cmd input_cmd_xkb_model;
 sway_cmd input_cmd_xkb_numlock;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -138,6 +138,9 @@ struct input_config {
 	char *xkb_options;
 	char *xkb_rules;
 	char *xkb_variant;
+	char *xkb_file;
+
+	bool xkb_file_is_set;
 
 	int xkb_numlock;
 	int xkb_capslock;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -28,6 +28,7 @@ static struct cmd_handler input_handlers[] = {
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
 	{ "tap_button_map", input_cmd_tap_button_map },
+	{ "xkb_file", input_cmd_xkb_file },
 	{ "xkb_layout", input_cmd_xkb_layout },
 	{ "xkb_model", input_cmd_xkb_model },
 	{ "xkb_options", input_cmd_xkb_options },
@@ -48,8 +49,8 @@ static struct cmd_handler input_config_handlers[] = {
 static void retranslate_keysyms(struct input_config *input_config) {
 	for (int i = 0; i < config->input_configs->length; ++i) {
 		struct input_config *ic = config->input_configs->items[i];
-		if (ic->xkb_layout) {
-			// this is the first config with xkb_layout
+		if (ic->xkb_layout || ic->xkb_file) {
+			// this is the first config with xkb_layout or xkb_file
 			if (ic->identifier == input_config->identifier) {
 				translate_keysyms(ic);
 			}

--- a/sway/commands/input/xkb_file.c
+++ b/sway/commands/input/xkb_file.c
@@ -1,0 +1,28 @@
+#define _POSIX_C_SOURCE 200809L
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "log.h"
+
+struct cmd_results *input_cmd_xkb_file(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "xkb_file", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	if (strcmp(argv[0], "-") == 0) {
+		free(ic->xkb_file);
+		ic->xkb_file = NULL;
+	} else {
+		ic->xkb_file = strdup(argv[0]);
+	}
+	ic->xkb_file_is_set = true;
+
+	sway_log(SWAY_DEBUG, "set-xkb_file for config: %s file: %s",
+			ic->identifier, ic->xkb_file);
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/commands/input/xkb_file.c
+++ b/sway/commands/input/xkb_file.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_file(int argc, char **argv) {

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {

--- a/sway/commands/input/xkb_numlock.c
+++ b/sway/commands/input/xkb_numlock.c
@@ -1,8 +1,6 @@
-#include <string.h>
-#include <strings.h>
+#define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "util.h"
 
 struct cmd_results *input_cmd_xkb_numlock(int argc, char **argv) {

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -1,7 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "sway/config.h"
 #include "sway/commands.h"
-#include "sway/input/input-manager.h"
 #include "log.h"
 
 struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -39,6 +39,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->repeat_rate = INT_MIN;
 	input->xkb_numlock = INT_MIN;
 	input->xkb_capslock = INT_MIN;
+	input->xkb_file_is_set = false;
 
 	return input;
 }
@@ -94,6 +95,11 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->tap_button_map != INT_MIN) {
 		dst->tap_button_map = src->tap_button_map;
+	}
+	if (src->xkb_file_is_set) {
+		free(dst->xkb_file);
+		dst->xkb_file = src->xkb_file ? strdup(src->xkb_file) : NULL;
+		dst->xkb_file_is_set = dst->xkb_file != NULL;
 	}
 	if (src->xkb_layout) {
 		free(dst->xkb_layout);
@@ -284,6 +290,8 @@ struct input_config *store_input_config(struct input_config *ic,
 		ic = current;
 	}
 
+	ic->xkb_file_is_set = ic->xkb_file != NULL;
+
 	if (!current || new_current) {
 		list_add(config_list, ic);
 	}
@@ -307,6 +315,7 @@ void free_input_config(struct input_config *ic) {
 		return;
 	}
 	free(ic->identifier);
+	free(ic->xkb_file);
 	free(ic->xkb_layout);
 	free(ic->xkb_model);
 	free(ic->xkb_options);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -160,6 +160,7 @@ sway_sources = files(
 	'commands/input/tap.c',
 	'commands/input/tap_button_map.c',
 	'commands/input/xkb_capslock.c',
+	'commands/input/xkb_file.c',
 	'commands/input/xkb_layout.c',
 	'commands/input/xkb_model.c',
 	'commands/input/xkb_numlock.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -44,6 +44,11 @@ on top of the existing device configurations.
 For more information on these xkb configuration options, see
 *xkeyboard-config*(7).
 
+*input* <identifier> xkb_file <file_name>
+	Sets all xkb configurations from a complete .xkb file. This file can be
+	dumped from _xkbcomp $DISPLAY keymap.xkb_. This setting overrides
+	xkb_layout, xkb_model, xkb_options, xkb_rules, and xkb_variant settings.
+
 *input* <identifier> xkb_layout <layout_name>
 	Sets the layout of the keyboard like _us_ or _de_.
 


### PR DESCRIPTION
Adds a new commend "xkb_file", which constructs the internal
xkb_keymap from a xkb file rather than an RMLVO configuration.
This allows greater flexibility when specifying xkb configurations.
An xkb file can be dumped with the xkbcomp program.