### PR TITLE
Set DesktopNames in sway.desktop to have `XDG_CURRENT_DESKTOP`

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
Setting DesktopNames in the desktop file sets the environment variable
`XDG_CURRENT_DESKTOP`, which can be used to find out the name of the
currently running session.

See also https://bugzilla.gnome.org/show_bug.cgi?id=727546 and https://bugzilla.redhat.com/show_bug.cgi?id=1787407.

We may want to allow additional names, e.g., Sway. I can update this PR if desired.