### PR TITLE
Remove extraneous load_swaybars call

### DIFF
--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -30,8 +30,6 @@ static void do_reload(void *data) {
 
 	ipc_event_workspace(NULL, NULL, "reload");
 
-	load_swaybars();
-
 	for (int i = 0; i < config->bars->length; ++i) {
 		struct bar_config *bar = config->bars->items[i];
 		for (int j = 0; j < bar_ids->length; ++j) {


### PR DESCRIPTION
Swaybars are already loaded after calling load_main_config

Due to this call, swaybar/status_command was spawned twice (with the second instance of status_command being kept alive for some reason) on each config reload.