### PR TITLE
Add support for linux-explicit-synchronization-unstable-v1

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -57,6 +57,8 @@ struct sway_output {
 	uint32_t refresh_nsec;
 	int max_render_time; // In milliseconds
 	struct wl_event_source *repaint_timer;
+
+	list_t *textured_buffers;
 };
 
 struct sway_output *output_create(struct wlr_output *wlr_output);

--- a/sway/server.c
+++ b/sway/server.c
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_gtk_primary_selection.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_linux_explicit_synchronization_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
@@ -148,6 +149,7 @@ bool server_init(struct sway_server *server) {
 	wlr_data_control_manager_v1_create(server->wl_display);
 	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
+	wlr_linux_explicit_synchronization_v1_create(server->wl_display);
 
 	server->socket = wl_display_add_socket_auto(server->wl_display);
 	if (!server->socket) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -107,6 +107,8 @@ struct sway_output *output_create(struct wlr_output *wlr_output) {
 		wl_list_init(&output->layers[i]);
 	}
 
+	output->textured_buffers = create_list();
+
 	return output;
 }
 
@@ -235,6 +237,7 @@ void output_destroy(struct sway_output *output) {
 	}
 	list_free(output->workspaces);
 	list_free(output->current.workspaces);
+	list_free(output->textured_buffers);
 	wl_event_source_remove(output->repaint_timer);
 	free(output);
 }


### PR DESCRIPTION
Add support for linux-explicit-synchronization-unstable-v1. See https://github.com/swaywm/wlroots/pull/2070

Depends on https://github.com/swaywm/sway/pull/5088