### PR TITLE
output: fix updating output manager config

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -101,7 +101,7 @@ struct sway_output *all_output_by_name_or_id(const char *name_or_id);
 
 void output_sort_workspaces(struct sway_output *output);
 
-void output_enable(struct sway_output *output);
+void output_configure(struct sway_output *output);
 
 void output_disable(struct sway_output *output);
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -345,6 +345,9 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		return wlr_output_commit(wlr_output);
 	}
 
+	bool was_enabled = output->enabled;
+	output->enabled = true;
+
 	if (!oc || oc->dpms_state != DPMS_OFF) {
 		sway_log(SWAY_DEBUG, "Turning on output %s", wlr_output->name);
 		wlr_output_enable(wlr_output, true);
@@ -393,6 +396,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		// output disabled for now and try again when the output gets the mode
 		// we asked for.
 		sway_log(SWAY_ERROR, "Failed to modeset output %s", wlr_output->name);
+		output->enabled = was_enabled;
 		return false;
 	}
 
@@ -432,8 +436,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	output->width = output_box->width;
 	output->height = output_box->height;
 
-	if ((!oc || oc->enabled) && !output->enabled) {
-		output_enable(output);
+	if ((!oc || oc->enabled) && !output->configured) {
+		output_configure(output);
 	}
 
 	if (oc && oc->dpms_state == DPMS_OFF) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -102,20 +102,19 @@ struct sway_output *output_create(struct wlr_output *wlr_output) {
 	output->workspaces = create_list();
 	output->current.workspaces = create_list();
 
-	return output;
-}
-
-void output_enable(struct sway_output *output) {
-	if (!sway_assert(!output->enabled, "output is already enabled")) {
-		return;
-	}
-	struct wlr_output *wlr_output = output->wlr_output;
 	size_t len = sizeof(output->layers) / sizeof(output->layers[0]);
 	for (size_t i = 0; i < len; ++i) {
 		wl_list_init(&output->layers[i]);
 	}
 
-	output->enabled = true;
+	return output;
+}
+
+void output_configure(struct sway_output *output) {
+	if (!sway_assert(!output->configured, "output is already configured")) {
+		return;
+	}
+	struct wlr_output *wlr_output = output->wlr_output;
 	output->configured = true;
 	list_add(root->outputs, output);
 


### PR DESCRIPTION
Fixes #5014 

The output manager config is created when the output is created. It is
updated when the mode, transform, scale, or layout for the output
changes, as well as, when the output is destroyed.

Since the output->enabled property was not being set before calling
apply_output_config, the output event handlers were early returning and
never updating the output manager config when the output state was
committed.

This fixes the issue by setting output->enabled in apply_output_config
below the output disabling section. There are also a few other minor
changes that are required to function.