### PR TITLE
Do not always modeset when applying output config

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -269,7 +269,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 			oc->height, oc->refresh_rate);
 		modeset_success = set_mode(wlr_output, oc->width, oc->height,
 			oc->refresh_rate, oc->custom_mode == 1);
-	} else if (!wl_list_empty(&wlr_output->modes)) {
+	} else if (!wl_list_empty(&wlr_output->modes) && !wlr_output->current_mode) {
 		struct wlr_output_mode *mode =
 			wl_container_of(wlr_output->modes.prev, mode, link);
 		modeset_success = wlr_output_set_mode(wlr_output, mode);


### PR DESCRIPTION
For most output config options, applying a config with the option unset
does not change the current value, but a modeset is always attempted
even if the output has no mode configured. This unexpectedly causes a
config reload to reset output modes, even if none are configured.

Change it to leave unconfigured outputs that already have a mode alone.

Fixes #4687