### PR TITLE
Typos

### DIFF
--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -76,7 +76,7 @@ struct cmd_results *cmd_splitv(int argc, char **argv) {
 
 struct cmd_results *cmd_splith(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "splitv", EXPECTED_EQUAL_TO, 0))) {
+	if ((error = checkarg(argc, "splith", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}
 	return do_split(L_HORIZ);
@@ -84,7 +84,7 @@ struct cmd_results *cmd_splith(int argc, char **argv) {
 
 struct cmd_results *cmd_splitt(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "splitv", EXPECTED_EQUAL_TO, 0))) {
+	if ((error = checkarg(argc, "splitt", EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -163,7 +163,7 @@ static void ipc_json_describe_output(struct sway_output *output,
 	json_object_object_add(object, "type", json_object_new_string("output"));
 	json_object_object_add(object, "active", json_object_new_boolean(true));
 	json_object_object_add(object, "dpms",
-			json_object_new_boolean(output->wlr_output->enabled));
+			json_object_new_boolean(wlr_output->enabled));
 	json_object_object_add(object, "primary", json_object_new_boolean(false));
 	json_object_object_add(object, "layout", json_object_new_string("output"));
 	json_object_object_add(object, "orientation",

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -35,11 +35,11 @@ on top of the existing device configurations.
 
 ## KEYBOARD CONFIGURATION
 
-*input* <identifier> repeat_delay <n>
-	Sets the delay before repeating a held-down key, in milliseconds.
+*input* <identifier> repeat_delay <milliseconds>
+	Sets the amount of time a key must be held before it starts repeating.
 
-*input* <identifier> repeat_rate <n>
-	Sets the key repeat rate in number of keypresses per second.
+*input* <identifier> repeat_rate <characters per second>
+	Sets the frequency of key repeats once the repeat_delay has passed.
 
 For more information on these xkb configuration options, see
 *xkeyboard-config*(7).
@@ -144,12 +144,6 @@ The following commands may only be used in the configuration file.
 
 *input* <identifier> pointer_accel [<-1|1>]
 	Changes the pointer acceleration for the specified input device.
-
-*input* <identifier> repeat_delay <milliseconds>
-	Sets the amount of time a key must be held before it starts repeating.
-
-*input* <identifier> repeat_rate <characters per second>
-	Sets the frequency of key repeats once the repeat_delay has passed.
 
 *input* <identifier> scroll_button disable|button[1-3,8,9]|<event-code-or-name>
 	Sets the button used for scroll_method on_button_down. The button can

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -356,8 +356,8 @@ runtime.
 		for_window <criteria> move container to output <output>
 
 *bindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] \
-		[--to-code] [--input-device=<device>] [--no-warn] [Group<1-4>+]<key combo> \
-		<command>
+[--to-code] [--input-device=<device>] [--no-warn] [Group<1-4>+]<key combo> \
+<command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
 	With the flag _--release_, the command is executed when the key combo is
@@ -409,7 +409,7 @@ runtime.
 ```
 
 	*bindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] \
-	[--locked] [--input-device=<device>] [--no-warn] [Group<1-4>+]<code> <command>
+[--locked] [--input-device=<device>] [--no-warn] [Group<1-4>+]<code> <command>
 	is also available for binding with key/button codes instead of key/button names.
 
 *bindswitch* [--locked] [--no-warn] [--reload] <switch>:<state> <command>
@@ -725,12 +725,14 @@ The default colors are:
 *unbindswitch* <switch>:<state>
 	Removes a binding for when <switch> changes to <state>.
 
-*unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--input-device=<device>] <key combo>
+*unbindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] \
+[--to-code] [--input-device=<device>] <key combo>
 	Removes the binding for _key combo_ that was previously bound with the
 	given flags.  If _input-device_ is given, only the binding for that
 	input device will be unbound.
 
-	*unbindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] [input-device=<device>] <code>
+	*unbindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] \
+[--locked] [input-device=<device>] <code>
 	is also available for unbinding with key/button codes instead of key/button names.
 
 *unmark* [<identifier>]


### PR DESCRIPTION
Here are some typos I noticed while working on sway. 

1. Error message copy/paste error in commands/split.c
2. wlr_output is already defined wlr_output = output->wlr_output 3 lines above.
3. The repeat_rate and repeat_delay descriptions are duplicated in the sway-input man page. I think the ones in the libinput configuration section are a mistake, but I liked their wording a bit better so I put those descriptions in the xkb section in place of the ones already there.
4. 1. unbindsym supports the same bind flags as bindsym, but some were missing in the man page.
    2. intermediate indents in the sway.5 markup cause an unintended space in the command arguments in the formatted document. Remove them.