### PR TITLE
config: improvements to the reload validation

### DIFF
--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -44,23 +44,6 @@ static struct cmd_handler input_config_handlers[] = {
 	{ "xkb_numlock", input_cmd_xkb_numlock },
 };
 
-/**
- * Re-translate keysyms if a change in the input config could affect them.
- */
-static void retranslate_keysyms(struct input_config *input_config) {
-	for (int i = 0; i < config->input_configs->length; ++i) {
-		struct input_config *ic = config->input_configs->items[i];
-		if (ic->xkb_layout || ic->xkb_file) {
-			// this is the first config with xkb_layout or xkb_file
-			if (ic->identifier == input_config->identifier) {
-				translate_keysyms(ic);
-			}
-
-			return;
-		}
-	}
-}
-
 struct cmd_results *cmd_input(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 2))) {
@@ -106,8 +89,9 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			return res;
 		}
 
-		input_manager_apply_input_config(ic);
-		retranslate_keysyms(ic);
+		if (!config->reloading) {
+			input_manager_apply_input_config(ic);
+		}
 	} else {
 		free_input_config(config->handler_context.input_config);
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -447,15 +447,17 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 				old_config->xwayland ? "enabled" : "disabled");
 		config->xwayland = old_config->xwayland;
 
-		if (old_config->swaybg_client != NULL) {
-			wl_client_destroy(old_config->swaybg_client);
-		}
+		if (!config->validating) {
+			if (old_config->swaybg_client != NULL) {
+				wl_client_destroy(old_config->swaybg_client);
+			}
 
-		if (old_config->swaynag_config_errors.client != NULL) {
-			wl_client_destroy(old_config->swaynag_config_errors.client);
-		}
+			if (old_config->swaynag_config_errors.client != NULL) {
+				wl_client_destroy(old_config->swaynag_config_errors.client);
+			}
 
-		input_manager_reset_all_inputs();
+			input_manager_reset_all_inputs();
+		}
 	}
 
 	config->current_config_path = path;
@@ -520,8 +522,13 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		return success;
 	}
 
-	if (is_active) {
+	if (is_active && !validating) {
 		input_manager_verify_fallback_seat();
+
+		for (int i = 0; i < config->input_configs->length; i++) {
+			input_manager_apply_input_config(config->input_configs->items[i]);
+		}
+
 		for (int i = 0; i < config->seat_configs->length; i++) {
 			input_manager_apply_seat_config(config->seat_configs->items[i]);
 		}

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -359,6 +359,23 @@ void input_manager_set_focus(struct sway_node *node) {
 	}
 }
 
+/**
+ * Re-translate keysyms if a change in the input config could affect them.
+ */
+static void retranslate_keysyms(struct input_config *input_config) {
+	for (int i = 0; i < config->input_configs->length; ++i) {
+		struct input_config *ic = config->input_configs->items[i];
+		if (ic->xkb_layout || ic->xkb_file) {
+			// this is the first config with xkb_layout or xkb_file
+			if (ic->identifier == input_config->identifier) {
+				translate_keysyms(ic);
+			}
+
+			return;
+		}
+	}
+}
+
 void input_manager_apply_input_config(struct input_config *input_config) {
 	struct sway_input_device *input_device = NULL;
 	bool wildcard = strcmp(input_config->identifier, "*") == 0;
@@ -376,6 +393,8 @@ void input_manager_apply_input_config(struct input_config *input_config) {
 			}
 		}
 	}
+
+	retranslate_keysyms(input_config);
 }
 
 void input_manager_reset_input(struct sway_input_device *input_device) {


### PR DESCRIPTION
Fixes #4744 

For the validation pass of reloading, there is no need to touch swaybg,
swaynag, inputs, outputs, or seats. This drastically improves the speed
of a reload by skipping over the expensive I/O configuration and
handling of wayland clients. As long as the syntax is valid, the
CMD_FAILURE's can be relayed during the actual reload.