### PR TITLE
input/libinput: fix typo in set_middle_emulation

### DIFF
--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -127,7 +127,7 @@ static bool set_middle_emulation(struct libinput_device *dev,
 		return false;
 	}
 	sway_log(SWAY_DEBUG, "middle_emulation_set_enabled(%d)", mid);
-	log_status(libinput_device_config_left_handed_set(dev, mid));
+	log_status(libinput_device_config_middle_emulation_set_enabled(dev, mid));
 	return true;
 }
 


### PR DESCRIPTION
Fixes #4387 

This fixes a typo in set_middle_emulation where it would set left
handed instead of middle emulation. _Apparently, I didn't do a 
good enough job double checking my refactor in #4342. Just
looked it over again and this looks like the only issue..._