### PR TITLE
config/output: apply scale_filter even when scale has not changed

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -366,7 +366,9 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	if (scale != wlr_output->scale) {
 		sway_log(SWAY_DEBUG, "Set %s scale to %f", oc->name, scale);
 		wlr_output_set_scale(wlr_output, scale);
+	}
 
+	if (oc) {
 		enum scale_filter_mode scale_filter_old = output->scale_filter;
 		switch (oc->scale_filter) {
 			case SCALE_FILTER_DEFAULT:


### PR DESCRIPTION
An accidental regression from 2f84d6e. scale_filter may change via the ipc even if scale has not changed.

This code previously lived in the `if (oc && oc->scale)` block, but previously an unset scale always meant an output scale of 1, so there was no issue when scale_filter wasn't applied. The more correct place to apply scale_filter seems to be in it's own block.