### PR TITLE
Re-add support for wlr_output's atomic API

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -560,8 +560,12 @@ int output_repaint_timer_handler(void *data) {
 		clock_gettime(CLOCK_MONOTONIC, &now);
 
 		output_render(output, &now, &damage);
-	} else if (surface_needs_frame) {
-		wlr_output_schedule_frame(output->wlr_output);
+	} else {
+		wlr_output_rollback(output->wlr_output);
+
+		if (surface_needs_frame) {
+			wlr_output_schedule_frame(output->wlr_output);
+		}
 	}
 
 	pixman_region32_fini(&damage);


### PR DESCRIPTION
This reverts commit 724926ea6ae119956dc7b1e39c2e30c1e3657676 and
re-applies commit 6e0565e9de4247bbf0ca662565c58e0a54258d6e.

See also: https://github.com/swaywm/wlroots/pull/1797 (wlroots PR)
See also: https://github.com/swaywm/sway/pull/4355 (Original sway PR)
See also: https://github.com/swaywm/sway/pull/4434 (Revert sway PR)