### PR TITLE
Update output manager on layout change

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -154,6 +154,8 @@ void scale_box(struct wlr_box *box, float scale);
 
 enum wlr_direction opposite_direction(enum wlr_direction d);
 
+void handle_output_layout_change(struct wl_listener *listener, void *data);
+
 void handle_output_manager_apply(struct wl_listener *listener, void *data);
 
 void handle_output_manager_test(struct wl_listener *listener, void *data);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -34,6 +34,7 @@ struct sway_server {
 	struct sway_input_manager *input;
 
 	struct wl_listener new_output;
+	struct wl_listener output_layout_change;
 
 	struct wlr_idle *idle;
 	struct sway_idle_inhibit_manager_v1 *idle_inhibit_manager_v1;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -688,6 +688,13 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	update_output_manager_config(server);
 }
 
+void handle_output_layout_change(struct wl_listener *listener,
+		void *data) {
+	struct sway_server *server =
+		wl_container_of(listener, server, output_layout_change);
+	update_output_manager_config(server);
+}
+
 void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 	struct sway_server *server =
 		wl_container_of(listener, server, output_manager_apply);

--- a/sway/server.c
+++ b/sway/server.c
@@ -66,6 +66,9 @@ bool server_init(struct sway_server *server) {
 
 	server->new_output.notify = handle_new_output;
 	wl_signal_add(&server->backend->events.new_output, &server->new_output);
+	server->output_layout_change.notify = handle_output_layout_change;
+	wl_signal_add(&root->output_layout->events.change,
+		&server->output_layout_change);
 
 	wlr_xdg_output_manager_v1_create(server->wl_display, root->output_layout);
 


### PR DESCRIPTION
The output manager config was not properly updated if the position
of the output got changed.