### PR TITLE
commands/move: Fix crash when required args not provided

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -918,11 +918,17 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 
 	if (strcasecmp(argv[0], "window") == 0 ||
 			strcasecmp(argv[0], "container") == 0) {
-		--argc; ++argv;
+		--argc;
+		if (argc > 0) {
+			++argv;
+		}
 	}
 
 	if (strcasecmp(argv[0], "to") == 0) {
-		--argc; ++argv;
+		--argc;
+		if (argc > 0) {
+			++argv;
+		}
 	}
 
 	if (!argc) {

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -916,19 +916,13 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 		--argc; ++argv;
 	}
 
-	if (strcasecmp(argv[0], "window") == 0 ||
-			strcasecmp(argv[0], "container") == 0) {
-		--argc;
-		if (argc > 0) {
-			++argv;
-		}
+	if (argc > 0 && (strcasecmp(argv[0], "window") == 0 ||
+			strcasecmp(argv[0], "container") == 0)) {
+		--argc; ++argv;
 	}
 
-	if (strcasecmp(argv[0], "to") == 0) {
-		--argc;
-		if (argc > 0) {
-			++argv;
-		}
+	if (argc > 0 && strcasecmp(argv[0], "to") == 0) {
+		--argc;	++argv;
 	}
 
 	if (!argc) {


### PR DESCRIPTION
Fixes #4919.

Crash was occurring because ++argv was going out of bounds.