### PR TITLE
(contrib/inactive-windows-transparency.py): Use transparency arg in the window focus event

### DIFF
--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -9,9 +9,9 @@ import argparse
 import i3ipc
 import signal
 import sys
+from functools import partial
 
-
-def on_window_focus(ipc, event):
+def on_window_focus(inactive_opacity, ipc, event):
     global prev_focused
     global prev_workspace
 
@@ -21,7 +21,7 @@ def on_window_focus(ipc, event):
     if focused.id != prev_focused.id:  # https://github.com/swaywm/sway/issues/2859
         focused.command("opacity 1")
         if workspace == prev_workspace:
-            prev_focused.command("opacity " + transparency_val)
+            prev_focused.command("opacity " + inactive_opacity)
         prev_focused = focused
         prev_workspace = workspace
 
@@ -60,5 +60,5 @@ if __name__ == "__main__":
             window.command("opacity " + args.opacity)
     for sig in [signal.SIGINT, signal.SIGTERM]:
         signal.signal(sig, lambda signal, frame: remove_opacity(ipc))
-    ipc.on("window::focus", on_window_focus)
+    ipc.on("window::focus", partial(on_window_focus, args.opacity))
     ipc.main()


### PR DESCRIPTION
Currently the transparency passed in on the command line is not being used in the `on_window_focus` event. This is unexpected since upon start-up, all the windows will be set to the correct transparency, but then switching between windows will set it to the default of 0.8.

It can be tested by running the script with `-o 0.1` to view the incorrect behavior, apply the patch, and then run the same test again to see the now correct behavior.