### PR TITLE
check for workspace command name arg (fix #5131)

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -140,7 +140,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			break;
 		}
 	}
-	if (output_location >= 0) {
+	if (output_location == 0) {
+		return cmd_results_new(CMD_INVALID, "Expected 'workspace "
+				"<name> output <output>'");
+	} else if (output_location > 0) {
 		if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST,
 						output_location + 2))) {
 			return error;

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -141,8 +141,8 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 	}
 	if (output_location == 0) {
-		return cmd_results_new(CMD_INVALID, "Expected 'workspace "
-				"<name> output <output>'");
+		return cmd_results_new(CMD_INVALID,
+			"Expected 'workspace <name> output <output>'");
 	} else if (output_location > 0) {
 		if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST,
 						output_location + 2))) {

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -60,6 +60,9 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 		int gaps_location) {
 	const char expected[] = "Expected 'workspace <name> gaps "
 		"inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
+	if (gaps_location == 0) {
+		return cmd_results_new(CMD_INVALID, expected);
+	}
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO,
 					gaps_location + 3))) {


### PR DESCRIPTION
For the 'workspace <name> output <output>' command, output_location must
be greater than zero or the attempt to get the workspace name with
join_args will segfault or abort() (depending on the flavor of
sway_assert() in use). This checks and returns an error instead.