### PR TITLE
Fix ordering of setgid and setuid

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -186,12 +186,17 @@ static void log_kernel(void) {
 
 static bool drop_permissions(void) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
-		if (setuid(getuid()) != 0 || setgid(getgid()) != 0) {
-			sway_log(SWAY_ERROR, "Unable to drop root, refusing to start");
+		// Set the gid and uid in the correct order.
+		if (setgid(getgid()) != 0) {
+			sway_log(SWAY_ERROR, "Unable to drop root group, refusing to start");
+			return false;
+		}
+		if (setuid(getuid()) != 0) {
+			sway_log(SWAY_ERROR, "Unable to drop root user, refusing to start");
 			return false;
 		}
 	}
-	if (setuid(0) != -1) {
+	if (setgid(0) != -1 || setuid(0) != -1) {
 		sway_log(SWAY_ERROR, "Unable to drop root (we shouldn't be able to "
 			"restore it after setuid), refusing to start");
 		return false;


### PR DESCRIPTION
It looks like the code to drop privileges may have been broken via commit 37f0e1f. That commit reverted the correct order from #911, which first drops the gid then the uid. If setuid is called first then the target user may not have the ability to setgid.

Fixes #4990.