### PR TITLE
Various small fixes

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -198,9 +198,6 @@ static void set_config_node(struct sway_node *node) {
 
 list_t *execute_command(char *_exec, struct sway_seat *seat,
 		struct sway_container *con) {
-	list_t *res_list = create_list();
-	char *exec = strdup(_exec);
-	char *head = exec;
 	char *cmd;
 	char matched_delim = ';';
 	list_t *views = NULL;
@@ -213,9 +210,16 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 		}
 	}
 
+	char *exec = strdup(_exec);
+	char *head = exec;
+	list_t *res_list = create_list();
+
+	if (!res_list || !exec) {
+		return NULL;
+	}
+
 	config->handler_context.seat = seat;
 
-	head = exec;
 	do {
 		for (; isspace(*head); ++head) {}
 		// Extract criteria (valid for this command list only).

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -414,6 +414,9 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 
+	if (!sway_assert(container, "Expected container to be non null")) {
+		return cmd_results_new(CMD_FAILURE, "");
+	}
 	struct sway_node *next_focus = NULL;
 	if (container_is_floating(container)) {
 		next_focus = node_get_in_direction_floating(container, seat, direction);

--- a/sway/config.c
+++ b/sway/config.c
@@ -687,8 +687,10 @@ static ssize_t getline_with_cont(char **lineptr, size_t *line_size, FILE *file,
 		nread += next_nread - 2;
 		if ((ssize_t) *line_size < nread + 1) {
 			*line_size = nread + 1;
+			char *old_ptr = *lineptr;
 			*lineptr = realloc(*lineptr, *line_size);
 			if (!*lineptr) {
+				free(old_ptr);
 				nread = -1;
 				break;
 			}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -39,8 +39,10 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->swaybar_command);
 	free(bar->font);
 	free(bar->separator_symbol);
-	for (int i = 0; i < bar->bindings->length; i++) {
-		free_bar_binding(bar->bindings->items[i]);
+	if (bar->bindings) {
+		for (int i = 0; i < bar->bindings->length; i++) {
+			free_bar_binding(bar->bindings->items[i]);
+		}
 	}
 	list_free(bar->bindings);
 	list_free_items_and_destroy(bar->outputs);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -905,12 +905,9 @@ static void set_workspace(struct sway_seat *seat,
 
 	if (seat->workspace) {
 		free(seat->prev_workspace_name);
-		seat->prev_workspace_name = malloc(strlen(seat->workspace->name) + 1);
+		seat->prev_workspace_name = strdup(seat->workspace->name);
 		if (!seat->prev_workspace_name) {
 			sway_log(SWAY_ERROR, "Unable to allocate previous workspace name");
-			seat->prev_workspace_name = NULL;
-		} else {
-			strcpy(seat->prev_workspace_name, seat->workspace->name);
 		}
 	}
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -259,6 +259,7 @@ int main(int argc, char **argv) {
 			exit(EXIT_SUCCESS);
 			break;
 		case 'c': // config
+			free(config_path);
 			config_path = strdup(optarg);
 			break;
 		case 'C': // validate


### PR DESCRIPTION
Some memory leaks in more or less pathological code paths, some simplifications and defensive null checks.

Most of these were found by running clang-tidy/analyzer.