### PR TITLE
Patches

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -117,7 +117,6 @@ struct ipc_response *ipc_recv_response(int socketfd) {
 	return response;
 error_2:
 	free(response);
-	free(payload);
 error_1:
 	sway_log(SWAY_ERROR, "Unable to allocate memory for IPC response");
 	return NULL;

--- a/sway/commands/bar/tray_bind.c
+++ b/sway/commands/bar/tray_bind.c
@@ -52,6 +52,7 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 		}
 	}
 	if (!binding->command) {
+		free(binding);
 		return cmd_results_new(CMD_INVALID, "[Bar %s] Invalid tray command %s",
 				config->current_bar->id, argv[1]);
 	}

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -75,7 +75,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 	} else if (strcmp(argv[0], "pixel") == 0) {
 		set_border(container, B_PIXEL);
 	} else if (strcmp(argv[0], "csd") == 0) {
-		if (!view || !view->xdg_decoration) {
+		if (!view->xdg_decoration) {
 			return cmd_results_new(CMD_INVALID,
 					"This window doesn't support client side decorations");
 		}

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -35,7 +35,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 
 	bool is_fullscreen = false;
 	for (struct sway_container *curr = container; curr; curr = curr->parent) {
-		if (curr && curr->fullscreen_mode != FULLSCREEN_NONE) {
+		if (curr->fullscreen_mode != FULLSCREEN_NONE) {
 			container = curr;
 			is_fullscreen = true;
 			break;

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -334,8 +334,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	if (cont && is_floating_or_child && !is_fullscreen_or_child &&
 			state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
-		if (button == btn_move && state == WLR_BUTTON_PRESSED &&
-				(mod_pressed || on_titlebar)) {
+		if (button == btn_move && (mod_pressed || on_titlebar)) {
 			while (cont->parent) {
 				cont = cont->parent;
 			}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -241,7 +241,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	bool is_floating_or_child = cont && container_is_floating_or_child(cont);
 	bool is_fullscreen_or_child = cont && container_is_fullscreen_or_child(cont);
 	enum wlr_edges edge = cont ? find_edge(cont, cursor) : WLR_EDGE_NONE;
-	enum wlr_edges resize_edge = edge ?
+	enum wlr_edges resize_edge = cont && edge ?
 		find_resize_edge(cont, cursor) : WLR_EDGE_NONE;
 	bool on_border = edge != WLR_EDGE_NONE;
 	bool on_contents = cont && !on_border && surface;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -709,7 +709,7 @@ void view_update_size(struct sway_view *view, int width, int height) {
 		con->surface_y = fmax(con->surface_y, con->content_y);
 	}
 	con->surface_width = width;
-	con->surface_width = height;
+	con->surface_height = height;
 }
 
 static const struct sway_view_child_impl subsurface_impl;

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -207,6 +207,7 @@ static struct icon_theme *read_theme_file(char *basedir, char *theme_name) {
 
 	struct icon_theme *theme = calloc(1, sizeof(struct icon_theme));
 	if (!theme) {
+		fclose(theme_file);
 		return NULL;
 	}
 	theme->subdirs = create_list();


### PR DESCRIPTION
Hello,
This is a bunch of patches for bugs reported by [PVS-Studio](https://www.viva64.com/en/pvs-studio/).

It mostly removes some dead code and checks, and fixes some memory leaks.

PVS-Studio also reports a whole lot of calls to malloc and the family, or strdup calls that are not checked for null results.
Another warning reported are expressions of the form `double x = y / 2` where `y` is of type int, that could be written as `double x = y / 2.` to avoid the loss of a fractional part. This is not fixed in this PR, let me know if it is more-or-less needed.
*Edit: this was fixed in 1372d61: Avoid loss of fractional part*
 

Thanks for the good work!