### PR TITLE
Have commands return cmd_results on the stack

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -6,7 +6,7 @@
 
 struct sway_container;
 
-typedef struct cmd_results *sway_cmd(int argc, char **argv);
+typedef struct cmd_results sway_cmd(int argc, char **argv);
 
 struct cmd_handler {
 	char *command;
@@ -43,7 +43,7 @@ enum expected_args {
 	EXPECTED_EQUAL_TO
 };
 
-struct cmd_results *checkarg(int argc, const char *name,
+bool checkarg(struct cmd_results *error, int argc, const char *name,
 		enum expected_args type, int val);
 
 struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
@@ -63,24 +63,24 @@ list_t *execute_command(char *command,  struct sway_seat *seat,
  *
  * Do not use this under normal conditions.
  */
-struct cmd_results *config_command(char *command, char **new_block);
+struct cmd_results config_command(char *command, char **new_block);
 /**
  * Parse and handle a sub command
  */
-struct cmd_results *config_subcommand(char **argv, int argc,
+struct cmd_results config_subcommand(char **argv, int argc,
 		struct cmd_handler *handlers, size_t handlers_size);
 /*
  * Parses a command policy rule.
  */
-struct cmd_results *config_commands_command(char *exec);
+struct cmd_results config_commands_command(char *exec);
 /**
- * Allocates a cmd_results object.
+ * Fills in and returns a cmd_results object.
  */
-struct cmd_results *cmd_results_new(enum cmd_status status, const char *error, ...);
+struct cmd_results cmd_results_new(enum cmd_status status, const char *error, ...);
 /**
- * Frees a cmd_results object.
+ * Frees the contents of a cmd_results object.
  */
-void free_cmd_results(struct cmd_results *results);
+void free_cmd_results(struct cmd_results results);
 /**
  * Serializes a list of cmd_results to a JSON string.
  *
@@ -88,7 +88,7 @@ void free_cmd_results(struct cmd_results *results);
  */
 char *cmd_results_to_json(list_t *res_list);
 
-struct cmd_results *add_color(char *buffer, const char *color);
+struct cmd_results add_color(char *buffer, const char *color);
 
 /**
  * TODO: Move this function and its dependent functions to container.c.

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -7,9 +7,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_assign(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "assign", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_assign(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "assign", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -51,9 +51,9 @@ static bool is_subcommand(char *name) {
 		find_handler(name, bar_config_handlers, sizeof(bar_config_handlers));
 }
 
-struct cmd_results *cmd_bar(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "bar", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_bar(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "bar", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 
@@ -98,7 +98,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		config->current_bar->id = id;
 	}
 
-	struct cmd_results *res = NULL;
+	struct cmd_results res;
 	if (find_handler(argv[0], bar_config_handlers,
 				sizeof(bar_config_handlers))) {
 		if (config->reading) {
@@ -112,7 +112,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		res = config_subcommand(argv, argc, bar_handlers, sizeof(bar_handlers));
 	}
 
-	if (res && res->status != CMD_SUCCESS) {
+	if (res.status != CMD_SUCCESS) {
 		if (id) {
 			free_bar_config(config->current_bar);
 			id = NULL;

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -9,7 +9,7 @@
 #include "log.h"
 #include "stringop.h"
 
-static struct cmd_results *binding_add(struct bar_binding *binding,
+static struct cmd_results binding_add(struct bar_binding *binding,
 		list_t *mode_bindings) {
 	const char *name = get_mouse_button_name(binding->button);
 	bool overwritten = false;
@@ -35,7 +35,7 @@ static struct cmd_results *binding_add(struct bar_binding *binding,
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *binding_remove(struct bar_binding *binding,
+static struct cmd_results binding_remove(struct bar_binding *binding,
 		list_t *mode_bindings) {
 	const char *name = get_mouse_button_name(binding->button);
 	for (int i = 0; i < mode_bindings->length; i++) {
@@ -52,7 +52,7 @@ static struct cmd_results *binding_remove(struct bar_binding *binding,
 		}
 	}
 
-	struct cmd_results *error = cmd_results_new(CMD_FAILURE, "Could not "
+	struct cmd_results error = cmd_results_new(CMD_FAILURE, "Could not "
 			"find binding for [bar %s]" " Button %u (%s)%s",
 			config->current_bar->id, binding->button, name,
 			binding->release ? " - release" : "");
@@ -60,7 +60,7 @@ static struct cmd_results *binding_remove(struct bar_binding *binding,
 	return error;
 }
 
-static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
+static struct cmd_results bar_cmd_bind(int argc, char **argv, bool code,
 		bool unbind) {
 	int minargs = 2;
 	const char *command;
@@ -71,8 +71,8 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
 		command = code ? "bar bindcode" : "bar bindsym";
 	}
 
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, command, EXPECTED_AT_LEAST, minargs))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, command, EXPECTED_AT_LEAST, minargs)) {
 		return error;
 	}
 
@@ -112,18 +112,18 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
 	return binding_add(binding, bindings);
 }
 
-struct cmd_results *bar_cmd_bindcode(int argc, char **argv) {
+struct cmd_results bar_cmd_bindcode(int argc, char **argv) {
 	return bar_cmd_bind(argc, argv, true, false);
 }
 
-struct cmd_results *bar_cmd_bindsym(int argc, char **argv) {
+struct cmd_results bar_cmd_bindsym(int argc, char **argv) {
 	return bar_cmd_bind(argc, argv, false, false);
 }
 
-struct cmd_results *bar_cmd_unbindcode(int argc, char **argv) {
+struct cmd_results bar_cmd_unbindcode(int argc, char **argv) {
 	return bar_cmd_bind(argc, argv, true, true);
 }
 
-struct cmd_results *bar_cmd_unbindsym(int argc, char **argv) {
+struct cmd_results bar_cmd_unbindsym(int argc, char **argv) {
 	return bar_cmd_bind(argc, argv, false, true);
 }

--- a/sway/commands/bar/binding_mode_indicator.c
+++ b/sway/commands/bar/binding_mode_indicator.c
@@ -4,10 +4,10 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc,
-			"binding_mode_indicator", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_binding_mode_indicator(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc,
+			"binding_mode_indicator", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	config->current_bar->binding_mode_indicator =

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -16,47 +16,43 @@ static struct cmd_handler bar_colors_handlers[] = {
 	{ "urgent_workspace", bar_colors_cmd_urgent_workspace },
 };
 
-static struct cmd_results *parse_single_color(char **color,
+static struct cmd_results parse_single_color(char **color,
 		const char *cmd_name, int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, cmd_name, EXPECTED_EQUAL_TO, 1))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, cmd_name, EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!*color && !(*color = malloc(10))) {
-		return NULL;
+		return cmd_results_new(CMD_FAILURE, "Allocation failure");
 	}
-	error = add_color(*color, argv[0]);
-	if (error) {
-		return error;
-	}
-	return cmd_results_new(CMD_SUCCESS, NULL);
+	return add_color(*color, argv[0]);
 }
 
-static struct cmd_results *parse_three_colors(char ***colors,
+static struct cmd_results parse_three_colors(char ***colors,
 		const char *cmd_name, int argc, char **argv) {
-	struct cmd_results *error = NULL;
+	struct cmd_results error;
 	if (argc != 3) {
 		return cmd_results_new(CMD_INVALID,
 				"Command '%s' requires exactly three color values", cmd_name);
 	}
 	for (size_t i = 0; i < 3; i++) {
 		if (!*colors[i] && !(*(colors[i]) = malloc(10))) {
-			return NULL;
+			return cmd_results_new(CMD_FAILURE, "Allocation failure");
 		}
 		error = add_color(*(colors[i]), argv[i]);
-		if (error) {
+		if (error.status != CMD_SUCCESS) {
 			return error;
 		}
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *bar_cmd_colors(int argc, char **argv) {
+struct cmd_results bar_cmd_colors(int argc, char **argv) {
 	return config_subcommand(argv, argc, bar_colors_handlers,
 			sizeof(bar_colors_handlers));
 }
 
-struct cmd_results *bar_colors_cmd_active_workspace(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_active_workspace(int argc, char **argv) {
 	char **colors[3] = {
 		&(config->current_bar->colors.active_workspace_border),
 		&(config->current_bar->colors.active_workspace_bg),
@@ -65,17 +61,17 @@ struct cmd_results *bar_colors_cmd_active_workspace(int argc, char **argv) {
 	return parse_three_colors(colors, "active_workspace", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_background(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_background(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.background),
 			"background", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_focused_background(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_focused_background(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.focused_background),
 			"focused_background", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_binding_mode(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_binding_mode(int argc, char **argv) {
 	char **colors[3] = {
 		&(config->current_bar->colors.binding_mode_border),
 		&(config->current_bar->colors.binding_mode_bg),
@@ -84,7 +80,7 @@ struct cmd_results *bar_colors_cmd_binding_mode(int argc, char **argv) {
 	return parse_three_colors(colors, "binding_mode", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_focused_workspace(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_focused_workspace(int argc, char **argv) {
 	char **colors[3] = {
 		&(config->current_bar->colors.focused_workspace_border),
 		&(config->current_bar->colors.focused_workspace_bg),
@@ -93,7 +89,7 @@ struct cmd_results *bar_colors_cmd_focused_workspace(int argc, char **argv) {
 	return parse_three_colors(colors, "focused_workspace", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_inactive_workspace(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_inactive_workspace(int argc, char **argv) {
 	char **colors[3] = {
 		&(config->current_bar->colors.inactive_workspace_border),
 		&(config->current_bar->colors.inactive_workspace_bg),
@@ -102,27 +98,27 @@ struct cmd_results *bar_colors_cmd_inactive_workspace(int argc, char **argv) {
 	return parse_three_colors(colors, "inactive_workspace", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_separator(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_separator(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.separator),
 			"separator", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_focused_separator(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_focused_separator(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.focused_separator),
 			"focused_separator", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_statusline(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_statusline(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.statusline),
 			"statusline", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_focused_statusline(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_focused_statusline(int argc, char **argv) {
 	return parse_single_color(&(config->current_bar->colors.focused_statusline),
 			"focused_statusline", argc, argv);
 }
 
-struct cmd_results *bar_colors_cmd_urgent_workspace(int argc, char **argv) {
+struct cmd_results bar_colors_cmd_urgent_workspace(int argc, char **argv) {
 	char **colors[3] = {
 		&(config->current_bar->colors.urgent_workspace_border),
 		&(config->current_bar->colors.urgent_workspace_bg),

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -4,9 +4,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *bar_cmd_font(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "font", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results bar_cmd_font(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "font", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	char *font = join_args(argv, argc);

--- a/sway/commands/bar/gaps.c
+++ b/sway/commands/bar/gaps.c
@@ -5,12 +5,12 @@
 #include "sway/ipc-server.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_gaps(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "gaps", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results bar_cmd_gaps(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "gaps", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
-	if ((error = checkarg(argc, "gaps", EXPECTED_AT_MOST, 4))) {
+	if (checkarg(&error, argc, "gaps", EXPECTED_AT_MOST, 4)) {
 		return error;
 	}
 

--- a/sway/commands/bar/height.c
+++ b/sway/commands/bar/height.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_height(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "height", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_height(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "height", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	int height = atoi(argv[0]);

--- a/sway/commands/bar/icon_theme.c
+++ b/sway/commands/bar/icon_theme.c
@@ -5,10 +5,10 @@
 #include "sway/config.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_icon_theme(int argc, char **argv) {
+struct cmd_results bar_cmd_icon_theme(int argc, char **argv) {
 #if HAVE_TRAY
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "icon_theme", EXPECTED_EQUAL_TO, 1))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "icon_theme", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_id(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "id", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_id(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "id", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -6,7 +6,7 @@
 #include "sway/ipc-server.h"
 #include "log.h"
 
-static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode) {
+static struct cmd_results bar_set_mode(struct bar_config *bar, const char *mode) {
 	char *old_mode = bar->mode;
 	if (strcasecmp("toggle", mode) == 0 && !config->reading) {
 		if (strcasecmp("dock", bar->mode) == 0) {
@@ -35,15 +35,15 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 
 	// free old mode
 	free(old_mode);
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *bar_cmd_mode(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "mode", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results bar_cmd_mode(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "mode", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
-	if ((error = checkarg(argc, "mode", EXPECTED_AT_MOST, 2))) {
+	if (checkarg(&error, argc, "mode", EXPECTED_AT_MOST, 2)) {
 		return error;
 	}
 	if (config->reading && argc > 1) {
@@ -59,20 +59,22 @@ struct cmd_results *bar_cmd_mode(int argc, char **argv) {
 
 	const char *mode = argv[0];
 	if (config->reading) {
-		error = bar_set_mode(config->current_bar, mode);
+		return bar_set_mode(config->current_bar, mode);
 	} else {
 		const char *id = argc == 2 ? argv[1] : NULL;
 		for (int i = 0; i < config->bars->length; ++i) {
 			struct bar_config *bar = config->bars->items[i];
 			if (id) {
 				if (strcmp(id, bar->id) == 0) {
-					error = bar_set_mode(bar, mode);
-					break;
+					return bar_set_mode(bar, mode);
 				}
-			} else if ((error = bar_set_mode(bar, mode))) {
-				break;
+			} else {
+				error = bar_set_mode(bar, mode);
+				if (error.status != CMD_SUCCESS) {
+					return error;
+				}
 			}
 		}
+		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
-	return error ? error : cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -4,9 +4,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "modifier", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_modifier(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "modifier", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/output.c
+++ b/sway/commands/bar/output.c
@@ -5,9 +5,9 @@
 #include "list.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_output(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "output", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_output(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "output", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/pango_markup.c
+++ b/sway/commands/bar/pango_markup.c
@@ -4,9 +4,9 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_pango_markup(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "pango_markup", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_pango_markup(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "pango_markup", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	config->current_bar->pango_markup =

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_position(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "position", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_position(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "position", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	char *valid[] = { "top", "bottom" };

--- a/sway/commands/bar/separator_symbol.c
+++ b/sway/commands/bar/separator_symbol.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_separator_symbol(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "separator_symbol", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_separator_symbol(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "separator_symbol", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	free(config->current_bar->separator_symbol);

--- a/sway/commands/bar/status_command.c
+++ b/sway/commands/bar/status_command.c
@@ -3,9 +3,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "status_command", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results bar_cmd_status_command(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "status_command", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	free(config->current_bar->status_command);

--- a/sway/commands/bar/status_edge_padding.c
+++ b/sway/commands/bar/status_edge_padding.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_status_edge_padding(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "status_edge_padding", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_status_edge_padding(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "status_edge_padding", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	char *end;

--- a/sway/commands/bar/status_padding.c
+++ b/sway/commands/bar/status_padding.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_status_padding(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "status_padding", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_status_padding(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "status_padding", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	char *end;

--- a/sway/commands/bar/strip_workspace_name.c
+++ b/sway/commands/bar/strip_workspace_name.c
@@ -4,10 +4,10 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_strip_workspace_name(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc,
-				"strip_workspace_name", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_strip_workspace_name(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc,
+				"strip_workspace_name", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/strip_workspace_numbers.c
+++ b/sway/commands/bar/strip_workspace_numbers.c
@@ -4,10 +4,10 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc,
-				"strip_workspace_numbers", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_strip_workspace_numbers(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc,
+				"strip_workspace_numbers", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/swaybar_command.c
+++ b/sway/commands/bar/swaybar_command.c
@@ -3,9 +3,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "swaybar_command", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results bar_cmd_swaybar_command(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "swaybar_command", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	free(config->current_bar->swaybar_command);

--- a/sway/commands/bar/tray_bind.c
+++ b/sway/commands/bar/tray_bind.c
@@ -5,11 +5,11 @@
 #include "sway/input/cursor.h"
 #include "log.h"
 
-static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
+static struct cmd_results tray_bind(int argc, char **argv, bool code) {
 #if HAVE_TRAY
 	const char *command = code ? "bar tray_bindcode" : "bar tray_bindsym";
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, command, EXPECTED_EQUAL_TO, 2))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, command, EXPECTED_EQUAL_TO, 2)) {
 		return error;
 	}
 
@@ -86,10 +86,10 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 #endif
 }
 
-struct cmd_results *bar_cmd_tray_bindcode(int argc, char **argv) {
+struct cmd_results bar_cmd_tray_bindcode(int argc, char **argv) {
 	return tray_bind(argc, argv, true);
 }
 
-struct cmd_results *bar_cmd_tray_bindsym(int argc, char **argv) {
+struct cmd_results bar_cmd_tray_bindsym(int argc, char **argv) {
 	return tray_bind(argc, argv, false);
 }

--- a/sway/commands/bar/tray_output.c
+++ b/sway/commands/bar/tray_output.c
@@ -6,10 +6,10 @@
 #include "list.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
+struct cmd_results bar_cmd_tray_output(int argc, char **argv) {
 #if HAVE_TRAY
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tray_output", EXPECTED_EQUAL_TO, 1))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tray_output", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/bar/tray_padding.c
+++ b/sway/commands/bar/tray_padding.c
@@ -5,13 +5,13 @@
 #include "sway/config.h"
 #include "log.h"
 
-struct cmd_results *bar_cmd_tray_padding(int argc, char **argv) {
+struct cmd_results bar_cmd_tray_padding(int argc, char **argv) {
 #if HAVE_TRAY
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tray_padding", EXPECTED_AT_LEAST, 1))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tray_padding", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
-	if ((error = checkarg(argc, "tray_padding", EXPECTED_AT_MOST, 2))) {
+	if (checkarg(&error, argc, "tray_padding", EXPECTED_AT_MOST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/bar/workspace_buttons.c
+++ b/sway/commands/bar/workspace_buttons.c
@@ -4,9 +4,9 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "workspace_buttons", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_workspace_buttons(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "workspace_buttons", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	config->current_bar->workspace_buttons =

--- a/sway/commands/bar/wrap_scroll.c
+++ b/sway/commands/bar/wrap_scroll.c
@@ -4,9 +4,9 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *bar_cmd_wrap_scroll(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "wrap_scroll", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results bar_cmd_wrap_scroll(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "wrap_scroll", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	config->current_bar->wrap_scroll =

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -56,9 +56,9 @@ static void border_toggle(struct sway_container *con) {
 	}
 }
 
-struct cmd_results *cmd_border(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "border", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_border(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "border", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/client.c
+++ b/sway/commands/client.c
@@ -53,10 +53,10 @@ static bool parse_color_float(char *hexstring, float dest[static 4]) {
 	return true;
 }
 
-static struct cmd_results *handle_command(int argc, char **argv,
+static struct cmd_results handle_command(int argc, char **argv,
 		struct border_colors *class, char *cmd_name) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, cmd_name, EXPECTED_EQUAL_TO, 5))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, cmd_name, EXPECTED_EQUAL_TO, 5)) {
 		return error;
 	}
 
@@ -97,23 +97,23 @@ static struct cmd_results *handle_command(int argc, char **argv,
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *cmd_client_focused(int argc, char **argv) {
+struct cmd_results cmd_client_focused(int argc, char **argv) {
 	return handle_command(argc, argv, &config->border_colors.focused, "client.focused");
 }
 
-struct cmd_results *cmd_client_focused_inactive(int argc, char **argv) {
+struct cmd_results cmd_client_focused_inactive(int argc, char **argv) {
 	return handle_command(argc, argv, &config->border_colors.focused_inactive, "client.focused_inactive");
 }
 
-struct cmd_results *cmd_client_unfocused(int argc, char **argv) {
+struct cmd_results cmd_client_unfocused(int argc, char **argv) {
 	return handle_command(argc, argv, &config->border_colors.unfocused, "client.unfocused");
 }
 
-struct cmd_results *cmd_client_urgent(int argc, char **argv) {
+struct cmd_results cmd_client_urgent(int argc, char **argv) {
 	return handle_command(argc, argv, &config->border_colors.urgent, "client.urgent");
 }
 
-struct cmd_results *cmd_client_noop(int argc, char **argv) {
+struct cmd_results cmd_client_noop(int argc, char **argv) {
 	sway_log(SWAY_INFO, "Warning: %s is ignored by sway", argv[-1]);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/create_output.c
+++ b/sway/commands/create_output.c
@@ -29,7 +29,7 @@ static void create_output(struct wlr_backend *backend, void *data) {
 /**
  * This command is intended for developer use only.
  */
-struct cmd_results *cmd_create_output(int argc, char **argv) {
+struct cmd_results cmd_create_output(int argc, char **argv) {
 	sway_assert(wlr_backend_is_multi(server.backend),
 			"Expected a multi backend");
 

--- a/sway/commands/default_border.c
+++ b/sway/commands/default_border.c
@@ -3,9 +3,9 @@
 #include "sway/config.h"
 #include "sway/tree/container.h"
 
-struct cmd_results *cmd_default_border(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "default_border", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_default_border(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "default_border", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/default_floating_border.c
+++ b/sway/commands/default_floating_border.c
@@ -3,10 +3,10 @@
 #include "sway/config.h"
 #include "sway/tree/container.h"
 
-struct cmd_results *cmd_default_floating_border(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "default_floating_border",
-					EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_default_floating_border(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "default_floating_border",
+					EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/default_orientation.c
+++ b/sway/commands/default_orientation.c
@@ -2,9 +2,9 @@
 #include <strings.h>
 #include "sway/commands.h"
 
-struct cmd_results *cmd_default_orientation(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "default_orientation", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_default_orientation(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "default_orientation", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (strcasecmp(argv[0], "horizontal") == 0) {

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -4,7 +4,7 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_exec(int argc, char **argv) {
+struct cmd_results cmd_exec(int argc, char **argv) {
 	if (!config->active) return cmd_results_new(CMD_DEFER, NULL);
 	if (config->reloading) {
 		char *args = join_args(argv, argc);

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -13,12 +13,12 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_exec_always(int argc, char **argv) {
-	struct cmd_results *error = NULL;
+struct cmd_results cmd_exec_always(int argc, char **argv) {
+	struct cmd_results error;
 	if (!config->active || config->validating) {
 		return cmd_results_new(CMD_DEFER, NULL);
 	}
-	if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
+	if (checkarg(&error, argc, argv[-1], EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 
@@ -26,7 +26,7 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	if (strcmp(argv[0], "--no-startup-id") == 0) {
 		sway_log(SWAY_INFO, "exec switch '--no-startup-id' not supported, ignored.");
 		--argc; ++argv;
-		if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
+		if (checkarg(&error, argc, argv[-1], EXPECTED_AT_LEAST, 1)) {
 			return error;
 		}
 	}

--- a/sway/commands/exit.c
+++ b/sway/commands/exit.c
@@ -4,9 +4,9 @@
 
 void sway_terminate(int exit_code);
 
-struct cmd_results *cmd_exit(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "exit", EXPECTED_EQUAL_TO, 0))) {
+struct cmd_results cmd_exit(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "exit", EXPECTED_EQUAL_TO, 0)) {
 		return error;
 	}
 	sway_terminate(0);

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -11,9 +11,9 @@
 #include "list.h"
 #include "util.h"
 
-struct cmd_results *cmd_floating(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_floating(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "floating", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!root->outputs->length) {

--- a/sway/commands/floating_minmax_size.c
+++ b/sway/commands/floating_minmax_size.c
@@ -13,10 +13,10 @@ static const char min_usage[] =
 static const char max_usage[] =
 	"Expected 'floating_maximum_size <width> x <height>'";
 
-static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
+static struct cmd_results handle_command(int argc, char **argv, char *cmd_name,
 		const char *usage, int *config_width, int *config_height) {
-	struct cmd_results *error;
-	if ((error = checkarg(argc, cmd_name, EXPECTED_EQUAL_TO, 3))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, cmd_name, EXPECTED_EQUAL_TO, 3)) {
 		return error;
 	}
 
@@ -41,12 +41,12 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *cmd_floating_minimum_size(int argc, char **argv) {
+struct cmd_results cmd_floating_minimum_size(int argc, char **argv) {
 	return handle_command(argc, argv, "floating_minimum_size", min_usage,
 			&config->floating_minimum_width, &config->floating_minimum_height);
 }
 
-struct cmd_results *cmd_floating_maximum_size(int argc, char **argv) {
+struct cmd_results cmd_floating_maximum_size(int argc, char **argv) {
 	return handle_command(argc, argv, "floating_maximum_size", max_usage,
 			&config->floating_maximum_width, &config->floating_maximum_height);
 }

--- a/sway/commands/floating_modifier.c
+++ b/sway/commands/floating_modifier.c
@@ -3,9 +3,9 @@
 #include "sway/config.h"
 #include "sway/input/keyboard.h"
 
-struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "floating_modifier", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_floating_modifier(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "floating_modifier", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -258,7 +258,7 @@ static struct sway_node *node_get_in_direction_floating(
 	return closest_con ? &closest_con->node : NULL;
 }
 
-static struct cmd_results *focus_mode(struct sway_workspace *ws,
+static struct cmd_results focus_mode(struct sway_workspace *ws,
 		struct sway_seat *seat, bool floating) {
 	struct sway_container *new_focus = NULL;
 	if (floating) {
@@ -277,7 +277,7 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *focus_output(struct sway_seat *seat,
+static struct cmd_results focus_output(struct sway_seat *seat,
 		int argc, char **argv) {
 	if (!argc) {
 		return cmd_results_new(CMD_INVALID,
@@ -322,7 +322,7 @@ static struct cmd_results *focus_output(struct sway_seat *seat,
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *focus_parent(void) {
+static struct cmd_results focus_parent(void) {
 	struct sway_seat *seat = config->handler_context.seat;
 	struct sway_container *con = config->handler_context.container;
 	if (!con || con->fullscreen_mode) {
@@ -336,7 +336,7 @@ static struct cmd_results *focus_parent(void) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *focus_child(void) {
+static struct cmd_results focus_child(void) {
 	struct sway_seat *seat = config->handler_context.seat;
 	struct sway_node *node = config->handler_context.node;
 	struct sway_node *focus = seat_get_active_tiling_child(seat, node);
@@ -347,7 +347,7 @@ static struct cmd_results *focus_child(void) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *cmd_focus(int argc, char **argv) {
+struct cmd_results cmd_focus(int argc, char **argv) {
 	if (config->reading || !config->active) {
 		return cmd_results_new(CMD_DEFER, NULL);
 	}

--- a/sway/commands/focus_follows_mouse.c
+++ b/sway/commands/focus_follows_mouse.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "util.h"
 
-struct cmd_results *cmd_focus_follows_mouse(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_focus_follows_mouse(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	} else if(strcmp(argv[0], "no") == 0) {
 		config->focus_follows_mouse = FOLLOWS_NO;

--- a/sway/commands/focus_on_window_activation.c
+++ b/sway/commands/focus_on_window_activation.c
@@ -1,9 +1,9 @@
 #include "sway/commands.h"
 
-struct cmd_results *cmd_focus_on_window_activation(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "focus_on_window_activation",
-					EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_focus_on_window_activation(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "focus_on_window_activation",
+					EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/focus_wrapping.c
+++ b/sway/commands/focus_wrapping.c
@@ -3,9 +3,9 @@
 #include "sway/config.h"
 #include "util.h"
 
-struct cmd_results *cmd_focus_wrapping(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "focus_wrapping", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_focus_wrapping(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "focus_wrapping", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/font.c
+++ b/sway/commands/font.c
@@ -5,9 +5,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_font(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "font", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_font(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "font", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	char *font = join_args(argv, argc);

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -5,9 +5,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_for_window(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "for_window", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_for_window(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "for_window", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/force_display_urgency_hint.c
+++ b/sway/commands/force_display_urgency_hint.c
@@ -1,10 +1,10 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_force_display_urgency_hint(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "force_display_urgency_hint",
-					EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_force_display_urgency_hint(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "force_display_urgency_hint",
+					EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/force_focus_wrapping.c
+++ b/sway/commands/force_focus_wrapping.c
@@ -3,7 +3,7 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
+struct cmd_results cmd_force_focus_wrapping(int argc, char **argv) {
 	sway_log(SWAY_INFO, "Warning: force_focus_wrapping is deprecated. "
 		"Use focus_wrapping instead.");
 	if (config->reading) {
@@ -11,9 +11,8 @@ struct cmd_results *cmd_force_focus_wrapping(int argc, char **argv) {
 			"Use focus_wrapping instead.");
 	}
 
-	struct cmd_results *error =
-		checkarg(argc, "force_focus_wrapping", EXPECTED_EQUAL_TO, 1);
-	if (error) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "force_focus_wrapping", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -9,9 +9,9 @@
 #include "util.h"
 
 // fullscreen [enable|disable|toggle] [global]
-struct cmd_results *cmd_fullscreen(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "fullscreen", EXPECTED_AT_MOST, 2))) {
+struct cmd_results cmd_fullscreen(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "fullscreen", EXPECTED_AT_MOST, 2)) {
 		return error;
 	}
 	if (!root->outputs->length) {

--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -45,9 +45,9 @@ static void prevent_invalid_outer_gaps(void) {
 // gaps inner|outer|horizontal|vertical|top|right|bottom|left <px>
 static const char expected_defaults[] =
 	"'gaps inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
-static struct cmd_results *gaps_set_defaults(int argc, char **argv) {
-	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_EQUAL_TO, 2);
-	if (error) {
+static struct cmd_results gaps_set_defaults(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "gaps", EXPECTED_EQUAL_TO, 2)) {
 		return error;
 	}
 
@@ -136,9 +136,9 @@ static void configure_gaps(struct sway_workspace *ws, void *_data) {
 // set|plus|minus <px>
 static const char expected_runtime[] = "'gaps inner|outer|horizontal|vertical|"
 	"top|right|bottom|left current|all set|plus|minus <px>'";
-static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
-	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_EQUAL_TO, 4);
-	if (error) {
+static struct cmd_results gaps_set_runtime(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "gaps", EXPECTED_EQUAL_TO, 4)) {
 		return error;
 	}
 	if (!root->outputs->length) {
@@ -203,9 +203,9 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 // gaps inner|outer|<dir>|<side> current|all set|plus|minus <px> - runtime only
 // <dir> = horizontal|vertical
 // <side> = top|right|bottom|left
-struct cmd_results *cmd_gaps(int argc, char **argv) {
-	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_AT_LEAST, 2);
-	if (error) {
+struct cmd_results cmd_gaps(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "gaps", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -3,12 +3,12 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/view.h"
 
-struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
+struct cmd_results cmd_hide_edge_borders(int argc, char **argv) {
 	const char *expected_syntax = "Expected 'hide_edge_borders [--i3] "
 		"none|vertical|horizontal|both|smart|smart_no_gaps";
 
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "hide_edge_borders", EXPECTED_AT_LEAST, 1))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "hide_edge_borders", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/include.c
+++ b/sway/commands/include.c
@@ -1,9 +1,9 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_include(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "include", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_include(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "include", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/inhibit_idle.c
+++ b/sway/commands/inhibit_idle.c
@@ -5,9 +5,9 @@
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 
-struct cmd_results *cmd_inhibit_idle(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "inhibit_idle", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_inhibit_idle(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "inhibit_idle", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -44,9 +44,9 @@ static struct cmd_handler input_config_handlers[] = {
 	{ "xkb_numlock", input_cmd_xkb_numlock },
 };
 
-struct cmd_results *cmd_input(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "input", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_input(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "input", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 
@@ -57,7 +57,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}
 
-	struct cmd_results *res;
+	struct cmd_results res;
 
 	if (find_handler(argv[1], input_config_handlers,
 			sizeof(input_config_handlers))) {
@@ -73,16 +73,14 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			input_handlers, sizeof(input_handlers));
 	}
 
-	if ((!res || res->status == CMD_SUCCESS) &&
+	if (res.status == CMD_SUCCESS &&
 			strcmp(argv[1], "xkb_switch_layout") != 0) {
 		char *error = NULL;
 		struct input_config *ic =
 			store_input_config(config->handler_context.input_config, &error);
 		if (!ic) {
 			free_input_config(config->handler_context.input_config);
-			if (res) {
-				free_cmd_results(res);
-			}
+			free_cmd_results(res);
 			res = cmd_results_new(CMD_FAILURE, "Failed to compile keymap: %s",
 					error ? error : "(details unavailable)");
 			free(error);

--- a/sway/commands/input/accel_profile.c
+++ b/sway/commands/input/accel_profile.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 
-struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "accel_profile", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_accel_profile(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "accel_profile", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/calibration_matrix.c
+++ b/sway/commands/input/calibration_matrix.c
@@ -8,9 +8,9 @@
 #include "stringop.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_calibration_matrix(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "calibration_matrix", EXPECTED_EQUAL_TO, 6))) {
+struct cmd_results input_cmd_calibration_matrix(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "calibration_matrix", EXPECTED_EQUAL_TO, 6)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/click_method.c
+++ b/sway/commands/input/click_method.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_click_method(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "click_method", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_click_method(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "click_method", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/drag.c
+++ b/sway/commands/input/drag.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_drag(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "drag", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_drag(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "drag", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/drag_lock.c
+++ b/sway/commands/input/drag_lock.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_drag_lock(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "drag_lock", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_drag_lock(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "drag_lock", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/dwt.c
+++ b/sway/commands/input/dwt.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_dwt(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "dwt", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_dwt(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "dwt", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -105,9 +105,9 @@ static void toggle_wildcard_send_events(int argc, char **argv) {
 	}
 }
 
-struct cmd_results *input_cmd_events(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "events", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_events(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "events", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "left_handed", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_left_handed(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "left_handed", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/map_from_region.c
+++ b/sway/commands/input/map_from_region.c
@@ -33,9 +33,9 @@ static bool parse_coords(const char *str, double *x, double *y, bool *mm) {
 	return true;
 }
 
-struct cmd_results *input_cmd_map_from_region(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "map_from_region", EXPECTED_EQUAL_TO, 2))) {
+struct cmd_results input_cmd_map_from_region(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "map_from_region", EXPECTED_EQUAL_TO, 2)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/map_to_output.c
+++ b/sway/commands/input/map_to_output.c
@@ -6,9 +6,9 @@
 #include "sway/input/input-manager.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_map_to_output(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "map_to_output", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_map_to_output(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "map_to_output", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/map_to_region.c
+++ b/sway/commands/input/map_to_region.c
@@ -5,9 +5,9 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *input_cmd_map_to_region(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "map_to_region", EXPECTED_EQUAL_TO, 4))) {
+struct cmd_results input_cmd_map_to_region(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "map_to_region", EXPECTED_EQUAL_TO, 4)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/middle_emulation.c
+++ b/sway/commands/input/middle_emulation.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_middle_emulation(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "middle_emulation", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_middle_emulation(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "middle_emulation", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/natural_scroll.c
+++ b/sway/commands/input/natural_scroll.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_natural_scroll(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "natural_scroll", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_natural_scroll(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "natural_scroll", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -6,9 +6,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "pointer_accel", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_pointer_accel(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "pointer_accel", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/repeat_delay.c
+++ b/sway/commands/input/repeat_delay.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 
-struct cmd_results *input_cmd_repeat_delay(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "repeat_delay", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_repeat_delay(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "repeat_delay", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/repeat_rate.c
+++ b/sway/commands/input/repeat_rate.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 
-struct cmd_results *input_cmd_repeat_rate(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "repeat_rate", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_repeat_rate(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "repeat_rate", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "sway/input/cursor.h"
 
-struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "scroll_button", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_scroll_button(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "scroll_button", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/scroll_factor.c
+++ b/sway/commands/input/scroll_factor.c
@@ -7,9 +7,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_scroll_factor(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "scroll_factor", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_scroll_factor(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "scroll_factor", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/scroll_method.c
+++ b/sway/commands/input/scroll_method.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 
-struct cmd_results *input_cmd_scroll_method(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "scroll_method", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_scroll_method(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "scroll_method", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/tap.c
+++ b/sway/commands/input/tap.c
@@ -6,9 +6,9 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_tap(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tap", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_tap(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tap", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/tap_button_map.c
+++ b/sway/commands/input/tap_button_map.c
@@ -4,9 +4,9 @@
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
 
-struct cmd_results *input_cmd_tap_button_map(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tap_button_map", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_tap_button_map(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tap_button_map", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_capslock.c
+++ b/sway/commands/input/xkb_capslock.c
@@ -5,9 +5,9 @@
 #include "sway/input/input-manager.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_xkb_capslock(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_capslock", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_xkb_capslock(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_capslock", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_file.c
+++ b/sway/commands/input/xkb_file.c
@@ -6,9 +6,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *input_cmd_xkb_file(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_file", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_file(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_file", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_xkb_layout(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_layout", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_layout(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_layout", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_xkb_model(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_model", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_model(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_model", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_numlock.c
+++ b/sway/commands/input/xkb_numlock.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "util.h"
 
-struct cmd_results *input_cmd_xkb_numlock(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_numlock", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results input_cmd_xkb_numlock(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_numlock", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_xkb_options(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_options", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_options(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_options", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_xkb_rules(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_rules", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_rules(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_rules", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_switch_layout.c
+++ b/sway/commands/input/xkb_switch_layout.c
@@ -13,9 +13,9 @@ static void switch_layout(struct wlr_keyboard *kbd, xkb_layout_index_t idx) {
 		kbd->modifiers.latched, kbd->modifiers.locked, idx);
 }
 
-struct cmd_results *input_cmd_xkb_switch_layout(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_switch_layout", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_switch_layout(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_switch_layout", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "log.h"
 
-struct cmd_results *input_cmd_xkb_variant(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xkb_variant", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results input_cmd_xkb_variant(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xkb_variant", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct input_config *ic = config->handler_context.input_config;

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -12,7 +12,7 @@ static void close_container_iterator(struct sway_container *con, void *data) {
 	}
 }
 
-struct cmd_results *cmd_kill(int argc, char **argv) {
+struct cmd_results cmd_kill(int argc, char **argv) {
 	if (!root->outputs->length) {
 		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -114,9 +114,9 @@ static enum sway_container_layout get_layout(int argc, char **argv,
 	return L_NONE;
 }
 
-struct cmd_results *cmd_layout(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "layout", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_layout(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "layout", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	if (!root->outputs->length) {

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -13,9 +13,9 @@
 // mark --add --toggle foo       Toggle current mark and persist other marks
 // mark --replace --toggle foo   Toggle current mark and remove other marks
 
-struct cmd_results *cmd_mark(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "mark", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_mark(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "mark", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;

--- a/sway/commands/max_render_time.c
+++ b/sway/commands/max_render_time.c
@@ -3,7 +3,7 @@
 #include "sway/config.h"
 #include "sway/tree/view.h"
 
-struct cmd_results *cmd_max_render_time(int argc, char **argv) {
+struct cmd_results cmd_max_render_time(int argc, char **argv) {
 	if (!argc) {
 		return cmd_results_new(CMD_INVALID, "Missing max render time argument.");
 	}

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -19,9 +19,9 @@ static struct cmd_handler mode_handlers[] = {
 	{ "unbindsym", cmd_unbindsym },
 };
 
-struct cmd_results *cmd_mode(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "mode", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_mode(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "mode", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 
@@ -79,7 +79,7 @@ struct cmd_results *cmd_mode(int argc, char **argv) {
 	}
 
 	// Create binding
-	struct cmd_results *result = config_subcommand(argv + 1, argc - 1,
+	struct cmd_results result = config_subcommand(argv + 1, argc - 1,
 			mode_handlers, sizeof(mode_handlers));
 	config->current_mode = stored_mode;
 

--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -2,9 +2,9 @@
 #include <strings.h>
 #include "sway/commands.h"
 
-struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "mouse_warping", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_mouse_warping(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "mouse_warping", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	} else if (strcasecmp(argv[0], "container") == 0) {
 		config->mouse_warping = WARP_CONTAINER;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -388,13 +388,13 @@ static bool container_move_in_direction(struct sway_container *container,
 	return false;
 }
 
-static struct cmd_results *cmd_move_to_scratchpad(void);
+static struct cmd_results cmd_move_to_scratchpad(void);
 
-static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
+static struct cmd_results cmd_move_container(bool no_auto_back_and_forth,
 		int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "move container/window",
-				EXPECTED_AT_LEAST, 2))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "move container/window",
+				EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 
@@ -629,9 +629,9 @@ static void workspace_move_to_output(struct sway_workspace *workspace,
 	ipc_event_workspace(NULL, workspace, "move");
 }
 
-static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "move workspace", EXPECTED_AT_LEAST, 1))) {
+static struct cmd_results cmd_move_workspace(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "move workspace", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 
@@ -666,7 +666,7 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *cmd_move_in_direction(
+static struct cmd_results cmd_move_in_direction(
 		enum wlr_direction direction, int argc, char **argv) {
 	int move_amt = 10;
 	if (argc) {
@@ -747,7 +747,7 @@ static const char expected_position_syntax[] =
 	"'move [absolute] position center' or "
 	"'move position cursor|mouse|pointer'";
 
-static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
+static struct cmd_results cmd_move_to_position(int argc, char **argv) {
 	struct sway_container *container = config->handler_context.container;
 	if (!container || !container_is_floating(container)) {
 		return cmd_results_new(CMD_FAILURE, "Only floating containers "
@@ -843,7 +843,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-static struct cmd_results *cmd_move_to_scratchpad(void) {
+static struct cmd_results cmd_move_to_scratchpad(void) {
 	struct sway_node *node = config->handler_context.node;
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
@@ -885,9 +885,9 @@ static const char expected_full_syntax[] = "Expected "
 	" or 'move [window|container] [to] [absolute] position center'"
 	" or 'move [window|container] [to] position mouse|cursor|pointer'";
 
-struct cmd_results *cmd_move(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "move", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_move(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "move", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	if (!root->outputs->length) {

--- a/sway/commands/new_float.c
+++ b/sway/commands/new_float.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_new_float(int argc, char **argv) {
+struct cmd_results cmd_new_float(int argc, char **argv) {
 	sway_log(SWAY_INFO, "Warning: new_float is deprecated. "
 		"Use default_floating_border instead.");
 	if (config->reading) {

--- a/sway/commands/new_window.c
+++ b/sway/commands/new_window.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_new_window(int argc, char **argv) {
+struct cmd_results cmd_new_window(int argc, char **argv) {
 	sway_log(SWAY_INFO, "Warning: new_window is deprecated. "
 		"Use default_border instead.");
 	if (config->reading) {

--- a/sway/commands/no_focus.c
+++ b/sway/commands/no_focus.c
@@ -4,9 +4,9 @@
 #include "list.h"
 #include "log.h"
 
-struct cmd_results *cmd_no_focus(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "no_focus", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_no_focus(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "no_focus", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/nop.c
+++ b/sway/commands/nop.c
@@ -1,5 +1,5 @@
 #include "sway/commands.h"
 
-struct cmd_results *cmd_nop(int argc, char **argv) {
+struct cmd_results cmd_nop(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -5,9 +5,9 @@
 #include "sway/tree/view.h"
 #include "log.h"
 
-struct cmd_results *cmd_opacity(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "opacity", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_opacity(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "opacity", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -25,9 +25,9 @@ static struct cmd_handler output_handlers[] = {
 	{ "transform", output_cmd_transform },
 };
 
-struct cmd_results *cmd_output(int argc, char **argv) {
-	struct cmd_results *error = checkarg(argc, "output", EXPECTED_AT_LEAST, 1);
-	if (error != NULL) {
+struct cmd_results cmd_output(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "output", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 
@@ -66,7 +66,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	}
 	if (!output) {
 		sway_log(SWAY_ERROR, "Failed to allocate output config");
-		return NULL;
+		return cmd_results_new(CMD_FAILURE, "Failed to allocate output config");
 	}
 	argc--; argv++;
 
@@ -84,7 +84,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 				"Invalid output subcommand: %s.", *argv);
 		}
 
-		if (error != NULL) {
+		if (error.status != CMD_SUCCESS) {
 			goto fail;
 		}
 

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -29,7 +29,7 @@ static bool validate_color(const char *color) {
 	return *ptr == '\0';
 }
 
-struct cmd_results *output_cmd_background(int argc, char **argv) {
+struct cmd_results output_cmd_background(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -80,7 +80,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 
 		char *src = join_args(argv, j);
 		if (!expand_path(&src)) {
-			struct cmd_results *cmd_res = cmd_results_new(CMD_INVALID,
+			struct cmd_results cmd_res = cmd_results_new(CMD_INVALID,
 				"Invalid syntax (%s)", src);
 			free(src);
 			return cmd_res;
@@ -150,5 +150,5 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/disable.c
+++ b/sway/commands/output/disable.c
@@ -1,7 +1,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_disable(int argc, char **argv) {
+struct cmd_results output_cmd_disable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -9,5 +9,5 @@ struct cmd_results *output_cmd_disable(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -2,7 +2,7 @@
 #include "sway/config.h"
 #include "util.h"
 
-struct cmd_results *output_cmd_dpms(int argc, char **argv) {
+struct cmd_results output_cmd_dpms(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -18,5 +18,5 @@ struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/enable.c
+++ b/sway/commands/output/enable.c
@@ -1,7 +1,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_enable(int argc, char **argv) {
+struct cmd_results output_cmd_enable(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -10,6 +10,6 @@ struct cmd_results *output_cmd_enable(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 

--- a/sway/commands/output/max_render_time.c
+++ b/sway/commands/output/max_render_time.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_max_render_time(int argc, char **argv) {
+struct cmd_results output_cmd_max_render_time(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -24,5 +24,5 @@ struct cmd_results *output_cmd_max_render_time(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/mode.c
+++ b/sway/commands/output/mode.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_mode(int argc, char **argv) {
+struct cmd_results output_cmd_mode(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -55,6 +55,6 @@ struct cmd_results *output_cmd_mode(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 

--- a/sway/commands/output/position.c
+++ b/sway/commands/output/position.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_position(int argc, char **argv) {
+struct cmd_results output_cmd_position(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -36,6 +36,6 @@ struct cmd_results *output_cmd_position(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 

--- a/sway/commands/output/scale.c
+++ b/sway/commands/output/scale.c
@@ -2,7 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *output_cmd_scale(int argc, char **argv) {
+struct cmd_results output_cmd_scale(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -18,5 +18,5 @@ struct cmd_results *output_cmd_scale(int argc, char **argv) {
 
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/scale_filter.c
+++ b/sway/commands/output/scale_filter.c
@@ -4,7 +4,7 @@
 #include "sway/config.h"
 #include "sway/output.h"
 
-struct cmd_results *output_cmd_scale_filter(int argc, char **argv) {
+struct cmd_results output_cmd_scale_filter(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -30,5 +30,5 @@ struct cmd_results *output_cmd_scale_filter(int argc, char **argv) {
 	config->handler_context.leftovers.argv = argv + 1;
 
 	oc->scale_filter = scale_filter;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/subpixel.c
+++ b/sway/commands/output/subpixel.c
@@ -4,7 +4,7 @@
 #include "sway/config.h"
 #include "sway/output.h"
 
-struct cmd_results *output_cmd_subpixel(int argc, char **argv) {
+struct cmd_results output_cmd_subpixel(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -32,5 +32,5 @@ struct cmd_results *output_cmd_subpixel(int argc, char **argv) {
 	config->handler_context.leftovers.argv = argv + 1;
 
 	oc->subpixel = subpixel;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/output/toggle.c
+++ b/sway/commands/output/toggle.c
@@ -2,7 +2,7 @@
 #include "sway/config.h"
 #include "sway/output.h"
 
-struct cmd_results *output_cmd_toggle(int argc, char **argv) {
+struct cmd_results output_cmd_toggle(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -32,6 +32,6 @@ struct cmd_results *output_cmd_toggle(int argc, char **argv) {
 	free(oc);
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 

--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -4,7 +4,7 @@
 #include "log.h"
 #include "sway/output.h"
 
-struct cmd_results *output_cmd_transform(int argc, char **argv) {
+struct cmd_results output_cmd_transform(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
@@ -38,7 +38,8 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 	if (argc > 1 &&
 			(strcmp(argv[1], "clockwise") == 0 || strcmp(argv[1], "anticlockwise") == 0)) {
 		if (!sway_assert(output->name != NULL, "Output config name not set")) {
-			return NULL;
+			return cmd_results_new(CMD_INVALID,
+				"Output config name not set");
 		}
 		if (strcmp(output->name, "*") == 0) {
 			return cmd_results_new(CMD_INVALID,
@@ -58,5 +59,5 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 		config->handler_context.leftovers.argc -= 1;
 	}
 	output->transform = transform;
-	return NULL;
+	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/popup_during_fullscreen.c
+++ b/sway/commands/popup_during_fullscreen.c
@@ -2,10 +2,10 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_popup_during_fullscreen(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "popup_during_fullscreen",
-					EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_popup_during_fullscreen(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "popup_during_fullscreen",
+					EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -49,9 +49,9 @@ static void do_reload(void *data) {
 	arrange_root();
 }
 
-struct cmd_results *cmd_reload(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0))) {
+struct cmd_results cmd_reload(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "reload", EXPECTED_EQUAL_TO, 0)) {
 		return error;
 	}
 

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -15,9 +15,9 @@ static const char expected_syntax[] =
 	"Expected 'rename workspace <old_name> to <new_name>' or "
 	"'rename workspace to <new_name>'";
 
-struct cmd_results *cmd_rename(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "rename", EXPECTED_AT_LEAST, 3))) {
+struct cmd_results cmd_rename(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "rename", EXPECTED_AT_LEAST, 3)) {
 		return error;
 	}
 	if (!root->outputs->length) {

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -216,7 +216,7 @@ void container_resize_tiled(struct sway_container *con,
 /**
  * Implement `resize <grow|shrink>` for a floating container.
  */
-static struct cmd_results *resize_adjust_floating(uint32_t axis,
+static struct cmd_results resize_adjust_floating(uint32_t axis,
 		struct resize_amount *amount) {
 	struct sway_container *con = config->handler_context.container;
 	int grow_width = 0, grow_height = 0;
@@ -273,7 +273,7 @@ static struct cmd_results *resize_adjust_floating(uint32_t axis,
 /**
  * Implement `resize <grow|shrink>` for a tiled container.
  */
-static struct cmd_results *resize_adjust_tiled(uint32_t axis,
+static struct cmd_results resize_adjust_tiled(uint32_t axis,
 		struct resize_amount *amount) {
 	struct sway_container *current = config->handler_context.container;
 
@@ -303,7 +303,7 @@ static struct cmd_results *resize_adjust_tiled(uint32_t axis,
 /**
  * Implement `resize set` for a tiled container.
  */
-static struct cmd_results *resize_set_tiled(struct sway_container *con,
+static struct cmd_results resize_set_tiled(struct sway_container *con,
 		struct resize_amount *width, struct resize_amount *height) {
 	if (width->amount) {
 		if (width->unit == RESIZE_UNIT_PPT ||
@@ -353,7 +353,7 @@ static struct cmd_results *resize_set_tiled(struct sway_container *con,
 /**
  * Implement `resize set` for a floating container.
  */
-static struct cmd_results *resize_set_floating(struct sway_container *con,
+static struct cmd_results resize_set_floating(struct sway_container *con,
 		struct resize_amount *width, struct resize_amount *height) {
 	int min_width, max_width, min_height, max_height, grow_width = 0, grow_height = 0;
 	floating_calculate_constraints(&min_width, &max_width,
@@ -424,9 +424,9 @@ static struct cmd_results *resize_set_floating(struct sway_container *con,
  *     : height <height> [px|ppt]
  *     : [width] <width> [px|ppt] [height] <height> [px|ppt]
  */
-static struct cmd_results *cmd_resize_set(int argc, char **argv) {
-	struct cmd_results *error;
-	if ((error = checkarg(argc, "resize", EXPECTED_AT_LEAST, 1))) {
+static struct cmd_results cmd_resize_set(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "resize", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	const char usage[] = "Expected 'resize set [width] <width> [px|ppt]' or "
@@ -484,7 +484,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
  * args: <direction> <amount> <unit>
  * args: <direction> <amount> <unit> or <amount> <other_unit>
  */
-static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
+static struct cmd_results cmd_resize_adjust(int argc, char **argv,
 		int multiplier) {
 	const char usage[] = "Expected 'resize grow|shrink <direction> "
 		"[<amount> px|ppt [or <amount> px|ppt]]'";
@@ -566,7 +566,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 	}
 }
 
-struct cmd_results *cmd_resize(int argc, char **argv) {
+struct cmd_results cmd_resize(int argc, char **argv) {
 	if (!root->outputs->length) {
 		return cmd_results_new(CMD_INVALID,
 				"Can't run this command while there's no outputs connected.");
@@ -576,8 +576,8 @@ struct cmd_results *cmd_resize(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Cannot resize nothing");
 	}
 
-	struct cmd_results *error;
-	if ((error = checkarg(argc, "resize", EXPECTED_AT_LEAST, 2))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "resize", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -89,9 +89,9 @@ static void scratchpad_toggle_container(struct sway_container *con) {
 	ipc_event_window(con, "move");
 }
 
-struct cmd_results *cmd_scratchpad(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "scratchpad", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_scratchpad(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "scratchpad", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (strcmp(argv[0], "show") != 0) {

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -25,18 +25,18 @@ static struct cmd_handler seat_handlers[] = {
 	{ "xcursor_theme", seat_cmd_xcursor_theme },
 };
 
-static struct cmd_results *action_handlers(int argc, char **argv) {
-	struct cmd_results *res = config_subcommand(argv, argc,
+static struct cmd_results action_handlers(int argc, char **argv) {
+	struct cmd_results res = config_subcommand(argv, argc,
 			seat_action_handlers, sizeof(seat_action_handlers));
 	free_seat_config(config->handler_context.seat_config);
 	config->handler_context.seat_config = NULL;
 	return res;
 }
 
-static struct cmd_results *config_handlers(int argc, char **argv) {
-	struct cmd_results *res = config_subcommand(argv, argc,
+static struct cmd_results config_handlers(int argc, char **argv) {
+	struct cmd_results res = config_subcommand(argv, argc,
 			seat_handlers, sizeof(seat_handlers));
-	if (res && res->status != CMD_SUCCESS) {
+	if (res.status != CMD_SUCCESS) {
 		free_seat_config(config->handler_context.seat_config);
 	} else {
 		struct seat_config *sc =
@@ -49,9 +49,9 @@ static struct cmd_results *config_handlers(int argc, char **argv) {
 	return res;
 }
 
-struct cmd_results *cmd_seat(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "seat", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_seat(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "seat", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 
@@ -69,12 +69,12 @@ struct cmd_results *cmd_seat(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Couldn't allocate config");
 	}
 
-	struct cmd_results *res = NULL;
+	struct cmd_results res;
 	if (find_handler(argv[1], seat_action_handlers,
 				sizeof(seat_action_handlers))) {
 		res = action_handlers(argc - 1, argv + 1);
 	} else {
 		res = config_handlers(argc - 1, argv + 1);
 	}
-	return res ? res : cmd_results_new(CMD_SUCCESS, NULL);
+	return res;
 }

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -4,9 +4,9 @@
 #include "sway/config.h"
 #include "stringop.h"
 
-struct cmd_results *seat_cmd_attach(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "attach", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results seat_cmd_attach(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "attach", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/fallback.c
+++ b/sway/commands/seat/fallback.c
@@ -2,9 +2,9 @@
 #include "sway/commands.h"
 #include "util.h"
 
-struct cmd_results *seat_cmd_fallback(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "fallback", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results seat_cmd_fallback(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "fallback", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/hide_cursor.c
+++ b/sway/commands/seat/hide_cursor.c
@@ -5,9 +5,9 @@
 #include "sway/input/seat.h"
 #include "stringop.h"
 
-struct cmd_results *seat_cmd_hide_cursor(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "hide_cursor", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results seat_cmd_hide_cursor(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "hide_cursor", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/idle.c
+++ b/sway/commands/seat/idle.c
@@ -38,9 +38,9 @@ static uint32_t parse_sources(int argc, char **argv) {
 	return sources;
 }
 
-struct cmd_results *seat_cmd_idle_inhibit(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "idle_inhibit", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results seat_cmd_idle_inhibit(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "idle_inhibit", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {
@@ -55,9 +55,9 @@ struct cmd_results *seat_cmd_idle_inhibit(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *seat_cmd_idle_wake(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "idle_wake", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results seat_cmd_idle_wake(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "idle_wake", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/keyboard_grouping.c
+++ b/sway/commands/seat/keyboard_grouping.c
@@ -3,9 +3,9 @@
 #include "sway/config.h"
 #include "stringop.h"
 
-struct cmd_results *seat_cmd_keyboard_grouping(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "keyboard_grouping", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results seat_cmd_keyboard_grouping(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "keyboard_grouping", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/pointer_constraint.c
+++ b/sway/commands/seat/pointer_constraint.c
@@ -12,9 +12,9 @@ enum operation {
 };
 
 // pointer_constraint [enable|disable|escape]
-struct cmd_results *seat_cmd_pointer_constraint(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "pointer_constraint", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results seat_cmd_pointer_constraint(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "pointer_constraint", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/seat/xcursor_theme.c
+++ b/sway/commands/seat/xcursor_theme.c
@@ -3,10 +3,10 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *seat_cmd_xcursor_theme(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xcursor_theme", EXPECTED_AT_LEAST, 1)) ||
-		(error = checkarg(argc, "xcursor_theme", EXPECTED_AT_MOST, 2))) {
+struct cmd_results seat_cmd_xcursor_theme(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xcursor_theme", EXPECTED_AT_LEAST, 1) ||
+		checkarg(&error, argc, "xcursor_theme", EXPECTED_AT_MOST, 2)) {
 		return error;
 	}
 	if (!config->handler_context.seat_config) {

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -24,9 +24,9 @@ void free_sway_variable(struct sway_variable *var) {
 	free(var);
 }
 
-struct cmd_results *cmd_set(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "set", EXPECTED_AT_LEAST, 2))) {
+struct cmd_results cmd_set(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "set", EXPECTED_AT_LEAST, 2)) {
 		return error;
 	}
 

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -14,9 +14,9 @@ static void rebuild_marks_iterator(struct sway_container *con, void *data) {
 	container_update_marks_textures(con);
 }
 
-struct cmd_results *cmd_show_marks(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "show_marks", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_show_marks(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "show_marks", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/smart_borders.c
+++ b/sway/commands/smart_borders.c
@@ -4,9 +4,9 @@
 #include "sway/tree/view.h"
 #include "util.h"
 
-struct cmd_results *cmd_smart_borders(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "smart_borders", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_smart_borders(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "smart_borders", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/smart_gaps.c
+++ b/sway/commands/smart_gaps.c
@@ -8,10 +8,9 @@
 #include "stringop.h"
 #include "util.h"
 
-struct cmd_results *cmd_smart_gaps(int argc, char **argv) {
-	struct cmd_results *error = checkarg(argc, "smart_gaps", EXPECTED_AT_LEAST, 1);
-
-	if (error) {
+struct cmd_results cmd_smart_gaps(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "smart_gaps", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -9,7 +9,7 @@
 #include "sway/input/seat.h"
 #include "log.h"
 
-static struct cmd_results *do_split(int layout) {
+static struct cmd_results do_split(int layout) {
 	struct sway_container *con = config->handler_context.container;
 	struct sway_workspace *ws = config->handler_context.workspace;
 	if (con) {
@@ -36,9 +36,9 @@ static struct cmd_results *do_split(int layout) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *cmd_split(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "split", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_split(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "split", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (!root->outputs->length) {
@@ -66,25 +66,25 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
-struct cmd_results *cmd_splitv(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "splitv", EXPECTED_EQUAL_TO, 0))) {
+struct cmd_results cmd_splitv(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "splitv", EXPECTED_EQUAL_TO, 0)) {
 		return error;
 	}
 	return do_split(L_VERT);
 }
 
-struct cmd_results *cmd_splith(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "splitv", EXPECTED_EQUAL_TO, 0))) {
+struct cmd_results cmd_splith(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "splitv", EXPECTED_EQUAL_TO, 0)) {
 		return error;
 	}
 	return do_split(L_HORIZ);
 }
 
-struct cmd_results *cmd_splitt(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "splitv", EXPECTED_EQUAL_TO, 0))) {
+struct cmd_results cmd_splitt(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "splitv", EXPECTED_EQUAL_TO, 0)) {
 		return error;
 	}
 

--- a/sway/commands/sticky.c
+++ b/sway/commands/sticky.c
@@ -12,9 +12,9 @@
 #include "log.h"
 #include "util.h"
 
-struct cmd_results *cmd_sticky(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "sticky", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_sticky(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "sticky", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -208,9 +208,9 @@ static bool test_mark(struct sway_container *container, void *mark) {
 	return false;
 }
 
-struct cmd_results *cmd_swap(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "swap", EXPECTED_AT_LEAST, 4))) {
+struct cmd_results cmd_swap(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "swap", EXPECTED_AT_LEAST, 4)) {
 		return error;
 	}
 	if (!root->outputs->length) {
@@ -242,22 +242,21 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	}
 
 	if (!other) {
-		error = cmd_results_new(CMD_FAILURE,
+		struct cmd_results res = cmd_results_new(CMD_FAILURE,
 				"Failed to find %s '%s'", argv[2], value);
+		free(value);
+		return res;
 	} else if (!current) {
-		error = cmd_results_new(CMD_FAILURE,
+		free(value);
+		return cmd_results_new(CMD_FAILURE,
 				"Can only swap with containers and views");
 	} else if (container_has_ancestor(current, other)
 			|| container_has_ancestor(other, current)) {
-		error = cmd_results_new(CMD_FAILURE,
+		free(value);
+		return cmd_results_new(CMD_FAILURE,
 				"Cannot swap ancestor and descendant");
 	}
-
 	free(value);
-
-	if (error) {
-		return error;
-	}
 
 	container_swap(current, other);
 

--- a/sway/commands/swaybg_command.c
+++ b/sway/commands/swaybg_command.c
@@ -3,9 +3,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_swaybg_command(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "swaybg_command", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_swaybg_command(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "swaybg_command", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/swaynag_command.c
+++ b/sway/commands/swaynag_command.c
@@ -3,9 +3,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_swaynag_command(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "swaynag_command", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_swaynag_command(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "swaynag_command", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/tiling_drag.c
+++ b/sway/commands/tiling_drag.c
@@ -1,9 +1,9 @@
 #include "sway/commands.h"
 #include "util.h"
 
-struct cmd_results *cmd_tiling_drag(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tiling_drag", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_tiling_drag(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tiling_drag", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/tiling_drag_threshold.c
+++ b/sway/commands/tiling_drag_threshold.c
@@ -3,9 +3,9 @@
 #include "sway/config.h"
 #include "log.h"
 
-struct cmd_results *cmd_tiling_drag_threshold(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "tiling_drag_threshold", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_tiling_drag_threshold(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "tiling_drag_threshold", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/title_align.c
+++ b/sway/commands/title_align.c
@@ -4,9 +4,9 @@
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 
-struct cmd_results *cmd_title_align(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "title_align", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_title_align(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "title_align", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -6,9 +6,9 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_title_format(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "title_format", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_title_format(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "title_format", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;

--- a/sway/commands/titlebar_border_thickness.c
+++ b/sway/commands/titlebar_border_thickness.c
@@ -5,9 +5,9 @@
 #include "sway/tree/arrange.h"
 #include "log.h"
 
-struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "titlebar_border_thickness", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_titlebar_border_thickness(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "titlebar_border_thickness", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/commands/titlebar_padding.c
+++ b/sway/commands/titlebar_padding.c
@@ -5,9 +5,9 @@
 #include "sway/tree/arrange.h"
 #include "log.h"
 
-struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "titlebar_padding", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_titlebar_padding(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "titlebar_padding", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -18,7 +18,7 @@ static void remove_all_marks_iterator(struct sway_container *con, void *data) {
 // [criteria] unmark       Remove all marks from matched view
 // [criteria] unmark foo   Remove single mark from matched view
 
-struct cmd_results *cmd_unmark(int argc, char **argv) {
+struct cmd_results cmd_unmark(int argc, char **argv) {
 	// Determine the container
 	struct sway_container *con = NULL;
 	if (config->handler_context.using_criteria) {

--- a/sway/commands/urgent.c
+++ b/sway/commands/urgent.c
@@ -6,9 +6,9 @@
 #include "sway/tree/view.h"
 #include "util.h"
 
-struct cmd_results *cmd_urgent(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "urgent", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_urgent(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "urgent", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	struct sway_container *container = config->handler_context.container;

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -56,13 +56,13 @@ static void prevent_invalid_outer_gaps(struct workspace_config *wsc) {
 	}
 }
 
-static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
+static struct cmd_results cmd_workspace_gaps(int argc, char **argv,
 		int gaps_location) {
 	const char expected[] = "Expected 'workspace <name> gaps "
 		"inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO,
-					gaps_location + 3))) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "workspace", EXPECTED_EQUAL_TO,
+					gaps_location + 3)) {
 		return error;
 	}
 	char *ws_name = join_args(argv, argc - 3);
@@ -119,9 +119,9 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	return error;
 }
 
-struct cmd_results *cmd_workspace(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST, 1))) {
+struct cmd_results cmd_workspace(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "workspace", EXPECTED_AT_LEAST, 1)) {
 		return error;
 	}
 
@@ -141,8 +141,8 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 	}
 	if (output_location >= 0) {
-		if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST,
-						output_location + 2))) {
+		if (checkarg(&error, argc, "workspace", EXPECTED_AT_LEAST,
+						output_location + 2)) {
 			return error;
 		}
 		char *ws_name = join_args(argv, output_location);
@@ -156,9 +156,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			list_add(wsc->outputs, strdup(argv[i]));
 		}
 	} else if (gaps_location >= 0) {
-		if ((error = cmd_workspace_gaps(argc, argv, gaps_location))) {
-			return error;
-		}
+		return cmd_workspace_gaps(argc, argv, gaps_location);
 	} else {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, NULL);
@@ -175,7 +173,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		bool no_auto_back_and_forth = false;
 		while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
 			no_auto_back_and_forth = true;
-			if ((error = checkarg(--argc, "workspace", EXPECTED_AT_LEAST, 1))) {
+			if (checkarg(&error, --argc, "workspace", EXPECTED_AT_LEAST, 1)) {
 				return error;
 			}
 			++argv;

--- a/sway/commands/workspace_layout.c
+++ b/sway/commands/workspace_layout.c
@@ -2,9 +2,9 @@
 #include <strings.h>
 #include "sway/commands.h"
 
-struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "workspace_layout", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_workspace_layout(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "workspace_layout", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	if (strcasecmp(argv[0], "default") == 0) {

--- a/sway/commands/ws_auto_back_and_forth.c
+++ b/sway/commands/ws_auto_back_and_forth.c
@@ -3,9 +3,9 @@
 #include "sway/commands.h"
 #include "util.h"
 
-struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "workspace_auto_back_and_forth", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_ws_auto_back_and_forth(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "workspace_auto_back_and_forth", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 	config->auto_back_and_forth = 

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -4,9 +4,9 @@
 #include "sway/server.h"
 #include "util.h"
 
-struct cmd_results *cmd_xwayland(int argc, char **argv) {
-	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "xwayland", EXPECTED_EQUAL_TO, 1))) {
+struct cmd_results cmd_xwayland(int argc, char **argv) {
+	struct cmd_results error;
+	if (checkarg(&error, argc, "xwayland", EXPECTED_EQUAL_TO, 1)) {
 		return error;
 	}
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -657,7 +657,8 @@ void run_deferred_commands(void) {
 				sway_log(SWAY_ERROR, "Error on line '%s': %s",
 						line, res->error);
 			}
-			free_cmd_results(res);
+			free_cmd_results(*res);
+			free(res);
 		}
 		list_del(config->cmd_queue, 0);
 		list_free(res_list);
@@ -820,7 +821,7 @@ bool read_config(FILE *file, struct sway_config *config,
 		}
 		config->current_config_line_number = line_number;
 		config->current_config_line = line;
-		struct cmd_results *res;
+		struct cmd_results res;
 		char *new_block = NULL;
 		if (block && strcmp(block, "<commands>") == 0) {
 			// Special case
@@ -828,15 +829,15 @@ bool read_config(FILE *file, struct sway_config *config,
 		} else {
 			res = config_command(expanded, &new_block);
 		}
-		switch(res->status) {
+		switch(res.status) {
 		case CMD_FAILURE:
 		case CMD_INVALID:
 			sway_log(SWAY_ERROR, "Error on line %i '%s': %s (%s)", line_number,
-				line, res->error, config->current_config_path);
+				line, res.error, config->current_config_path);
 			if (!config->validating) {
 				swaynag_log(config->swaynag_command, swaynag,
 					"Error on line %i (%s) '%s': %s", line_number,
-					config->current_config_path, line, res->error);
+					config->current_config_path, line, res.error);
 			}
 			success = false;
 			break;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -637,10 +637,10 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 		int length = strlen(json);
 		ipc_send_reply(client, payload_type, json, (uint32_t)length);
 		free(json);
-		while (res_list->length) {
-			struct cmd_results *results = res_list->items[0];
-			free_cmd_results(results);
-			list_del(res_list, 0);
+		for (int i = 0; i < res_list->length; ++i) {
+			struct cmd_results *res = res_list->items[i];
+			free_cmd_results(*res);
+			free(res);
 		}
 		list_free(res_list);
 		goto exit_cleanup;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -441,7 +441,8 @@ void view_execute_criteria(struct sway_view *view) {
 				criteria->cmdlist, NULL, view->container);
 		while (res_list->length) {
 			struct cmd_results *res = res_list->items[0];
-			free_cmd_results(res);
+			free_cmd_results(*res);
+			free(res);
 			list_del(res_list, 0);
 		}
 		list_free(res_list);


### PR DESCRIPTION
> sway commands are implemented using functions that return an error code and (if the function was not successful) an error string. The two are bundled together by the type `struct cmd_results`. This
patch alters the command handler prototype so that the cmd_results objects are returned by value (on the stack), instead of by a pointer to a heap allocated instance of a cmd_results.

> The latter method had the flaw that, if the heap allocation of the cmd_results object failed, the exact return code would be lost. Furthermore, for some command handlers (such as those in sway/commands/output), returning NULL signified success, so an allocation failure could lead to an ignored error. This change prevents both classes of errors.

I've been sitting on this patch for a while, as allocation failures are very rare in practice and require nonstandard system configuration to achieve. This isn't the largest allocation-related issue to fix (as it won't even cause a crash), but one must start somewhere.