### PR TITLE
Support focus next|prev [sibling] i3 commands

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -120,6 +120,11 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 *focus* up|right|down|left
 	Moves focus to the next container in the specified direction.
 
+*focus* prev|next [sibling]
+	Moves focus to the previous or next container in the current layout. By default,
+	the last active child of the newly focused container will be focused. The _sibling_
+	option indicates not to immediately focus a child of the container.
+
 *focus* child
 	Moves focus to the last-focused child of the focused container.
 


### PR DESCRIPTION
Support `focus prev|next [sibling]` from i3 -- steps 2+3 for #4638 .

PTAL. If the behavior does not match i3, let me know.