### PR TITLE
Create container before selecting workspace

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -566,6 +566,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 	view->surface = wlr_surface;
 	view_populate_pid(view);
+	view->container = container_create(view);
 
 	// If there is a request to be opened fullscreen on a specific output, try
 	// to honor that request. Otherwise, fallback to assigns, pid mappings,
@@ -592,7 +593,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		ws = seat_get_last_known_workspace(seat);
 	}
 
-	view->container = container_create(view);
 	if (target_sibling) {
 		container_add_sibling(target_sibling, view->container, 1);
 	} else if (ws) {


### PR DESCRIPTION
This is my attempt at fixing #4578 . This is my first time working on sway, so sorry if there is a glaring issue with the patch.

My understanding is this: some criteria like 'tiling' and 'floating' predicates need a container to determine if they match. When container is null it causes a segfault. All I've done is move container_create earlier in view_map so that it precedes select_workspace and all the criteria can check matches without error.

This avoids the segfault for me, and it doesn't seem that view is modified in the intermediate code, so I don't think there will be unintended side-effects.