### PR TITLE
Fix lingering workspace with scratchpad show

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -131,6 +131,7 @@ void root_scratchpad_show(struct sway_container *con) {
 	// Show the container
 	if (old_ws) {
 		container_detach(con);
+		workspace_consider_destroy(old_ws);
 	}
 	workspace_add_floating(new_ws, con);
 


### PR DESCRIPTION
Showing a window in the scratchpad can move a visible scratchpad window
from another workspace to the current one. If the scratchpad window was
the last visible container in that workspace, the old workspace should
be destroyed.

Fixes #4806