### PR TITLE
Rename symbol set_cloexec to sway_set_cloexec, remove duplicates.

### DIFF
--- a/client/pool-buffer.c
+++ b/client/pool-buffer.c
@@ -11,19 +11,7 @@
 #include <wayland-client.h>
 #include "config.h"
 #include "pool-buffer.h"
-
-static bool set_cloexec(int fd) {
-	long flags = fcntl(fd, F_GETFD);
-	if (flags == -1) {
-		return false;
-	}
-
-	if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
-		return false;
-	}
-
-	return true;
-}
+#include "util.h"
 
 static int create_pool_file(size_t size, char **name) {
 	static const char template[] = "sway-client-XXXXXX";
@@ -46,7 +34,7 @@ static int create_pool_file(size_t size, char **name) {
 		return -1;
 	}
 
-	if (!set_cloexec(fd)) {
+	if (!sway_set_cloexec(fd, true)) {
 		close(fd);
 		return -1;
 	}

--- a/common/util.c
+++ b/common/util.c
@@ -77,7 +77,7 @@ const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel) 
 	return NULL;
 }
 
-bool set_cloexec(int fd, bool cloexec) {
+bool sway_set_cloexec(int fd, bool cloexec) {
 	int flags = fcntl(fd, F_GETFD);
 	if (flags == -1) {
 		sway_log_errno(SWAY_ERROR, "fcntl failed");

--- a/include/util.h
+++ b/include/util.h
@@ -32,6 +32,6 @@ float parse_float(const char *value);
 
 const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel);
 
-bool set_cloexec(int fd, bool cloexec);
+bool sway_set_cloexec(int fd, bool cloexec);
 
 #endif

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -192,7 +192,7 @@ static void invoke_swaybar(struct bar_config *bar) {
 		sway_log_errno(SWAY_ERROR, "socketpair failed");
 		return;
 	}
-	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
+	if (!sway_set_cloexec(sockets[0], true) || !sway_set_cloexec(sockets[1], true)) {
 		return;
 	}
 
@@ -220,7 +220,7 @@ static void invoke_swaybar(struct bar_config *bar) {
 			sway_log_errno(SWAY_ERROR, "fork failed");
 			_exit(EXIT_FAILURE);
 		} else if (pid == 0) {
-			if (!set_cloexec(sockets[1], false)) {
+			if (!sway_set_cloexec(sockets[1], false)) {
 				_exit(EXIT_FAILURE);
 			}
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -505,7 +505,7 @@ static bool _spawn_swaybg(char **command) {
 		sway_log_errno(SWAY_ERROR, "socketpair failed");
 		return false;
 	}
-	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
+	if (!sway_set_cloexec(sockets[0], true) || !sway_set_cloexec(sockets[1], true)) {
 		return false;
 	}
 
@@ -529,7 +529,7 @@ static bool _spawn_swaybg(char **command) {
 			sway_log_errno(SWAY_ERROR, "fork failed");
 			_exit(EXIT_FAILURE);
 		} else if (pid == 0) {
-			if (!set_cloexec(sockets[1], false)) {
+			if (!sway_set_cloexec(sockets[1], false)) {
 				_exit(EXIT_FAILURE);
 			}
 

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -36,7 +36,7 @@ bool swaynag_spawn(const char *swaynag_command,
 			sway_log(SWAY_ERROR, "Failed to create pipe for swaynag");
 			return false;
 		}
-		if (!set_cloexec(swaynag->fd[1], true)) {
+		if (!sway_set_cloexec(swaynag->fd[1], true)) {
 			goto failed;
 		}
 	}
@@ -46,7 +46,7 @@ bool swaynag_spawn(const char *swaynag_command,
 		sway_log_errno(SWAY_ERROR, "socketpair failed");
 		goto failed;
 	}
-	if (!set_cloexec(sockets[0], true) || !set_cloexec(sockets[1], true)) {
+	if (!sway_set_cloexec(sockets[0], true) || !sway_set_cloexec(sockets[1], true)) {
 		goto failed;
 	}
 
@@ -69,7 +69,7 @@ bool swaynag_spawn(const char *swaynag_command,
 			sway_log_errno(SWAY_ERROR, "fork failed");
 			_exit(EXIT_FAILURE);
 		} else if (pid == 0) {
-			if (!set_cloexec(sockets[1], false)) {
+			if (!sway_set_cloexec(sockets[1], false)) {
 				_exit(EXIT_FAILURE);
 			}
 


### PR DESCRIPTION
set_cloexec is defined by both sway and wlroots (and who-knows-else),
so rename the sway one for supporting static linkage. We also remove
the duplicate version of this in client/.

Fixes: https://github.com/swaywm/sway/issues/4677