### PR TITLE
arrange: remove gaps for workspace location deltas

### DIFF
--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -262,8 +262,8 @@ void arrange_workspace(struct sway_workspace *workspace) {
 			area->width, area->height, area->x, area->y);
 
 	bool first_arrange = workspace->width == 0 && workspace->height == 0;
-	double prev_x = workspace->x;
-	double prev_y = workspace->y;
+	double prev_x = workspace->x - workspace->current_gaps.left;
+	double prev_y = workspace->y - workspace->current_gaps.top;
 	workspace->width = area->width;
 	workspace->height = area->height;
 	workspace->x = output->lx + area->x;


### PR DESCRIPTION
Fixes #4369 

When arranging the workspace, `prev_x` and `prev_y` should be ignoring the
current gaps otherwise the workspace `diff_x` and `diff_y` location deltas
will be off. When the deltas are off, each arrangement of the workspace
would incorrectly move floaters an extra `-workspace->current_gaps.left`
along the x-axis and an extra `-workspace->current_gaps.top` along the
y-axis.