### PR TITLE
xwayland.c handle_map(): NULL out xsurface->data() to prevent crashing.

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -401,6 +401,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		// This window used not to have the override redirect flag and has it
 		// now. Switch to unmanaged.
 		handle_destroy(&xwayland_view->destroy, view);
+		xsurface->data = NULL;
 		struct sway_xwayland_unmanaged *unmanaged = create_unmanaged(xsurface);
 		unmanaged_handle_map(&unmanaged->map, xsurface);
 		return;


### PR DESCRIPTION
Fixes #4647

When changing a surface from managed to unmanaged in handle_map(), the
call to handle_destroy(.., view) causes the sway_xwayland_view pointed
to by the untyped wlr_xwayland_surface.data field to become invalid
garbage, yet the untyped wlr_xwayland_surface.data continues to point
at it.  In particular: view_get_*(view_from_wlr_surface(..)), even
with appropriate NULL checking, will crash sway when this codepath is
exercised (reliable test case: drop-down menus in Google Earth).