### PR TITLE
Make fullscreen check for fullscreen parents

### DIFF
--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -33,8 +33,15 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		}
 	}
 
-	bool is_fullscreen = container &&
-		container->fullscreen_mode != FULLSCREEN_NONE;
+	bool is_fullscreen = false;
+	for (struct sway_container *curr = container; curr; curr = curr->parent) {
+		if (curr && curr->fullscreen_mode != FULLSCREEN_NONE) {
+			container = curr;
+			is_fullscreen = true;
+			break;
+		}
+	}
+
 	bool global = false;
 	bool enable = !is_fullscreen;
 


### PR DESCRIPTION
This ensures that a child of a fullscreen container cannot be fullscreened.

Fixes #4332.