### PR TITLE
libinput: fix set_send_events

### DIFF
--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -15,7 +15,7 @@ static void log_status(enum libinput_config_status status) {
 }
 
 static bool set_send_events(struct libinput_device *device, uint32_t mode) {
-	if ((libinput_device_config_send_events_get_mode(device) & mode) == 0) {
+	if (libinput_device_config_send_events_get_mode(device) == mode) {
 		return false;
 	}
 	sway_log(SWAY_DEBUG, "send_events_set_mode(%d)", mode);


### PR DESCRIPTION
This just fixes the check in set_send_events for whether the mode has
changed. LIBINPUT_CONFIG_SEND_EVENTS_ENABLED is 0 so the bitmask check
cannot be fixed, but Sway doesn't allow multiple modes to be set anyway
(not really sure why you would need to) so a basic equality check works