### PR TITLE
add --no-repeat option for bindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -41,6 +41,7 @@ enum binding_flags {
 	BINDING_CODE=32,     // keyboard only; convert keysyms into keycodes
 	BINDING_RELOAD=64,   // switch only; (re)trigger binding on reload
 	BINDING_INHIBITED=128,	// keyboard only: ignore shortcut inhibitor
+	BINDING_NOREPEAT=256, // keyboard only; do not trigger when repeating a held key
 };
 
 /**

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -373,6 +373,8 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			binding->input = strdup(argv[0] + strlen("--input-device="));
 		} else if (strcmp("--no-warn", argv[0]) == 0) {
 			warn = false;
+		} else if (strcmp("--no-repeat", argv[0]) == 0) {
+			binding->flags |= BINDING_NOREPEAT;
 		} else {
 			break;
 		}

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -431,7 +431,8 @@ static void handle_key_event(struct sway_keyboard *keyboard,
 
 	// Set up (or clear) keyboard repeat for a pressed binding. Since the
 	// binding may remove the keyboard, the timer needs to be updated first
-	if (binding && wlr_device->keyboard->repeat_info.delay > 0) {
+	if (binding && !(binding->flags & BINDING_NOREPEAT) &&
+			wlr_device->keyboard->repeat_info.delay > 0) {
 		keyboard->repeat_binding = binding;
 		if (wl_event_source_timer_update(keyboard->key_repeat_source,
 				wlr_device->keyboard->repeat_info.delay) < 0) {

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -356,7 +356,7 @@ runtime.
 		for_window <criteria> move container to output <output>
 
 *bindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] \
-[--to-code] [--input-device=<device>] [--no-warn] [Group<1-4>+]<key combo> \
+[--to-code] [--input-device=<device>] [--no-warn] [--no-repeat] [Group<1-4>+]<key combo> \
 <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*xev*(1) is a good tool for discovering these).
@@ -381,6 +381,10 @@ runtime.
 	to the remote or virtual session. The _--inhibited_ flag allows to
 	define bindings which will be exempt from pass-through to such
 	software. The same preference logic as for _--locked_ applies.
+
+	Unless the flag _--no-repeat_ is set, the command will be run
+	repeatedly when the key is held, according to the repeat
+	settings specified in the input configuration.
 
 	Bindings to keysyms are layout-dependent. This can be changed with the
 	_--to-code_ flag. In this case, the keysyms will be translated into the


### PR DESCRIPTION
This allows e.g. triggering one command while a key is held, then
triggering another to undo the change performed by it afterwards. One
use case for this is triggering push-to-talk functionality for VoIP
tools without granting them full access to all input events.

Fixes #3151