### PR TITLE
Fix hit test for floaters that cross outputs

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -289,7 +289,10 @@ static struct sway_container *container_at_linear(struct sway_node *parent,
 
 static struct sway_container *floating_container_at(double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
-	for (int i = 0; i < root->outputs->length; ++i) {
+	// For outputs with floating containers that overhang the output bounds,
+	// those at the end of the output list appear on top of floating
+	// containers from other outputs, so iterate the list in reverse.
+	for (int i = root->outputs->length - 1; i >= 0; --i) {
 		struct sway_output *output = root->outputs->items[i];
 		for (int j = 0; j < output->workspaces->length; ++j) {
 			struct sway_workspace *ws = output->workspaces->items[j];


### PR DESCRIPTION
In the case of multiple overlapping floating windows, this commit fixes an issue where the wrong window would be focused in response to a cursor if one of the windows came from a different output (overhanging).

![cross-output_floater_hittest_bug](https://user-images.githubusercontent.com/175146/77751020-33009b00-7025-11ea-8803-33261ff35698.png)

This fix is similar to 8789ceea8 (fixes #2315) which switched to reverse iteration on the floating list, whereas this fix does it on the output list.