### PR TITLE
input/keyboard: handle event->group_update

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -359,6 +359,12 @@ static void handle_key_event(struct sway_keyboard *keyboard,
 				code_modifiers);
 	}
 
+	// A keyboard was added to/removed from the group, just update the status
+	if (event->group_update) {
+		assert(wlr_keyboard_group_from_wlr_keyboard(wlr_device->keyboard));
+		return;
+	}
+
 	bool handled = false;
 	// Identify active release binding
 	struct sway_binding *binding_released = NULL;


### PR DESCRIPTION
**Depends on swaywm/wlroots#1973**

When a keyboard is added to or removed from a wlr_keyboard_group, a key
event will be emitted for all keys that only pressed for that keyboard
in the group. This allows for compositors to update their internal
state. However because these keys were already down, bindings should not
be executed and surfaces should not receive a key event.