### PR TITLE
Optionally add focused window title to the bar

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -136,3 +136,33 @@ void pango_printf(cairo_t *cairo, const char *font,
 	g_object_unref(layout);
 	free(buf);
 }
+
+void pango_printf_ellipsized(cairo_t *cairo, const char *font,
+		double scale, bool markup, int max_width, const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	// Add one since vsnprintf excludes null terminator.
+	int length = vsnprintf(NULL, 0, fmt, args) + 1;
+	va_end(args);
+
+	char *buf = malloc(length);
+	if (buf == NULL) {
+		sway_log(SWAY_ERROR, "Failed to allocate memory");
+		return;
+	}
+	va_start(args, fmt);
+	vsnprintf(buf, length, fmt, args);
+	va_end(args);
+
+	PangoLayout *layout = get_pango_layout(cairo, font, buf, scale, markup);
+	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+	pango_layout_set_width(layout, pango_units_from_double(max_width));
+	cairo_font_options_t *fo = cairo_font_options_create();
+	cairo_get_font_options(cairo, fo);
+	pango_cairo_context_set_font_options(pango_layout_get_context(layout), fo);
+	cairo_font_options_destroy(fo);
+	pango_cairo_update_layout(cairo, layout);
+	pango_cairo_show_layout(cairo, layout);
+	g_object_unref(layout);
+	free(buf);
+}

--- a/include/pango.h
+++ b/include/pango.h
@@ -19,5 +19,7 @@ void get_text_size(cairo_t *cairo, const char *font, int *width, int *height,
 		int *baseline, double scale, bool markup, const char *fmt, ...);
 void pango_printf(cairo_t *cairo, const char *font,
 		double scale, bool markup, const char *fmt, ...);
+void pango_printf_ellipsized(cairo_t *cairo, const char *font,
+		double scale, bool markup, int max_width, const char *fmt, ...);
 
 #endif

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -221,6 +221,7 @@ sway_cmd bar_cmd_tray_padding;
 sway_cmd bar_cmd_unbindcode;
 sway_cmd bar_cmd_unbindsym;
 sway_cmd bar_cmd_wrap_scroll;
+sway_cmd bar_cmd_window_title;
 sway_cmd bar_cmd_workspace_buttons;
 
 sway_cmd bar_colors_cmd_active_workspace;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -271,6 +271,7 @@ struct bar_config {
 	bool strip_workspace_name;
 	bool binding_mode_indicator;
 	bool verbose;
+	bool window_title;
 	struct side_gaps gaps;
 	int status_padding;
 	int status_edge_padding;

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -34,10 +34,12 @@ struct swaybar_config {
 	char *mode;
 	char *hidden_state;
 	char *modifier;
+	char *title;
 	bool strip_workspace_numbers;
 	bool strip_workspace_name;
 	bool binding_mode_indicator;
 	bool wrap_scroll;
+	bool window_title;
 	bool workspace_buttons;
 	list_t *bindings;
 	struct wl_list outputs; // config_output::link
@@ -51,6 +53,7 @@ struct swaybar_config {
 		int bottom;
 		int left;
 	} gaps;
+	uint64_t window_app_id;
 
 	struct {
 		uint32_t background;

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -34,6 +34,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "tray_padding", bar_cmd_tray_padding },
 	{ "unbindcode", bar_cmd_unbindcode },
 	{ "unbindsym", bar_cmd_unbindsym },
+	{ "window_title", bar_cmd_window_title },
 	{ "workspace_buttons", bar_cmd_workspace_buttons },
 	{ "wrap_scroll", bar_cmd_wrap_scroll },
 };

--- a/sway/commands/bar/window_title.c
+++ b/sway/commands/bar/window_title.c
@@ -1,0 +1,22 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "log.h"
+#include "util.h"
+
+struct cmd_results *bar_cmd_window_title(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "window_title", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	config->current_bar->window_title =
+		parse_boolean(argv[0], config->current_bar->window_title);
+	if (config->current_bar->window_title) {
+		sway_log(SWAY_DEBUG, "Enabling window title on bar: %s",
+				config->current_bar->id);
+	} else {
+		sway_log(SWAY_DEBUG, "Disabling window title on bar: %s",
+				config->current_bar->id);
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -958,6 +958,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 			json_object_new_int(bar->status_edge_padding));
 	json_object_object_add(json, "wrap_scroll",
 			json_object_new_boolean(bar->wrap_scroll));
+	json_object_object_add(json, "window_title",
+			json_object_new_boolean(bar->window_title));
 	json_object_object_add(json, "workspace_buttons",
 			json_object_new_boolean(bar->workspace_buttons));
 	json_object_object_add(json, "strip_workspace_numbers",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -137,6 +137,7 @@ sway_sources = files(
 	'commands/bar/tray_bind.c',
 	'commands/bar/tray_output.c',
 	'commands/bar/tray_padding.c',
+	'commands/bar/window_title.c',
 	'commands/bar/workspace_buttons.c',
 	'commands/bar/wrap_scroll.c',
 

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -48,6 +48,9 @@ Sway allows configuring swaybar in the sway configuration file.
 	Enables or disables wrapping when scrolling through workspaces with the
 	scroll wheel. Default is _no_.
 
+*window_title* yes|no
+	Enables or disables focused window title on the bar. Default is _no_.
+
 *workspace_buttons* yes|no
 	Enables or disables workspace buttons on the bar. Default is _yes_.
 


### PR DESCRIPTION
When using sway without title bars it's useful to be able to display window titles in the bar.  Add a "window_title yes|no" bar command that displays the title of the focused window on the bar by reacting to window events.