### PR TITLE
Rename field 'node' to 'nodes' from the 'GET_TREE' reply in the sway-ipc docs

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -343,7 +343,7 @@ node and will have the following properties:
 |- focus
 :  array
 :  Array of child node IDs in the current focus order
-|- node
+|- nodes
 :  array
 :  The tiling children nodes for the node
 |- floating_nodes


### PR DESCRIPTION
While implementing rust bindings for the sway-ipc I noticed this small bug in the sway-ipc docs.
Hope this will prevent future confusion if someone wants to implement other bindings.
