### PR TITLE
Keyboard shortcuts inhibit

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -288,6 +288,7 @@ sway_cmd seat_cmd_idle_inhibit;
 sway_cmd seat_cmd_idle_wake;
 sway_cmd seat_cmd_keyboard_grouping;
 sway_cmd seat_cmd_pointer_constraint;
+sway_cmd seat_cmd_shortcuts_inhibitor;
 sway_cmd seat_cmd_xcursor_theme;
 
 sway_cmd cmd_ipc_cmd;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -39,7 +39,7 @@ enum binding_flags {
 	BINDING_CONTENTS=8,  // mouse only; trigger on container contents
 	BINDING_TITLEBAR=16, // mouse only; trigger on container titlebar
 	BINDING_CODE=32,     // keyboard only; convert keysyms into keycodes
-	BINDING_RELOAD=62,   // switch only; (re)trigger binding on reload
+	BINDING_RELOAD=64,   // switch only; (re)trigger binding on reload
 };
 
 /**

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -177,6 +177,12 @@ enum seat_config_allow_constrain {
 	CONSTRAIN_DISABLE
 };
 
+enum seat_config_shortcuts_inhibit {
+	SHORTCUTS_INHIBIT_DEFAULT,  // the default is currently enabled
+	SHORTCUTS_INHIBIT_ENABLE,
+	SHORTCUTS_INHIBIT_DISABLE
+};
+
 enum seat_keyboard_grouping {
 	KEYBOARD_GROUP_DEFAULT,  // the default is currently smart
 	KEYBOARD_GROUP_NONE,
@@ -201,6 +207,7 @@ struct seat_config {
 	list_t *attachments; // list of seat_attachment configs
 	int hide_cursor_timeout;
 	enum seat_config_allow_constrain allow_constrain;
+	enum seat_config_shortcuts_inhibit shortcuts_inhibit;
 	enum seat_keyboard_grouping keyboard_grouping;
 	uint32_t idle_inhibit_sources, idle_wake_sources;
 	struct {

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -40,6 +40,7 @@ enum binding_flags {
 	BINDING_TITLEBAR=16, // mouse only; trigger on container titlebar
 	BINDING_CODE=32,     // keyboard only; convert keysyms into keycodes
 	BINDING_RELOAD=64,   // switch only; (re)trigger binding on reload
+	BINDING_INHIBITED=128,	// keyboard only: ignore shortcut inhibitor
 };
 
 /**

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -2,6 +2,7 @@
 #define _SWAY_INPUT_INPUT_MANAGER_H
 #include <libinput.h>
 #include <wlr/types/wlr_input_inhibitor.h>
+#include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include "sway/server.h"
@@ -20,12 +21,14 @@ struct sway_input_manager {
 	struct wl_list seats;
 
 	struct wlr_input_inhibit_manager *inhibit;
+	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *keyboard_shortcuts_inhibit;
 	struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard;
 	struct wlr_virtual_pointer_manager_v1 *virtual_pointer;
 
 	struct wl_listener new_input;
 	struct wl_listener inhibit_activate;
 	struct wl_listener inhibit_deactivate;
+	struct wl_listener keyboard_shortcuts_inhibit_new_inhibitor;
 	struct wl_listener virtual_keyboard_new;
 	struct wl_listener virtual_pointer_new;
 };

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_INPUT_SEAT_H
 #define _SWAY_INPUT_SEAT_H
 
+#include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/util/edges.h>
@@ -94,6 +95,8 @@ struct sway_seat {
 
 	struct wl_list devices; // sway_seat_device::link
 	struct wl_list keyboard_groups; // sway_keyboard_group::link
+	struct wl_list keyboard_shortcuts_inhibitors;
+				// sway_keyboard_shortcuts_inhibitor::link
 
 	struct wl_list link; // input_manager::seats
 };
@@ -102,6 +105,14 @@ struct sway_pointer_constraint {
 	struct wlr_pointer_constraint_v1 *constraint;
 
 	struct wl_listener destroy;
+};
+
+struct sway_keyboard_shortcuts_inhibitor {
+	struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor;
+
+	struct wl_listener destroy;
+
+	struct wl_list link; // sway_seat::keyboard_shortcuts_inhibitors
 };
 
 struct sway_seat *seat_create(const char *seat_name);
@@ -268,5 +279,12 @@ void seatop_render(struct sway_seat *seat, struct sway_output *output,
 		pixman_region32_t *damage);
 
 bool seatop_allows_set_cursor(struct sway_seat *seat);
+
+/**
+ * Returns the keyboard shortcuts inhibitor that applies to the currently
+ * focused surface of a seat or NULL if none exists.
+ */
+struct sway_keyboard_shortcuts_inhibitor *
+keyboard_shortcuts_inhibitor_get_for_focused_surface(const struct sway_seat *seat);
 
 #endif

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -72,7 +72,8 @@ static bool binding_key_compare(struct sway_binding *binding_a,
 	}
 
 	uint32_t conflict_generating_flags = BINDING_RELEASE | BINDING_BORDER
-			| BINDING_CONTENTS | BINDING_TITLEBAR | BINDING_LOCKED;
+			| BINDING_CONTENTS | BINDING_TITLEBAR | BINDING_LOCKED
+			| BINDING_INHIBITED;
 	if ((binding_a->flags & conflict_generating_flags) !=
 			(binding_b->flags & conflict_generating_flags)) {
 		return false;
@@ -354,6 +355,8 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			binding->flags |= BINDING_RELEASE;
 		} else if (strcmp("--locked", argv[0]) == 0) {
 			binding->flags |= BINDING_LOCKED;
+		} else if (strcmp("--inhibited", argv[0]) == 0) {
+			binding->flags |= BINDING_INHIBITED;
 		} else if (strcmp("--whole-window", argv[0]) == 0) {
 			binding->flags |= BINDING_BORDER | BINDING_CONTENTS | BINDING_TITLEBAR;
 		} else if (strcmp("--border", argv[0]) == 0) {

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -22,6 +22,7 @@ static struct cmd_handler seat_handlers[] = {
 	{ "idle_wake", seat_cmd_idle_wake },
 	{ "keyboard_grouping", seat_cmd_keyboard_grouping },
 	{ "pointer_constraint", seat_cmd_pointer_constraint },
+	{ "shortcuts_inhibitor", seat_cmd_shortcuts_inhibitor },
 	{ "xcursor_theme", seat_cmd_xcursor_theme },
 };
 

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -71,7 +71,7 @@ struct cmd_results *seat_cmd_cursor(int argc, char **argv) {
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {
 			error = handle_command(seat->cursor, argc, argv);
-			if ((error && error->status != CMD_SUCCESS)) {
+			if (error && error->status != CMD_SUCCESS) {
 				break;
 			}
 		}

--- a/sway/commands/seat/shortcuts_inhibitor.c
+++ b/sway/commands/seat/shortcuts_inhibitor.c
@@ -1,0 +1,96 @@
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/input/seat.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+static struct cmd_results *handle_action(struct seat_config *sc,
+		struct sway_seat *seat, const char *action) {
+	struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor = NULL;
+	if (strcmp(action, "disable") == 0) {
+		sc->shortcuts_inhibit = SHORTCUTS_INHIBIT_DISABLE;
+
+		wl_list_for_each(sway_inhibitor,
+				&seat->keyboard_shortcuts_inhibitors, link) {
+			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
+					sway_inhibitor->inhibitor);
+		}
+
+		sway_log(SWAY_DEBUG, "Deactivated all keyboard shortcuts inhibitors");
+	} else {
+		sway_inhibitor = keyboard_shortcuts_inhibitor_get_for_focused_surface(seat);
+		if (!sway_inhibitor) {
+			return cmd_results_new(CMD_FAILURE,
+					"No inhibitor found for focused surface");
+		}
+
+		struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+			sway_inhibitor->inhibitor;
+		bool inhibit;
+		if (strcmp(action, "activate") == 0) {
+			inhibit = true;
+		} else if (strcmp(action, "deactivate") == 0) {
+			inhibit = false;
+		} else if (strcmp(action, "toggle") == 0) {
+			inhibit = !inhibitor->active;
+		} else {
+			return cmd_results_new(CMD_INVALID, "Expected enable|"
+					"disable|activate|deactivate|toggle");
+		}
+
+		if (inhibit) {
+			wlr_keyboard_shortcuts_inhibitor_v1_activate(inhibitor);
+		} else {
+			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(inhibitor);
+		}
+
+		sway_log(SWAY_DEBUG, "%sctivated keyboard shortcuts inhibitor",
+				inhibit ? "A" : "Dea");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+// shortcuts_inhibitor [enable|disable|activate|deactivate|toggle]
+struct cmd_results *seat_cmd_shortcuts_inhibitor(int argc, char **argv) {
+	struct cmd_results *error =
+		checkarg(argc, "shortcuts_inhibitor", EXPECTED_EQUAL_TO, 1);
+	if (error) {
+		return error;
+	}
+
+	struct seat_config *sc = config->handler_context.seat_config;
+	if (!sc) {
+		return cmd_results_new(CMD_FAILURE, "No seat defined");
+	}
+
+	if (strcmp(argv[0], "enable") == 0) {
+		sc->shortcuts_inhibit = SHORTCUTS_INHIBIT_ENABLE;
+	// at runtime disable is an action that also deactivates all active
+	// inhibitors handled in handle_action()
+	} else if (strcmp(argv[0], "disable") == 0 && !config->active) {
+		sc->shortcuts_inhibit = SHORTCUTS_INHIBIT_DISABLE;
+	} else if (!config->active) {
+		return cmd_results_new(CMD_INVALID, "only enable and disable "
+				"can be used in the config");
+	} else {
+		if (strcmp(sc->name, "*") != 0) {
+			struct sway_seat *seat = input_manager_get_seat(sc->name, false);
+			if (!seat) {
+				return cmd_results_new(CMD_FAILURE,
+						"Seat %s does not exist", sc->name);
+			}
+			error = handle_action(sc, seat, argv[0]);
+		} else {
+			struct sway_seat *seat = NULL;
+			wl_list_for_each(seat, &server.input->seats, link) {
+				error = handle_action(sc, seat, argv[0]);
+				if (error && error->status != CMD_SUCCESS) {
+					break;
+				}
+			}
+		}
+	}
+
+	return error ? error : cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -30,6 +30,7 @@ struct seat_config *new_seat_config(const char* name) {
 	}
 	seat->hide_cursor_timeout = -1;
 	seat->allow_constrain = CONSTRAIN_DEFAULT;
+	seat->shortcuts_inhibit = SHORTCUTS_INHIBIT_DEFAULT;
 	seat->keyboard_grouping = KEYBOARD_GROUP_DEFAULT;
 	seat->xcursor_theme.name = NULL;
 	seat->xcursor_theme.size = 24;
@@ -152,6 +153,10 @@ void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 
 	if (source->allow_constrain != CONSTRAIN_DEFAULT) {
 		dest->allow_constrain = source->allow_constrain;
+	}
+
+	if (source->shortcuts_inhibit != SHORTCUTS_INHIBIT_DEFAULT) {
+		dest->shortcuts_inhibit = source->shortcuts_inhibit;
 	}
 
 	if (source->keyboard_grouping != KEYBOARD_GROUP_DEFAULT) {

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -333,6 +333,26 @@ static void handle_keyboard_shortcuts_inhibit_new_inhibitor(
 	struct sway_seat *seat = inhibitor->seat->data;
 	wl_list_insert(&seat->keyboard_shortcuts_inhibitors, &sway_inhibitor->link);
 
+	struct seat_config *config = seat_get_config(seat);
+	if (!config) {
+		config = seat_get_config_by_name("*");
+	}
+
+	if (config && config->shortcuts_inhibit == SHORTCUTS_INHIBIT_DISABLE) {
+		/**
+		 * Here we deny to honour the inhibitor by never sending the
+		 * activate signal. We can not, however, destroy the inhibitor
+		 * because the protocol doesn't allow for it. So it will linger
+		 * until the client removes it im- or explicitly. But at least
+		 * it can only be one inhibitor per surface and seat at a time.
+		 *
+		 * We also want to allow the user to activate the inhibitor
+		 * manually later which is why we do this check here where the
+		 * inhibitor is already attached to its seat and ready for use.
+		 */
+		return;
+	}
+
 	wlr_keyboard_shortcuts_inhibitor_v1_activate(inhibitor);
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -557,6 +557,7 @@ struct sway_seat *seat_create(const char *seat_name) {
 		handle_request_set_primary_selection;
 
 	wl_list_init(&seat->keyboard_groups);
+	wl_list_init(&seat->keyboard_shortcuts_inhibitors);
 
 	wl_list_insert(&server.input->seats, &seat->link);
 
@@ -1472,4 +1473,19 @@ void seatop_render(struct sway_seat *seat, struct sway_output *output,
 
 bool seatop_allows_set_cursor(struct sway_seat *seat) {
 	return seat->seatop_impl->allow_set_cursor;
+}
+
+struct sway_keyboard_shortcuts_inhibitor *
+keyboard_shortcuts_inhibitor_get_for_focused_surface(
+		const struct sway_seat *seat) {
+	struct wlr_surface *focused_surface =
+		seat->wlr_seat->keyboard_state.focused_surface;
+	struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor = NULL;
+	wl_list_for_each(sway_inhibitor, &seat->keyboard_shortcuts_inhibitors, link) {
+		if (sway_inhibitor->inhibitor->surface == focused_surface) {
+			return sway_inhibitor;
+		}
+	}
+
+	return NULL;
 }

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -94,6 +94,7 @@ sway_sources = files(
 	'commands/seat/idle.c',
 	'commands/seat/keyboard_grouping.c',
 	'commands/seat/pointer_constraint.c',
+	'commands/seat/shortcuts_inhibitor.c',
 	'commands/seat/xcursor_theme.c',
 	'commands/set.c',
 	'commands/show_marks.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -239,6 +239,25 @@ correct seat.
 	by default) for the seat. This is primarily useful for video games. The
 	"escape" command can be used at runtime to escape from a captured client.
 
+*seat* <name> shortcuts_inhibitor enable|disable|activate|deactivate|toggle
+	Enables or disables the ability of clients to inhibit keyboard
+	shortcuts for the seat. This is primarily useful for virtualization and
+	remote desktop software. Subcommands _enable_ and _disable_ affect
+	whether future inhibitors are honoured by default, i.e. activated
+	automatically, the default being _enable_. When used at runtime,
+	_disable_ also disables any currently active inhibitors. _activate_,
+	_deactivate_ and _toggle_ are only useable at runtime and change the
+	state of a potentially existing inhibitor on the currently focused
+	window. This can be used with the current seat alias (_-_) to affect
+	only the currently focused window of the current seat. Subcommand
+	_deactivate_ is particularly useful in an _--inhibited_ *bindsym* to
+	escape a state where shortcuts are inhibited and the client becomes
+	uncooperative. It is worth noting that whether disabled or deactivated
+	inhibitors are removed is entirely up to the client. Depending on the
+	client it may therefore be possible to (re-)activate them later. Any
+	visual indication that an inhibitor is present is currently left to the
+	client as well.
+
 *seat* <name> xcursor_theme <theme> [<size>]
 	Override the system default XCursor theme. The default seat's
 	(_seat0_) theme is also used as the default cursor theme in

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -374,6 +374,14 @@ runtime.
 	and one has both _--input-device_ and _--locked_ and the other has neither,
 	the former will be preferred even when unlocked.
 
+	Unless the flag _--inhibited_ is set, the command will not be run when
+	a keyboard shortcuts inhibitor is active for the currently focused
+	window. Such inhibitors are usually requested by remote desktop and
+	virtualization software to enable the user to send keyboard shortcuts
+	to the remote or virtual session. The _--inhibited_ flag allows to
+	define bindings which will be exempt from pass-through to such
+	software. The same preference logic as for _--locked_ applies.
+
 	Bindings to keysyms are layout-dependent. This can be changed with the
 	_--to-code_ flag. In this case, the keysyms will be translated into the
 	corresponding keycodes in the first configured layout.


### PR DESCRIPTION
Adding support for the keyboard shortcuts inhibit protocol allows remote
desktop and virtualisation software to receive all keyboard input in
order to pass it through to their clients so users can fully interact
the their remote/virtual session. The software usually provides its own
key combination to release its "grab" to all keyboard input. The
inhibitor can be deactivated by the user by removing focus from the
surface using another input device such as the pointer.

Use support for the procotol in wlroots (swaywm/wlroots#2026) to add support to sway. Extend
the input manager with handlers for inhibitor creation and destruction
and appropriate bookkeeping. Attach the inhibitors to the seats they
apply to to avoid having to search the list of all currently existing
inhibitors on every keystroke and passing the inhibitor manager around.
Add a helper function to retrieve the inhibitor applying to the
currently focused surface of a seat, if one exists.

Extend bindsym with a flag for bindings that should be processed even if
an inhibitor is active. Conversely this disables all normal shortcuts if
an inhibitor is found for the currently focused surface in
keyboard::handle_key_event() since they don't have that flag set. Use
above helper function to determine if an inhibitor exists for the
surface that would eventually receive input.

Also, add a command to influence keyboard shortcuts inhibitors. In its current
form it can be used to activate, deactivate or toggle an existing
inhibitor on the surface currently receiving input. This can be used to
define an escape shortcut such as:
```
bindsym --inhibited $mod+Ctrl+Shift+q shortcuts_inhibitor deactivate
```