### PR TITLE
Add -Wno-missing-braces

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ add_project_arguments(
 
 		'-Wno-unused-parameter',
 		'-Wno-unused-result',
+		'-Wno-missing-braces',
 		'-Wundef',
 		'-Wvla',
 	],


### PR DESCRIPTION
-Wmissing-braces makes it annoying to zero-initialize structs with = {0}
when the first field is a struct. See for instance [1].

[1]: https://builds.sr.ht/~sircmpwn/job/110425