### PR TITLE
cmd_swap: fix test_mark condition

### DIFF
--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -202,8 +202,8 @@ static bool test_id(struct sway_container *container, void *data) {
 
 static bool test_mark(struct sway_container *container, void *mark) {
 	if (container->marks->length) {
-		return !list_seq_find(container->marks,
-				(int (*)(const void *, const void *))strcmp, mark);
+		return list_seq_find(container->marks,
+				(int (*)(const void *, const void *))strcmp, mark) != -1;
 	}
 	return false;
 }


### PR DESCRIPTION
Fixes #5007

The condition in test_mark was checking the negation of list_seq_find.
This works fine for the first mark, but fails for every other mark. This
fixes the condition to check for anything other than -1, which is the
value returned from list_seq_find for index not found.