### PR TITLE
Document input selector precedence

### DIFF
--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -13,6 +13,14 @@ in place of _\<identifier\>_ in the commands below. In addition, the settings
 can be applied to a type of device, by using _type:\<input_type\>_ in place
 of _\<identifier\>_.
 
+In the configuration file, settings with a more specific selector take
+precedence over more general ones: _\<identifier\>_ \> _type:\<input_type\>_ \>
+_\*_.  When executing input commands, however, the settings are applied to all
+matching input devices!  This means that _type:\<input_type\>_ can override
+previously set _\<identifier\>_ settings, even though in a configuration file
+they would take precedence.  Similarly _\*_ can override both _\<identifier\>_
+and _type:\<input_type\>_ settings, if applied later.
+
 Tip: If the configuration settings do not appear to be taking effect, you could
 try using _\*_ instead of _\<identifier\>_. If it works with the wildcard, try
 using a different identifier from *swaymsg -t get_inputs* until you find the


### PR DESCRIPTION
From the current manpage it was not clear to me which input settings will take precedence, if `identifier`, `type` and `*` are all being used, so I ventured out into the code:
* https://github.com/swaywm/sway/blob/33a984bbc5c5ec4202f24bacf6ddd584b95a9ec0/sway/config.c#L522-L529
* https://github.com/swaywm/sway/blob/3ee5aace33f1b5673ab372afba38480338ba8b90/sway/input/input-manager.c#L506-L525
* https://github.com/swaywm/sway/blob/90d8a4df32747161c7218c006bb96e8214d8f7f2/sway/input/libinput.c#L273-L295
* https://github.com/swaywm/sway/blob/30e666f1710e5fcff46e9a75660dc2331d79dca8/sway/input/input-manager.c#L619-L640
* https://github.com/swaywm/sway/blob/30e666f1710e5fcff46e9a75660dc2331d79dca8/sway/input/input-manager.c#L233-L235
* https://github.com/swaywm/sway/blob/30e666f1710e5fcff46e9a75660dc2331d79dca8/sway/input/input-manager.c#L122-L151
* https://github.com/swaywm/sway/blob/218b5b9dc0f90693be0a77f0bd3001f1912b86aa/sway/config/input.c#L47-L156
* https://github.com/swaywm/sway/blob/218b5b9dc0f90693be0a77f0bd3001f1912b86aa/sway/config/input.c#L263-L336
* https://github.com/swaywm/sway/blob/218b5b9dc0f90693be0a77f0bd3001f1912b86aa/sway/config/input.c#L201-L215
* https://github.com/swaywm/sway/blob/218b5b9dc0f90693be0a77f0bd3001f1912b86aa/sway/config/input.c#L236-L250

Please review this carefully, as I am not sure that I fully understand the code. `merge_input_config` overrides settings in `dst` (first argument) with setting from `src` (second argument). Thus in `store_input_config` it appears as if `identifier` overrides `type` overrides `*`. But `input_device_get_config` appears to select first `identifier` (if it exists), then `*` (if it exists) and finally tries `type`.