### PR TITLE
workspace: do not destroy if any seat is focusing

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -155,9 +155,19 @@ void workspace_consider_destroy(struct sway_workspace *ws) {
 	if (ws->tiling->length || ws->floating->length) {
 		return;
 	}
+
 	if (ws->output && output_get_active_workspace(ws->output) == ws) {
 		return;
 	}
+
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		struct sway_node *node = seat_get_focus_inactive(seat, &root->node);
+		if (node == &ws->node) {
+			return;
+		}
+	}
+
 	workspace_begin_destroy(ws);
 }
 


### PR DESCRIPTION
Follow-Up for #4446 

Since each seat has its own focus, do not destroy a workspace until it
is no longer focused by any seat. This prevents seats from being forced
to evacuate the workspace just because another seat switched focus away
from it