### PR TITLE
container_replace: copy {width,height}_fraction

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1324,8 +1324,12 @@ void container_replace(struct sway_container *container,
 		root_scratchpad_remove_container(container);
 	}
 	if (container->parent || container->workspace) {
+		float width_fraction = container->width_fraction;
+		float height_fraction = container->height_fraction;
 		container_add_sibling(container, replacement, 1);
 		container_detach(container);
+		replacement->width_fraction = width_fraction;
+		replacement->height_fraction = height_fraction;
 	}
 	if (scratchpad) {
 		root_scratchpad_add_container(replacement, ws);


### PR DESCRIPTION
Fixes #4422

This copies the width and height fractions from the container to the
container replacing it. Without setting these values, the container
is treated as a new container and throws off the existing sizing. Since
one container is replacing the other, it makes sense for the sizing to
remain the same.