### PR TITLE
xdg_shell: remember size supplied by surface

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -290,6 +290,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
+			wlr_xdg_toplevel_set_size(xdg_surface, new_geo.width, new_geo.height);
 			desktop_damage_view(view);
 			transaction_commit_dirty();
 		} else {


### PR DESCRIPTION
Evince sends new (cached?) size when opening document from recents. It hits `unexpected new size handling` for floating and fullscreen views in xdg_shell and produces weird results for tiled view. New size isn't stored in window properties and old size is sent in next `configure` (for example, when focus leaves the window), fixing the glitched state

![2019-09-27-18-16-44](https://user-images.githubusercontent.com/3686499/65780977-8156df00-e153-11e9-9648-be515f50b8a2.png)
![2019-09-27-18-16-48](https://user-images.githubusercontent.com/3686499/65780975-8156df00-e153-11e9-97ed-addc081969b5.png)
![2019-09-27-18-16-49](https://user-images.githubusercontent.com/3686499/65780973-8156df00-e153-11e9-89e4-9b3b42497e2d.png)
![2019-09-27-18-14-50](https://user-images.githubusercontent.com/3686499/65780984-81ef7580-e153-11e9-81dc-5f88fbc7585f.png)
![2019-09-27-18-14-53](https://user-images.githubusercontent.com/3686499/65780982-81ef7580-e153-11e9-8c7c-85ebc7cbf127.png)
![2019-09-27-18-14-55](https://user-images.githubusercontent.com/3686499/65780981-81ef7580-e153-11e9-9ded-1fff7f5e6b23.png)

I see three possible fixes sway could implement:
1) Immediately resend configure hoping view will be happy with it (presented here)
2) Save requested size and relayout workspace (I don't know how sway handles tiled windows refusing to resize)
3) Make window floating