### PR TITLE
cmd_opacity: add relative opacity changes

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -650,9 +650,9 @@ The default colors are:
 	Any mark that starts with an underscore will not be drawn even if
 	*show_marks* is yes. The default is _yes_.
 
-*opacity* <value>
-	Set the opacity of the window between 0 (completely transparent) and 1
-	(completely opaque).
+*opacity* [set|plus|minus] <value>
+	Adjusts the opacity of the window between 0 (completely transparent) and
+	1 (completely opaque). If the operation is omitted, _set_ will be used.
 
 *tiling_drag*  enable|disable|toggle
 	Sets whether or not tiling containers can be dragged with the mouse. If


### PR DESCRIPTION
This enhances the opacity command to support relative assignment as well
as the currently implemented absolute assignment. The syntax is inspired
by the syntax used in pactl and looks like this in a sway config:

// relative change (new feature)
bindsym button4 opacity +.1
bindsym button5 opacity -.1

// absolute change (already implemented)
bindsym button4 opacity 1
bindsym button5 opacity .3