### PR TITLE
Optionally show all workspace buttons in the bar, even the ones on other outputs

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -222,6 +222,7 @@ sway_cmd bar_cmd_unbindcode;
 sway_cmd bar_cmd_unbindsym;
 sway_cmd bar_cmd_wrap_scroll;
 sway_cmd bar_cmd_workspace_buttons;
+sway_cmd bar_cmd_workspace_buttons_all_outputs;
 
 sway_cmd bar_colors_cmd_active_workspace;
 sway_cmd bar_colors_cmd_background;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -265,6 +265,7 @@ struct bar_config {
 	char *font;
 	int height; // -1 not defined
 	bool workspace_buttons;
+	bool workspace_buttons_all_outputs;
 	bool wrap_scroll;
 	char *separator_symbol;
 	bool strip_workspace_numbers;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -39,6 +39,7 @@ struct swaybar_config {
 	bool binding_mode_indicator;
 	bool wrap_scroll;
 	bool workspace_buttons;
+	bool workspace_buttons_all_outputs;
 	list_t *bindings;
 	struct wl_list outputs; // config_output::link
 	bool all_outputs;

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -35,6 +35,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "unbindcode", bar_cmd_unbindcode },
 	{ "unbindsym", bar_cmd_unbindsym },
 	{ "workspace_buttons", bar_cmd_workspace_buttons },
+	{ "workspace_buttons_all_outputs", bar_cmd_workspace_buttons_all_outputs },
 	{ "wrap_scroll", bar_cmd_wrap_scroll },
 };
 

--- a/sway/commands/bar/workspace_buttons_all_outputs.c
+++ b/sway/commands/bar/workspace_buttons_all_outputs.c
@@ -1,0 +1,25 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "log.h"
+#include "util.h"
+
+struct cmd_results *bar_cmd_workspace_buttons_all_outputs(int argc,
+        char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_buttons_all_outputs",
+			EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	config->current_bar->workspace_buttons_all_outputs =
+		parse_boolean(argv[0],
+		config->current_bar->workspace_buttons_all_outputs);
+	if (config->current_bar->workspace_buttons) {
+		sway_log(SWAY_DEBUG, "Enabling all output workspace buttons on bar: %s",
+				config->current_bar->id);
+	} else {
+		sway_log(SWAY_DEBUG, "Disabling all output workspace buttons on bar: %s",
+				config->current_bar->id);
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -94,6 +94,7 @@ struct bar_config *default_bar_config(void) {
 	bar->font = NULL;
 	bar->height = 0;
 	bar->workspace_buttons = true;
+	bar->workspace_buttons_all_outputs = false;
 	bar->wrap_scroll = false;
 	bar->separator_symbol = NULL;
 	bar->strip_workspace_numbers = false;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -960,6 +960,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 			json_object_new_boolean(bar->wrap_scroll));
 	json_object_object_add(json, "workspace_buttons",
 			json_object_new_boolean(bar->workspace_buttons));
+	json_object_object_add(json, "workspace_buttons_all_outputs",
+			json_object_new_boolean(bar->workspace_buttons_all_outputs));
 	json_object_object_add(json, "strip_workspace_numbers",
 			json_object_new_boolean(bar->strip_workspace_numbers));
 	json_object_object_add(json, "strip_workspace_name",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -138,6 +138,7 @@ sway_sources = files(
 	'commands/bar/tray_output.c',
 	'commands/bar/tray_padding.c',
 	'commands/bar/workspace_buttons.c',
+	'commands/bar/workspace_buttons_all_outputs.c',
 	'commands/bar/wrap_scroll.c',
 
 	'commands/input/accel_profile.c',

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -51,6 +51,10 @@ Sway allows configuring swaybar in the sway configuration file.
 *workspace_buttons* yes|no
 	Enables or disables workspace buttons on the bar. Default is _yes_.
 
+*workspace_buttons_all_outputs* yes|no
+	If set to _yes_ all workspaces are listed in the bar, even the ones that do
+	not belong to the output the bar is on. Default is _no_.
+
 *strip_workspace_name* yes|no
 	If set to _yes_, then workspace names will be omitted from the workspace
 	button and only the custom number will be shown. Default is _no_.

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -35,6 +35,7 @@ struct swaybar_config *init_config(void) {
 	config->binding_mode_indicator = true;
 	config->wrap_scroll = false;
 	config->workspace_buttons = true;
+	config->workspace_buttons_all_outputs = true;
 	config->bindings = create_list();
 	wl_list_init(&config->outputs);
 	config->status_padding = 1;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -175,6 +175,7 @@ static bool ipc_parse_config(
 	}
 	json_object *markup, *mode, *hidden_state, *position, *status_command;
 	json_object *font, *gaps, *bar_height, *wrap_scroll, *workspace_buttons;
+	json_object *workspace_buttons_all_outputs;
 	json_object *strip_workspace_numbers, *strip_workspace_name;
 	json_object *binding_mode_indicator, *verbose, *colors, *sep_symbol;
 	json_object *outputs, *bindings, *status_padding, *status_edge_padding;
@@ -187,6 +188,8 @@ static bool ipc_parse_config(
 	json_object_object_get_ex(bar_config, "bar_height", &bar_height);
 	json_object_object_get_ex(bar_config, "wrap_scroll", &wrap_scroll);
 	json_object_object_get_ex(bar_config, "workspace_buttons", &workspace_buttons);
+	json_object_object_get_ex(bar_config, "workspace_buttons_all_outputs",
+		&workspace_buttons_all_outputs);
 	json_object_object_get_ex(bar_config, "strip_workspace_numbers", &strip_workspace_numbers);
 	json_object_object_get_ex(bar_config, "strip_workspace_name", &strip_workspace_name);
 	json_object_object_get_ex(bar_config, "binding_mode_indicator", &binding_mode_indicator);
@@ -228,6 +231,10 @@ static bool ipc_parse_config(
 	}
 	if (workspace_buttons) {
 		config->workspace_buttons = json_object_get_boolean(workspace_buttons);
+	}
+	if (workspace_buttons_all_outputs) {
+		config->workspace_buttons_all_outputs =
+			json_object_get_boolean(workspace_buttons_all_outputs);
 	}
 	if (bar_height) {
 		config->height = json_object_get_int(bar_height);
@@ -383,7 +390,8 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 
 		wl_list_for_each(output, &bar->outputs, link) {
 			const char *ws_output = json_object_get_string(out);
-			if (strcmp(ws_output, output->name) == 0) {
+			if (strcmp(ws_output, output->name) == 0 ||
+					bar->config->workspace_buttons_all_outputs) {
 				struct swaybar_workspace *ws =
 					calloc(1, sizeof(struct swaybar_workspace));
 				ws->num = json_object_get_int(num);


### PR DESCRIPTION
Add a bar command that makes it so all workspaces are shown, even the ones that do not belong to the bar's output. I find this useful when disabling the bar on external screens and yet wanting to figure out what workspaces have been created in those outputs. Waybar includes a similar option.