### PR TITLE
Fix refresh rate scale of output

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -260,7 +260,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 
 	bool modeset_success;
 	if (oc && oc->width > 0 && oc->height > 0) {
-		sway_log(SWAY_DEBUG, "Set %s mode to %dx%d (%f GHz)", oc->name, oc->width,
+		sway_log(SWAY_DEBUG, "Set %s mode to %dx%d (%f Hz)", oc->name, oc->width,
 			oc->height, oc->refresh_rate);
 		modeset_success =
 			set_mode(wlr_output, oc->width, oc->height, oc->refresh_rate);
@@ -329,7 +329,7 @@ static void default_output_config(struct output_config *oc,
 			wl_container_of(wlr_output->modes.prev, mode, link);
 		oc->width = mode->width;
 		oc->height = mode->height;
-		oc->refresh_rate = mode->refresh;
+		oc->refresh_rate = mode->refresh / 1000.f;
 	}
 	oc->x = oc->y = -1;
 	oc->scale = 1;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -856,7 +856,7 @@ void handle_output_manager_apply(struct wl_listener *listener, void *data) {
 			struct wlr_output_mode *mode = config_head->state.mode;
 			oc->width = mode->width;
 			oc->height = mode->height;
-			oc->refresh_rate = mode->refresh;
+			oc->refresh_rate = mode->refresh / 1000.f;
 		} else {
 			oc->width = config_head->state.custom_mode.width;
 			oc->height = config_head->state.custom_mode.height;


### PR DESCRIPTION
When applying config, value mode->refresh is mHz; convert it to Hz before
assigning it to the temporary output config. oc->refresh_rate will
be converted back to mHz in set_mode function.

Fix debug log printing GHz instead of Hz.

Based on #4577, fixes https://github.com/emersion/kanshi/issues/51 .