### PR TITLE
tree/view: do not attempt enter on hidden child

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -896,8 +896,10 @@ void view_child_init(struct sway_view_child *child,
 	wl_signal_add(&view->events.unmap, &child->view_unmap);
 	child->view_unmap.notify = view_child_handle_view_unmap;
 
-	struct sway_output *output = child->view->container->workspace->output;
-	wlr_surface_send_enter(child->surface, output->wlr_output);
+	struct sway_workspace *workspace = child->view->container->workspace;
+	if (workspace) {
+		wlr_surface_send_enter(child->surface, workspace->output->wlr_output);
+	}
 
 	view_init_subsurfaces(child->view, surface);
 }


### PR DESCRIPTION
If a subsurface is created for a surface that is associated with a
scratchpad hidden view, do not attempt to send an enter to it. The
subsurface is not on any output and since there is no workspace
associated with the view, attempting to get the output for the NULL
workspace will result in a SIGSEGV.

There is likely other ways to reproduce, but I ran into this with the following for_window rule and attempting to do a video conference in firefox-nightly using wayland backend for firefox.
```
for_window [title="Nightly - Sharing Indicator"] move to scratchpad
```