### PR TITLE
Repaint scheduling

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -271,6 +271,7 @@ sway_cmd output_cmd_background;
 sway_cmd output_cmd_disable;
 sway_cmd output_cmd_dpms;
 sway_cmd output_cmd_enable;
+sway_cmd output_cmd_max_render_time;
 sway_cmd output_cmd_mode;
 sway_cmd output_cmd_position;
 sway_cmd output_cmd_scale;

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -145,6 +145,7 @@ sway_cmd cmd_kill;
 sway_cmd cmd_layout;
 sway_cmd cmd_log_colors;
 sway_cmd cmd_mark;
+sway_cmd cmd_max_render_time;
 sway_cmd cmd_mode;
 sway_cmd cmd_mouse_warping;
 sway_cmd cmd_move;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -212,6 +212,7 @@ struct output_config {
 	float scale;
 	int32_t transform;
 	enum wl_output_subpixel subpixel;
+	int max_render_time; // In milliseconds
 
 	char *background;
 	char *background_option;

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -72,7 +72,7 @@ struct sway_output *output_get_in_direction(struct sway_output *reference,
 void output_add_workspace(struct sway_output *output,
 		struct sway_workspace *workspace);
 
-typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
+typedef void (*sway_surface_iterator_func_t)(struct sway_output *output, struct sway_view *view,
 	struct wlr_surface *surface, struct wlr_box *box, float rotation,
 	void *user_data);
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -51,6 +51,11 @@ struct sway_output {
 	struct {
 		struct wl_signal destroy;
 	} events;
+
+	struct timespec last_presentation;
+	uint32_t refresh_nsec;
+	int max_render_time; // In milliseconds
+	struct wl_event_source *repaint_timer;
 };
 
 struct sway_output *output_create(struct wlr_output *wlr_output);
@@ -70,6 +75,8 @@ void output_add_workspace(struct sway_output *output,
 typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
 	struct wlr_surface *surface, struct wlr_box *box, float rotation,
 	void *user_data);
+
+int output_repaint_timer_handler(void *data);
 
 void output_damage_whole(struct sway_output *output);
 

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -28,6 +28,8 @@ struct sway_server {
 	struct wlr_backend *noop_backend;
 
 	struct wlr_compositor *compositor;
+	struct wl_listener compositor_new_surface;
+
 	struct wlr_data_device_manager *data_device_manager;
 
 	struct sway_input_manager *input;
@@ -99,6 +101,7 @@ void server_fini(struct sway_server *server);
 bool server_start(struct sway_server *server);
 void server_run(struct sway_server *server);
 
+void handle_compositor_new_surface(struct wl_listener *listener, void *data);
 void handle_new_output(struct wl_listener *listener, void *data);
 
 void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);

--- a/include/sway/surface.h
+++ b/include/sway/surface.h
@@ -6,6 +6,13 @@ struct sway_surface {
 	struct wlr_surface *wlr_surface;
 
 	struct wl_listener destroy;
+
+	/**
+	 * This timer can be used for issuing delayed frame done callbacks (for
+	 * example, to improve presentation latency). Its handler is set to a
+	 * function that issues a frame done callback to this surface.
+	 */
+	struct wl_event_source *frame_done_timer;
 };
 
 #endif

--- a/include/sway/surface.h
+++ b/include/sway/surface.h
@@ -1,0 +1,11 @@
+#ifndef _SWAY_SURFACE_H
+#define _SWAY_SURFACE_H
+#include <wlr/types/wlr_surface.h>
+
+struct sway_surface {
+	struct wlr_surface *wlr_surface;
+
+	struct wl_listener destroy;
+};
+
+#endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -108,6 +108,8 @@ struct sway_view {
 	} events;
 
 	struct wl_listener surface_new_subsurface;
+
+	int max_render_time; // In milliseconds
 };
 
 struct sway_xdg_shell_view {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -119,6 +119,7 @@ static struct cmd_handler command_handlers[] = {
 	{ "kill", cmd_kill },
 	{ "layout", cmd_layout },
 	{ "mark", cmd_mark },
+	{ "max_render_time", cmd_max_render_time },
 	{ "move", cmd_move },
 	{ "nop", cmd_nop },
 	{ "opacity", cmd_opacity },

--- a/sway/commands/max_render_time.c
+++ b/sway/commands/max_render_time.c
@@ -1,0 +1,32 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/view.h"
+
+struct cmd_results *cmd_max_render_time(int argc, char **argv) {
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, "Missing max render time argument.");
+	}
+
+	int max_render_time;
+	if (!strcmp(*argv, "off")) {
+		max_render_time = 0;
+	} else {
+		char *end;
+		max_render_time = strtol(*argv, &end, 10);
+		if (*end || max_render_time <= 0) {
+			return cmd_results_new(CMD_INVALID, "Invalid max render time.");
+		}
+	}
+
+	struct sway_container *container = config->handler_context.container;
+	if (!container || !container->view) {
+		return cmd_results_new(CMD_INVALID,
+				"Only views can have a max_render_time");
+	}
+
+	struct sway_view *view = container->view;
+	view->max_render_time = max_render_time;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -12,6 +12,7 @@ static struct cmd_handler output_handlers[] = {
 	{ "disable", output_cmd_disable },
 	{ "dpms", output_cmd_dpms },
 	{ "enable", output_cmd_enable },
+	{ "max_render_time", output_cmd_max_render_time },
 	{ "mode", output_cmd_mode },
 	{ "pos", output_cmd_position },
 	{ "position", output_cmd_position },

--- a/sway/commands/output/max_render_time.c
+++ b/sway/commands/output/max_render_time.c
@@ -1,0 +1,28 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+struct cmd_results *output_cmd_max_render_time(int argc, char **argv) {
+	if (!config->handler_context.output_config) {
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
+	}
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, "Missing max render time argument.");
+	}
+
+	int max_render_time;
+	if (!strcmp(*argv, "off")) {
+		max_render_time = 0;
+	} else {
+		char *end;
+		max_render_time = strtol(*argv, &end, 10);
+		if (*end || max_render_time <= 0) {
+			return cmd_results_new(CMD_INVALID, "Invalid max render time.");
+		}
+	}
+	config->handler_context.output_config->max_render_time = max_render_time;
+
+	config->handler_context.leftovers.argc = argc - 1;
+	config->handler_context.leftovers.argv = argv + 1;
+	return NULL;
+}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -47,6 +47,7 @@ struct output_config *new_output_config(const char *name) {
 	oc->scale = -1;
 	oc->transform = -1;
 	oc->subpixel = WL_OUTPUT_SUBPIXEL_UNKNOWN;
+	oc->max_render_time = -1;
 	return oc;
 }
 
@@ -80,6 +81,9 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 	}
 	if (src->transform != -1) {
 		dst->transform = src->transform;
+	}
+	if (src->max_render_time != -1) {
+		dst->max_render_time = src->max_render_time;
 	}
 	if (src->background) {
 		free(dst->background);
@@ -153,11 +157,12 @@ static void merge_id_on_name(struct output_config *oc) {
 			list_add(config->output_configs, ion_oc);
 			sway_log(SWAY_DEBUG, "Generated id on name output config \"%s\""
 				" (enabled: %d) (%dx%d@%fHz position %d,%d scale %f "
-				"transform %d) (bg %s %s) (dpms %d)", ion_oc->name,
-				ion_oc->enabled, ion_oc->width, ion_oc->height,
+				"transform %d) (bg %s %s) (dpms %d) (max render time: %d)",
+				ion_oc->name, ion_oc->enabled, ion_oc->width, ion_oc->height,
 				ion_oc->refresh_rate, ion_oc->x, ion_oc->y, ion_oc->scale,
 				ion_oc->transform, ion_oc->background,
-				ion_oc->background_option, ion_oc->dpms_state);
+				ion_oc->background_option, ion_oc->dpms_state,
+				ion_oc->max_render_time);
 		}
 	}
 	free(id_on_name);
@@ -197,10 +202,12 @@ struct output_config *store_output_config(struct output_config *oc) {
 	}
 
 	sway_log(SWAY_DEBUG, "Config stored for output %s (enabled: %d) (%dx%d@%fHz "
-		"position %d,%d scale %f subpixel %s transform %d) (bg %s %s) (dpms %d)",
+		"position %d,%d scale %f subpixel %s transform %d) (bg %s %s) (dpms %d) "
+		"(max render time: %d)",
 		oc->name, oc->enabled, oc->width, oc->height, oc->refresh_rate,
 		oc->x, oc->y, oc->scale, sway_wl_output_subpixel_to_string(oc->subpixel),
-		oc->transform, oc->background, oc->background_option, oc->dpms_state);
+		oc->transform, oc->background, oc->background_option, oc->dpms_state,
+		oc->max_render_time);
 
 	return oc;
 }
@@ -325,6 +332,12 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		wlr_output_enable(wlr_output, false);
 	}
 
+	if (oc && oc->max_render_time >= 0) {
+		sway_log(SWAY_DEBUG, "Set %s max render time to %d",
+			oc->name, oc->max_render_time);
+		output->max_render_time = oc->max_render_time;
+	}
+
 	return true;
 }
 
@@ -343,6 +356,7 @@ static void default_output_config(struct output_config *oc,
 	oc->subpixel = output->detected_subpixel;
 	oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;
 	oc->dpms_state = DPMS_ON;
+	oc->max_render_time = 0;
 }
 
 static struct output_config *get_output_config(char *identifier,
@@ -396,10 +410,11 @@ static struct output_config *get_output_config(char *identifier,
 
 		sway_log(SWAY_DEBUG, "Generated output config \"%s\" (enabled: %d)"
 			" (%dx%d@%fHz position %d,%d scale %f transform %d) (bg %s %s)"
-			" (dpms %d)", result->name, result->enabled, result->width,
-			result->height, result->refresh_rate, result->x, result->y,
-			result->scale, result->transform, result->background,
-			result->background_option, result->dpms_state);
+			" (dpms %d) (max render time: %d)", result->name, result->enabled,
+			result->width, result->height, result->refresh_rate,
+			result->x, result->y, result->scale, result->transform,
+			result->background, result->background_option, result->dpms_state,
+			result->max_render_time);
 	} else if (oc_name) {
 		// No identifier config, just return a copy of the name config
 		free(result->name);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -508,6 +508,10 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 
 int output_repaint_timer_handler(void *data) {
 	struct sway_output *output = data;
+	if (output->wlr_output == NULL) {
+		return 0;
+	}
+
 	output->wlr_output->block_idle_frame = false;
 
 	struct sway_workspace *workspace = output->current.active_workspace;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -97,7 +97,7 @@ damage_finish:
 	pixman_region32_fini(&damage);
 }
 
-static void render_surface_iterator(struct sway_output *output,
+static void render_surface_iterator(struct sway_output *output, struct sway_view *view,
 		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
 		void *_data) {
 	struct render_data *data = _data;
@@ -214,11 +214,11 @@ static void render_view_toplevels(struct sway_view *view,
 			render_surface_iterator, &data);
 }
 
-static void render_popup_iterator(struct sway_output *output,
+static void render_popup_iterator(struct sway_output *output, struct sway_view *view,
 		struct wlr_surface *surface, struct wlr_box *box, float rotation,
 		void *data) {
 	// Render this popup's surface
-	render_surface_iterator(output, surface, box, rotation, data);
+	render_surface_iterator(output, view, surface, box, rotation, data);
 
 	// Render this popup's child toplevels
 	output_surface_for_each_surface(output, surface, box->x, box->y,

--- a/sway/desktop/surface.c
+++ b/sway/desktop/surface.c
@@ -1,4 +1,6 @@
+#define _POSIX_C_SOURCE 200112L
 #include <stdlib.h>
+#include <time.h>
 #include <wlr/types/wlr_surface.h>
 #include "sway/server.h"
 #include "sway/surface.h"
@@ -9,7 +11,19 @@ void handle_destroy(struct wl_listener *listener, void *data) {
 	surface->wlr_surface->data = NULL;
 	wl_list_remove(&surface->destroy.link);
 
+	wl_event_source_remove(surface->frame_done_timer);
+
 	free(surface);
+}
+
+static int surface_frame_done_timer_handler(void *data) {
+	struct sway_surface *surface = data;
+
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	wlr_surface_send_frame_done(surface->wlr_surface, &now);
+
+	return 0;
 }
 
 void handle_compositor_new_surface(struct wl_listener *listener, void *data) {
@@ -21,4 +35,7 @@ void handle_compositor_new_surface(struct wl_listener *listener, void *data) {
 
 	surface->destroy.notify = handle_destroy;
 	wl_signal_add(&wlr_surface->events.destroy, &surface->destroy);
+
+	surface->frame_done_timer = wl_event_loop_add_timer(server.wl_event_loop,
+		surface_frame_done_timer_handler, surface);
 }

--- a/sway/desktop/surface.c
+++ b/sway/desktop/surface.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <wlr/types/wlr_surface.h>
+#include "sway/server.h"
+#include "sway/surface.h"
+
+void handle_destroy(struct wl_listener *listener, void *data) {
+	struct sway_surface *surface = wl_container_of(listener, surface, destroy);
+
+	surface->wlr_surface->data = NULL;
+	wl_list_remove(&surface->destroy.link);
+
+	free(surface);
+}
+
+void handle_compositor_new_surface(struct wl_listener *listener, void *data) {
+	struct wlr_surface *wlr_surface = data;
+
+	struct sway_surface *surface = calloc(1, sizeof(struct sway_surface));
+	surface->wlr_surface = wlr_surface;
+	wlr_surface->data = surface;
+
+	surface->destroy.notify = handle_destroy;
+	wl_signal_add(&wlr_surface->events.destroy, &surface->destroy);
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -224,6 +224,8 @@ static void ipc_json_describe_output(struct sway_output *output,
 				* ((double)output->height / parent_box.height);
 		json_object_object_add(object, "percent", json_object_new_double(percent));
 	}
+
+	json_object_object_add(object, "max_render_time", json_object_new_int(output->max_render_time));
 }
 
 json_object *ipc_json_describe_disabled_output(struct sway_output *output) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -418,6 +418,8 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	struct wlr_box geometry = {0, 0, c->view->natural_width, c->view->natural_height};
 	json_object_object_add(object, "geometry", ipc_json_create_rect(&geometry));
 
+	json_object_object_add(object, "max_render_time", json_object_new_int(c->view->max_render_time));
+
 #if HAVE_XWAYLAND
 	if (c->view->type == SWAY_VIEW_XWAYLAND) {
 		json_object_object_add(object, "window",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -68,6 +68,7 @@ sway_sources = files(
 	'commands/inhibit_idle.c',
 	'commands/kill.c',
 	'commands/mark.c',
+	'commands/max_render_time.c',
 	'commands/opacity.c',
 	'commands/include.c',
 	'commands/input.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -16,6 +16,7 @@ sway_sources = files(
 	'desktop/layer_shell.c',
 	'desktop/output.c',
 	'desktop/render.c',
+	'desktop/surface.c',
 	'desktop/transaction.c',
 	'desktop/xdg_shell.c',
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -175,6 +175,7 @@ sway_sources = files(
 	'commands/output/disable.c',
 	'commands/output/dpms.c',
 	'commands/output/enable.c',
+	'commands/output/max_render_time.c',
 	'commands/output/mode.c',
 	'commands/output/position.c',
 	'commands/output/scale.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -59,6 +59,10 @@ bool server_init(struct sway_server *server) {
 	wlr_renderer_init_wl_display(renderer, server->wl_display);
 
 	server->compositor = wlr_compositor_create(server->wl_display, renderer);
+	server->compositor_new_surface.notify = handle_compositor_new_surface;
+	wl_signal_add(&server->compositor->events.new_surface,
+		&server->compositor_new_surface);
+
 	server->data_device_manager =
 		wlr_data_device_manager_create(server->wl_display);
 

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -134,6 +134,12 @@ must be separated by one space. For example:
 	To achieve even lower latency, see the *max_render_time* surface
 	property in *sway*(5).
 
+	Note that this property has an effect only on backends which report the
+	presentation timestamp and the predicted output refresh rate—the DRM
+	and the Wayland backends. Furthermore, under the Wayland backend the
+	optimal max_render_time value may vary based on the parent compositor
+	rendering timings.
+
 # SEE ALSO
 
 *sway*(5) *sway-input*(5)

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -107,6 +107,30 @@ must be separated by one space. For example:
 	Enables or disables the specified output via DPMS. To turn an output off
 	(ie. blank the screen but keep workspaces as-is), one can set DPMS to off.
 
+*output* <name> max_render_time off|<msec>
+	When set to a positive number of milliseconds, enables delaying output
+	rendering to reduce latency. The rendering is delayed in such a way as
+	to leave the specified number of milliseconds before the next
+	presentation for rendering.
+
+	The output rendering normally takes place immediately after a
+	presentation (vblank, buffer flip, etc.) and the frame callbacks are
+	sent to surfaces immediately after the rendering to give surfaces the
+	most time to draw their next frame. This results in slightly below 2
+	frames of latency between the surface rendering and committing new
+	contents, and the contents being shown on screen, on average. When the
+	output rendering is delayed, the frame callbacks are sent immediately
+	after presentation, and the surfaces have a small timespan (1 /
+	(refresh rate) - max_render_time) to render and commit new contents to
+	be shown on the next presentation, resulting in below 1 frame of
+	latency.
+
+	To set this up for optimal latency:
+	. Launch some _full-screen_ application that renders continuously, like
+	  *glxgears*.
+	. Start with *max_render_time 1*. Increment by *1* if you see frame
+	  drops.
+
 # SEE ALSO
 
 *sway*(5) *sway-input*(5)

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -131,6 +131,9 @@ must be separated by one space. For example:
 	. Start with *max_render_time 1*. Increment by *1* if you see frame
 	  drops.
 
+	To achieve even lower latency, see the *max_render_time* surface
+	property in *sway*(5).
+
 # SEE ALSO
 
 *sway*(5) *sway-input*(5)

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -182,6 +182,22 @@ set|plus|minus <amount>
 *layout* toggle [split|tabbed|stacking|splitv|splith] [split|tabbed|stacking|splitv|splith]...
 	Cycles the layout mode of the focused container through a list of layouts.
 
+*max_render_time* off|<msec>
+	Works together with *output max_render_time* to reduce the latency even
+	further by delaying the frame callbacks sent to a surface. When set to
+	a positive number of milliseconds, delays the frame callback in such a
+	way that the surface has the specified number of milliseconds to render
+	and commit new contents before being sampled by the compositor for the
+	next presentation. See *max_render_time* in *sway-output*(5) for
+	further details.
+
+	To set this up for optimal latency:
+	. Set up *output max_render_time*.
+	. Put the target application in _full-screen_ and have it continuously
+	  render something.
+	. Start by setting *max_render_time 1*. If the application drops
+	  frames, increment by *1*.
+
 *move* left|right|up|down [<px> px]
 	Moves the focused container in the direction specified. If the container,
 	the optional _px_ argument specifies how many pixels to move the container.

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -242,6 +242,7 @@ void output_destroy(struct sway_output *output) {
 	}
 	list_free(output->workspaces);
 	list_free(output->current.workspaces);
+	wl_event_source_remove(output->repaint_timer);
 	free(output);
 }
 

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -189,13 +189,14 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(o, "focused", &focused);
 	json_object_object_get_ex(o, "active", &active);
 	json_object_object_get_ex(o, "current_workspace", &ws);
-	json_object *make, *model, *serial, *scale, *subpixel, *transform;
+	json_object *make, *model, *serial, *scale, *subpixel, *transform, *max_render_time;
 	json_object_object_get_ex(o, "make", &make);
 	json_object_object_get_ex(o, "model", &model);
 	json_object_object_get_ex(o, "serial", &serial);
 	json_object_object_get_ex(o, "scale", &scale);
 	json_object_object_get_ex(o, "subpixel_hinting", &subpixel);
 	json_object_object_get_ex(o, "transform", &transform);
+	json_object_object_get_ex(o, "max_render_time", &max_render_time);
 	json_object *x, *y;
 	json_object_object_get_ex(rect, "x", &x);
 	json_object_object_get_ex(rect, "y", &y);
@@ -215,7 +216,8 @@ static void pretty_print_output(json_object *o) {
 			"  Scale factor: %f\n"
 			"  Subpixel hinting: %s\n"
 			"  Transform: %s\n"
-			"  Workspace: %s\n",
+			"  Workspace: %s\n"
+			"  Max render time: ",
 			json_object_get_string(name),
 			json_object_get_string(make),
 			json_object_get_string(model),
@@ -230,6 +232,8 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_string(transform),
 			json_object_get_string(ws)
 		);
+		int max_render_time_int = json_object_get_int(max_render_time);
+		printf(max_render_time_int == 0 ? "off\n" : "%d ms\n", max_render_time_int);
 	} else {
 		printf(
 			"Output %s '%s %s %s' (inactive)\n",


### PR DESCRIPTION
Requires https://github.com/swaywm/wlroots/pull/1832.

This PR establishes the necessary infrastructure to delay output renders and frame callbacks to reduce the visual latency between a surface committing new contents and the contents being shown on-screen. Additionally, it adds configurable **constant** delays to individual output renders, and to individual view frame callbacks. The way the code is structured makes it possible to subsequently add some kind of an _adaptive_ mode which figures out the delays automatically for lowest possible latency with minimal dropped frames.

For more details on how this works see [how it's done in Weston](https://www.collabora.com/about-us/blog/2015/02/12/weston-repaint-scheduling/): this PR does pretty much the exact same thing, except it also adds frame callback delaying. Also see https://github.com/swaywm/wlroots/issues/655#issuecomment-511098029 for my comments after implementing a proof-of-concept of this in rootston.

Currently undergoing dogfooding, thus far seems to work well. I have a test client which renders on frame callbacks and prints the delay from receiving a frame callback and the subsequent presentation time. Using this client, I was able to monitor a drop in latency from a little less than 2 frames on the default configuration to about half a frame on two different setups.

How to set up the constants:
1. `output max_render_time`. Run something animating and full-screen, like `glxgears` (as I noted in https://github.com/swaywm/wlroots/issues/655#issuecomment-511098029, the damaged region affects the commit time). Start with `1`, then go up if you see frame drops. On my laptop with an integrated Intel graphics card this works out to be about `5`–`6` ms (Weston went with `7` by default). My desktop with an AMD GPU can easily do `1` (the lowest value).
1. View `max_render_time`. This one will vary per application (since every application obviously takes a different time to render). Run the application full-screen, start with `1`, increase until it stops dropping frames. My test client runs well at `2`, and a game I'm playing runs well at `3`. I haven't tried adjusting this for anything else because I don't really need those extra couple of milliseconds of reduced latency for anything else.