### PR TITLE
render: set surface as sampled for presentation

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -120,6 +120,8 @@ static void render_surface_iterator(struct sway_output *output,
 		wlr_output->transform_matrix);
 
 	render_texture(wlr_output, output_damage, texture, &box, matrix, alpha);
+
+	wlr_presentation_surface_sampled(server.presentation, surface);
 }
 
 static void render_layer(struct sway_output *output,
@@ -267,6 +269,10 @@ static void render_saved_view(struct sway_view *view,
 
 	render_texture(wlr_output, damage, view->saved_buffer->texture,
 			&box, matrix, alpha);
+
+	// FIXME: we should set the surface that this saved buffer originates from
+	// as sampled here.
+	// https://github.com/swaywm/sway/pull/4465#discussion_r321082059
 }
 
 /**


### PR DESCRIPTION
Fixes #4451, requires https://github.com/swaywm/wlroots/pull/1798.

There's one issue: it looks like the very first drawn frame frequently gets a discarded presentation feedback. I can't quite figure out why. Is there any other path where a surface can get rendered? I tried adding a similar call to `render_saved_view` but that didn't help.

Update: might actually not be an issue, but just how new tiled views are handled and how the timings align.

Update 2: I recorded the screen with my phone and it seems that the discarded/presented notifications correspond exactly to frames shown on screen, so yeah, looks like no issue with this PR.

Update 3: Actually, sometimes it does seem to deliver discarded events to presented frames, most notably when resizing a floating window with mouse fast enough.