### PR TITLE
workspace_split: focus middle if workspace focused

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -744,6 +744,13 @@ struct sway_container *workspace_split(struct sway_workspace *workspace,
 	workspace->layout = layout;
 	middle->layout = old_layout;
 
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		if (seat_get_focus(seat) == &workspace->node) {
+			seat_set_focus(seat, &middle->node);
+		}
+	}
+
 	return middle;
 }
 


### PR DESCRIPTION
Fixes #4423

In workspace_split, the middle container that wraps the workspace's
children should be focused for any seat that is focusing the workspace