### PR TITLE
sway{,-bar}.5: add link to pango font description

### DIFF
--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -37,7 +37,9 @@ Sway allows configuring swaybar in the sway configuration file.
 	Executes custom bar command. Default is _swaybar_.
 
 *font* <font>
-	Specifies the font to be used in the bar.
+	Specifies the font to be used in the bar. _font_ should be specified as a
+	pango font description. For more information on pango font descriptions,
+	see https://developer.gnome.org/pango/stable/pango-Fonts.html#pango-font-description-from-string
 
 *separator_symbol* <symbol>
 	Specifies the separator symbol to separate blocks on the bar.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -563,7 +563,10 @@ The default colors are:
 	Sets font to use for the title bars. To enable support for pango markup,
 	preface the font name with _pango:_. For example, _monospace 10_ is the
 	default font. To enable support for pango markup, _pango:monospace 10_
-	should be used instead.
+	should be used instead. Regardless of whether pango markup is enabled,
+	_font_ should be specified as a pango font description. For more
+	information on pango font descriptions, see
+	https://developer.gnome.org/pango/stable/pango-Fonts.html#pango-font-description-from-string
 
 *titlebar_border_thickness* <thickness>
 	Thickness of the titlebar border in pixels


### PR DESCRIPTION
Closes #4457 

This just specifies that both cmd_font and bar_cmd_font should be
specified using the pango font description and adds a link to the pango
documentation regarding the font description