### PR TITLE
config: fix validation exit code and log level

### DIFF
--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -103,7 +103,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	// If reloading, the output configs will be applied after reading the
 	// entire config and before the deferred commands so that an auto generated
 	// workspace name is not given to re-enabled outputs.
-	if (!config->reloading) {
+	if (!config->reloading && !config->validating) {
 		apply_output_config_to_outputs(output);
 		if (background) {
 			spawn_swaybg();

--- a/sway/config.c
+++ b/sway/config.c
@@ -404,7 +404,7 @@ static bool load_config(const char *path, struct sway_config *config,
 		sway_log(SWAY_ERROR, "Error(s) loading config!");
 	}
 
-	return true;
+	return config->active || !config->validating || config_load_success;
 }
 
 bool load_main_config(const char *file, bool is_active, bool validating) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -310,7 +310,7 @@ int main(int argc, char **argv) {
 	if (debug) {
 		sway_log_init(SWAY_DEBUG, sway_terminate);
 		wlr_log_init(WLR_DEBUG, NULL);
-	} else if (verbose || validate) {
+	} else if (verbose) {
 		sway_log_init(SWAY_INFO, sway_terminate);
 		wlr_log_init(WLR_INFO, NULL);
 	} else {


### PR DESCRIPTION
Fixes #4976

This makes it so invalid configs will return the exit code 1 when the
validation flag is given. This also reduces the log level to SWAY_ERROR,
which makes it so only the errors are shown. If someone wants more
verbose output, they can use the -V/--verbose or -d/--debug flags.
Additionally, this also makes it so swaybg will not be spawned when
validating the config.