### PR TITLE
layer-shell: unfocus output-less layer on unmap

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -301,6 +301,15 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 }
 
 static void unmap(struct sway_layer_surface *sway_layer) {
+	struct sway_seat *seat;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		if (seat->focused_layer == sway_layer->layer_surface) {
+			seat_set_focus_layer(seat, NULL);
+		}
+	}
+
+	cursor_rebase_all();
+
 	struct wlr_output *wlr_output = sway_layer->layer_surface->output;
 	if (wlr_output == NULL) {
 		return;
@@ -311,15 +320,6 @@ static void unmap(struct sway_layer_surface *sway_layer) {
 	}
 	output_damage_surface(output, sway_layer->geo.x, sway_layer->geo.y,
 		sway_layer->layer_surface->surface, true);
-
-	struct sway_seat *seat;
-	wl_list_for_each(seat, &server.input->seats, link) {
-		if (seat->focused_layer == sway_layer->layer_surface) {
-			seat_set_focus_layer(seat, NULL);
-		}
-	}
-
-	cursor_rebase_all();
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Fixes #4599 

If a layer is focused by any seat, it needs to be unfocused on unmap. If
the unmap was due to an output being disabled, there would not be a
sway_output and unmap would do an early return. This results in a
use-after-free if the layer was focused by any seat prior to being
unmapped. This change just moves the refocusing code above the early
returns.