### PR TITLE
Add timespec helpers

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -54,7 +54,7 @@ struct sway_output {
 	} events;
 
 	struct timespec last_presentation;
-	uint32_t refresh_nsec;
+	uint32_t next_refresh_nsec;
 	int max_render_time; // In milliseconds
 	struct wl_event_source *repaint_timer;
 	bool surface_needs_frame;

--- a/include/util.h
+++ b/include/util.h
@@ -37,4 +37,13 @@ const char *sway_wl_output_subpixel_to_string(enum wl_output_subpixel subpixel);
 
 bool sway_set_cloexec(int fd, bool cloexec);
 
+struct timespec;
+
+void timespec_sub(struct timespec *r, const struct timespec *a,
+	const struct timespec *b);
+int64_t timespec_sub_to_nsec(const struct timespec *a, const struct timespec *b);
+void timespec_add_nsec(struct timespec *r, const struct timespec *a,
+	int64_t nsec);
+int64_t timespec_to_nsec(const struct timespec *t);
+
 #endif


### PR DESCRIPTION
Borrow timespec helpers from Weston [1]. We'll re-use these helpers for
adaptive sync in a future commit.

Rename refresh_nsec to next_refresh_nsec, because this value only
applies to the next output presentation.

[1]: https://gitlab.freedesktop.org/wayland/weston/-/blob/467e6b98831f76c066c10dfb9d8a8688307feea6/shared/timespec-util.h