### PR TITLE
build: update wlroots version, be more strict

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ rt             = cc.find_library('rt')
 git            = find_program('git', native: true, required: false)
 
 # Try first to find wlroots as a subproject, then as a system dependency
-wlroots_version = '>=0.6'
+wlroots_version = ['>=0.7.0', '<0.8.0']
 wlroots_proj = subproject(
 	'wlroots',
 	default_options: ['rootston=false', 'examples=false'],


### PR DESCRIPTION
wlroots versions are incompatible with each other. Often our users struggle
with figuring out that their wlroots version is too old after a new release.
Use a more strict version check to prevent building sway with incompatible
wlroots versions.