### PR TITLE
input: Avoid creating the PAD device multiple times

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -723,7 +723,7 @@ static void seat_configure_tablet_tool(struct sway_seat *seat,
 
 static void seat_configure_tablet_pad(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
-	if (!sway_device->tablet) {
+	if (!sway_device->tablet_pad) {
 		sway_device->tablet_pad = sway_tablet_pad_create(seat, sway_device);
 	}
 	sway_configure_tablet_pad(sway_device->tablet_pad);

--- a/sway/input/tablet.c
+++ b/sway/input/tablet.c
@@ -56,8 +56,10 @@ void sway_configure_tablet(struct sway_tablet *tablet) {
 		seat_configure_xcursor(seat);
 	}
 
-	tablet->tablet_v2 =
-		wlr_tablet_create(server.tablet_v2, seat->wlr_seat, device);
+	if (!tablet->tablet_v2) {
+		tablet->tablet_v2 =
+			wlr_tablet_create(server.tablet_v2, seat->wlr_seat, device);
+	}
 
 	/* Search for a sibling tablet pad */
 	if (!wlr_input_device_is_libinput(device)) {
@@ -238,8 +240,10 @@ void sway_configure_tablet_pad(struct sway_tablet_pad *tablet_pad) {
 		tablet_pad->seat_device->input_device->wlr_device;
 	struct sway_seat *seat = tablet_pad->seat_device->sway_seat;
 
-	tablet_pad->tablet_v2_pad =
-		wlr_tablet_pad_create(server.tablet_v2, seat->wlr_seat, device);
+	if (!tablet_pad->tablet_v2_pad) {
+		tablet_pad->tablet_v2_pad =
+			wlr_tablet_pad_create(server.tablet_v2, seat->wlr_seat, device);
+	}
 
 	wl_list_remove(&tablet_pad->attach.link);
 	tablet_pad->attach.notify = handle_tablet_pad_attach;


### PR DESCRIPTION
If a pad device for a tablet exists, reloading the configuration,
removing/reading the device or even suspending the system will recreate
the same Wayland input device multiple times.

Make sure we don't re-create the same Wayland device more than
necessary.

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>

Closes: https://github.com/swaywm/sway/issues/5093

Thanks @ofourdan for the patch!