### PR TITLE
Keep windows in bounds on move to position mouse

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -760,19 +760,18 @@ static struct cmd_results *cmd_move_to_position_pointer(
 	double ly = cursor->y - container->height / 2;
 
 	/* Correct target coordinates to be in bounds (on screen). */
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct wlr_box box;
-		output_get_box(root->outputs->items[i], &box);
-		if (wlr_box_contains_point(&box, cursor->x, cursor->y)) {
-			lx = fmax(lx, box.x);
-			ly = fmax(ly, box.y);
-			if (lx + container->width > box.x + box.width) {
-				lx = box.x + box.width - container->width;
-			}
-			if (ly + container->height > box.y + box.height) {
-				ly = box.y + box.height - container->height;
-			}
-			break;
+	struct wlr_output *output = wlr_output_layout_output_at(
+			root->output_layout, cursor->x, cursor->y);
+	if (output) {
+		struct wlr_box *box =
+				wlr_output_layout_get_box(root->output_layout, output);
+		lx = fmax(lx, box->x);
+		ly = fmax(ly, box->y);
+		if (lx + container->width > box->x + box->width) {
+			lx = box->x + box->width - container->width;
+		}
+		if (ly + container->height > box->y + box->height) {
+			ly = box->y + box->height - container->height;
 		}
 	}
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <ctype.h>
+#include <math.h>
 #include <stdbool.h>
 #include <string.h>
 #include <strings.h>
@@ -747,6 +748,39 @@ static struct cmd_results *cmd_move_in_direction(
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
+static struct cmd_results *cmd_move_to_position_pointer(
+		struct sway_container *container) {
+	struct sway_seat *seat = config->handler_context.seat;
+	if (!seat->cursor) {
+		return cmd_results_new(CMD_FAILURE, "No cursor device");
+	}
+	struct wlr_cursor *cursor = seat->cursor->cursor;
+	/* Determine where to put the window. */
+	double lx = cursor->x - container->width / 2;
+	double ly = cursor->y - container->height / 2;
+
+	/* Correct target coordinates to be in bounds (on screen). */
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct wlr_box box;
+		output_get_box(root->outputs->items[i], &box);
+		if (wlr_box_contains_point(&box, cursor->x, cursor->y)) {
+			lx = fmax(lx, box.x);
+			ly = fmax(ly, box.y);
+			if (lx + container->width > box.x + box.width) {
+				lx = box.x + box.width - container->width;
+			}
+			if (ly + container->height > box.y + box.height) {
+				ly = box.y + box.height - container->height;
+			}
+			break;
+		}
+	}
+
+	/* Actually move the container. */
+	container_floating_move_to(container, lx, ly);
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
 static const char expected_position_syntax[] =
 	"Expected 'move [absolute] position <x> [px] <y> [px]' or "
 	"'move [absolute] position center' or "
@@ -784,14 +818,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		if (absolute) {
 			return cmd_results_new(CMD_INVALID, expected_position_syntax);
 		}
-		struct sway_seat *seat = config->handler_context.seat;
-		if (!seat->cursor) {
-			return cmd_results_new(CMD_FAILURE, "No cursor device");
-		}
-		double lx = seat->cursor->cursor->x - container->width / 2;
-		double ly = seat->cursor->cursor->y - container->height / 2;
-		container_floating_move_to(container, lx, ly);
-		return cmd_results_new(CMD_SUCCESS, NULL);
+		return cmd_move_to_position_pointer(container);
 	} else if (strcmp(argv[0], "center") == 0) {
 		double lx, ly;
 		if (absolute) {


### PR DESCRIPTION
If the mouse/cursor/pointer is near the edge of an output when a "move
position to pointer" command is run, then the floating container will be
constrained to fit inside the bounds of the output as much as possible.

This behavior matches what i3 does in this scenario. I also think it is
a better user experience.

Relates to #4906

The logic for the bounds check follows the implementation in i3: https://github.com/i3/i3/blob/733077822302d8b77eacb606a26fd002a42f534f/src/floating.c#L536
