### PR TITLE
Keyboard shortcuts inhibitors criteria

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -24,6 +24,14 @@ struct pattern {
 	pcre *regex;
 };
 
+enum criteria_keyboard_shortcuts_inhibitor {
+	// implicit: C_KEYBOARD_SHORTCUTS_INHIBITOR_UNSPEC = 0,
+	C_KEYBOARD_SHORTCUTS_INHIBITOR_PRESENT = 1,
+	C_KEYBOARD_SHORTCUTS_INHIBITOR_ABSENT,
+	C_KEYBOARD_SHORTCUTS_INHIBITOR_ACTIVE,
+	C_KEYBOARD_SHORTCUTS_INHIBITOR_INACTIVE,
+};
+
 struct criteria {
 	enum criteria_type type;
 	char *raw; // entire criteria string (for logging)
@@ -47,6 +55,7 @@ struct criteria {
 	char urgent; // 'l' for latest or 'o' for oldest
 	struct pattern *workspace;
 	pid_t pid;
+	enum criteria_keyboard_shortcuts_inhibitor keyboard_shortcuts_inhibitor;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -343,4 +343,7 @@ void view_save_buffer(struct sway_view *view);
 
 bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 
+void view_schedule_criteria_execution_from_wlr_surface(
+		struct wlr_surface *wlr_surface);
+
 #endif

--- a/sway/commands/shortcuts_inhibitor.c
+++ b/sway/commands/shortcuts_inhibitor.c
@@ -33,12 +33,20 @@ struct cmd_results *cmd_shortcuts_inhibitor(int argc, char **argv) {
 				continue;
 			}
 
-			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
-					sway_inhibitor->inhibitor);
+			struct wlr_keyboard_shortcuts_inhibitor_v1 *inhibitor =
+				sway_inhibitor->inhibitor;
+			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(inhibitor);
 			sway_log(SWAY_DEBUG, "Deactivated keyboard shortcuts "
 					"inhibitor for seat %s on view",
 					seat->wlr_seat->name);
 
+			// execute criteria on the affected view after
+			// inhibitor changed state
+			struct sway_view *view =
+				view_from_wlr_surface(inhibitor->surface);
+			if (view) {
+				view_execute_criteria(view);
+			}
 		}
 	} else {
 		return cmd_results_new(CMD_INVALID,

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -266,9 +266,10 @@ correct seat.
 	escape a state where shortcuts are inhibited and the client becomes
 	uncooperative. It is worth noting that whether disabled or deactivated
 	inhibitors are removed is entirely up to the client. Depending on the
-	client it may therefore be possible to (re-)activate them later. Any
-	visual indication that an inhibitor is present is currently left to the
-	client as well.
+	client it may therefore be possible to (re-)activate them later.
+	Note that visual indication of inhibitor presence and state beyond what
+	the client may provide can be implemented using criteria with match
+	_shortcuts_inhibitor_.
 
 *seat* <name> xcursor_theme <theme> [<size>]
 	Override the system default XCursor theme. The default seat's

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -902,6 +902,14 @@ The following attributes may be matched with:
 	Can be a regular expression. If value is \_\_focused\_\_, then the shell
 	must be the same as that of the currently focused window.
 
+*shortcuts_inhibitor*
+	Matches the state of keyboard shortcuts inhibitors on windows. Values
+	can be "present", "absent", "active" or "inactive" and will match
+	windows where an inhibitor is present, absent, active or inactive,
+	respectively. Note that currently any existing inhibitor (present) will
+	either be active or inactive, so criteria can overlap and revert each
+	others changes depdending on their order in the config file.
+
 *tiling*
 	Matches tiling windows.
 


### PR DESCRIPTION
Introduction of keyboard shortcuts inhibitors in #5021 postponed two areas of functionality:

1. Per-client configurability of default activation of new inhibitors, particularly through criteria.
2. Visual feedback to users.

Here are some attempts to address those:

Add a separate per-view `shortcuts_inhibitor` command that can be used with criteria to override the per-seat defaults. This allows to e.g. disable shortcuts inhibiting globally but enable it for specific, known-good virtualization and remote desktop software or, alternatively, to blacklist that one slightly broken piece of software that just doesn't seem to get it right but insists on trying.

Allow re-execution of criteria. This allows its action to be re-executed once the criterion once again matches the view. Add a criteria selector that allows to match presence and state of keyboard shortcuts inhibitors on views. This allows to give visual feedback to the user on the state of an inhibitor through e.g.:
```
for_window [shortcuts_inhibitor=inactive] title_format !-%title
for_window [shortcuts_inhibitor=active] title_format !+%title
for_window  shortcuts_inhibitor=present] title_format !%title
for_window  shortcuts_inhibitor=absent] title_format %title
```

Add additional criteria execution call sites right after keyboard shortcuts inhibitor state changes. This allows to immediately and efficiently visually reflect inhibitor state changes to the user (or trigger any other desired action).

Add an additional criteria selector for idle inhibitors to showcase the functionality (and because I want to be able to visually tell that a client will prevent screen lock from coming on).