### PR TITLE
fix build errors when using -fno-common

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -78,7 +78,7 @@ struct sway_server {
 	list_t *dirty_nodes;
 };
 
-struct sway_server server;
+extern struct sway_server server;
 
 struct sway_debug {
 	bool noatomic;         // Ignore atomic layout updates
@@ -92,7 +92,7 @@ struct sway_debug {
 	} damage;
 };
 
-struct sway_debug debug;
+extern struct sway_debug debug;
 
 /* Prepares an unprivileged server_init by performing all privileged operations in advance */
 bool server_privileged_prepare(struct sway_server *server);

--- a/sway/main.c
+++ b/sway/main.c
@@ -27,6 +27,7 @@
 static bool terminate_request = false;
 static int exit_value = 0;
 struct sway_server server = {0};
+struct sway_debug debug = {0};
 
 void sway_terminate(int exit_code) {
 	if (!server.wl_display) {


### PR DESCRIPTION
GCC 10 will enable -fno-common by default and sway currently fails to compile when using this flag.