### PR TITLE
Remove all wayland-server.h includes

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -2,7 +2,7 @@
 #define _SWAY_OUTPUT_H
 #include <time.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output.h>
 #include "config.h"

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -1,7 +1,7 @@
 #ifndef _SWAY_SERVER_H
 #define _SWAY_SERVER_H
 #include <stdbool.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -1,6 +1,6 @@
 #ifndef _SWAY_VIEW_H
 #define _SWAY_VIEW_H
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include "config.h"

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@ project(
 
 add_project_arguments(
 	[
-		'-DWL_HIDE_DEPRECATED',
 		'-DWLR_USE_UNSTABLE',
 
 		'-Wno-unused-parameter',

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output_damage.h>

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_buffer.h>

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <time.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_buffer.h>

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -2,7 +2,7 @@
 #include <float.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/edges.h>
 #include "log.h"

--- a/sway/desktop/xdg_shell_v6.c
+++ b/sway/desktop/xdg_shell_v6.c
@@ -2,7 +2,7 @@
 #include <float.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include "log.h"
 #include "sway/decoration.h"

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -1,7 +1,7 @@
 #define _POSIX_C_SOURCE 199309L
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/xwayland.h>

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -14,7 +14,7 @@
 #include <sys/ioctl.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/desktop/transaction.h"

--- a/sway/server.c
+++ b/sway/server.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/noop.h>
 #include <wlr/backend/session.h>

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_xdg_shell.h>

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,7 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <strings.h>
-#include <wayland-server.h>
+#include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_output_layout.h>


### PR DESCRIPTION
The documentation for wayland-server.h says:

> Use of this header file is discouraged. Prefer including
> wayland-server-core.h instead, which does not include the server protocol
> header and as such only defines the library PI, excluding the deprecated API
> below.

Replacing wayland-server.h with wayland-server-core.h allows us to drop the
WL_HIDE_DEPRECATED declaration.

This commit si similar to wlroots' ca45f4490ccc ("Remove all wayland-server.h
includes").