### PR TITLE
cmd_xwayland: add force for immediate launch

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -424,6 +424,12 @@ enum alignment {
 	ALIGN_RIGHT
 };
 
+enum xwayland_mode {
+	XWAYLAND_MODE_DISABLED,
+	XWAYLAND_MODE_LAZY,
+	XWAYLAND_MODE_IMMEADIATE
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -464,7 +470,7 @@ struct sway_config {
 	size_t urgent_timeout;
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;
-	bool xwayland;
+	enum xwayland_mode xwayland;
 
 	// swaybg
 	char *swaybg_command;

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -11,7 +11,15 @@ struct cmd_results *cmd_xwayland(int argc, char **argv) {
 	}
 
 #ifdef HAVE_XWAYLAND
-	bool xwayland = parse_boolean(argv[0], true);
+	enum xwayland_mode xwayland;
+	if (strcmp(argv[0], "force") == 0) {
+		xwayland = XWAYLAND_MODE_IMMEADIATE;
+	} else if (parse_boolean(argv[0], true)) {
+		xwayland = XWAYLAND_MODE_LAZY;
+	} else {
+		xwayland = XWAYLAND_MODE_DISABLED;
+	}
+
 	if (config->reloading && config->xwayland != xwayland) {
 		return cmd_results_new(CMD_FAILURE,
 				"xwayland can only be enabled/disabled at launch");

--- a/sway/config.c
+++ b/sway/config.c
@@ -248,7 +248,7 @@ static void config_defaults(struct sway_config *config) {
 	config->font_height = 17; // height of monospace 10
 	config->urgent_timeout = 500;
 	config->popup_during_fullscreen = POPUP_SMART;
-	config->xwayland = true;
+	config->xwayland = XWAYLAND_MODE_LAZY;
 
 	config->titlebar_border_thickness = 1;
 	config->titlebar_h_padding = 5;

--- a/sway/server.c
+++ b/sway/server.c
@@ -172,10 +172,12 @@ void server_fini(struct sway_server *server) {
 
 bool server_start(struct sway_server *server) {
 #if HAVE_XWAYLAND
-	if (config->xwayland) {
-		sway_log(SWAY_DEBUG, "Initializing Xwayland");
+	if (config->xwayland != XWAYLAND_MODE_DISABLED) {
+		sway_log(SWAY_DEBUG, "Initializing Xwayland (lazy=%d)",
+				config->xwayland == XWAYLAND_MODE_LAZY);
 		server->xwayland.wlr_xwayland =
-			wlr_xwayland_create(server->wl_display, server->compositor, true);
+			wlr_xwayland_create(server->wl_display, server->compositor,
+					config->xwayland == XWAYLAND_MODE_LAZY);
 		wl_signal_add(&server->xwayland.wlr_xwayland->events.new_surface,
 			&server->xwayland_surface);
 		server->xwayland_surface.notify = handle_xwayland_surface;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -85,9 +85,12 @@ The following commands may only be used in the configuration file.
 	It can be disabled by setting the command to a single dash:
 	_swaynag\_command -_
 
-*xwayland* enable|disable
+*xwayland* enable|disable|force
 	Enables or disables Xwayland support, which allows X11 applications to be
-	used.
+	used. _enable_ will lazily load Xwayland so Xwayland will not be launched
+	until the first client attempts to connect. In some cases, such as slower
+	machines, it may be desirable to have Xwayland started immediately by
+	using _force_ instead of _enable_.
 
 The following commands cannot be used directly in the configuration file.
 They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).


### PR DESCRIPTION
Closes #4359

This just adds a force option to cmd_xwayland that allows for xwayland
to be immediately launched instead of lazily launched. This is useful
for slower machines so it can be part of the startup time instead of
when the user is actively trying to use it