### PR TITLE
Fix scratchpad hidden split container related segfaults

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -357,4 +357,6 @@ void container_raise_floating(struct sway_container *con);
 
 bool container_is_scratchpad_hidden(struct sway_container *con);
 
+bool container_is_scratchpad_hidden_or_child(struct sway_container *con);
+
 #endif

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -365,7 +365,7 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 	}
 
 	if (argc == 0 && container) {
-		if (container_is_scratchpad_hidden(container)) {
+		if (container_is_scratchpad_hidden_or_child(container)) {
 			root_scratchpad_show(container);
 		}
 		seat_set_focus_container(seat, container);

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -13,7 +13,7 @@ static struct cmd_results *do_split(int layout) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (con) {
-		if (container_is_scratchpad_hidden(con) &&
+		if (container_is_scratchpad_hidden_or_child(con) &&
 				con->fullscreen_mode != FULLSCREEN_GLOBAL) {
 			return cmd_results_new(CMD_FAILURE,
 					"Cannot split a hidden scratchpad container");

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1527,3 +1527,10 @@ void container_raise_floating(struct sway_container *con) {
 bool container_is_scratchpad_hidden(struct sway_container *con) {
 	return con->scratchpad && !con->workspace;
 }
+
+bool container_is_scratchpad_hidden_or_child(struct sway_container *con) {
+	while (con->parent) {
+		con = con->parent;
+	}
+	return con->scratchpad && !con->workspace;
+}

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -132,6 +132,11 @@ void root_scratchpad_show(struct sway_container *con) {
 	if (old_ws) {
 		container_detach(con);
 		workspace_consider_destroy(old_ws);
+	} else {
+		// Act on the ancestor of scratchpad hidden split containers
+		while (con->parent) {
+			con = con->parent;
+		}
 	}
 	workspace_add_floating(new_ws, con);
 


### PR DESCRIPTION
Fixes #4788, Replaces #4789 

OK, so there are a few bugs handling scratchpad hidden split containers (SPHSCs).

Originally reported segfault:
<details>
<summary>
`scratchpad toggle` causes segfault on focused hidden container (because it is inadvertantly possible to focus SPHSCs)
</summary>

 - stack trace in [comment](https://github.com/swaywm/sway/issues/4788#issuecomment-562295664)
</details>
But I've also found:
<details>
<summary>
`move to &lt;dest&gt;` causes segfault on SPHSC dest
</summary>

```
#0  0x0000564610a32042 in node_is_view (node=node@entry=0x0) at ../sway/sway/tree/node.c:41
#1  0x0000564610a10b9c in seat_get_active_tiling_child (seat=0x5646126c4220, parent=parent@entry=0x0) at ../sway/sway/input/seat.c:1251
        current = <optimized out>
#2  0x0000564610a040c6 in output_get_active_workspace (output=output@entry=0x0) at ../sway/sway/desktop/output.c:371
        seat = <optimized out>
        focus = <optimized out>
#3  0x0000564610a211db in cmd_move_container (argv=<optimized out>, argc=<optimized out>, no_auto_back_and_forth=<optimized out>) at ../sway/sway/commands/move.c:522
        new_output = 0x0
        new_workspace = <optimized out>
        node = <optimized out>
        seat = 0x5646126c4220
        old_parent = 0x0
        old_ws = 0x564612c41e60
        new_output_last_ws = <optimized out>
        focus = <optimized out>
        error = 0x0
        workspace = <optimized out>
        container = 0x564612c47540
        old_output = 0x564612715d40
        destination = 0x564612cca330
        __PRETTY_FUNCTION__ = "cmd_move_container"
        error = <optimized out>
        no_auto_back_and_forth = <optimized out>
#4  0x0000564610a211db in cmd_move (argc=<optimized out>, argv=<optimized out>) at ../sway/sway/commands/move.c:941
        error = <optimized out>
        no_auto_back_and_forth = <optimized out>
#5  0x00005646109f6548 in execute_command (_exec=_exec@entry=0x564612cdf870 "move to mark test", seat=0x5646126c4220, seat@entry=0x0, con=con@entry=0x0) at ../sway/sway/commands.c:286
        node = <optimized out>
        res = <optimized out>
        argc = 4
        argv = 0x564612ce8800
        handler = 0x564610a5a0c0 <command_handlers+160>
        cmd = <optimized out>
        matched_delim = 0 '\000'
        views = 0x0
        __PRETTY_FUNCTION__ = "execute_command"
        exec = 0x564612ce0870 "move to mark test"
        head = 0x0
        res_list = 0x564612502b30
#6  0x00005646109ff21c in ipc_client_handle_command (payload_type=<optimized out>, payload_length=<optimized out>, client=0x564612ce96f0) at ../sway/sway/ipc-server.c:634
        line = <optimized out>
        res_list = <optimized out>
        json = <optimized out>
        length = <optimized out>
        buf = 0x564612cdf870 "move to mark test"
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
#7  0x00005646109ff21c in ipc_client_handle_command (client=0x564612ce96f0, payload_length=17, payload_type=<optimized out>) at ../sway/sway/ipc-server.c:596
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
#8  0x00005646109fff29 in ipc_client_handle_readable (mask=<optimized out>, data=0x564612ce96f0, client_fd=108) at ../sway/sway/ipc-server.c:269
        pending_length = <optimized out>
        pending_type = <optimized out>
        read_available = 31
        buf = "i3-ipc\021\000\000\000\000\000\000"
        buf32 = 0x7fff07a85ae0
        received = <optimized out>
        client = 0x564612ce96f0
#9  0x00005646109fff29 in ipc_client_handle_readable (client_fd=108, mask=<optimized out>, data=0x564612ce96f0) at ../sway/sway/ipc-server.c:205
        client = 0x564612ce96f0
#10 0x00007fe6fc33a7f2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#11 0x00007fe6fc33939c in wl_display_run () at /usr/lib/libwayland-server.so.0
#12 0x00005646109f558c in main (argc=1, argv=0x7fff07a85e78) at ../sway/sway/main.c:403
        verbose = 0
        debug = 0
        validate = 0
        allow_unsupported_gpu = 0
        long_options = 
            {{name = 0x564610a3e47b "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x564610a416d1 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x564610a3e480 "validate", has_arg = 0, flag = 0x0, val = 67}, {name = 0x564610a3e489 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x564610a3e3df "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x564610a3d57c "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x564610a3e48f "get-socketpath", has_arg = 0, flag = 0x0, val = 112}, {name = 0x564610a3e49e "unsupported-gpu", has_arg = 0, flag = 0x0, val = 117}, {name = 0x564610a3e4ae "my-next-gpu-wont-be-nvidia", has_arg = 0, flag = 0x0, val = 117}, {name = 0x0, has_arg = 0, flag = 0x0, val = 0}}
        config_path = 0x0
        usage = 0x564610a3e7e0 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
        c = <optimized out>
```
</details>

<details>
<summary>
`split &lt;layout&gt;` causes segfault on SPHSC context
</summary>

```
#0  0x0000556008d41d2c in arrange_workspace (workspace=workspace@entry=0x0) at ../sway/sway/tree/arrange.c:251
        output = <optimized out>
        area = <optimized out>
        first_arrange = <optimized out>
        prev_x = <optimized out>
        prev_y = <optimized out>
        diff_x = <optimized out>
        diff_y = <optimized out>
#1  0x0000556008d420f5 in arrange_workspace (workspace=workspace@entry=0x0) at ../sway/sway/tree/arrange.c:252
#2  0x0000556008d39671 in do_split (layout=2) at ../sway/sway/commands/split.c:33
        con = 0x55600a32bfe0
        ws = 0x0
#3  0x0000556008d0a6fb in execute_command (_exec=_exec@entry=0x55600a325e30 "[con_mark=test] split toggle", seat=0x556009d04210, seat@entry=0x0, con=con@entry=0x0) at ../sway/sway/commands.c:300
        view = <optimized out>
        res = <optimized out>
        i = 0
        fail_res = 0x0
        argc = 2
        argv = 0x55600a316c20
        handler = 0x556008d6e130 <command_handlers+272>
        cmd = <optimized out>
        matched_delim = 0 '\000'
        views = 0x55600a32e9e0
        __PRETTY_FUNCTION__ = "execute_command"
        exec = 0x55600a2037d0 "[con_mark=test] split toggle"
        head = 0x0
        res_list = 0x55600a31ff20
#4  0x0000556008d1321c in ipc_client_handle_command (payload_type=<optimized out>, payload_length=<optimized out>, client=0x55600a31df60) at ../sway/sway/ipc-server.c:634
        line = <optimized out>
        res_list = <optimized out>
        json = <optimized out>
        length = <optimized out>
        buf = 0x55600a325e30 "[con_mark=test] split toggle"
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
#5  0x0000556008d1321c in ipc_client_handle_command (client=0x55600a31df60, payload_length=28, payload_type=<optimized out>) at ../sway/sway/ipc-server.c:596
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
#6  0x0000556008d13f29 in ipc_client_handle_readable (mask=<optimized out>, data=0x55600a31df60, client_fd=108) at ../sway/sway/ipc-server.c:269
        pending_length = <optimized out>
        pending_type = <optimized out>
        read_available = 42
        buf = "i3-ipc\034\000\000\000\000\000\000"
        buf32 = 0x7ffdfc63a900
        received = <optimized out>
        client = 0x55600a31df60
#7  0x0000556008d13f29 in ipc_client_handle_readable (client_fd=108, mask=<optimized out>, data=0x55600a31df60) at ../sway/sway/ipc-server.c:205
        client = 0x55600a31df60
#8  0x00007f83a811e7f2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#9  0x00007f83a811d39c in wl_display_run () at /usr/lib/libwayland-server.so.0
#10 0x0000556008d0958c in main (argc=1, argv=0x7ffdfc63ac98) at ../sway/sway/main.c:403
        verbose = 0
        debug = 0
        validate = 0
        allow_unsupported_gpu = 0
        long_options = 
            {{name = 0x556008d5247b "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x556008d556d1 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x556008d52480 "validate", has_arg = 0, flag = 0x0, val = 67}, {name = 0x556008d52489 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x556008d523df "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x556008d5157c "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x556008d5248f "get-socketpath", has_arg = 0, flag = 0x0, val = 112}, {name = 0x556008d5249e "unsupported-gpu", has_arg = 0, flag = 0x0, val = 117}, {name = 0x556008d524ae "my-next-gpu-wont-be-nvidia", has_arg = 0, flag = 0x0, val = 117}, {name = 0x0, has_arg = 0, flag = 0x0, val = 0}}
        config_path = 0x0
        usage = 0x556008d527e0 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
        c = <optimized out>
```
</details>

I feel like there might be more.

These segfaults all sort of had a common theme, so with this patch I changed `container_is_scratchpad_hidden` to also return true when the container is a child of a scratchpad hidden container. It seems semantically correct to me at least (a child of a scratchpad hidden container is also scratchpad hidden) and fixes the segfaults I found. I also changed `focus` to make SPHSCs visible on focus, as it does for normal split containers, to fix the originally reported segfault.

The change basically transforms segfault cases into "refusal" cases, i.e. the command returns failure after refusing to act. But some commands _could_ do something useful with a SPHSC. I've gone ahead and implemented `move to` for SPHSCs in the second commit, which is mostly some refactoring.

Possibly there could just be a different function `container_is_scratchpad_hidden_or_child` or something, but I looked through the existing uses and the new behavior seems accurate, or at least unharmful, everywhere it is in use.

PTAL.

EDIT: On second look, I'm wondering if the 'make SPHSCs visible again' bit belongs within root_scratchpad_show.