### PR TITLE
Add contrib/keyboard-layout-per-window.py

### DIFF
--- a/contrib/keyboard-layout-per-window.py
+++ b/contrib/keyboard-layout-per-window.py
@@ -37,7 +37,11 @@ def on_window(ipc: i3ipc.connection.Connection, event: i3ipc.events.WindowEvent)
 
 if __name__ == "__main__":
     ipc = i3ipc.Connection()
-    prev_focused = ipc.get_tree().find_focused().id
+    focused = ipc.get_tree().find_focused()
+    if focused:
+        prev_focused = focused.id
+    else:
+        prev_focused = None
     windows = {}
 
     ipc.on("window", on_window)

--- a/contrib/keyboard-layout-per-window.py
+++ b/contrib/keyboard-layout-per-window.py
@@ -7,11 +7,7 @@
 
 import i3ipc
 
-ipc = i3ipc.Connection()
-prev_focused = ipc.get_tree().find_focused().id
-windows = {}
-
-def on_window_focus(ipc, event):
+def on_window_focus(ipc: i3ipc.connection.Connection, event: i3ipc.events.WindowEvent):
     global windows, prev_focused
 
     # Save current layout
@@ -23,21 +19,26 @@ def on_window_focus(ipc, event):
     if event.container.id in windows:
         for (kdb_id, layout_index) in windows[event.container.id].items():
             if layout_index != layouts[kdb_id]:
-                ipc.command("""input "{}" xkb_switch_layout {}""".format(
-                    kdb_id, layout_index))
+                ipc.command(f"input \"{kdb_id}\" xkb_switch_layout {layout_index}")
+                break
 
     prev_focused = event.container.id
 
-def on_window_close(ipc, event):
+def on_window_close(ipc: i3ipc.connection.Connection, event: i3ipc.events.WindowEvent):
     global windows
     if event.container.id in windows:
         del(windows[event.container.id])
 
-def on_window(ipc, event):
+def on_window(ipc: i3ipc.connection.Connection, event: i3ipc.events.WindowEvent):
     if event.change == "focus":
         on_window_focus(ipc, event)
     elif event.change == "close":
         on_window_close(ipc, event)
 
-ipc.on("window", on_window)
-ipc.main()
+if __name__ == "__main__":
+    ipc = i3ipc.Connection()
+    prev_focused = ipc.get_tree().find_focused().id
+    windows = {}
+
+    ipc.on("window", on_window)
+    ipc.main()

--- a/contrib/keyboard-layout-per-window.py
+++ b/contrib/keyboard-layout-per-window.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# This script keeps track of active keyboard layouts per window.
+#
+# This script requires i3ipc-python package (install it from a system package
+# manager or pip).
+
+import i3ipc
+
+ipc = i3ipc.Connection()
+prev_focused = ipc.get_tree().find_focused().id
+windows = {}
+
+def on_window_focus(ipc, event):
+    global windows, prev_focused
+
+    # Save current layout
+    layouts = {input.identifier : input.xkb_active_layout_index
+               for input in ipc.get_inputs()}
+    windows[prev_focused] = layouts
+
+    # Restore layout of the newly focused window
+    if event.container.id in windows:
+        for (kdb_id, layout_index) in windows[event.container.id].items():
+            if layout_index != layouts[kdb_id]:
+                ipc.command("""input "{}" xkb_switch_layout {}""".format(
+                    kdb_id, layout_index))
+
+    prev_focused = event.container.id
+
+def on_window_close(ipc, event):
+    global windows
+    if event.container.id in windows:
+        del(windows[event.container.id])
+
+def on_window(ipc, event):
+    if event.change == "focus":
+        on_window_focus(ipc, event)
+    elif event.change == "close":
+        on_window_close(ipc, event)
+
+ipc.on("window", on_window)
+ipc.main()


### PR DESCRIPTION
Re-opening https://github.com/swaywm/sway/pull/3155 since I'm currently using it and I think could be useful to others. It adds a contrib script to keep track of active keyboard layouts per window.

I think it would be nice to have this feature directly in sway (https://github.com/swaywm/sway/pull/3155), but I don't have enough knowledge about sway's internals to do that PR.

This PR uses the code from the initial PR but tries to fix all the comments.

## Questions that are still opened
### What about `seats`
This script doesn't support them. I think the current state of the script make sense by itself even without seats.

### Unplugging a keyboard
> Which btw raises a question: what happens if we detached a keyboard? I guess the dictionary now gonna have stale entries, that needs to be cleaned up.

I unplugged my usb-c hub containing, among other things, my keyboard. It kept the same ID even after being reconnected. This means that the script kept working as expected.