### PR TITLE
Fix sway_log using non initialised output_config pointer

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -334,7 +334,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	}
 
 	if (!oc || oc->dpms_state != DPMS_OFF) {
-		sway_log(SWAY_DEBUG, "Turning on output %s", oc->name);
+		sway_log(SWAY_DEBUG, "Turning on output %s", wlr_output->name);
 		wlr_output_enable(wlr_output, true);
 
 		if (oc && oc->width > 0 && oc->height > 0) {


### PR DESCRIPTION
This fixes a crash where the `oc->name` would be accessed by sway_log()
even when `oc` was NULL.