### PR TITLE
Fix typo (an -> and)

### DIFF
--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -97,7 +97,7 @@ The following commands may only be used in the configuration file.
 	Ignores inputs from this device that do not occur within the specified
 	region. Can be in millimeters (e.g. 10x20mm 20x40mm) or in terms of 0..1
 	(e.g. 0.5x0.5 0.7x0.7). Not all devices support millimeters. Only meaningful
-	if the device is not a keyboard an provides events in absolute terms (such
+	if the device is not a keyboard and provides events in absolute terms (such
 	as a drawing tablet or touch screen - most pointers provide events relative
 	to the previous frame).
 


### PR DESCRIPTION
While I'm at it could I ask a question?

I have a device that provides absolute events (a wacom tablet), how can I make it relative?