### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199506L
+#define _POSIX_C_SOURCE 200112L
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
Regressed by https://github.com/swaywm/sway/pull/5075. See [error log](https://github.com/swaywm/sway/files/4301714/sway-1.2.r1.242.log).

`CLOCK_MONOTONIC` was added in POSIX.1-2001 according to CHANGE HISTORY in https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html
