### PR TITLE
Docs: Add max_render_time field to get_tree response

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -355,6 +355,10 @@ node and will have the following properties:
 |- floating_nodes
 :  array
 :  The floating children nodes for the node
+|- max_render_time
+:  integer
+:  Number of milliseconds a surface has to render and commit new contents before
+   being sampled by the compositor for the next presentation. "off" means none.
 |- representation
 :  string
 :  (Only workspaces) A string representation of the layout of the workspace


### PR DESCRIPTION
This was added to the get_tree output in bd9a53f1a3e7dba247aab0a4e4268724acc12c38.

If it's not intended to be documented then perhaps we could add a disclaimer in the docs as per [i3](https://i3wm.org/docs/ipc.html#_tree_reply):

> While the nodes might have more properties, please do not use any properties which are not documented here. They are not yet finalized and will probably change!