### PR TITLE
Add an adaptive_sync output command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -266,6 +266,7 @@ sway_cmd input_cmd_xkb_rules;
 sway_cmd input_cmd_xkb_switch_layout;
 sway_cmd input_cmd_xkb_variant;
 
+sway_cmd output_cmd_adaptive_sync;
 sway_cmd output_cmd_background;
 sway_cmd output_cmd_disable;
 sway_cmd output_cmd_dpms;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -238,6 +238,7 @@ struct output_config {
 	int32_t transform;
 	enum wl_output_subpixel subpixel;
 	int max_render_time; // In milliseconds
+	int adaptive_sync;
 
 	char *background;
 	char *background_option;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -7,6 +7,7 @@
 
 // must be in order for the bsearch
 static struct cmd_handler output_handlers[] = {
+	{ "adaptive_sync", output_cmd_adaptive_sync },
 	{ "background", output_cmd_background },
 	{ "bg", output_cmd_background },
 	{ "disable", output_cmd_disable },

--- a/sway/commands/output/adaptive_sync.c
+++ b/sway/commands/output/adaptive_sync.c
@@ -1,0 +1,22 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "util.h"
+
+struct cmd_results *output_cmd_adaptive_sync(int argc, char **argv) {
+	if (!config->handler_context.output_config) {
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
+	}
+	if (argc == 0) {
+		return cmd_results_new(CMD_INVALID, "Missing adaptive_sync argument");
+	}
+
+	if (parse_boolean(argv[0], true)) {
+		config->handler_context.output_config->adaptive_sync = 1;
+	} else {
+		config->handler_context.output_config->adaptive_sync = 0;
+	}
+
+	config->handler_context.leftovers.argc = argc - 1;
+	config->handler_context.leftovers.argv = argv + 1;
+	return NULL;
+}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -64,6 +64,7 @@ struct output_config *new_output_config(const char *name) {
 	oc->transform = -1;
 	oc->subpixel = WL_OUTPUT_SUBPIXEL_UNKNOWN;
 	oc->max_render_time = -1;
+	oc->adaptive_sync = -1;
 	return oc;
 }
 
@@ -103,6 +104,9 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 	}
 	if (src->max_render_time != -1) {
 		dst->max_render_time = src->max_render_time;
+	}
+	if (src->adaptive_sync != -1) {
+		dst->adaptive_sync = src->adaptive_sync;
 	}
 	if (src->background) {
 		free(dst->background);
@@ -388,6 +392,10 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	if (scale != wlr_output->scale) {
 		sway_log(SWAY_DEBUG, "Set %s scale to %f", wlr_output->name, scale);
 		wlr_output_set_scale(wlr_output, scale);
+	}
+
+	if (oc && oc->adaptive_sync != -1) {
+		wlr_output_enable_adaptive_sync(wlr_output, oc->adaptive_sync == 1);
 	}
 
 	sway_log(SWAY_DEBUG, "Committing output %s", wlr_output->name);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -85,6 +85,19 @@ static const char *ipc_json_output_transform_description(enum wl_output_transfor
 	return NULL;
 }
 
+static const char *ipc_json_output_adaptive_sync_status_description(
+		enum wlr_output_adaptive_sync_status status) {
+	switch (status) {
+	case WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED:
+		return "disabled";
+	case WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED:
+		return "enabled";
+	case WLR_OUTPUT_ADAPTIVE_SYNC_UNKNOWN:
+		return "unknown";
+	}
+	return NULL;
+}
+
 #if HAVE_XWAYLAND
 static const char *ipc_json_xwindow_type_description(struct sway_view *view) {
 	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
@@ -219,6 +232,11 @@ static void ipc_json_describe_output(struct sway_output *output,
 	json_object_object_add(object, "transform",
 		json_object_new_string(
 			ipc_json_output_transform_description(wlr_output->transform)));
+	const char *adaptive_sync_status =
+		ipc_json_output_adaptive_sync_status_description(
+			wlr_output->adaptive_sync_status);
+	json_object_object_add(object, "adaptive_sync_status",
+		json_object_new_string(adaptive_sync_status));
 
 	struct sway_workspace *ws = output_get_active_workspace(output);
 	if (!sway_assert(ws, "Expected output to have a workspace")) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -175,6 +175,7 @@ sway_sources = files(
 	'commands/input/xkb_switch_layout.c',
 	'commands/input/xkb_variant.c',
 
+	'commands/output/adaptive_sync.c',
 	'commands/output/background.c',
 	'commands/output/disable.c',
 	'commands/output/dpms.c',

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -148,6 +148,15 @@ must be separated by one space. For example:
 	optimal max_render_time value may vary based on the parent compositor
 	rendering timings.
 
+*output* <name> adaptive_sync on|off
+	Enables or disables adaptive synchronization (often referred to as Variable
+	Refresh Rate, or by the vendor-specific names FreeSync/G-Sync).
+
+	Adaptive sync allows clients to submit frames a little to late without
+	having to wait a whole refresh period to display it on screen. Enabling
+	adaptive sync can improve latency, but can cause flickering on some
+	hardware.
+
 # SEE ALSO
 
 *sway*(5) *sway-input*(5)

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -190,7 +190,7 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(o, "active", &active);
 	json_object_object_get_ex(o, "current_workspace", &ws);
 	json_object *make, *model, *serial, *scale, *scale_filter, *subpixel,
-		*transform, *max_render_time;
+		*transform, *max_render_time, *adaptive_sync_status;
 	json_object_object_get_ex(o, "make", &make);
 	json_object_object_get_ex(o, "model", &model);
 	json_object_object_get_ex(o, "serial", &serial);
@@ -199,6 +199,7 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(o, "subpixel_hinting", &subpixel);
 	json_object_object_get_ex(o, "transform", &transform);
 	json_object_object_get_ex(o, "max_render_time", &max_render_time);
+	json_object_object_get_ex(o, "adaptive_sync_status", &adaptive_sync_status);
 	json_object *x, *y;
 	json_object_object_get_ex(rect, "x", &x);
 	json_object_object_get_ex(rect, "y", &y);
@@ -219,8 +220,7 @@ static void pretty_print_output(json_object *o) {
 			"  Scale filter: %s\n"
 			"  Subpixel hinting: %s\n"
 			"  Transform: %s\n"
-			"  Workspace: %s\n"
-			"  Max render time: ",
+			"  Workspace: %s\n",
 			json_object_get_string(name),
 			json_object_get_string(make),
 			json_object_get_string(model),
@@ -236,8 +236,13 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_string(transform),
 			json_object_get_string(ws)
 		);
+
 		int max_render_time_int = json_object_get_int(max_render_time);
+		printf("  Max render time: ");
 		printf(max_render_time_int == 0 ? "off\n" : "%d ms\n", max_render_time_int);
+
+		printf("  Adaptive sync: %s\n",
+			json_object_get_string(adaptive_sync_status));
 	} else {
 		printf(
 			"Output %s '%s %s %s' (inactive)\n",


### PR DESCRIPTION
This enables/disables adaptive synchronization on the output.

For now, the default is disabled because it might cause flickering on
some hardware if clients don't submit frames at regular enough
intervals. In the future an "auto" option will only enable adaptive sync
if a fullscreen client opts-in via a Wayland protocol.

Testing:

- Set `output * adaptive_sync on` to enable VRR on all outputs that support it
- Set up output scheduling parameters so that clients will miss the deadline. On my hardware, `output * max_render_time 1` plus `max_render_time 1` works well.
- Check that adaptive sync is marked as enabled in `swaymsg -t get_outputs` (alternatively, "VRR enabled on connector" should appear in the debug logs)
- Run `weston-presentation-shm` on an output without adaptive sync enabled. The "p2p" (presentation-to-presentation) delay should be twice the refresh period (in my case, I have a 60Hz monitor, so it's 33ms). p2p should be pretty stable.
- Run `weston-presentation-shm` on an output with adaptive sync enabled. The "p2p" delay should be greater than the refresh period but smaller than twice the period (in my case, between 16 and 20ms). p2p should be pretty unstable.

Depends on https://github.com/swaywm/wlroots/pull/1987

cc @nstickney