### PR TITLE
Fix segfault in set_mode

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -222,7 +222,9 @@ static bool set_mode(struct wlr_output *output, int width, int height,
 				best = mode;
 				break;
 			}
-			best = mode->refresh > best->refresh ? mode : best;
+			if (best == NULL || mode->refresh > best->refresh) {
+				best = mode;
+			}
 		}
 	}
 	if (!best) {


### PR DESCRIPTION
best is NULL prior to being assigned to a mode.

Closes: https://github.com/swaywm/sway/issues/4705