### PR TITLE
Avoid screen flickering by not using title content in size calculations

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -513,8 +513,16 @@ void container_calculate_title_height(struct sway_container *container) {
 	cairo_t *cairo = cairo_create(NULL);
 	int height;
 	int baseline;
-	get_text_size(cairo, config->font, NULL, &height, &baseline, 1,
+	/* Calculate height using regular ASCII characters and allow larger glyphs to
+	 * "leak" into the margins. This avoids distracting height changes if switching
+	 * between containers that have differently sized text.
+	 * Larger characters might get cut off, but affected users can work around it by
+	 * increasing the title margins */
+	get_text_size(cairo, config->font, NULL, &height, NULL, 1,
+			config->pango_markup, "%s", "ASCII Baseline");
+	get_text_size(cairo, config->font, NULL, NULL, &baseline, 1,
 			config->pango_markup, "%s", container->formatted_title);
+
 	cairo_destroy(cairo);
 	container->title_height = height;
 	container->title_baseline = baseline;


### PR DESCRIPTION
This is more of a request-for-comments PR, so that perhaps someone else can come up with a better solution. I'd also like to know what it looks like for someone using display scaling, since I don't have a high DPI monitor to test on.

NOTE: I have not yet tested this from the master branch since I can only build 1.4 on my machine at the moment without rebuilding a bunch of dependencies as well; I don't have time to do that right now (need sleep), but might get around to it later.

This prevents very noticeable screen flashing in certain scenarios and seems to work acceptably
with larger glyphs (Tested with Japanese, which is the only non-latin character set I'm familiar with).

This is most likely not the best solution but personally I find it much preferable to the current behaviour at least. The patch causes non-latin title text to be slightly off-center, but I couldn't figure out how to fix that.

Fixes #4992