### PR TITLE
Fix redundant call to seat_send_focus()

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -288,8 +288,11 @@ static void handle_seat_node_destroy(struct wl_listener *listener, void *data) {
 		}
 		// The structure change might have caused it to move up to the top of
 		// the focus stack without sending focus notifications to the view
-		seat_send_focus(next_focus, seat);
-		seat_set_focus(seat, next_focus);
+		if (seat_get_focus(seat) == next_focus) {
+			seat_send_focus(next_focus, seat);
+		} else {
+			seat_set_focus(seat, next_focus);
+		}
 	} else {
 		// Setting focus_inactive
 		focus = seat_get_focus_inactive(seat, &root->node);


### PR DESCRIPTION
This commit fixes calling to `seat_send_focus()` twice when a view is closed.
This PR basically revert #2580.
I have tested that the original issue no longer exists. Closing a fullscreen view can successful focus to another view even after reverting.