### PR TITLE
container_at_{tabbed,stacked}: check x-axis bounds

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -208,7 +208,8 @@ static struct sway_container *container_at_tabbed(struct sway_node *parent,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	struct wlr_box box;
 	node_get_box(parent, &box);
-	if (ly < box.y || ly > box.y + box.height) {
+	if (lx < box.x || lx > box.x + box.width ||
+			ly < box.y || ly > box.y + box.height) {
 		return NULL;
 	}
 	struct sway_seat *seat = input_manager_current_seat();
@@ -242,7 +243,8 @@ static struct sway_container *container_at_stacked(struct sway_node *parent,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	struct wlr_box box;
 	node_get_box(parent, &box);
-	if (ly < box.y || ly > box.y + box.height) {
+	if (lx < box.x || lx > box.x + box.width ||
+			ly < box.y || ly > box.y + box.height) {
 		return NULL;
 	}
 	struct sway_seat *seat = input_manager_current_seat();


### PR DESCRIPTION
Fixes #4969

The container_at_tabbed and container_at_stacked container were checking
the bounds along the y-axis, but not the x-axis. This made it possible
to cause a segfault for specific resolution, horizontal gap, and
workspace children lengths. The issue is that child_index was -1 and was
resulting in a buffer underflow. Adding the x-axis bound checks for
early returns should prevent this from happening.