### PR TITLE
seat: avoid unneeded reloading xcursor theme

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -593,7 +593,9 @@ static void seat_apply_input_config(struct sway_seat *seat,
 
 static void seat_configure_pointer(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
-	seat_configure_xcursor(seat);
+	if ((seat->wlr_seat->capabilities & WL_SEAT_CAPABILITY_POINTER) == 0) {
+		seat_configure_xcursor(seat);
+	}
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 	seat_apply_input_config(seat, sway_device);
@@ -633,7 +635,9 @@ static void seat_configure_touch(struct sway_seat *seat,
 
 static void seat_configure_tablet_tool(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
-	seat_configure_xcursor(seat);
+	if ((seat->wlr_seat->capabilities & WL_SEAT_CAPABILITY_POINTER) == 0) {
+		seat_configure_xcursor(seat);
+	}
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 	seat_apply_input_config(seat, sway_device);


### PR DESCRIPTION
Load xcursor theme on configuring pointer or tablet tool only if
there was no pointer cap before.

With #4521 , this also avoid resetting cursor to left_ptr if new
device is added but there was pointer cap already. 