### PR TITLE
Pass gesture events to clients

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
+#include <wlr/types/wlr_pointer_gestures_v1.h>
 #include <wlr/types/wlr_surface.h>
 #include "sway/input/seat.h"
 
@@ -31,6 +32,14 @@ struct sway_cursor {
 
 	struct wlr_pointer_constraint_v1 *active_constraint;
 	pixman_region32_t confine; // invalid if active_constraint == NULL
+
+	struct wlr_pointer_gestures_v1 *pointer_gestures;
+	struct wl_listener pinch_begin;
+	struct wl_listener pinch_update;
+	struct wl_listener pinch_end;
+	struct wl_listener swipe_begin;
+	struct wl_listener swipe_update;
+	struct wl_listener swipe_end;
 
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;


### PR DESCRIPTION
Fixes #4724.

This change can be tested quite easily if you use a backend which supports gestures (i.e. libinput). Open evince and your favourite pdf and you shall now see that pinch-to-zoom works properly. Prior to this, pinch-to-zoom would not do anything since the pinch and swipe events generated by the libinput backend are not handled anywhere (i.e. passed to the active client).

I'm not too sure how this will affect #1904 but I think there shouldn't be a huge change, as this change is solely passing pointer gestures to clients, rather than detecting a configurable gesture and executing a sway routine.