### PR TITLE
swaymsg: return 2 for sway errors

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -475,7 +475,7 @@ int main(int argc, char **argv) {
 		ret = 1;
 	} else {
 		if (!success(obj, true)) {
-			ret = 1;
+			ret = 2;
 		}
 		if (!quiet && (type != IPC_SUBSCRIBE  || ret != 0)) {
 			if (raw) {

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -86,6 +86,19 @@ _swaymsg_ [options...] [message]
 	provided in the form of a valid JSON array. If any of the types are invalid
 	or if an valid JSON array is not provided, this will result in an failure.
 
+# RETURN CODES
+
+*0*
+	Success
+
+*1*
+	swaymsg errors such as invalid syntax, unable to connect to the ipc socket
+	or unable to parse sway's reply
+
+*2*
+	Sway returned an error when processing the command (ex. invalid command,
+	command failed, and invalid subscription request)
+
 # SEE ALSO
 
 *sway*(5) *sway-bar*(5) *sway-input*(5) *sway-output*(5) *sway-ipc*(7)


### PR DESCRIPTION
This mirrors a change in i3 4.17 that returns 2 for errors from sway,
including invalid command, command failed, and invalid subscription
requests

https://github.com/i3/i3/blob/next/RELEASE-NOTES-4.17
https://github.com/i3/i3/pull/3614