### PR TITLE
layer-shell: Fix damage tracking of nested popups

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -373,10 +373,8 @@ static void popup_damage(struct sway_layer_popup *layer_popup, bool whole) {
 	while (true) {
 		if (layer_popup->parent_type == LAYER_PARENT_POPUP) {
 			layer_popup = layer_popup->parent_popup;
-			ox += layer_popup->wlr_popup->base->geometry.x +
-				layer_popup->wlr_popup->geometry.x;
-			oy += layer_popup->wlr_popup->base->geometry.y +
-				layer_popup->wlr_popup->geometry.y;
+			ox += layer_popup->wlr_popup->geometry.x;
+			oy += layer_popup->wlr_popup->geometry.y;
 		} else {
 			layer = layer_popup->parent_layer;
 			ox += layer->geo.x;


### PR DESCRIPTION
Popups are positioned relative to local surface coordinates of the parent surface. There's no need to consider values set with `xdg_surface.set_window_geometry` for parent surfaces.

This fixes damaging issues in mate-panel.