### PR TITLE
Only schedule a frame if client has requested a frame callback

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -57,7 +57,6 @@ struct sway_output {
 	uint32_t refresh_nsec;
 	int max_render_time; // In milliseconds
 	struct wl_event_source *repaint_timer;
-	bool surface_needs_frame;
 };
 
 struct sway_output *output_create(struct wlr_output *wlr_output);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -515,9 +515,6 @@ static int output_repaint_timer_handler(void *data) {
 
 	output->wlr_output->frame_pending = false;
 
-	bool surface_needs_frame = output->surface_needs_frame;
-	output->surface_needs_frame = false;
-
 	struct sway_workspace *workspace = output->current.active_workspace;
 	if (workspace == NULL) {
 		return 0;
@@ -562,10 +559,6 @@ static int output_repaint_timer_handler(void *data) {
 		output_render(output, &now, &damage);
 	} else {
 		wlr_output_rollback(output->wlr_output);
-
-		if (surface_needs_frame) {
-			wlr_output_schedule_frame(output->wlr_output);
-		}
 	}
 
 	pixman_region32_fini(&damage);
@@ -682,7 +675,6 @@ static void damage_surface_iterator(struct sway_output *output, struct sway_view
 	}
 
 	if (!wl_list_empty(&surface->current.frame_callback_list)) {
-		output->surface_needs_frame = true;
 		wlr_output_schedule_frame(output->wlr_output);
 	}
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -681,8 +681,10 @@ static void damage_surface_iterator(struct sway_output *output, struct sway_view
 		wlr_output_damage_add_box(output->damage, &box);
 	}
 
-	output->surface_needs_frame = true;
-	wlr_output_schedule_frame(output->wlr_output);
+	if (!wl_list_empty(&surface->current.frame_callback_list)) {
+		output->surface_needs_frame = true;
+		wlr_output_schedule_frame(output->wlr_output);
+	}
 }
 
 void output_damage_surface(struct sway_output *output, double ox, double oy,


### PR DESCRIPTION
When a client hasn't damaged its surface, we only need to schedule an
output frame if the client has requested a frame callback.