### PR TITLE
Fix segfault on toggling a scratchpad hidden view

### DIFF
--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -28,7 +28,7 @@ static void scratchpad_toggle_auto(void) {
 
 	// Check if the currently focused window is a scratchpad window and should
 	// be hidden again.
-	if (focus && focus->scratchpad) {
+	if (focus && focus->scratchpad && focus->workspace) {
 		sway_log(SWAY_DEBUG, "Focus is a scratchpad window - hiding %s",
 				focus->title);
 		root_scratchpad_hide(focus);


### PR DESCRIPTION
Fixes #4788 

It's possible to focus scratchpad hidden views (does i3 allow this?). Previously, sway would crash trying to hide an already hidden view. Now focused scratchpad hidden views will be made visible on the active workspace like other scratchpad hidden views.