### PR TITLE
Change focus_on_window_activation default to urgent

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -241,6 +241,7 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->font = strdup("monospace 10"))) goto cleanup;
 	config->font_height = 17; // height of monospace 10
 	config->urgent_timeout = 500;
+	config->focus_on_window_activation = FOWA_URGENT;
 	config->popup_during_fullscreen = POPUP_SMART;
 	config->xwayland = XWAYLAND_MODE_LAZY;
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -580,7 +580,7 @@ The default colors are:
 	window activation. If set to _urgent_, the urgent state will be set
 	for that window. If set to _focus_, the window will become focused.
 	If set to _smart_, the window will become focused only if it is already
-	visible, otherwise the urgent state will be set. Default is _smart_.
+	visible, otherwise the urgent state will be set. Default is _urgent_.
 
 *focus_wrapping* yes|no|force|workspace
 	This option determines what to do when attempting to focus over the edge


### PR DESCRIPTION
Before the default was "smart". This means a visible app could steal focus
whenever it wanted to. This can be an issue since having focus allows for
e.g. clipboard access.

This commit changes the default to "urgent" instead.

Closes: https://github.com/swaywm/sway/issues/5139