### PR TITLE
view: remove workspace pid mapping for assigns

### DIFF
--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -72,6 +72,8 @@ struct sway_workspace *root_workspace_for_pid(pid_t pid);
 
 void root_record_workspace_pid(pid_t pid);
 
+void root_remove_workspace_pid(pid_t pid);
+
 void root_for_each_workspace(void (*f)(struct sway_workspace *ws, void *data),
 		void *data);
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -503,6 +503,7 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 	}
 	list_free(criterias);
 	if (ws) {
+		root_remove_workspace_pid(view->pid);
 		return ws;
 	}
 


### PR DESCRIPTION
Related #4892 (fixes first bullet)

If a view is mapped to a workspace using an assign, the pid should still
be removed from the pid mapping list. This prevents child processes from
matching against it and mapping a view to a likely undesired workspace.