### PR TITLE
[WIP] Output-namespaced workspaces

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -190,6 +190,7 @@ sway_cmd cmd_unmark;
 sway_cmd cmd_urgent;
 sway_cmd cmd_workspace;
 sway_cmd cmd_workspace_layout;
+sway_cmd cmd_workspace_namespace;
 sway_cmd cmd_ws_auto_back_and_forth;
 sway_cmd cmd_xwayland;
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -471,6 +471,11 @@ enum xwayland_mode {
 	XWAYLAND_MODE_IMMEDIATE
 };
 
+enum sway_workspace_namespace {
+	WORKSPACE_NAMESPACE_GLOBAL,
+	WORKSPACE_NAMESPACE_OUTPUT,
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -512,6 +517,7 @@ struct sway_config {
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;
 	enum xwayland_mode xwayland;
+	enum sway_workspace_namespace workspace_namespace;
 
 	// swaybg
 	char *swaybg_command;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -58,14 +58,14 @@ void workspace_begin_destroy(struct sway_workspace *workspace);
 
 void workspace_consider_destroy(struct sway_workspace *ws);
 
-char *workspace_next_name(const char *output_name);
+char *workspace_next_name(struct sway_output *output);
 
 bool workspace_switch(struct sway_workspace *workspace,
 		bool no_auto_back_and_forth);
 
-struct sway_workspace *workspace_by_number(const char* name);
+struct sway_workspace *workspace_by_number(struct sway_output *output, const char* name);
 
-struct sway_workspace *workspace_by_name(const char*);
+struct sway_workspace *workspace_by_name(struct sway_output *output, const char* name);
 
 struct sway_workspace *workspace_output_next(
 		struct sway_workspace *current, bool create);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -105,6 +105,7 @@ static struct cmd_handler config_handlers[] = {
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },
 	{ "workspace_layout", cmd_workspace_layout },
+	{ "workspace_namespace", cmd_workspace_namespace },
 	{ "xwayland", cmd_xwayland },
 };
 

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -31,6 +31,12 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	int argn = 1;
 	struct sway_workspace *workspace = NULL;
 
+	struct sway_seat *seat = config->handler_context.seat;
+	struct sway_workspace *current = seat_get_focused_workspace(seat);
+	if (!current) {
+		return cmd_results_new(CMD_FAILURE, "No workspace available");
+	}
+
 	if (strcasecmp(argv[1], "to") == 0) {
 		// 'rename workspace to new_name'
 		workspace = config->handler_context.workspace;
@@ -40,7 +46,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 			return cmd_results_new(CMD_INVALID,
 					"Invalid workspace number '%s'", argv[2]);
 		}
-		workspace = workspace_by_number(argv[2]);
+		workspace = workspace_by_number(current->output, argv[2]);
 		while (argn < argc && strcasecmp(argv[argn], "to") != 0) {
 			++argn;
 		}
@@ -51,7 +57,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 			++end;
 		}
 		char *old_name = join_args(argv + argn, end - argn);
-		workspace = workspace_by_name(old_name);
+		workspace = workspace_by_name(current->output, old_name);
 		free(old_name);
 		argn = end;
 	}
@@ -79,7 +85,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID,
 				"Cannot use special workspace name '%s'", argv[argn]);
 	}
-	struct sway_workspace *tmp_workspace = workspace_by_name(new_name);
+	struct sway_workspace *tmp_workspace = workspace_by_name(current->output, new_name);
 	if (tmp_workspace) {
 		free(new_name);
 		if (tmp_workspace == workspace) {

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -198,15 +198,15 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				return cmd_results_new(CMD_INVALID,
 						"Invalid workspace number '%s'", argv[1]);
 			}
-			if (!(ws = workspace_by_number(argv[1]))) {
+			if (!(ws = workspace_by_number(current->output, argv[1]))) {
 				char *name = join_args(argv + 1, argc - 1);
-				ws = workspace_create(NULL, name);
+				ws = workspace_create(current->output, name);
 				free(name);
 			}
 		} else if (strcasecmp(argv[0], "next") == 0 ||
 				strcasecmp(argv[0], "prev") == 0 ||
 				strcasecmp(argv[0], "current") == 0) {
-			ws = workspace_by_name(argv[0]);
+			ws = workspace_by_name(current->output, argv[0]);
 		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
 			ws = workspace_output_next(current, create);
 		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
@@ -216,13 +216,13 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				return cmd_results_new(CMD_INVALID,
 						"There is no previous workspace");
 			}
-			if (!(ws = workspace_by_name(argv[0]))) {
-				ws = workspace_create(NULL, seat->prev_workspace_name);
+			if (!(ws = workspace_by_name(current->output, argv[0]))) {
+				ws = workspace_create(current->output, seat->prev_workspace_name);
 			}
 		} else {
 			char *name = join_args(argv, argc);
-			if (!(ws = workspace_by_name(name))) {
-				ws = workspace_create(NULL, name);
+			if (!(ws = workspace_by_name(current->output, name))) {
+				ws = workspace_create(current->output, name);
 			}
 			free(name);
 		}

--- a/sway/commands/workspace_namespace.c
+++ b/sway/commands/workspace_namespace.c
@@ -1,0 +1,27 @@
+#include <strings.h>
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
+#include "util.h"
+
+// workspace_namespace [global|output]
+struct cmd_results *cmd_workspace_namespace(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_namespace", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	if (strcasecmp(argv[0], "global") == 0 ||
+			strcasecmp(argv[0], "default") == 0) {
+		config->workspace_namespace = WORKSPACE_NAMESPACE_GLOBAL;
+	} else if (strcasecmp(argv[0], "output") == 0) {
+		config->workspace_namespace = WORKSPACE_NAMESPACE_OUTPUT;
+	} else {
+		return cmd_results_new(CMD_FAILURE,
+				"Expected 'workspace_namespace <default|global|output>'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -114,6 +114,7 @@ sway_sources = files(
 	'commands/urgent.c',
 	'commands/workspace.c',
 	'commands/workspace_layout.c',
+	'commands/workspace_namespace.c',
 	'commands/ws_auto_back_and_forth.c',
 	'commands/xwayland.c',
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -88,6 +88,9 @@ The following commands may only be used in the configuration file.
 *workspace_layout* default|stacking|tabbed
 	Specifies the initial layout for new workspaces.
 
+*workspace_namespace* default|global|output
+	Specifies the workspace namespacing.
+
 *xwayland* enable|disable|force
 	Enables or disables Xwayland support, which allows X11 applications to be
 	used. _enable_ will lazily load Xwayland so Xwayland will not be launched

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -252,7 +252,7 @@ struct sway_workspace *root_workspace_for_pid(pid_t pid) {
 found:
 
 	if (pw && pw->workspace) {
-		ws = workspace_by_name(pw->workspace);
+		ws = workspace_by_name(pw->output, pw->workspace);
 
 		if (!ws) {
 			sway_log(SWAY_DEBUG,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -470,6 +470,11 @@ static void view_populate_pid(struct sway_view *view) {
 
 static struct sway_workspace *select_workspace(struct sway_view *view) {
 	struct sway_seat *seat = input_manager_current_seat();
+	struct sway_workspace *current = seat_get_focused_workspace(seat);
+	if (!sway_assert(current != NULL, "no workspace is focused")) {
+		return NULL;
+	}
+	struct sway_output *output = current->output;
 
 	// Check if there's any `assign` criteria for the view
 	list_t *criterias = criteria_for_view(view,
@@ -486,16 +491,16 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 		} else {
 			// CT_ASSIGN_WORKSPACE(_NUMBER)
 			ws = criteria->type == CT_ASSIGN_WORKSPACE_NUMBER ?
-				workspace_by_number(criteria->target) :
-				workspace_by_name(criteria->target);
+				workspace_by_number(output, criteria->target) :
+				workspace_by_name(output, criteria->target);
 
 			if (!ws) {
 				if (strcasecmp(criteria->target, "back_and_forth") == 0) {
 					if (seat->prev_workspace_name) {
-						ws = workspace_create(NULL, seat->prev_workspace_name);
+						ws = workspace_create(output, seat->prev_workspace_name);
 					}
 				} else {
-					ws = workspace_create(NULL, criteria->target);
+					ws = workspace_create(output, criteria->target);
 				}
 			}
 			break;


### PR DESCRIPTION
This PR implements configurable workspace namespacing. There are two namespace options, `global` and `output`. `global`, the default, behaves exactly like sway has always done.

`output`, on the other hand, behaves a bit more like tags from awesomewm, in that workspaces are local to an output.

I have been running this for a while, and although a very simple change, it has made multiple workspaces on my laptop (which docks to a varying number of screens) *much* more pleasant, where it previously was in fact very frustrating.

Fixes #4771

# A bit of explanation

## Global

Imagine a setup with 3 displays. With `global` namespacing, these will be born with workspaces "1", "2" and "3", with the order appearing from a user-perspective to be somewhat arbitrary. if you run `workspace 2`, focus will go to display 2. If you run `workspace 4`, a workspace named `4` will be created on whatever output is focused, perhaps leaving you with:

display | workspaces
----------|-----------------
1          | 2
2          | 1
3          | 3, 4

With dynamic screen setups and frequent use of namespaces, this ends up chaotic rather fast. This is made much worse should one decide to hide or not use a bar, leaving them with no map of the mess of workspaces that they have created.

This can be managed for static dual-screen setups by creating output-specific navigation binds (e.g. `mod+NUM` for output 1, `mod+shift+NUM` for output 2), but this is merely a workaround and does not scale to arbitrary or dynamic display configurations.

`prev_on_output`/`next_on_output` tries to assist with this, but falls short as it will not create new workspaces and only allows `alt-tab`-style navigation.

## Output namespacing

With `output` namespacing, each output has its own set of workspaces, and thus all displays start with its very own workspace "1". If you run `workspace 2`, a workspace named "2" will be created on the current output. Thus, you'd end up with:

display | workspaces
----------|-----------------
1          | 1
2          | 1
3          | 1, 2

This provides for very predictable behavior regardless of display configuration. This 

## `output` behaviors worth noting

- Navigating to a workspace will never change what output is in focus. It will either go to the workspace if it exists on the focused output, or create it on the focused output.
- Moving a workspace between outputs can result in name conflicts, which are automatically solved by using `workspace_next_name`. This also applies to move done due to an output disconnecting.