### PR TITLE
grimshot: fix branching on command exit status

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -51,8 +51,7 @@ die() {
 
 check() {
   COMMAND=$1
-  command -v "$COMMAND" > /dev/null 2>&1
-  if [ $? ]; then
+  if command -v "$COMMAND" > /dev/null 2>&1; then
     RESULT="OK"
   else
     RESULT="NOT FOUND"
@@ -102,8 +101,7 @@ if [ "$ACTION" = "copy" ] ; then
   rm "$TMP"
   notifyOk "$WHAT copied to buffer"
 else
-  takeScreenshot "$FILE" "$GEOM"
-  if [ $? ]; then
+  if takeScreenshot "$FILE" "$GEOM"; then
     TITLE="Screenshot of $SUBJECT"
     MESSAGE=$(basename "$FILE")
     notifyOk "$MESSAGE" "$TITLE"


### PR DESCRIPTION
The previous behavior was incorrect because `if` was checking the return
status of the `[` command which was never going to be an error. `[`
seems to only return an error if no args are provided. This was
basically a useless use of `[` anyway since it was just meant as a
straight interpretation of command exit, something that `if` can do
itself.

Compare:

```sh
[ ]; echo ?=$?
[ /bin/false ]; echo ?=$?
if [ /bin/false ]; then echo this is the unintended bug; fi
if /bin/false; then echo this will not be printed; fi
```