### PR TITLE
output: Ensure that frame_done is delayed on max_render_time

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -426,7 +426,7 @@ static void send_frame_done_iterator(struct sway_output *output, struct sway_vie
 	int delay = data->msec_until_refresh - output->max_render_time
 			- view_max_render_time;
 
-	if (output->max_render_time == 0 || view_max_render_time == 0 || delay < 1) {
+	if ((output->max_render_time == 0 && view_max_render_time == 0) || delay < 1) {
 		wlr_surface_send_frame_done(surface, &data->when);
 	} else {
 		struct sway_surface *sway_surface = surface->data;


### PR DESCRIPTION
max_render_time can be set on output, view, or both. However, if only
applied to the output, send_frame_done_iterator would erroneously send
frame_done immediately, ignoring the output max_render_time. As
damage_handle_frame processed max_render_time correctly, idle frames
would be blocked in anticipation of the delay that was meant to happen.

Without the delay, frame events would be dispatched during the idle
frame block, and some clients would never receive the frame done events
they had requested, at least not until something else actively drove
another render.

Respecting both view and output max_render_time in
send_frame_done_iterator ensures that the frame events are always
correctly delayed.

Fixes #4756