### PR TITLE
Refactor color parsing related code

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#include <ctype.h>
 #include <float.h>
 #include <fcntl.h>
 #include <math.h>
@@ -13,21 +14,21 @@ int wrap(int i, int max) {
 	return ((i % max) + max) % max;
 }
 
-uint32_t parse_color(const char *color) {
+bool parse_color(const char *color, uint32_t *result) {
 	if (color[0] == '#') {
 		++color;
 	}
-
 	int len = strlen(color);
-	if (len != 6 && len != 8) {
-		sway_log(SWAY_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
-		return 0xFFFFFFFF;
+	if ((len != 6 && len != 8) || !isxdigit(color[0]) || !isxdigit(color[1])) {
+		return false;
 	}
-	uint32_t res = (uint32_t)strtoul(color, NULL, 16);
-	if (strlen(color) == 6) {
-		res = (res << 8) | 0xFF;
+	char *ptr;
+	uint32_t parsed = strtoul(color, &ptr, 16);
+	if (*ptr != '\0') {
+		return false;
 	}
-	return res;
+	*result = len == 6 ? ((parsed << 8) | 0xFF) : parsed;
+	return true;
 }
 
 bool parse_boolean(const char *boolean, bool current) {

--- a/common/util.c
+++ b/common/util.c
@@ -31,6 +31,13 @@ bool parse_color(const char *color, uint32_t *result) {
 	return true;
 }
 
+void color_to_rgba(float dest[static 4], uint32_t color) {
+	dest[0] = ((color >> 24) & 0xff) / 255.0;
+	dest[1] = ((color >> 16) & 0xff) / 255.0;
+	dest[2] = ((color >> 8) & 0xff) / 255.0;
+	dest[3] = (color & 0xff) / 255.0;
+}
+
 bool parse_boolean(const char *boolean, bool current) {
 	if (strcasecmp(boolean, "1") == 0
 			|| strcasecmp(boolean, "yes") == 0

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -88,8 +88,6 @@ void free_cmd_results(struct cmd_results *results);
  */
 char *cmd_results_to_json(list_t *res_list);
 
-struct cmd_results *add_color(char *buffer, const char *color);
-
 /**
  * TODO: Move this function and its dependent functions to container.c.
  */

--- a/include/swaybar/i3bar.h
+++ b/include/swaybar/i3bar.h
@@ -9,7 +9,8 @@ struct i3bar_block {
 	int ref_count;
 	char *full_text, *short_text, *align, *min_width_str;
 	bool urgent;
-	uint32_t *color;
+	uint32_t color;
+	bool color_set;
 	int min_width;
 	char *name, *instance;
 	bool separator;

--- a/include/util.h
+++ b/include/util.h
@@ -17,6 +17,8 @@ int wrap(int i, int max);
  */
 bool parse_color(const char *color, uint32_t *result);
 
+void color_to_rgba(float dest[static 4], uint32_t color);
+
 /**
  * Given a string that represents a boolean, return the boolean value. This
  * function also takes in the current boolean value to support toggling. If

--- a/include/util.h
+++ b/include/util.h
@@ -11,10 +11,11 @@
 int wrap(int i, int max);
 
 /**
- * Given a string that represents an RGB(A) color, return a uint32_t
- * version of the color.
+ * Given a string that represents an RGB(A) color, result will be set to a
+ * uint32_t version of the color, as long as it is valid. If it is invalid,
+ * then false will be returned and result will be untouched.
  */
-uint32_t parse_color(const char *color);
+bool parse_color(const char *color, uint32_t *result);
 
 /**
  * Given a string that represents a boolean, return the boolean value. This

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -567,34 +567,3 @@ char *cmd_results_to_json(list_t *res_list) {
 	json_object_put(result_array);
 	return res;
 }
-
-/**
- * Check and add color to buffer.
- *
- * return error object, or NULL if color is valid.
- */
-struct cmd_results *add_color(char *buffer, const char *color) {
-	int len = strlen(color);
-	if (len != 7 && len != 9) {
-		return cmd_results_new(CMD_INVALID,
-				"Invalid color definition %s", color);
-	}
-	if (color[0] != '#') {
-		return cmd_results_new(CMD_INVALID,
-				"Invalid color definition %s", color);
-	}
-	for (int i = 1; i < len; ++i) {
-		if (!isxdigit(color[i])) {
-			return cmd_results_new(CMD_INVALID,
-					"Invalid color definition %s", color);
-		}
-	}
-	strcpy(buffer, color);
-	// add default alpha channel if color was defined without it
-	if (len == 7) {
-		buffer[7] = 'f';
-		buffer[8] = 'f';
-	}
-	buffer[9] = '\0';
-	return NULL;
-}

--- a/sway/config.c
+++ b/sway/config.c
@@ -31,6 +31,7 @@
 #include "stringop.h"
 #include "list.h"
 #include "log.h"
+#include "util.h"
 
 struct sway_config *config = NULL;
 
@@ -192,13 +193,6 @@ static void destroy_removed_seats(struct sway_config *old_config,
 	}
 }
 
-static void set_color(float dest[static 4], uint32_t color) {
-	dest[0] = ((color >> 16) & 0xff) / 255.0;
-	dest[1] = ((color >> 8) & 0xff) / 255.0;
-	dest[2] = (color & 0xff) / 255.0;
-	dest[3] = 1.0;
-}
-
 static void config_defaults(struct sway_config *config) {
 	if (!(config->swaynag_command = strdup("swaynag"))) goto cleanup;
 	config->swaynag_config_errors = (struct swaynag_instance){0};
@@ -300,37 +294,37 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_lone_tab = false;
 
 	// border colors
-	set_color(config->border_colors.focused.border, 0x4C7899);
-	set_color(config->border_colors.focused.background, 0x285577);
-	set_color(config->border_colors.focused.text, 0xFFFFFFFF);
-	set_color(config->border_colors.focused.indicator, 0x2E9EF4);
-	set_color(config->border_colors.focused.child_border, 0x285577);
+	color_to_rgba(config->border_colors.focused.border, 0x4C7899FF);
+	color_to_rgba(config->border_colors.focused.background, 0x285577FF);
+	color_to_rgba(config->border_colors.focused.text, 0xFFFFFFFF);
+	color_to_rgba(config->border_colors.focused.indicator, 0x2E9EF4FF);
+	color_to_rgba(config->border_colors.focused.child_border, 0x285577FF);
 
-	set_color(config->border_colors.focused_inactive.border, 0x333333);
-	set_color(config->border_colors.focused_inactive.background, 0x5F676A);
-	set_color(config->border_colors.focused_inactive.text, 0xFFFFFFFF);
-	set_color(config->border_colors.focused_inactive.indicator, 0x484E50);
-	set_color(config->border_colors.focused_inactive.child_border, 0x5F676A);
+	color_to_rgba(config->border_colors.focused_inactive.border, 0x333333FF);
+	color_to_rgba(config->border_colors.focused_inactive.background, 0x5F676AFF);
+	color_to_rgba(config->border_colors.focused_inactive.text, 0xFFFFFFFF);
+	color_to_rgba(config->border_colors.focused_inactive.indicator, 0x484E50FF);
+	color_to_rgba(config->border_colors.focused_inactive.child_border, 0x5F676AFF);
 
-	set_color(config->border_colors.unfocused.border, 0x333333);
-	set_color(config->border_colors.unfocused.background, 0x222222);
-	set_color(config->border_colors.unfocused.text, 0x88888888);
-	set_color(config->border_colors.unfocused.indicator, 0x292D2E);
-	set_color(config->border_colors.unfocused.child_border, 0x222222);
+	color_to_rgba(config->border_colors.unfocused.border, 0x333333FF);
+	color_to_rgba(config->border_colors.unfocused.background, 0x222222FF);
+	color_to_rgba(config->border_colors.unfocused.text, 0x88888888);
+	color_to_rgba(config->border_colors.unfocused.indicator, 0x292D2EFF);
+	color_to_rgba(config->border_colors.unfocused.child_border, 0x222222FF);
 
-	set_color(config->border_colors.urgent.border, 0x2F343A);
-	set_color(config->border_colors.urgent.background, 0x900000);
-	set_color(config->border_colors.urgent.text, 0xFFFFFFFF);
-	set_color(config->border_colors.urgent.indicator, 0x900000);
-	set_color(config->border_colors.urgent.child_border, 0x900000);
+	color_to_rgba(config->border_colors.urgent.border, 0x2F343AFF);
+	color_to_rgba(config->border_colors.urgent.background, 0x900000FF);
+	color_to_rgba(config->border_colors.urgent.text, 0xFFFFFFFF);
+	color_to_rgba(config->border_colors.urgent.indicator, 0x900000FF);
+	color_to_rgba(config->border_colors.urgent.child_border, 0x900000FF);
 
-	set_color(config->border_colors.placeholder.border, 0x000000);
-	set_color(config->border_colors.placeholder.background, 0x0C0C0C);
-	set_color(config->border_colors.placeholder.text, 0xFFFFFFFF);
-	set_color(config->border_colors.placeholder.indicator, 0x000000);
-	set_color(config->border_colors.placeholder.child_border, 0x0C0C0C);
+	color_to_rgba(config->border_colors.placeholder.border, 0x000000FF);
+	color_to_rgba(config->border_colors.placeholder.background, 0x0C0C0CFF);
+	color_to_rgba(config->border_colors.placeholder.text, 0xFFFFFFFF);
+	color_to_rgba(config->border_colors.placeholder.indicator, 0x000000FF);
+	color_to_rgba(config->border_colors.placeholder.child_border, 0x0C0C0CFF);
 
-	set_color(config->border_colors.background, 0xFFFFFF);
+	color_to_rgba(config->border_colors.background, 0xFFFFFFFF);
 
 	// Security
 	if (!(config->command_policies = create_list())) goto cleanup;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -55,117 +55,42 @@ char *parse_font(const char *font) {
 
 static void ipc_parse_colors(
 		struct swaybar_config *config, json_object *colors) {
-	json_object *background, *statusline, *separator;
-	json_object *focused_background, *focused_statusline, *focused_separator;
-	json_object *focused_workspace_border, *focused_workspace_bg, *focused_workspace_text;
-	json_object *inactive_workspace_border, *inactive_workspace_bg, *inactive_workspace_text;
-	json_object *active_workspace_border, *active_workspace_bg, *active_workspace_text;
-	json_object *urgent_workspace_border, *urgent_workspace_bg, *urgent_workspace_text;
-	json_object *binding_mode_border, *binding_mode_bg, *binding_mode_text;
-	json_object_object_get_ex(colors, "background", &background);
-	json_object_object_get_ex(colors, "statusline", &statusline);
-	json_object_object_get_ex(colors, "separator", &separator);
-	json_object_object_get_ex(colors, "focused_background", &focused_background);
-	json_object_object_get_ex(colors, "focused_statusline", &focused_statusline);
-	json_object_object_get_ex(colors, "focused_separator", &focused_separator);
-	json_object_object_get_ex(colors, "focused_workspace_border", &focused_workspace_border);
-	json_object_object_get_ex(colors, "focused_workspace_bg", &focused_workspace_bg);
-	json_object_object_get_ex(colors, "focused_workspace_text", &focused_workspace_text);
-	json_object_object_get_ex(colors, "active_workspace_border", &active_workspace_border);
-	json_object_object_get_ex(colors, "active_workspace_bg", &active_workspace_bg);
-	json_object_object_get_ex(colors, "active_workspace_text", &active_workspace_text);
-	json_object_object_get_ex(colors, "inactive_workspace_border", &inactive_workspace_border);
-	json_object_object_get_ex(colors, "inactive_workspace_bg", &inactive_workspace_bg);
-	json_object_object_get_ex(colors, "inactive_workspace_text", &inactive_workspace_text);
-	json_object_object_get_ex(colors, "urgent_workspace_border", &urgent_workspace_border);
-	json_object_object_get_ex(colors, "urgent_workspace_bg", &urgent_workspace_bg);
-	json_object_object_get_ex(colors, "urgent_workspace_text", &urgent_workspace_text);
-	json_object_object_get_ex(colors, "binding_mode_border", &binding_mode_border);
-	json_object_object_get_ex(colors, "binding_mode_bg", &binding_mode_bg);
-	json_object_object_get_ex(colors, "binding_mode_text", &binding_mode_text);
-	if (background) {
-		config->colors.background = parse_color(
-				json_object_get_string(background));
-	}
-	if (statusline) {
-		config->colors.statusline = parse_color(
-				json_object_get_string(statusline));
-	}
-	if (separator) {
-		config->colors.separator = parse_color(
-				json_object_get_string(separator));
-	}
-	if (focused_background) {
-		config->colors.focused_background = parse_color(
-				json_object_get_string(focused_background));
-	}
-	if (focused_statusline) {
-		config->colors.focused_statusline = parse_color(
-				json_object_get_string(focused_statusline));
-	}
-	if (focused_separator) {
-		config->colors.focused_separator = parse_color(
-				json_object_get_string(focused_separator));
-	}
-	if (focused_workspace_border) {
-		config->colors.focused_workspace.border = parse_color(
-				json_object_get_string(focused_workspace_border));
-	}
-	if (focused_workspace_bg) {
-		config->colors.focused_workspace.background = parse_color(
-				json_object_get_string(focused_workspace_bg));
-	}
-	if (focused_workspace_text) {
-		config->colors.focused_workspace.text = parse_color(
-				json_object_get_string(focused_workspace_text));
-	}
-	if (active_workspace_border) {
-		config->colors.active_workspace.border = parse_color(
-				json_object_get_string(active_workspace_border));
-	}
-	if (active_workspace_bg) {
-		config->colors.active_workspace.background = parse_color(
-				json_object_get_string(active_workspace_bg));
-	}
-	if (active_workspace_text) {
-		config->colors.active_workspace.text = parse_color(
-				json_object_get_string(active_workspace_text));
-	}
-	if (inactive_workspace_border) {
-		config->colors.inactive_workspace.border = parse_color(
-				json_object_get_string(inactive_workspace_border));
-	}
-	if (inactive_workspace_bg) {
-		config->colors.inactive_workspace.background = parse_color(
-				json_object_get_string(inactive_workspace_bg));
-	}
-	if (inactive_workspace_text) {
-		config->colors.inactive_workspace.text = parse_color(
-				json_object_get_string(inactive_workspace_text));
-	}
-	if (urgent_workspace_border) {
-		config->colors.urgent_workspace.border = parse_color(
-				json_object_get_string(urgent_workspace_border));
-	}
-	if (urgent_workspace_bg) {
-		config->colors.urgent_workspace.background = parse_color(
-				json_object_get_string(urgent_workspace_bg));
-	}
-	if (urgent_workspace_text) {
-		config->colors.urgent_workspace.text = parse_color(
-				json_object_get_string(urgent_workspace_text));
-	}
-	if (binding_mode_border) {
-		config->colors.binding_mode.border = parse_color(
-				json_object_get_string(binding_mode_border));
-	}
-	if (binding_mode_bg) {
-		config->colors.binding_mode.background = parse_color(
-				json_object_get_string(binding_mode_bg));
-	}
-	if (binding_mode_text) {
-		config->colors.binding_mode.text = parse_color(
-				json_object_get_string(binding_mode_text));
+	struct {
+		const char *name;
+		uint32_t *color;
+	} properties[] = {
+		{ "background", &config->colors.background },
+		{ "statusline", &config->colors.statusline },
+		{ "separator", &config->colors.separator },
+		{ "focused_background", &config->colors.focused_background },
+		{ "focused_statusline", &config->colors.focused_statusline },
+		{ "focused_separator", &config->colors.focused_separator },
+		{ "focused_workspace_border", &config->colors.focused_workspace.border },
+		{ "focused_workspace_bg", &config->colors.focused_workspace.background },
+		{ "focused_workspace_text", &config->colors.focused_workspace.text },
+		{ "active_workspace_border", &config->colors.active_workspace.border },
+		{ "active_workspace_bg", &config->colors.active_workspace.background },
+		{ "active_workspace_text", &config->colors.active_workspace.text },
+		{ "inactive_workspace_border", &config->colors.inactive_workspace.border },
+		{ "inactive_workspace_bg", &config->colors.inactive_workspace.background },
+		{ "inactive_workspace_text", &config->colors.inactive_workspace.text },
+		{ "urgent_workspace_border", &config->colors.urgent_workspace.border },
+		{ "urgent_workspace_bg", &config->colors.urgent_workspace.background },
+		{ "urgent_workspace_text", &config->colors.urgent_workspace.text },
+		{ "binding_mode_border", &config->colors.binding_mode.border },
+		{ "binding_mode_bg", &config->colors.binding_mode.background },
+		{ "binding_mode_text", &config->colors.binding_mode.text },
+	};
+
+	for (size_t i = 0; i < sizeof(properties) / sizeof(properties[i]); i++) {
+		json_object *object;
+		if (json_object_object_get_ex(colors, properties[i].name, &object)) {
+			const char *hexstring = json_object_get_string(object);
+			if (!parse_color(hexstring, properties[i].color)) {
+				sway_log(SWAY_ERROR, "Ignoring invalid %s: %s",
+						properties[i].name, hexstring);
+			}
+		}
 	}
 }
 

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -265,7 +265,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 	}
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_move_to(cairo, offset, (int)floor(text_y));
-	uint32_t color = block->color ?  *block->color : config->colors.statusline;
+	uint32_t color = block->color_set ? block->color : config->colors.statusline;
 	color = block->urgent ? config->colors.urgent_workspace.text : color;
 	cairo_set_source_u32(cairo, color);
 	pango_printf(cairo, config->font, output->scale,

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -221,28 +221,28 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			fprintf(stdout, "swaynag version " SWAY_VERSION "\n");
 			return -1;
 		case TO_COLOR_BACKGROUND: // Background color
-			if (type) {
-				type->background = parse_color(optarg);
+			if (type && !parse_color(optarg, &type->background)) {
+				fprintf(stderr, "Invalid background color: %s", optarg);
 			}
 			break;
 		case TO_COLOR_BORDER: // Border color
-			if (type) {
-				type->border = parse_color(optarg);
+			if (type && !parse_color(optarg, &type->border)) {
+				fprintf(stderr, "Invalid border color: %s", optarg);
 			}
 			break;
 		case TO_COLOR_BORDER_BOTTOM: // Bottom border color
-			if (type) {
-				type->border_bottom = parse_color(optarg);
+			if (type && !parse_color(optarg, &type->border_bottom)) {
+				fprintf(stderr, "Invalid border bottom color: %s", optarg);
 			}
 			break;
 		case TO_COLOR_BUTTON:  // Button background color
-			if (type) {
-				type->button_background = parse_color(optarg);
+			if (type && !parse_color(optarg, &type->button_background)) {
+				fprintf(stderr, "Invalid button background color: %s", optarg);
 			}
 			break;
 		case TO_COLOR_TEXT:  // Text color
-			if (type) {
-				type->text = parse_color(optarg);
+			if (type && !parse_color(optarg, &type->text)) {
+				fprintf(stderr, "Invalid text color: %s", optarg);
 			}
 			break;
 		case TO_THICK_BAR_BORDER:  // Bottom border thickness


### PR DESCRIPTION
There are currently multiple color parsing functions in use by sway. This purpose of this PR is to remove some duplicated code and refactor some of the calling code along the way. This PR also ensures that although the colors may be stored in different formats (uint32_t, float[4], const char *), they are all parsed in the same way.

See the individual commits for the full commit messages, but here's a summary:
- First commit: adds color validation to parse_color and refactors swaybar's ipc_parse_colors
- Second commit: remove duplicated float array color code in cmd_client_* and config
- Third commit: remove add_color and refactor bar_cmd_colors color parsing

_Note: I am aware that this PR does not touch the color validation for colors in `output_cmd_background`. For that command, the colors must be rgb, not rgba. Since all other locations allow for rgb or rgba, it would introduce unnecessary code complexity to remove this duplication._