### PR TITLE
Allow for empty criteria

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -668,11 +668,6 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 		goto cleanup;
 	}
 
-	if (criteria_is_empty(criteria)) {
-		*error_arg = strdup("Criteria is empty");
-		goto cleanup;
-	}
-
 	++head;
 	int len = head - raw;
 	criteria->raw = calloc(len + 1, 1);


### PR DESCRIPTION
Some folks on the irc were wondering if there was a cleaner way to use for_window on all windows than [app_id=".*"] and I couldn't think of any. This little change seems like it works to allow empty criteria, [], which match all windows and might be useful to some. Allowing empty criteria doesn't seem so bad to me. I feel like I'm missing something -- anyone know why this check is here in the first place?

Just a thought.