### PR TITLE
container: add inactive fullscreen to focus stack

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -958,6 +958,11 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 			focus_ws = seat_get_focused_workspace(seat);
 			if (focus_ws == con->workspace) {
 				seat_set_focus_container(seat, con);
+			} else {
+				struct sway_node *focus =
+					seat_get_focus_inactive(seat, &root->node);
+				seat_set_raw_focus(seat, &con->node);
+				seat_set_raw_focus(seat, focus);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #4892 
Fixed #4823 

When a container was being made fullscreen and it is on the focused
workspace for a seat, focus was being set to the container. However,
when the container was on a non-focused workspace, the focus stack
wasn't being touched. When assigning a fullscreen container to a
workspace or moving a fullscreen container to a different workspace,
this would make it so the fullscreen container was never added to the
focus stack for the workspace thus preventing access to the workspace.
This adds the container to the top of the focus stack, behind the
container on the focused workspace.