### PR TITLE
sway(5): Add a missing verb, highlight a valid value in the description of tiling_drag

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -675,7 +675,7 @@ The default colors are:
 
 *tiling_drag*  enable|disable|toggle
 	Sets whether or not tiling containers can be dragged with the mouse. If
-	enabled (default), the _floating_mod_ can be used to drag tiling, as well
+	_enabled_ (default), the _floating_mod_ can be used to drag tiling, as well
 	as floating, containers. Using the left mouse button on title bars without
 	the _floating_mod_ will also allow the container to be dragged. _toggle_
 	should not be used in the config file.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -628,7 +628,7 @@ The default colors are:
 	is specified mark will remove _identifier_ if it is already marked.
 
 *mode* <mode>
-	Switches to the specified mode. The default mode _default_.
+	Switches to the specified mode. The default mode is _default_.
 
 *mode* [--pango_markup] <mode> <mode-subcommands...>
 	The only valid _mode-subcommands..._ are *bindsym*, *bindcode*,


### PR DESCRIPTION
Just like the title / commit messages say. Both of the changes follow the style used in other descriptions.