### PR TITLE
input/seatop_default: fix focusing floating titles

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -339,10 +339,11 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 			state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_move = config->floating_mod_inverse ? BTN_RIGHT : BTN_LEFT;
 		if (button == btn_move && (mod_pressed || on_titlebar)) {
+			seat_set_focus_container(seat,
+					seat_get_focus_inactive_view(seat, &cont->node));
 			while (cont->parent) {
 				cont = cont->parent;
 			}
-			seat_set_focus_container(seat, cont);
 			seatop_begin_move_floating(seat, cont);
 			return;
 		}


### PR DESCRIPTION
Fixes #4728 

When clicking on the titlebar of a floating container (or descendant of
a floating container), the top-level floating container was being
focused and then allowing you to move the top-level floating container.
This made it so you couldn't switch to a different tab/stack within the
floating container. With this patch, the focus inactive view for the
container that the titlebar is associated with is focused, then the
traversal to the top-level floating container is performed to use with
the move floating operation.