### PR TITLE
view_from_wlr_xwayland_surface(): fix miscasting of types

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -574,7 +574,7 @@ static void handle_set_hints(struct wl_listener *listener, void *data) {
 
 struct sway_view *view_from_wlr_xwayland_surface(
 		struct wlr_xwayland_surface *xsurface) {
-	return xsurface->data;
+	return &((struct sway_xwayland_view*)xsurface->data)->view;
 }
 
 void handle_xwayland_surface(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
The existing code works by accident because the "view" field (of type
sway_view) just happens to be the first field in the
sway_xwayland_view struct.  Depending on that is error-prone; all it
takes is a simple reordering of fields in that struct to trigger a
nonlocal bug.  Adding the correct casting sequence will ensure that
reodering fields won't cause problems.