### PR TITLE
Fix seat_set_focus_layer crash when disabling output

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -222,7 +222,7 @@ void arrange_layers(struct sway_output *output) {
 	}
 }
 
-static struct sway_layer_surface *find_any_layer_by_client(
+static struct sway_layer_surface *find_mapped_layer_by_client(
 		struct wl_client *client, struct wlr_output *ignore_output) {
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
@@ -234,7 +234,8 @@ static struct sway_layer_surface *find_any_layer_by_client(
 		wl_list_for_each(lsurface,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], link) {
 			struct wl_resource *resource = lsurface->layer_surface->resource;
-			if (wl_resource_get_client(resource) == client) {
+			if (wl_resource_get_client(resource) == client
+					&& lsurface->layer_surface->mapped) {
 				return lsurface;
 			}
 		}
@@ -258,7 +259,7 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 
 	if (set_focus) {
 		struct sway_layer_surface *layer =
-			find_any_layer_by_client(client, sway_layer->layer_surface->output);
+			find_mapped_layer_by_client(client, sway_layer->layer_surface->output);
 		if (layer) {
 			seat_set_focus_layer(seat, layer->layer_surface);
 		}


### PR DESCRIPTION
This fixes the following crash:

    #0  0x00007f7daac3af25 in raise () at /usr/lib/libc.so.6
    #1  0x00007f7daac24897 in abort () at /usr/lib/libc.so.6
    #2  0x00007f7daac24767 in _nl_load_domain.cold () at /usr/lib/libc.so.6
    #3  0x00007f7daac33526 in  () at /usr/lib/libc.so.6
    #4  0x0000555bfbc35029 in seat_set_focus_layer (seat=0x555bfd76d860, layer=0x555bfdda2ff0)
        at ../sway/input/seat.c:1164
            __PRETTY_FUNCTION__ = "seat_set_focus_layer"
            __PRETTY_FUNCTION__ = "seat_set_focus_layer"
    #5  0x0000555bfbc35029 in seat_set_focus_layer (seat=seat@entry=0x555bfd76d860, layer=0x555bfdda2ff0)
        at ../sway/input/seat.c:1164
            __PRETTY_FUNCTION__ = "seat_set_focus_layer"
    #6  0x0000555bfbc25899 in handle_output_destroy (listener=0x555bfdb90688, data=<optimized out>)
        at ../sway/desktop/layer_shell.c:263
            layer = 0x555bfdd6b040
            sway_layer = 0x555bfdb90610
            seat = 0x555bfd76d860
            client = 0x555bfdb76d70
            set_focus = <optimized out>
    #7  0x0000555bfbc5b669 in wl_signal_emit (data=0x555bfd795930, signal=0x555bfd795ae0)
        at /usr/include/wayland-server-core.h:472
            l = <optimized out>
            next = 0x555bfdb6a3e8
            __PRETTY_FUNCTION__ = "output_disable"
            index = <optimized out>
    #8  0x0000555bfbc5b669 in output_disable (output=output@entry=0x555bfd795930)
        at ../sway/tree/output.c:263
            __PRETTY_FUNCTION__ = "output_disable"
            index = <optimized out>
    #9  0x0000555bfbc3b890 in apply_output_config (oc=0x555bfd7d73d0, output=output@entry=0x555bfd795930)
        at ../sway/config/output.c:321
            wlr_output = 0x555bfd7afaf0
            scale = <optimized out>
            output_box = <optimized out>
    #10 0x0000555bfbc28309 in handle_output_manager_apply
        (listener=0x555bfbc7f148 <server+488>, data=0x555bfdca6eb0) at ../sway/desktop/output.c:936
            wlr_output = <optimized out>
            output = 0x555bfd795930
            oc = <optimized out>
            server = 0x555bfbc7ef60 <server>
            config = 0x555bfdca6eb0
            config_head = 0x555bfdb79350
            ok = true
    #11 0x00007f7dab4fbf7c in wlr_signal_emit_safe (signal=<optimized out>, data=0x555bfdca6eb0)
        at ../subprojects/wlroots/util/signal.c:29
            pos = 0x555bfbc7f148 <server+488>
            l = 0x555bfbc7f148 <server+488>
            cursor =
              {link = {prev = 0x555bfbc7f148 <server+488>, next = 0x7fff238a8390}, notify = 0x7f7dab4fbef0 <handle_noop>}
            end =
              {link = {prev = 0x7fff238a8370, next = 0x555bfd7419f8}, notify = 0x7f7dab4fbef0 <handle_noop>}
    #12 0x00007f7daa45469a in ffi_call_unix64 () at /usr/lib/libffi.so.6
    #13 0x00007f7daa453fb6 in ffi_call () at /usr/lib/libffi.so.6
    #14 0x00007f7daae6f82f in  () at /usr/lib/libwayland-server.so.0
    #15 0x00007f7daae6c193 in  () at /usr/lib/libwayland-server.so.0
    #16 0x00007f7daae6d7f2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
    #17 0x00007f7daae6c39c in wl_display_run () at /usr/lib/libwayland-server.so.0

This crash happens because focus can only be set on mapped surfaces.