### PR TITLE
pthread_sigmask()-out SIGUSR1 in main() so GPU drivers (i.e. libMali) that spawn threads don't get sway killed by xwayland's SIGUSR1

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -214,6 +214,19 @@ void enable_debug_flag(const char *flag) {
 }
 
 int main(int argc, char **argv) {
+
+	// Shared libraries (such as libMali.so, the Mali OpenGL
+	// driver) may create their own threads.  To ensure that
+	// Xwayland's SIGUSR1 does not hit those threads and kill
+	// sway, we must call pthread_sigmask() as early as possible.
+	// See also weston commit
+	// f59dc1112be50467b7c0f8aeba68f3aa10d36725 which does the
+	// same thing.
+	sigset_t mask;
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGUSR1);
+	pthread_sigmask(SIG_BLOCK, &mask, NULL);
+
 	static int verbose = 0, debug = 0, validate = 0, allow_unsupported_gpu = 0;
 
 	static struct option long_options[] = {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -210,5 +210,6 @@ executable(
 	include_directories: [sway_inc],
 	dependencies: sway_deps,
 	link_with: [lib_sway_common],
-	install: true
+	install: true,
+	link_args : '-lpthread'
 )


### PR DESCRIPTION
Sway needs to mask SIGUSR1 in main() like Weston does.  Otherwise the compositor dies a grisly death as soon as the user does anything that triggers xwayland loading if the GPU driver shared library uses threads.  Tested on rk3399/libMali with claws-mail, which works now.

Apologies if this pull request is entered or formatted improperly.  I've been using git for quite a while but this is my first time using github to submit a patch instead of just emailing it.

Fixes https://github.com/swaywm/sway/issues/4538