### PR TITLE
Introduce pid criteria token

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -46,6 +46,7 @@ struct criteria {
 	bool tiling;
 	char urgent; // 'l' for latest or 'o' for oldest
 	struct pattern *workspace;
+	pid_t pid;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -31,7 +31,8 @@ bool criteria_is_empty(struct criteria *criteria) {
 		&& !criteria->floating
 		&& !criteria->tiling
 		&& !criteria->urgent
-		&& !criteria->workspace;
+		&& !criteria->workspace
+		&& !criteria->pid;
 }
 
 // The error pointer is used for parsing functions, and saves having to pass it
@@ -370,6 +371,12 @@ static bool criteria_matches_view(struct criteria *criteria,
 		}
 	}
 
+	if (criteria->pid) {
+		if (criteria->pid != view->pid) {
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -458,6 +465,7 @@ enum criteria_token {
 	T_TITLE,
 	T_URGENT,
 	T_WORKSPACE,
+	T_PID,
 
 	T_INVALID,
 };
@@ -493,6 +501,8 @@ static enum criteria_token token_from_name(char *name) {
 		return T_TILING;
 	} else if (strcmp(name, "floating") == 0) {
 		return T_FLOATING;
+	} else if (strcmp(name, "pid") == 0) {
+		return T_PID;
 	}
 	return T_INVALID;
 }
@@ -586,6 +596,12 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		break;
 	case T_WORKSPACE:
 		pattern_create(&criteria->workspace, value);
+		break;
+	case T_PID:
+		criteria->pid = strtoul(value, &endptr, 10);
+		if (*endptr != 0) {
+			error = strdup("The value for 'pid' should be numeric");
+		}
 		break;
 	case T_INVALID:
 		break;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -850,6 +850,9 @@ The following attributes may be matched with:
 	value is \_\_focused\_\_, then the window instance must be the same as that
 	of the currently focused window.
 
+*pid*
+	Compare value against the window's process ID. Must be numeric.
+
 *shell*
 	Compare value against the window shell, such as "xdg_shell" or "xwayland".
 	Can be a regular expression. If value is \_\_focused\_\_, then the shell


### PR DESCRIPTION
One of my barriers to switching to a Wayland native terminal emulator is the lack of urgency support. I have my shell configured to echo a bell character when commands are completed, which makes most X terminal emulators set the window to urgent. This is generally not possible in Wayland due to no native urgency support.

With this patch I can apply this behaviour in a Wayland native terminal using the following in my `~/.zshrc`:

    precmd() {
        swaymsg "[pid=$PPID] urgent enable"
    }

So when a shell command completes, zsh runs that swaymsg command with the PID of the terminal emulator. Sway then sets the terminal emulator to urgent.

You can test it by putting the above in your zsh config, then run `sleep 1` in a Wayland native terminal and focus away before the sleep completes. This assumes your terminal emulator uses one process per window.
