### PR TITLE
input/keyboard: keyboard group destruction via keybind fixes

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -675,6 +675,8 @@ static void sway_keyboard_group_remove(struct sway_keyboard *keyboard) {
 		struct sway_keyboard_group *sway_group = wlr_group->data;
 		wlr_group->data = NULL;
 		wl_list_remove(&sway_group->link);
+		wl_list_remove(&sway_group->keyboard_key.link);
+		wl_list_remove(&sway_group->keyboard_modifiers.link);
 		sway_keyboard_destroy(sway_group->seat_device->keyboard);
 		free(sway_group->seat_device->input_device);
 		free(sway_group->seat_device);


### PR DESCRIPTION
Fixes #4799 

This includes two fixes related to changing the keymap of the last keyboard in a keyboard group with a keyboard binding. The first commit removes the listeners for the keyboard group's keyboard when destroying the keyboard group. The second commit defers the destruction of the wlr_keyboard_group until idle so that the keyboard group's keyboard is not destroyed in the middle of handling the key event for the binding.