### PR TITLE
Do not apply scroll_factor for switching windows in tabbed layout.

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -546,7 +546,7 @@ static void handle_axis(struct sway_seat *seat,
 				seat_get_active_tiling_child(seat, tabcontainer);
 			list_t *siblings = container_get_siblings(cont);
 			int desired = list_find(siblings, active->sway_container) +
-				round(scroll_factor * event->delta_discrete);
+				event->delta_discrete;
 			if (desired < 0) {
 				desired = 0;
 			} else if (desired >= siblings->length) {


### PR DESCRIPTION
Partial fix for #4679. Only removes discrete scaling for switching windows in tabbed/stacked layouts, and leaves the axis_discrete scaling for clients alone.

I figure this should be changed anyway, as switching windows by scrolling a touchpad that doesn't emit axis_discrete doesn't work at all in the first place, so the feature is just broken in all cases with scroll_factor.