### PR TITLE
desktop/output: fix mem leak in handle_new_output

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -901,6 +901,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	} else {
 		wlr_output_enable(output->wlr_output, false);
 	}
+	free_output_config(oc);
 
 	transaction_commit_dirty();
 


### PR DESCRIPTION
This fixes a memory leak of oc (the output config) in handle_new_output.
Output configs returned from find_output_config are not stored and need
to be freed after use.