### PR TITLE
Implement split none command

### DIFF
--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -36,6 +36,24 @@ static struct cmd_results *do_split(int layout) {
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 
+static struct cmd_results *do_unsplit() {
+	struct sway_container *con = config->handler_context.container;
+	struct sway_workspace *ws = config->handler_context.workspace;
+
+	if (con && con->parent && con->parent->children->length == 1) {
+		container_flatten(con->parent);
+	} else {
+		return cmd_results_new(CMD_FAILURE, "Can only flatten a child container with no siblings");
+	}
+
+	if (root->fullscreen_global) {
+		arrange_root();
+	} else {
+		arrange_workspace(ws);
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
 struct cmd_results *cmd_split(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "split", EXPECTED_EQUAL_TO, 1))) {
@@ -59,6 +77,9 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 		} else {
 			return do_split(L_VERT);
 		}
+	} else if (strcasecmp(argv[0], "n") == 0 ||
+			strcasecmp(argv[0], "none") == 0) {
+		return do_unsplit();
 	} else {
 		return cmd_results_new(CMD_FAILURE,
 			"Invalid split command (expected either horizontal or vertical).");

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -319,8 +319,10 @@ set|plus|minus <amount>
 	established by the *seat* subcommand of the same name. See
 	*sway-input*(5) for more ways to affect inhibitors.
 
-*split* vertical|v|horizontal|h|toggle|t
-	Splits the current container, vertically or horizontally. When _toggle_ is
+*split* vertical|v|horizontal|h|none|n|toggle|t
+	Splits the current container, vertically or horizontally. When _none_ is
+	specified, the effect of a previous split is undone if the current
+	container is the only child of a split parent. When _toggle_ is
 	specified, the current container is split opposite to the parent
 	container's layout.
 


### PR DESCRIPTION
While browsing the i3 issue tracker I saw issue i3/i3#3808 "split none" command with an accepted label. 

Not sure if we want it yet, but I figured this one was pretty easy to implement for sway so here it is. i3 doesn't have an implementation yet, so I can't really compare it to theirs, but I expect this is the intended behavior.