### PR TITLE
swaybar: Fix scrolling to switch workspace with precise trackpads

### DIFF
--- a/include/swaybar/input.h
+++ b/include/swaybar/input.h
@@ -2,12 +2,16 @@
 #define _SWAYBAR_INPUT_H
 
 #include <wayland-client.h>
+#include <stdbool.h>
 #include "list.h"
 
 #define SWAY_SCROLL_UP KEY_MAX + 1
 #define SWAY_SCROLL_DOWN KEY_MAX + 2
 #define SWAY_SCROLL_LEFT KEY_MAX + 3
 #define SWAY_SCROLL_RIGHT KEY_MAX + 4
+
+#define SWAY_CONTINUOUS_SCROLL_TIMEOUT 1000
+#define SWAY_CONTINUOUS_SCROLL_THRESHOLD 10000
 
 struct swaybar;
 struct swaybar_output;
@@ -50,6 +54,12 @@ struct swaybar_hotspot {
 	void *data;
 };
 
+struct swaybar_scroll_axis {
+	wl_fixed_t value;
+	uint32_t discrete_steps;
+	uint32_t update_time;
+};
+
 struct swaybar_seat {
 	struct swaybar *bar;
 	uint32_t wl_name;
@@ -57,6 +67,7 @@ struct swaybar_seat {
 	struct swaybar_pointer pointer;
 	struct swaybar_touch touch;
 	struct wl_list link; // swaybar_seat:link
+	struct swaybar_scroll_axis axis[2];
 };
 
 extern const struct wl_seat_listener seat_listener;

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -340,7 +340,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 		}
 		seat->bar = bar;
 		seat->wl_name = name;
-		seat->wl_seat = wl_registry_bind(registry, name, &wl_seat_interface, 3);
+		seat->wl_seat = wl_registry_bind(registry, name, &wl_seat_interface, 5);
 		wl_seat_add_listener(seat->wl_seat, &seat_listener, seat);
 		wl_list_insert(&bar->seats, &seat->link);
 	} else if (strcmp(interface, wl_shm_interface.name) == 0) {


### PR DESCRIPTION
This patch implements some logic to try to emulate scrolling in discrete steps for devices which scroll continuously, such as modern touchpads. It keeps track of whether the axis event is discrete or not, so it shouldn't have any effect on switching workspaces with scroll wheels (assuming an axis_discrete event is always fired before an axis event for devices which scroll wheels, which seems to be the case).

This is related to https://github.com/swaywm/sway/issues/1930.

Note that this patch makes swaybar depend on wl_seat v5 instead of v3.

Here's exactly how the decision about whether to switch workspaces or not is done:

``` C
bool do_scroll =
	(axis == WL_POINTER_AXIS_VERTICAL_SCROLL && seat->scroll_is_discrete_vertical) ||
	(axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL && seat->scroll_is_discrete_horizontal) ||
	fabs(amt) >= 10 ||
	(fabs(amt) >= 1 && time >= seat->scroll_time + 200);
```

Switch workspace if:

* The event is from a device with discrete scroll steps.
* The movement in this one event is really big. This allows for making a large motion to scroll through lots of workspaces at once, typically to get to the first or last workspace.
* The time since the last workspace switch is at least 200ms (and the event's delta isn't tiny). This makes a slow, controlled motion first switch workspace instantly, then every 200ms.

This feels pretty good to me on my laptop with my touchpad, but I haven't tested it on others. Maybe some tuning of the values is necessary (or maybe they should even be configurable).