### PR TITLE
Add --custom to `output mode` command

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -198,6 +198,7 @@ struct output_config {
 	int enabled;
 	int width, height;
 	float refresh_rate;
+	int custom_mode;
 	int x, y;
 	float scale;
 	int32_t transform;

--- a/sway/commands/output/mode.c
+++ b/sway/commands/output/mode.c
@@ -12,6 +12,14 @@ struct cmd_results *output_cmd_mode(int argc, char **argv) {
 
 	struct output_config *output = config->handler_context.output_config;
 
+	if (strcmp(argv[0], "--custom") == 0) {
+		argv++;
+		argc--;
+		output->custom_mode = 1;
+	} else {
+		output->custom_mode = 0;
+	}
+
 	char *end;
 	output->width = strtol(*argv, &end, 10);
 	if (*end) {

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -24,11 +24,15 @@ must be separated by one space. For example:
 
 # COMMANDS
 
-*output* <name> mode|resolution|res <WIDTHxHEIGHT>[@<RATE>[Hz]]
+*output* <name> mode|resolution|res [--custom] <WIDTHxHEIGHT>[@<RATE>[Hz]]
 	Configures the specified output to use the given mode. Modes are a
 	combination of width and height (in pixels) and a refresh rate that your
 	display can be configured to use. For a list of available modes for each
 	output, use *swaymsg -t get_outputs*.
+
+	To set a custom mode not listed in the list of available modes, use
+	*--custom*. You should probably only use this if you know what you're
+	doing.
 
 	Examples:
 


### PR DESCRIPTION
This forces to set the mode as a custom mode.

Closes: https://github.com/swaywm/sway/issues/3791 (with https://github.com/swaywm/wlroots/pull/1881)