### PR TITLE
layer-shell: refocus if keyboard interactive lost

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -215,6 +215,9 @@ void arrange_layers(struct sway_output *output) {
 	wl_list_for_each(seat, &server.input->seats, link) {
 		if (topmost != NULL) {
 			seat_set_focus_layer(seat, topmost->layer_surface);
+		} else if (seat->focused_layer &&
+				!seat->focused_layer->current.keyboard_interactive) {
+			seat_set_focus_layer(seat, NULL);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4840 

When arranging layer-shell layers, verify that the currently focused
layer, if any, for each seat is still keyboard interactive. If the layer
is no longer keyboard interactive and there is not a keyboard
interactive overlay or top layer to change the focus to, refocus the
focus inactive node for the seat.