### PR TITLE
Revert "Don't apply exclusive zones of unmapped layer-shell surfaces"

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -88,8 +88,7 @@ static void arrange_layer(struct sway_output *output, struct wl_list *list,
 	wl_list_for_each(sway_layer, list, link) {
 		struct wlr_layer_surface_v1 *layer = sway_layer->layer_surface;
 		struct wlr_layer_surface_v1_state *state = &layer->current;
-		if (!layer->mapped ||
-				exclusive != (state->exclusive_zone > 0)) {
+		if (exclusive != (state->exclusive_zone > 0)) {
 			continue;
 		}
 		struct wlr_box bounds;


### PR DESCRIPTION
Reverts swaywm/sway#5032

https://github.com/swaywm/sway/pull/5032#issuecomment-590646108
> swaybg silently fails after this commit for me, and wofi dies with the protocol error "layer_surface has never been configured".