### PR TITLE
Skip line continuation when it is a comment

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -677,7 +677,7 @@ static ssize_t getline_with_cont(char **lineptr, size_t *line_size, FILE *file,
 	size_t next_line_size = 0;
 	ssize_t nread = getline(lineptr, line_size, file);
 	*nlines = nread == -1 ? 0 : 1;
-	while (nread >= 2 && strcmp(&(*lineptr)[nread - 2], "\\\n") == 0) {
+	while (nread >= 2 && strcmp(&(*lineptr)[nread - 2], "\\\n") == 0 && (*lineptr)[0] != '#') {
 		ssize_t next_nread = getline(&next_line, &next_line_size, file);
 		if (next_nread == -1) {
 			break;


### PR DESCRIPTION
Currently commented lines ending in the backslash character will be
concatenated with the following line.

```
# with this comment \
exec swaynag -m 'will not run'
```

This change modifies `getline_with_cont` to stop reading when the
initial character is a '#'.


Closes #4585 