### PR TITLE
Error out on unknown debug flag

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -211,6 +211,8 @@ void enable_debug_flag(const char *flag) {
 		debug.txn_timings = true;
 	} else if (strncmp(flag, "txn-timeout=", 12) == 0) {
 		server.txn_timeout_ms = atoi(&flag[12]);
+	} else {
+		sway_log(SWAY_ERROR, "Unknown debug flag: %s", flag);
 	}
 }
 


### PR DESCRIPTION
Otehrwise it's pretty easy to misremember a flag and think damage=rerender is
enabled when it's not.