### PR TITLE
Subsurface overlap

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -367,7 +367,7 @@ struct sway_container *container_at(struct sway_workspace *workspace,
 	// Focused view's popups
 	if (focus && focus->view) {
 		c = surface_at_view(focus, lx, ly, surface, sx, sy);
-		if (c && surface_is_popup(*surface)) {
+		if (c && (is_floating || surface_is_popup(*surface))) {
 			return c;
 		}
 		*surface = NULL;


### PR DESCRIPTION
I believe this mostly fixes problems with subsurfaces extending beyond the views bounding box as described in #4924. 

What this does:

- Handles input events for subsurfaces extending beyond the border for focused views that are floating (this was already working if the view was tiled and not floating)
- Render the border before the view, so that subsurfaces that overlap the border are drawn on top
- Render the active child of linear tiled containers last, so that subsurfaces are not covered up by other children while that child is active. 

What it doesn't fix:

- If a floating view has subsurfaces that extend beyond its bounding box but the view isn't focused, those subsurfaces will be rendered but won't receive input events. Honestly I think the best solution in this case might be to clip the view to its bounding box if it isn't focused, or something like that.
- Possibly other edge conditions?

I would welcome feedback on this PR.