### PR TITLE
Fix inverted transforms

### DIFF
--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -50,6 +50,10 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Invalid output transform.");
 	}
 
+	// Sway uses clockwise transforms, while WL_OUTPUT_TRANSFORM_* describe
+	// anti-clockwise transforms
+	transform = invert_rotation_direction(transform);
+
 	struct output_config *output = config->handler_context.output_config;
 	config->handler_context.leftovers.argc = argc - 1;
 	config->handler_context.leftovers.argv = argv + 1;

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -99,10 +99,10 @@ must be separated by one space. For example:
 *output* <name> transform <transform> [clockwise|anticlockwise]
 	Sets the background transform to the given value. Can be one of "90", "180",
 	"270" for rotation; or "flipped", "flipped-90", "flipped-180", "flipped-270"
-	to apply a rotation and flip, or "normal" to apply no transform. If a single
-	output is chosen and a rotation direction is specified (_clockwise_ or
-	_anticlockwise_) then the transform is added or subtracted from the current
-	transform.
+	to apply a rotation and flip, or "normal" to apply no transform. The
+	rotation is performed clockwise. If a single output is chosen and a
+	rotation direction is specified (_clockwise_ or _anticlockwise_) then the
+	transform is added or subtracted from the current transform.
 
 *output* <name> disable|enable
 	Enables or disables the specified output (all outputs are enabled by


### PR DESCRIPTION
This patch makes it so users that have configured their screen with a
transform don't have to update their config after the wlroots breaking
change.

References: https://github.com/swaywm/wlroots/pull/2023