### PR TITLE
handle_seat_node_destroy: do not focus own node

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -153,6 +153,7 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 	struct sway_node *focus = seat_get_focus(seat);
 
 	if (node->type == N_WORKSPACE) {
+		seat_node_destroy(seat_node);
 		// If an unmanaged or layer surface is focused when an output gets
 		// disabled and an empty workspace on the output was focused by the
 		// seat, the seat needs to refocus it's focus inactive to update the
@@ -166,7 +167,6 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 				seat->workspace = NULL;
 			}
 		}
-		seat_node_destroy(seat_node);
 		return;
 	}
 


### PR DESCRIPTION
Fixes #4444 

In handle_seat_node_destroy, it was possible to focus the node attached
to the seat node that is being destroyed when an empty workspace was
being destroyed in a multiple seat environment. This resulted in
infinite recursion when attempting to destroy the workspace. This just
moves the seat node destruction higher so it cannot be the focus
inactive for the seat. This is the same ordering that is applied to
destruction of seat nodes for containers

--

On a related note, since seats have their own focus, should the workspace
not actually be destroyed until all seats have switched focus away (even if
the workspace is hidden) instead of forcing all seats to vacate the empty
workspace?