### PR TITLE
Only destroy swaybar surface via ipc when needed

### DIFF
--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -528,8 +528,10 @@ static bool handle_barconfig_update(struct swaybar *bar, const char *payload,
 		ipc_get_workspaces(bar);
 	}
 
+	bool moving_layer = strcmp(oldcfg->mode, newcfg->mode) != 0;
+
 	free_config(oldcfg);
-	determine_bar_visibility(bar, true);
+	determine_bar_visibility(bar, moving_layer);
 	return true;
 }
 


### PR DESCRIPTION
Currently when changing properties via ipc like `workspace_buttons`, which don't affect the bar's surface at all, the surface is still destroyed and recreated. This causes sway to recalculate the workspace height twice in rapid succession, which is rather unpleasant. This fix only requests destruction if the mode was changed.