### PR TITLE
render: do not render indicator on floating views

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -339,7 +339,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		container_current_parent_layout(con);
 
 	if (state->border_right) {
-		if (siblings->length == 1 && layout == L_HORIZ) {
+		if (con->current.parent && siblings->length == 1 && layout == L_HORIZ) {
 			memcpy(&color, colors->indicator, sizeof(float) * 4);
 		} else {
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
@@ -354,7 +354,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 	}
 
 	if (state->border_bottom) {
-		if (siblings->length == 1 && layout == L_VERT) {
+		if (con->current.parent && siblings->length == 1 && layout == L_VERT) {
 			memcpy(&color, colors->indicator, sizeof(float) * 4);
 		} else {
 			memcpy(&color, colors->child_border, sizeof(float) * 4);


### PR DESCRIPTION
Fixes #4860 

This adds a check to make it so the indicator is only rendered on views
with a parent, which floating views do not. Since floating views do not
have a parent, the workspace layout was being incorrectly used to
determine whether to show the split indicator previously. This has no
impact on floating containers and a view within a floating container
will still have indicators rendered appropriately.