### PR TITLE
Remember if direct scanout fails

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -75,6 +75,7 @@ struct sway_view {
 	char *title_format;
 
 	bool using_csd;
+	bool failed_scan_out;
 
 	struct timespec urgent;
 	bool allow_request_urgent;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -453,6 +453,10 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
+	if (view->failed_scan_out) {
+		return false;
+	}
+
 	if (view->saved_buffer) {
 		return false;
 	}
@@ -502,9 +506,16 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		wlr_output);
 
 	if (!wlr_output_attach_buffer(wlr_output, surface->buffer)) {
+		view->failed_scan_out = true;
 		return false;
 	}
-	return wlr_output_commit(wlr_output);
+
+	if (!wlr_output_commit(wlr_output)) {
+		view->failed_scan_out = true;
+		return false;
+	}
+
+	return true;
 }
 
 int output_repaint_timer_handler(void *data) {


### PR DESCRIPTION
If a view fails direct scanout, we remember if it fails so we don't
bother trying again. This removes a lot of log spam of the atomic DRM
test failing in this case.