### PR TITLE
Add zsh sway command completions for swaymsg

### DIFF
--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -1,39 +1,754 @@
 #compdef swaymsg
-#-----------------
-# Description
-# -----------
-#
-# Completion script for swaymsg in sway wm (http://swaywm.org)
-#
-# ------------------------------------------------------
-# Author
-# --------
-#
-#  * Seth Barberee <seth.barberee@gmail.com>
-#
-#  -------------------------------------------
 
-types=(
-'get_workspaces'
-'get_seats'
-'get_inputs'
-'get_outputs'
-'get_tree'
-'get_marks'
-'get_bar_config'
-'get_version'
-'get_binding_modes'
-'get_config'
-'send_tick'
-'subscribe'
+typeset -A opt_args
+__swaymsg() {
+	# Reuse socket path from command line if present
+	swaymsg ${(kv)opt_args[(I)-s|--socket]} "$@" 2>/dev/null
+}
+
+# _sway_* completions
+# sway ipc {{{
+(( $+functions[_sway_ipc_types] )) ||
+_sway_ipc_types() {
+	local -a ipc_types=(
+		'get_workspaces:Get a list of workspaces and their status'
+		'get_inputs:Get a list of current inputs'
+		'get_outputs:Get the list of current outputs'
+		'get_tree:Get a JSON-encoded layout tree'
+		'get_seats:Get a list of all seats, their properties and assigned devices'
+		'get_marks:Get a JSON-encoded list of marks'
+		'get_bar_config:Get a JSON-encoded configuration for swaybar'
+		'get_version:Get JSON-encoded version information for the running instance of sway'
+		'get_binding_modes:Get a JSON-encoded list of currently configured binding modes'
+		'get_config:Get a JSON-encoded copy of the current configuration'
+		'send_tick:Sends a tick event to all subscribed clients'
+		'subscribe:Subscribe to a list of event types'
+	)
+	_describe -t sway-ipc-type 'ipc type' ipc_types "$@"
+}
+
+(( $+functions[_sway_ipc_events] )) ||
+_sway_ipc_events() {
+	local -a ipc_events=(
+		'"workspace"[Sent whenever an event involving a workspace occurs]'
+		'"mode"[Sent whenever the binding mode changes]'
+		'"window"[Sent whenever an enever involving a view occurs]'
+		'"barconfig_update"[Sent whenever a bar config changes]'
+		'"binding"[Sent when a configured binding is executed]'
+		'"shutdown"[Sent when the ipc shuts down because sway is exiting]'
+		'"tick"[Sent when an ipc client sends a send_tick message]'
+		'"bar_status_update"[Sent when the visibility of a bar should change]'
+		'"input"[Sent when something related to input devices changes]'
+	)
+	if (( $+compstate[quote] )); then
+		compset -P '\['
+		compset -P '*,'
+		_values -s, "event" $ipc_events
+	fi
+}
+# }}}
+# sway objects {{{
+local -a subcmd_{criteria,output,input,workspace,mark,seat}
+(( $+functions[_sway_criteria] )) ||
+_sway_criteria() {
+	# Only worth completing in quoted args. Manually insert "[ prefix, then complete.
+	if (( $+compstate[quote] )) && compset -P '\['; then
+		_values -s ' ' "attribute" \
+		'app_id[Specific name of wayland applications]:' \
+		'class[class of X11 applications]:' \
+		'con_id[Unique id of containers]:' \
+		'con_mark[Window marks]:' \
+		'floating[Match floating windows]' \
+		'id[X11 window ID]:' \
+		'instance[Window instance]:' \
+		'shell[Window shell]:' \
+		'tiling[Match tiling windows]' \
+		'title[Window title]' \
+		'urgent[Urgent state of windows]:state:(first last latest newest oldest recent)' \
+		'window_role[X11 WM_WINDOW_ROLE]:' \
+		'window_type[EWMH _NET_WM_WINDOW_TYPE]:type:(normal dialog utility toolbar splash menu dropdown_menu popup_menu tooltip notification)' \
+		'workspace[Workspace name for view]:'
+	fi
+}
+subcmd_criteria=(/$'[[][^\0]#[\\]]\0'/ ':_sway_criteria')
+
+(( $+functions[_sway_outputs] )) ||
+_sway_outputs() {
+	local -a outputs
+	if (( $+commands[jq] )); then
+		outputs=( ${(@f)"$(__swaymsg -rt get_outputs | jq -r '.[].name')"} )
+	else
+		__swaymsg -pt get_outputs | while read OUTPUT NAME OTHER; do
+			[[ $OUTPUT == "Output" ]] && outputs+="$NAME"
+		done
+	fi
+	compadd "$@" -a outputs
+}
+subcmd_output=(/$'[^\0]#\0'/ ':output:output device:_sway_outputs')
+
+(( $+functions[_sway_inputs] )) || _sway_inputs() {
+	local -A inputs
+	if (( $+commands[jq] )); then
+		inputs=( ${(@f)"$(__swaymsg -rt get_inputs | jq -r '.[] | (.identifier, .name)' )"} )
+	fi
+	local -a comps=( "${(@k)inputs//:/\\:}" )
+	local -a descr=( "${(@v)inputs//:/\\:}" )
+	_describe "input device" descr comps
+}
+subcmd_input=(/$'[^\0]#\0'/ ':input:input device:_sway_inputs')
+
+(( $+functions[_sway_workspaces] )) ||
+_sway_workspaces() {
+	local -a workspaces
+	if (( $+commands[jq] )); then
+		workspaces=( ${(@f)"$(__swaymsg -rt get_workspaces | jq -r '.[].name')"} )
+	else
+		__swaymsg -pt get_workspaces | while read WORK NAME OTHER; do
+			[[ $WORK == "Workspace" ]] && workspaces+="$NAME"
+		done
+	fi
+	compadd "$@" -a workspaces
+}
+subcmd_workspace=(/$'[^\0]#\0'/ ':workspace:workspace:_sway_workspaces')
+
+(( $+functions[_sway_marks] )) ||
+_sway_marks() {
+	local -a marks
+	if (( $+commands[jq] )); then
+		marks=( ${(@f)"$(__swaymsg -rt get_marks | jq -r '.[]')"} )
+	fi
+	compadd "$@" -a marks
+}
+subcmd_mark=( /$'[^\0]#\0'/ ':mark:mark:_sway_marks' )
+
+(( $+functions[_sway_seats] )) ||
+_sway_seats() {
+	local -a seats
+	if (( $+commands[jq] )); then
+		seats=( ${(@f)"$(__swaymsg -rt get_seats | jq -r '.[].name')"} )
+	else
+		__swaymsg -pt get_seats | while read SEAT NAME; do
+			[[ $SEAT == "Seat:" ]] && seats+="$NAME"
+		done
+	fi
+	compadd "$@" -a seats
+}
+subcmd_seat=(/$'[^\0]#\0'/ ':seat:_sway_seats')
+# }}}
+# _swaycmd
+# common subcmds {{{
+local -a reply subcmd_{string,number,direction,edt}
+subcmd_string=(/$'[^\0]#\0'/ ':( )')
+subcmd_number=(/$'[0-9]##\0'/ ':number:number:( )')
+subcmd_edt=(/$'(enable|disable|toggle)\0'/ ':(enable disable toggle)')
+subcmd_dir=(/$'(left|right|up|down)\0'/ ':(left right up down)')
+# }}}
+# swaymsg border {{{
+local -a swaycmd_border
+_regex_words arguments "border option" \
+	'none:No border' \
+	'normal:Border thickness \[n\] and a title bar:$subcmd_number' \
+	'csd:Allow client-side-decorations' \
+	'pixel:Border thickness \[n\]:$subcmd_number' \
+	'toggle:Cycle through the available border styles'
+swaycmd_border=("$reply[@]")
+# }}}
+# swaymsg focus {{{
+local -a swaycmd_focus_output swaycmd_focus
+_swaycmd_focus_output() {
+	_alternative \
+		'direction:direction:(up down left right)' \
+		'output:output:_sway_outputs'
+}
+swaycmd_focus_output=(
+	/$'[^\0]#\0'/ # match any word here, as it may be an output name
+	':_swaycmd_focus_output'
 )
 
-_arguments -s \
+_regex_words arguments "focus option" \
+	{up,down,left,right}':Move focus to the next container' \
+	'child:Move focus to the last-focused child of the focused container' \
+	'parent:Move focus to the parent' \
+	'tiling:Set focus to the last focused tiling container' \
+	'floating:Set focus to the last focused floating container' \
+	'mode_toggle:Move focus between the floating and tiled layers' \
+	'output:Move focus between outputs:$swaycmd_focus_output'
+swaycmd_focus=("$reply[@]")
+# }}}
+# swaymsg fullscreen {{{
+_regex_words arguments "global option" "global:Make the view fullscreen across all outputs"
+local -a swaycmd_fullscreen=($subcmd_edt "$reply[@]")
+# }}}
+# swaymsg gaps {{{
+local -a swaycmd_gaps swaycmd_gaps1 swaycmd_gaps2 swaycmd_gaps3
+_regex_words arguments "gaps option" \
+	'inner:Set gaps around each view' \
+	'outer:Set gaps around each workspace' \
+	'horizontal:Set outer gaps in the horizontal direction ' \
+	'vertical:Set outer gaps in the vertical direction' \
+	{top,right,bottom,left}':Set gaps per side'
+swaycmd_gaps1=("$reply[@]")
+
+_regex_words arguments "gaps option" \
+	'all:Affect all workspaces' \
+	'current:Affect the current workspace'
+	swaycmd_gaps2=( "$reply[@]" )
+
+swaycmd_gaps3=(
+	/$'(set|plus|minus)\0'/ ':(set plus minus)' $subcmd_number
+)
+
+swaycmd_gaps=(
+	$swaycmd_gaps1
+	"(" $swaycmd_gaps2 "|" $subcmd_number ")"
+	$swaycmd_gaps3
+)
+# }}}
+# swaymsg inhibit_idle {{{
+local -a swaycmd_inhibit_idle
+_regex_words arguments "inhibit_idle option" \
+	'focus:Inhibit when the view is focused by any seat' \
+	'fullscreen:Inhibit when the view is fullscreen and visible' \
+	'open:Inhibit until the view is closed' \
+	'visible:Inhibit while the view is visible on any output' \
+	'none:Remove any existing idle inhibitor for the view'
+swaycmd_inhibit_idle=("$reply[@]")
+# }}}
+# swaymsg layout {{{
+local -a swaycmd_layout swaycmd_layout_toggle
+_regex_words arguments "layouts" "split" "tabbed" "stacking" "splitv" "splith"
+swaycmd_layout_toggle=(
+	# No argument
+	"(" "|"
+	# Long form
+	"$reply[@]" "#" "|"
+	# Short form
+	/$'(split|all)\0'/ ':(split all)'
+	")"
+)
+
+_regex_words arguments "layout option" \
+	'default' 'splith' 'splitv' 'stacking' 'tabbed' \
+	'toggle:Cycle layout modes:$swaycmd_layout_toggle'
+swaycmd_layout=("$reply[@]")
+# }}}
+# swaymsg move {{{
+local -a subcmd_px=( /$'px\0'/ ':(px)' )
+local -a subcmd_px_opt=( "(" /$'px\0'/ ':(px)' "|" ")" )
+local -a swaycmd_move_dir=(
+	$subcmd_dir
+	"(" $subcmd_number $subcmd_px "|" ")"
+)
+
+local cursor=cursor
+(( $+functions[_swaycmd_sub_cursor] )) ||
+_swaycmd_sub_cursor() {
+	compadd "$@" $cursor
+}
+local -a swaycmd_move_position=(
+	"(" "|" /$'absolute\0'/ -'unset cursor' ':(absolute)' ")"
+	/$'position\0'/ ':(position)'
+	"(" /$'center\0'/ ':(center)' "|"
+	/$'(cursor|mouse|pointer)'/ ":_swaycmd_sub_cursor"  "|"
+	$subcmd_number $subcmd_px_opt $subcmd_number $subcmd_px_opt ")"
+)
+
+_regex_words arguments "move option" \
+	'mark:Move focused container to the specified mark:$subcmd_mark' \
+	'workspace:Move focused container to the specified workspace:$subcmd_workspace' \
+	'output:Move focused container to specified output:$subcmd_output' \
+	'scratchpad:Move focused container to the scratchpad'
+
+local -a swaycmd_move_container=(
+	"(" "|" /$'(container|window)\0'/ ':(container window)' ")"
+	/$'to\0'/ ':(to)'
+	"$reply[@]"
+)
+
+_swaycmd_move_workspace() {
+	_alternative \
+		'direction:direction:(up down left right)' \
+		':current:(current)' \
+		'output:output:_sway_outputs'
+}
+local -a swaycmd_move_workspace=(
+	/$'workspace\0'/ ':(workspace)' /$'to\0'/ ':(to)'
+	/$'[^\0]#\0'/ ':_swaycmd_move_workspace'
+)
+
+local -a swaycmd_move=(
+	"("
+	$swaycmd_move_dir "|"
+	$swaycmd_move_position "|"
+	$swaycmd_move_container "|"
+	$swaycmd_move_workspace "|"
+	")"
+)
+# }}}
+# swaymsg rename workspace {{{
+local -a swaycmd_rename_workspace=(
+	/$'workspace\0'/ ':(workspace)'
+	"(" $subcmd_workspace "|" ")"
+	/$'to\0'/ ':(to)'
+	/$'[^\0]#\0'/ ':workspace:name:( )'
+)
+# }}}
+# swaymsg resize {{{
+local -a subcmd_unit_opt=(
+	"(" "|" /$'(px|ppt)'/ ':(px ppt)' ")"
+)
+
+local -a swaycmd_resize=(
+	"(" "("
+	/$'(shrink|grow)\0'/ ':(shrink grow set)'
+	/$'(width|height)\0'/ ':(width height)'
+	$subcmd_number $subcmd_unit_opt
+	")" "|"
+	/$'set\0'/ ':(set)'
+	/$'(width|height)\0'/ ':(width height)' $subcmd_number $subcmd_unit_opt
+	/$'(height)\0'/ ':(height)' $subcmd_number $subcmd_unit_opt ")"
+)
+# }}}
+#swaymsg split {{{
+_regex_words arguments "split option" \
+	'v*ertical:Split the current container vertically' \
+	'h*orizontal:Split the current container horizontally' \
+	't*oggle:Split opposite the parent container layout'
+local -a swaycmd_split=("$reply[@]")
+#}}}
+# swaymsg assign{{{
+local -a swaycmd_assign swaycmd_assign_output
+_swaycmd_assign_output() {
+	_alternative \
+		':direction:(left right up down)' \
+		':output:_sway_outputs'
+}
+swaycmd_assign_output=(/$'[^\0]#\0'/ ':_swaycmd_assign_output')
+
+_regex_words arguments "assign option" \
+	'workspace:Assign to specified workspace:$subcmd_workspace' \
+	'output:Assign to specified output:$swaycmd_assign_output'
+swaycmd_assign=(
+	$subcmd_criteria
+	# don't complete the arrow, just match it if it's there
+	"(" "|" /$'\u2192\0'/ ':( )' ")"
+	"$reply[@]"
+)
+# }}}
+# swaymsg bindsym/bindcode/unbindsym/unbindcode {{{
+local -a swaycmd_{un,}bind{sym,code}
+local -a bindsym_common=(
+	'--whole-window[Mouse only option. Enable mousekey binding anywhere]' 
+	'--border[Mouse only option. Enable mousekey binding over window borders]' 
+	'--exclude-titlebar[Mouse only option. Disable mousekey bindings over titlebars]' 
+	'--release[Trigger binding on key release instead of key press]' 
+	'--input-device=[Only trigger with the specified input device]' 
+	'--locked[Allow this binding to trigger when a screen locker program is active]'
+	'--no-warn[Do not give the user a warning when overwriting a binding]' 
+)
+(( $+functions[_swaycmd_bindsym] )) ||
+_swaycmd_bindsym() {
+	compset -n 2
+	_arguments $bindsym_common \
+		'--to-code[Translate the bound keysym to a keycode in the first configured layout]' \
+		':key combo' \
+		'*:::sway command:= _swaycmd'
+}
+(( $+functions[_swaycmd_bindcode] )) ||
+_swaycmd_bindcode() {
+	compset -n 2
+	_arguments $bindsym_common \
+		':key code' \
+		'*:::sway command:= _swaycmd'
+}
+
+swaycmd_bindsym=(/$'[^\0]#\0'/ ':_swaycmd_bindsym' "#")
+swaycmd_bindcode=(/$'[^\0]#\0'/ ':_swaycmd_bindcode' "#")
+swaycmd_unbindsym=(/$'--[^\0]#\0'/ ':_swaycmd_bindsym' "#")
+swaycmd_unbindcode=(/$'--[^\0]#\0'/ ':_swaycmd_bindcode' "#")
+# }}}
+# swaymsg bindswitch/unbindswitch {{{
+local -a swaycmd_{un,}bindswitch
+(( $+functions[_swaycmd_bindswitch] )) ||
+_swaycmd_bindswitch() {
+	local -a switches=(lid tablet) states=(on off toggle)
+	compset -n 2
+	_arguments \
+		'--locked[Allow this binding to trigger when a screen locker program is active]' \
+		'--no-warn[Do not give the user a warning when overwriting a binding]' \
+		'--reload[Also execute the command when the config is reloaded]' \
+		':switch state:_sep_parts switches \: states' \
+		'*:::sway command:= _swaycmd'
+}
+swaycmd_bindswitch=( /$'[^\0]#\0'/ ':_swaycmd_bindswitch' "#")
+swaycmd_unbindswitch=( /$'[^\0]#\0'/ ':_sep_parts switches \: states' )
+# }}}
+# swaymsg client.<class> {{{
+# TODO manually add these to swaycmd regex
+local -a classes=(focused focused_inactive unfocused urgent)
+local -a client_classes=( client.${^classes} )
+(( $+functions[_swaycmd_client] )) ||
+_swaycmd_client() {
+	compset -n 2
+	_arguments ':border' ':background' ':text' ':indicator' ':child_border'
+}
+local -a swaycmd_client=(
+	/"${(j.|.)client_classes})"$'\0'/ -repeat=0
+	":( ${client_classes} )"
+	"(" /$'\\#[0-9a-fA-F]#\0'/ -'(( repeat++ < 5 ))' ':( )' ")" "#"
+)
+# }}}
+# swaymsg default_border {{{
+_regex_words arguments "default_border option" \
+	'normal:Standard border with a title bar:$subcmd_number' \
+	'pixel:Standard border with given width:$subcmd_number' \
+	'none:No border'
+local -a swaycmd_default_border=( "$reply[@]" )
+# }}}
+# swaymsg exec {{{
+local -a swaycmd_exec=( /$'[^\0]#\0'/ ':{compset -n 3; _normal}' "#")
+# }}}
+# swaymsg for_window {{{
+local -a swaycmd_for_window
+(( $+functions[_swaycmd_for_window] )) ||
+_swaycmd_for_window() {
+	compset -n 2
+	_arguments \
+		':criteria:_sway_criteria' \
+		'*:::sway command:= _swaycmd'
+}
+swaycmd_for_window=( /$'[^\0]#\0'/ ':_swaycmd_for_window' "#")
+# }}}
+# swaymsg urgent {{{
+_regex_words arguments "option" \
+	"enable:Manually set the urgent state for a window" \
+	"disable:Manually unset the urgent state for a window" \
+	"allow:Allow a window to set its own urgent state" \
+	"deny:Disallow a window from setting its own urgent state"
+local -a swaycmd_urgent=("$reply[@]")
+# }}}
+# swaymsg workspace {{{
+local -a swaycmd_workspace swaycmd_workspace_cmd
+
+local -a subcmd_output_repeat=( $subcmd_output "#" )
+_regex_words arguments "workspace option" \
+	'gaps:Specify gaps for a workspace when it is created:$swaycmd_gaps1' \
+	'output:Specify which output to show the given workspace:$subcmd_output_repeat'
+swaycmd_workspace_cmd=("$reply[@]")
+
+_regex_words arguments "workspace option" \
+	'prev:Previous workspace on any output' \
+	'next:Next workspace on any output' \
+	'prev_on_output:Previous workspace on this output' \
+	'next_on_output:Next workspace on this output' \
+	'back_and_forth:Switch to the previously focused workspace'
+swaycmd_workspace=(
+	"("
+	"$reply[@]" "|"
+	"("
+		"(" "|" /$'--no-auto-back-and-forth\0'/ ':(--no-auto-back-and-forth)' ")"
+		"(" "|" /$'number\0'/ ':(number)' ")"
+		$subcmd_workspace
+	")" "|"
+	$subcmd_workspace "$swaycmd_workspace_output[@]" ")"
+)
+# }}}
+# swaymsg floating_maximum_size/floating_minimum_size {{{
+local -a swaymcmd_floating_size=(
+	/$'[0-9]#\0'/ ':width:( )'
+	/$'x\0'/ ':(x)'
+	/$'[0-9]#\0'/ ':height:( )'
+)
+# }}}
+# swaymsg focus_on_window_activation {{{
+_regex_words arguments "fowa option" \
+	'urgent:Set the urgent state for the activated windows' \
+	'focus:Set focus to the activated windows' \
+	'smart:Set focus to the activated window if it is already visible' \
+	'none:Do nothing'
+local -a swaycmd_fowa=("$reply[@]")
+# }}}
+# swaymsg titlebar_padding {{{
+local -a swaycmd_titlebar_padding=(
+	/$'[0-9]#\0'/ ':horizontal:( )'
+	/$'[0-9]#\0'/ ':vertical:( )'
+)
+# }}}
+# swaymsg floating_modifier {{{
+_regex_words arguments "floating_modifier option" \
+	'normal:Left click to move windows, right click to resize' \
+	'inverse:Left click to resize windows, right click to move'
+local -a swaycmd_floating_modifier=("$reply[@]")
+# }}}
+# swaymsg input {{{
+local -a swaycmd_input
+(( $+functions[_sway_input_spec] )) || _sway_input_spec() {
+	local -a input_types=(
+		touchpad pointer keyboard touch
+		tablet_tool tablet_pad switch
+	)
+	input_types=("type:${(@)^input_types}")
+	_alternative \
+		':input device:_sway_inputs' \
+		":device class:( $input_types )"
+}
+local -a subcmd_input_spec=( /$'[^\0]#\0'/ ':_sway_input_spec' )
+local -a subcmd_xkb_file=( /$'[^\0]#\0'/ ':_files -g "*.xkb"' )
+
+local swaycmd_active_input
+(( $+functions[_sway_input_layouts] )) ||
+_sway_input_layouts() {
+	local device="$words[3]"
+	local -a layout_names
+	if (( $+commands[jq] )); then
+		layout_names=(
+			${(@f)"$(
+			__swaymsg -rt get_inputs |
+				jq -r ".[] | select(.identifier == \"$device\").xkb_layout_names[]"
+			)"}
+		)
+	fi
+	local -a descr=( "${(@)layout_names}" )
+	local -a comps=( {1..${#layout_names}} )
+	_describe 'layout index' descr comps
+}
+local -a subcmd_input_layout=(
+	/$'[^\0]#\0'/
+	':_sway_input_layouts $swaycmd_active_input'
+)
+
+_regex_words arguments "accel profile" "adaptive" "flat"
+local -a subcmd_input_accel_profile=("$reply[@]")
+
+_regex_words arguments "click method" "none" "button_areas" "clickfinger"
+local -a subcmd_input_click_method=("$reply[@]")
+
+_regex_words arguments "option" "enabled" "disabled"
+local -a subcmd_ed=("$reply[@]")
+
+_regex_words arguments "option" "enabled" "disabled" "disabled_on_external_mouse" "toggle"
+local -a subcmd_input_events=("$reply[@]")
+
+_regex_words arguments "scroll button" "disable" button{{1..3},8,9}
+local -a subcmd_input_scroll_button=("$reply[@]")
+
+_regex_words arguments "scroll method" "none" "two_finger" "edge" "on_button_down"
+local -a subcmd_input_scroll_method=("$reply[@]")
+
+_regex_words arguments "button map" "lrm:left-right-middle" "lmr:left-middle-right" 
+local -a subcmd_input_tap_button_map=("$reply[@]")
+
+_regex_words input-command "input option" \
+	'repeat_delay:Set the delay before repeating a held-down key in ms:$subcmd_number' \
+	'repeat_rate:Set the key repeat rate in number of keypresses per second:$subcmd_number' \
+	'xkb_file:Set all xkb configurations from a complete .xkb file:$subcmd_xkb_file' \
+	'xkb_layout:Set the layout of the keyboard' \
+	'xkb_model:Set the model of the keyboard' \
+	'xkb_options:Set extra xkb configuration options' \
+	'xkb_rules:Set files or rules for keyboard mapping composition' \
+	'xkb_switch_layout:Switch the active keyboard layout by index:$subcmd_input_layout' \
+	'xkb_variant:Set the keyboard variant' \
+	'map_to_output:Map inputs from this device to specified output:$subcmd_output' \
+	'map_to_region:Map inputs from this device to specified region' \
+	'map_from_region:Ignore inputs from this device outside the specified region' \
+	'accel_profile:Set the pointer acceleration profile:$subcmd_input_accel_profile' \
+	'calibration_matrix:Set the calibration matrix' \
+	'click_method:Set the click method:$subcmd_input_click_method' \
+	'drag:Enable or disable tap-and-drag:$subcmd_ed' \
+	'drag_lock:Enable or disable drag lock:$subcmd_ed' \
+	'dwt:Enable or disable disable-while-typing:$subcmd_ed' \
+	'events:Enable or disable send_events:$subcmd_input_events' \
+	'left_handed:Enable or disable left handed mode:$subcmd_ed' \
+	'middle_emulation:Enable or disable middle buttom emulation:$subcmd_ed' \
+	'natural_scroll:Enable or diable natural (inverted) scrolling:$subcmd_ed' \
+	'pointer_accel:Set the pointer acceleration' \
+	'scroll_button:Set the button used for scroll_method on_button_down:$subcmd_input_scroll_button' \
+	'scroll_factor:Set the scroll factor' \
+	'scroll_method:Set the scroll method:$subcmd_input_scroll_method' \
+	'tap:Enable or disable tap click:$subcmd_ed' \
+	'tap_button_map:Set the button mapping for tap click:$subcmd_input_tap_button_map'
+swaycmd_input=($subcmd_input_spec "$reply[@]")
+# }}}
+# swaymsg output {{{
+local -a swaycmd_output
+local -a subcmd_output_bg=(/$'[^\0]#\0'/ ':color:( )' /$'solid_color\0'/ ':(solid_color)')
+_regex_words arguments "subpixel hint" "rgb" "bgr" "vrgb" "vbgr" "none"
+local -a subcmd_output_subpixel_hint=("$reply[@]")
+
+_regex_words arguments "transform" "normal" "flipped" {flipped-,}{90,180,270}
+local -a subcmd_output_transform=("$reply[@]")
+_regex_words arguments "rotation direction" "clockwise" "anticlockwise"
+subcmd_output_transform+=("$reply[@]")
+
+_regex_words arguments "option" "on" "off"
+local -a subcmd_output_dpms=("$reply[@]")
+
+_regex_words output-command "output option" \
+	'mode:Configure the specified output to use the given mode' \
+	'res*olution:Configure the specified output to use the given mode' \
+	'pos*ition:Place the specified output at a specific position' \
+	'scale:Scale the specified output' \
+	'subpixel:Manually set subpixel hinting for the specified output:$subcmd_output_subpixel_hint' \
+	'background:Set the background of the specified output' \
+	'transform:Transform the specified output:$subcmd_output_transform' \
+	'disable:Disable the specified output' \
+	'enable:Enable the specified output' \
+	'toggle:Toggle the specified output' \
+	'dpms:Enable or disable the specified output via DPMS:$subcmd_output_dpms'
+swaycmd_output=( $subcmd_output "$reply[@]" )
+# }}}
+# swaymsg bar {{{
+local -a swaycmd_bar
+(( $+functions[_sway_bar] )) ||
+_sway_bar() {
+	local -a bars
+	if (( $+commands[jq] )); then
+		bars=( ${(@f)"$(__swaymsg -rt | jq -r '.[]')"} )
+	fi
+	compadd "$@" -a bars
+}
+local -a subcmd_bar=(/$'[^\0]#\0'/ ':bar id:_sway_bar')
+_regex_words arguments "bar state" "hide" "show" "toggle"
+local -a subcmd_bar_hidden_state=("$reply[@]" $subcmd_bar)
+
+_regex_words arguments "bar mode" \
+	"dock:Permanently visible" \
+	"hide:Hidden unless the modifier key is pressed" \
+	"invisible:Permanently hidden" \
+	"overlay:Permanently visible on top of other windows" \
+	"toggle:Switch between dock and hide"
+local -a subcmd_bar_mode=("$reply[@]" $subcmd_bar)
+
+_regex_words bar-commands "bar option" \
+	'hidden_state:Set the hidden state of the bar:$subcmd_bar_hidden_state' \
+	'mode:Set the mode of the bar:$subcmd_bar_mode'
+swaycmd_bar=("$reply[@]")
+# }}}
+# swaymsg <generic> {{{
+_regex_words arguments "option" "show"
+local -a swaycmd_scratchpad=("$reply[@]")
+
+_regex_words arguments "option" "yes" "no" "always"
+local -a swaycmd_focus_follows_mouse=("$reply[@]")
+
+_regex_words arguments "option" "yes" "no" "force"
+local -a swaycmd_focus_wrapping=("$reply[@]")
+
+_regex_words arguments "option" "on" "no_gaps" "off"
+local -a swaycmd_smart_borders=("$reply[@]")
+
+_regex_words arguments "option" "on" "off"
+local -a swaycmd_smart_gaps=("$reply[@]")
+
+_regex_words arguments "option" "output" "container" "none"
+local -a swaycmd_mouse_warping=("$reply[@]")
+
+_regex_words arguments "option" "smart" "ignore" "leave_fullscreen"
+local -a swaycmd_popup_during_fullscreen=("$reply[@]")
+
+_regex_words arguments "option" "yes" "no"
+local -a swaycmd_show_marks=("$reply[@]")
+
+_regex_words arguments "option" "set" "plus" "minus"
+local -a swaycmd_opacity=("$reply[@]" $subcmd_number)
+
+_regex_words arguments "option" "left" "center" "right"
+local -a swaycmd_title_align=("$reply[@]")
+
+# }}}
+# swaymsg <command> {{{
+_regex_words commands 'sway commands' \
+	'border:Set border style for the focused window:$swaycmd_border' \
+	'exit:Exit sway and end your Wayland session' \
+	'floating:Make focused view floating or non-floating:$subcmd_edt' \
+	'focus:Set focus:$swaycmd_focus' \
+	'fullscreen:Make focused view fullscreen or non-fullscreen:$swaycmd_fullscreen' \
+	'gaps:Set workspace gaps:$swaycmd_gaps' \
+	'inhibit_idle:Set or unset an idle inhibitor for the view:$swaycmd_inhibit_idle' \
+	'layout:Set the layout mode for the focused container:$swaycmd_layout' \
+	'move:Rearrange containers in workspaces and outputs:$swaycmd_move'  \
+	'reload:Reload the sway config file and apply any changes' \
+	'rename:Rename workspaces:$swaycmd_rename_workspace' \
+	'resize:Resize containers:$swaycmd_resize' \
+	'scratchpad:Show windows from the scratchpad:$swaycmd_scratchpad' \
+	'split:Split the current container:$swaycmd_split' \
+	'sticky:Stick a floating window to the current output:$subcmd_edt' \
+	'swap:Swap the position and geometry of two containers:$swaycmd_swap' \
+	'title_format:Set the window title format:$subcmd_string' \
+	'assign:Assign views matching criteria to a workspace:$swaycmd_assign' \
+	'bindsym:Bind key combo to execute the given sway command (by keysym):$swaycmd_bindsym' \
+	'bindcode:Bind key combo to execute the given sway command (by keycode):$swaycmd_bindsym' \
+	'bindswitch:Bind switch to execute the given sway command on state changes:$swaycmd_bindswitch' \
+	'default_border:Set default border style for new windows:$swaycmd_default_border' \
+	'default_floating_border:Set default border style for new floating windows:$swaycmd_default_border' \
+	'exec:Execute a shell command with sh:$swaycmd_exec' \
+	'exec_always:Like exec, but also execute after reload:$swaycmd_exec' \
+	'floating_maximum_size:Set the maximum size of all floating windows:$swaycmd_floating_size' \
+	'floating_minimum_size:Set the minimum size of all floating windows:$swaycmd_floating_size' \
+	'floating_modifier:Set the modifier for manipulating floating windows:$swaycmd_floating_modifier' \
+	'focus_follow_mouse:Set the focus behavior on mouse movement:$swaycmd_focus_follow_mouse' \
+	'focus_on_window_activate:Set the behavior for when xwayland clients request activation:$swaycmd_fowa' \
+	'focus_wrapping:Set focus wrapping behavior:$swaycmd_focus_wrapping' \
+	'font:Set the font to use for title bars' \
+	'titlebar_border_thickness:Set the thickness of the titlebar border in pixels:$subcmd_number' \
+	'titlebar_padding:Set the padding of text in the titlebar:$swaycmd_titlebar_padding' \
+	'for_window:Set a list of commands to run whenever a window matching criteria appear:$swaycmd_for_window' \
+	'hide_edge_borders:Hide window borders adjacent to the screen edges:$swaycmd_hide_edge_borders' \
+	'input:Configure input devices:$swaycmd_input' \
+	'seat:Configure seats:$swaycmd_seat' \
+	'kill:Close a window and its children' \
+	'smart_borders:Set smart borders:$swaycmd_smart_borders' \
+	'smart_gaps:Set smart gaps:$swaycmd_smart_gaps' \
+	'mark:Add or remove marks:$swaycmd_mark' \
+	'mode:Switch mode:$swaycmd_mode' \
+	'mouse_warping:Set cursor behavior on focus change:$swaycmd_mouse_warping' \
+	'no_focus:Prevent windows matching criteria from being focused on creation:$subcmd_criteria' \
+	'output:Configure output devices:$swaycmd_output' \
+	'popup_during_fullscreen:Set popup behavior for fullscreen views:$swaycmd_popup_during_fullscreen' \
+	'set:Set variables to use in future commands' \
+	'show_marks:Display marks in window borders' \
+	'opacity:Adjust window opacity:$swaycmd_opacity' \
+	'tiling_drag:Enable or disable tiling drag:$subcmd_edt' \
+	'tiling_drag_threshold:Set tilng drag threshold:$subcmd_number' \
+	'title_align:Set the title alignment:$swaycmd_title_align' \
+	'unbindswitch:Remove a switch binding:$swaycmd_unbindswitch' \
+	'unbindsym:Remove a keysym binding:$swaycmd_unbindsym' \
+	'unbindcode:Remove a keycode binding:$swaycmd_unbindcode' \
+	'unmark:Remove a mark:$subcmd_mark' \
+	'urgent:Set or unset a window urgent state:$swaycmd_urgent' \
+	'workspace:Switch workspaces:$swaycmd_workspace' \
+	'workspace_auto_back_and_forth:Allow repeating a workspace switch command:$swaycmd_workspace_auto_back_and_forth' \
+	'workspace_layout:Set the default layout for new workspaces:$swaycmd_workspace_layout' \
+	'bar:Configure status bars:$swaycmd_bar'
+
+local -a swaycmd=(/$'[^\0]#\0'/ "(" "|" $subcmd_criteria ")" "$reply[@]")
+_regex_arguments _swaycmd "$swaycmd[@]"
+# }}}
+
+(( $+functions[_swaymsg_payload] )) ||
+_swaymsg_payload() {
+	case ${(Lv)opt_args[(I)-t|--type]:-command} in
+		"subscribe")
+			_sway_ipc_events
+			;;
+		"command")
+			_swaycmd
+			;;
+		*)
+			_message "no arguments"
+			;;
+	esac	
+}
+
+_arguments -S -s\
 	'(-h --help)'{-h,--help}'[Show help message and quit]' \
-	'(-m --monitor)'{-m,--monitor}'[Monitor until killed (-t SUBSCRIBE only)]' \
-	'(-p --pretty)'{-p,--pretty}'[Use pretty output even when not using a tty]' \
-	'(-q --quiet)'{-q,--quiet}'[Be quiet]' \
+	'(-v --version)'{-v,--version}'[Print the version (of swaymsg) and quit]' \
+	'(-m --monitor)'{-m,--monitor}'[Monitor for responses until killed instead of exiting after the first response]' \
+	'(-p --pretty)'{-p,--pretty}'[Use raw output even when not using a tty]' \
+	'(-q --quiet)'{-q,--quiet}'[Send the IPC message but do not print the response from sway]' \
 	'(-r --raw)'{-r,--raw}'[Use raw output even if using a tty]' \
-	'(-s --socket)'{-s,--socket}'[Use the specified socket path]:files:_files' \
-	'(-t --type)'{-t,--type}'[Specify the message type]:type:{_describe "type" types}' \
-	'(-v --version)'{-v,--version}'[Show the version number and quit]'
+	'(-s --socket)'{-s,--socket=}'[Use the specified socket path]:socket:_files -g "*(=,/)"' \
+	'(-t --type)'{-t,--type=}'[Specify the type of IPC message]:ipc type:_sway_ipc_types' \
+	'*::sway command:= _swaymsg_payload'
+
+# vim: set fdm=marker:

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -696,7 +696,7 @@ The default colors are:
 *unbindswitch* <switch>:<state>
 	Removes a binding for when <switch> changes to <state>.
 
-*unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--input-device=<device>] <key combo>
+*unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--to-code] [--input-device=<device>] <key combo>
 	Removes the binding for _key combo_ that was previously bound with the
 	given flags.  If _input-device_ is given, only the binding for that
 	input device will be unbound.


### PR DESCRIPTION
So this started as just a personal thing when I could never remember the order of some arguments to sway commands in swaymsg and I added to it over time. Now I've cleaned it up and made it more complete. The main new things are:
- Complete sway commands and their arguments where appropriate
- Complete criteria attributes where appropriate
- Complete sway-ipc event types for subscribe where appropriate
- A boat load of descriptions mostly copy/pasted from the man pages for you to read if you have verbose menu completions on

Some nouns, like input device identifiers, are only offered completions if the user has jq installed, as sway/swaymsg doesn't really have an output format that's particularly suitable for parsing in the shell. Users without jq shouldn't have any issues though.

I had to read the man pages a lot and I noticed some errors. Looks like few are already fixed (I'm on 1.2) but I included the --to-code flag for unbindsym in sway(5) (and in the completion definition) because it appears to be valid in the case and worked as expected for me when I tried it. Also in sway-input(5), repeat_rate and repeat_delay are documented twice: once up front and again under "libinput configuration". I left the man page alone because I'm not sure which instance should be removed.

So yeah if you're a zsh user try these out. I tried to test them a lot, but the completions are quite long now so I might have missed something. Thanks to the folks on #zsh freenode and the zsh-users mailing list who helped answer my questions.