### PR TITLE
Don't apply exclusive zones of unmapped layer-shell surfaces

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -88,7 +88,8 @@ static void arrange_layer(struct sway_output *output, struct wl_list *list,
 	wl_list_for_each(sway_layer, list, link) {
 		struct wlr_layer_surface_v1 *layer = sway_layer->layer_surface;
 		struct wlr_layer_surface_v1_state *state = &layer->current;
-		if (exclusive != (state->exclusive_zone > 0)) {
+		if (!layer->mapped ||
+				exclusive != (state->exclusive_zone > 0)) {
 			continue;
 		}
 		struct wlr_box bounds;


### PR DESCRIPTION
Backport of [1].

[1]: https://github.com/emersion/rootston/pull/15/files