### PR TITLE
xwayland: handle size_hints == NULL

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -298,6 +298,15 @@ static void get_constraints(struct sway_view *view, double *min_width,
 		double *max_width, double *min_height, double *max_height) {
 	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
 	struct wlr_xwayland_surface_size_hints *size_hints = surface->size_hints;
+
+	if (size_hints == NULL) {
+		*min_width = DBL_MIN;
+		*max_width = DBL_MAX;
+		*min_height = DBL_MIN;
+		*max_height = DBL_MAX;
+		return;
+	}
+
 	*min_width = size_hints->min_width > 0 ? size_hints->min_width : DBL_MIN;
 	*max_width = size_hints->max_width > 0 ? size_hints->max_width : DBL_MAX;
 	*min_height = size_hints->min_height > 0 ? size_hints->min_height : DBL_MIN;


### PR DESCRIPTION
In case xcb-iccm is not installed on the system, size_hints will be
null. Handle this as if the get_constraints functions was not
implemented and return the defaults.

Fixes #4870