### PR TITLE
criteria: make literal comparison for __focused__ values

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -14,29 +14,38 @@ enum criteria_type {
 	CT_NO_FOCUS                = 1 << 4,
 };
 
+enum pattern_type {
+	PATTERN_PCRE,
+	PATTERN_FOCUSED,
+};
+
+struct pattern {
+	enum pattern_type match_type;
+	pcre *regex;
+};
+
 struct criteria {
 	enum criteria_type type;
 	char *raw; // entire criteria string (for logging)
 	char *cmdlist;
 	char *target; // workspace or output name for `assign` criteria
 
-	bool autofail; // __focused__ while no focus or n/a for focused view
-	pcre *title;
-	pcre *shell;
-	pcre *app_id;
-	pcre *con_mark;
+	struct pattern *title;
+	struct pattern *shell;
+	struct pattern *app_id;
+	struct pattern *con_mark;
 	uint32_t con_id; // internal ID
 #if HAVE_XWAYLAND
-	pcre *class;
+	struct pattern *class;
 	uint32_t id; // X11 window ID
-	pcre *instance;
-	pcre *window_role;
+	struct pattern *instance;
+	struct pattern *window_role;
 	enum atom_name window_type;
 #endif
 	bool floating;
 	bool tiling;
 	char urgent; // 'l' for latest or 'o' for oldest
-	pcre *workspace;
+	struct pattern *workspace;
 };
 
 bool criteria_is_empty(struct criteria *criteria);


### PR DESCRIPTION
This is another fix for #4586 which replaces #4587.

This time, I have modified criteria to make a literal comparison rather than a regex comparison when the attribute value is `__focused__`. The behavior should now better match [i3's logic](https://github.com/i3/i3/blob/7db0d179a3aa659f1dc109012d253403094c72a2/src/match.c) .

previously, the criteria->autofail field was used to disqualify criteria that had a `__focused__` attribute value, but had no focused container at the time of parsing. Criteria now compare against the focused container at match time, like i3 does, so the field is no longer necessary, but criteria should have the same matching behavior as before.

con_id never made a regex comparison in the first place, so I kept the logic the same. When there is no focused container, criteria->con_id will be 0 and always fail, like before.