### PR TITLE
input/cursor: handle image surface destroy

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -58,6 +58,7 @@ struct sway_cursor {
 	uint32_t tool_buttons;
 
 	struct wl_listener request_set_cursor;
+	struct wl_listener image_surface_destroy;
 
 	struct wl_listener constraint_commit;
 


### PR DESCRIPTION
Fixes #4880

This adds a listener for the destroy event of the cursor image surface.
This prevents a use-after-free when the last visible image surface is
freed, there has not been a new cursor set, and the cursor is reshown.