### PR TITLE
input/cursor: correctly transfer focus when using tablet pen

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -515,8 +515,8 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 	struct sway_seat *seat = cursor->seat;
-	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y,
-		&surface, &sx, &sy);
+	struct sway_node *focused_node = node_at_coords(seat, cursor->cursor->x,
+		cursor->cursor->y, &surface, &sx, &sy);
 	struct sway_tablet_tool *sway_tool = tool->data;
 
 	if (!surface || !wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) {
@@ -527,6 +527,10 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 
 	wlr_tablet_v2_tablet_tool_notify_proximity_in(sway_tool->tablet_v2_tool,
 		tablet->tablet_v2, surface);
+
+	if (focused_node && config->focus_follows_mouse != FOLLOWS_NO) {
+		seat_set_focus(seat, focused_node);
+	}
 
 	wlr_tablet_v2_tablet_tool_notify_motion(sway_tool->tablet_v2_tool, sx, sy);
 }


### PR DESCRIPTION
Tentatively fixes #4819.

This commit ensures that `seatop_motion` is called to transfer focus when a window is selected via a pen. Previously, it would race with `node_at_coords`, and only properly transfer focus if its returned `surface` was `NULL`.

I've tested this locally, and it fixes the issues I was experiencing.

Calling `seatop_motion` directly here works as well, but my impression is that the confine handling inside `cursor_motion` should be done for tablet devices too. Applications see the following sequence of events:

```
[912231.664] wl_pointer@3.motion(7987491, 281.539062, 991.007812)
[912231.673] zwp_tablet_tool_v2@4278190083.motion(281.539062, 991.007812)
[912231.676] zwp_tablet_tool_v2@4278190083.frame(7987491)
```

In a GNOME session on the same application, the `wl_pointer` event is not present. I don't know enough to say which is the correct behaviour, or if it even matters. Sway infrequently omits the `wl_pointer` event, too.