### PR TITLE
Fix direct scan-out flickering

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -927,72 +927,6 @@ static void render_seatops(struct sway_output *output,
 	}
 }
 
-static void count_surface_iterator(struct sway_output *output,
-		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
-		void *data) {
-	size_t *n = data;
-	(*n)++;
-}
-
-static bool scan_out_fullscreen_view(struct sway_output *output,
-		struct sway_view *view) {
-	struct wlr_output *wlr_output = output->wlr_output;
-	struct sway_workspace *workspace = output->current.active_workspace;
-	if (!sway_assert(workspace, "Expected an active workspace")) {
-		return false;
-	}
-
-	if (view->saved_buffer) {
-		return false;
-	}
-
-	for (int i = 0; i < workspace->current.floating->length; ++i) {
-		struct sway_container *floater =
-			workspace->current.floating->items[i];
-		if (container_is_transient_for(floater, view->container)) {
-			return false;
-		}
-	}
-
-#if HAVE_XWAYLAND
-	if (!wl_list_empty(&root->xwayland_unmanaged)) {
-		return false;
-	}
-#endif
-
-	if (!wl_list_empty(&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY])) {
-		return false;
-	}
-	if (!wl_list_empty(&root->drag_icons)) {
-		return false;
-	}
-
-	struct wlr_surface *surface = view->surface;
-	if (surface == NULL) {
-		return false;
-	}
-	size_t n_surfaces = 0;
-	output_view_for_each_surface(output, view,
-		count_surface_iterator, &n_surfaces);
-	if (n_surfaces != 1) {
-		return false;
-	}
-
-	if (surface->buffer == NULL) {
-		return false;
-	}
-
-	if ((float)surface->current.scale != wlr_output->scale ||
-			surface->current.transform != wlr_output->transform) {
-		return false;
-	}
-
-	if (!wlr_output_attach_buffer(wlr_output, surface->buffer)) {
-		return false;
-	}
-	return wlr_output_commit(wlr_output);
-}
-
 void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
@@ -1012,25 +946,6 @@ void output_render(struct sway_output *output, struct timespec *when,
 	struct sway_container *fullscreen_con = root->fullscreen_global;
 	if (!fullscreen_con) {
 		fullscreen_con = workspace->current.fullscreen;
-	}
-
-	if (fullscreen_con && fullscreen_con->view) {
-		// Try to scan-out the fullscreen view
-		static bool last_scanned_out = false;
-		bool scanned_out =
-			scan_out_fullscreen_view(output, fullscreen_con->view);
-
-		if (scanned_out && !last_scanned_out) {
-			sway_log(SWAY_DEBUG, "Scanning out fullscreen view");
-		}
-		if (last_scanned_out && !scanned_out) {
-			sway_log(SWAY_DEBUG, "Stopping fullscreen view scan out");
-		}
-		last_scanned_out = scanned_out;
-
-		if (scanned_out) {
-			return;
-		}
 	}
 
 	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);


### PR DESCRIPTION
Sometimes when using direct scan-out, some flickering between the
fullscreen app and the regular desktop could be seen.

This happened because we called wlr_output_attach_render and then
wlr_output_attach_buffer for direct scan-out. wlr_output_attach_render
makes the OpenGL context current but also attaches the OpenGL buffer to
the primary plane apparently (all of this happens inside
eglMakeCurrent).

This patch moves the scan-out logic outside of output_render, before
wlr_output_attach_render. This lines it up with rootston's
implementation. This also makes more sense since no rendering is
involved when using direct scan-out.

Sorry about that, I should've tested this with more clients. The new
code has been tested with mpv and a GLFW demo.