### PR TITLE
Docs: Add marks field to get_tree response

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -343,6 +343,9 @@ node and will have the following properties:
 |- sticky
 :  boolean
 :  Whether the node is sticky (shows on all workspaces)
+|- marks
+:  array
+:  List of marks assigned to the node
 |- focused
 :  boolean
 :  Whether the node is currently focused by the default seat (_seat0_)


### PR DESCRIPTION
This was previously undocumented in i3 until [recently](https://github.com/i3/i3/pull/3871), however it has now been confirmed stable.