### PR TITLE
Avoid calling strcmp on nullptr

### DIFF
--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -89,7 +89,10 @@ static bool validate_icon_theme(struct icon_theme *theme) {
 static bool group_handler(char *old_group, char *new_group,
 		struct icon_theme *theme) {
 	if (!old_group) { // first group must be "Icon Theme"
-		return strcmp(new_group, "Icon Theme");
+		if (!new_group) {
+			return true;
+		}
+		return strcmp(new_group, "Icon Theme") != 0;
 	}
 
 	if (strcmp(old_group, "Icon Theme") == 0) {


### PR DESCRIPTION
The function group_handler may get a nullptr as `new_group`. If that's
the case, return -1, as if `new_group` was the empty string.

This fixes a build failure on s390x on Fedora rawhide:
```
[132/268] cc -Iswaybar/cf785bf@@swaybar@exe -Iswaybar -I../swaybar -Iinclude -I../include -Iprotocols -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/json-c -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/fribidi -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=c11 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla '-DSYSCONFDIR="//etc"' '-DSWAY_VERSION="1.4"' -fmacro-prefix-map=../= -O2 -g -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection -pthread -MD -MQ 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o' -MF 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o.d' -o 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o' -c ../swaybar/tray/icon.c
FAILED: swaybar/cf785bf@@swaybar@exe/tray_icon.c.o 
cc -Iswaybar/cf785bf@@swaybar@exe -Iswaybar -I../swaybar -Iinclude -I../include -Iprotocols -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/json-c -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/fribidi -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=c11 -DWLR_USE_UNSTABLE -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla '-DSYSCONFDIR="//etc"' '-DSWAY_VERSION="1.4"' -fmacro-prefix-map=../= -O2 -g -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection -pthread -MD -MQ 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o' -MF 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o.d' -o 'swaybar/cf785bf@@swaybar@exe/tray_icon.c.o' -c ../swaybar/tray/icon.c
In function 'group_handler',
    inlined from 'read_theme_file' at ../swaybar/tray/icon.c:277:11,
    inlined from 'load_themes_in_dir' at ../swaybar/tray/icon.c:304:30,
    inlined from 'init_themes' at ../swaybar/tray/icon.c:355:24:
../swaybar/tray/icon.c:92:10: error: argument 1 null where non-null expected [-Werror=nonnull]
   92 |   return strcmp(new_group, "Icon Theme");
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../swaybar/tray/icon.c:7:
../swaybar/tray/icon.c: In function 'init_themes':
/usr/include/string.h:137:12: note: in a call to function 'strcmp' declared here
  137 | extern int strcmp (const char *__s1, const char *__s2)
      |            ^~~~~~
cc1: all warnings being treated as errors
```