### PR TITLE
Allow moving a container hidden in scratchpad

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -900,6 +900,9 @@ void container_floating_move_to(struct sway_container *con,
 		return;
 	}
 	container_floating_translate(con, lx - con->x, ly - con->y);
+	if (container_is_scratchpad_hidden(con)) {
+		return;
+	}
 	struct sway_workspace *old_workspace = con->workspace;
 	struct sway_output *new_output = container_floating_find_output(con);
 	if (!sway_assert(new_output, "Unable to find any output")) {


### PR DESCRIPTION
i3 allows this and it seemed easy to support here as well.