### PR TITLE
seatop_default: only focus container on press

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -400,7 +400,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 
 	// Handle clicking a container surface or decorations
-	if (cont) {
+	if (cont && state == WLR_BUTTON_PRESSED) {
 		node = seat_get_focus_inactive(seat, &cont->node);
 		seat_set_focus(seat, node);
 		seat_pointer_notify_button(seat, time_msec, button, state);


### PR DESCRIPTION
Fixes #4529

This matches i3's behavior of only focusing a container when pressed.
This allows for `bindsym button1 nop`, `bindsym BTN_LEFT nop`, or
`bindcode 272 nop` to be used to disable focusing when clicking on the
title (or with additional flags to `bind{code,sym}` other portions of
the container).

Without this additional condition, the user would need both
`bindsym button1 nop` and `bindsym --release button1 nop` to override
both the pressed and released behavior.