### PR TITLE
seat: set cursor image only if no pointer cap previously

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -516,6 +516,7 @@ struct sway_seat *seat_create(const char *seat_name) {
 
 static void seat_update_capabilities(struct sway_seat *seat) {
 	uint32_t caps = 0;
+	uint32_t previous_caps = seat->wlr_seat->capabilities;
 	struct sway_seat_device *seat_device;
 	wl_list_for_each(seat_device, &seat->devices, link) {
 		switch (seat_device->input_device->wlr_device->type) {
@@ -545,7 +546,9 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 		wlr_seat_set_capabilities(seat->wlr_seat, caps);
 	} else {
 		wlr_seat_set_capabilities(seat->wlr_seat, caps);
-		cursor_set_image(seat->cursor, "left_ptr", NULL);
+		if ((previous_caps & WL_SEAT_CAPABILITY_POINTER) == 0) {
+			cursor_set_image(seat->cursor, "left_ptr", NULL);
+		}
 	}
 }
 


### PR DESCRIPTION
This make seat_update_capabilities set cursor image only if
there was no pointer cap before update. This avoid resetting
cursor to left_ptr if an input device is removed.