### PR TITLE
swaynag: fix segfault on exit when arguments are not correct

### DIFF
--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -27,6 +27,8 @@ int main(int argc, char **argv) {
 
 	memset(&swaynag, 0, sizeof(swaynag));
 	swaynag.buttons = create_list();
+	wl_list_init(&swaynag.outputs);
+	wl_list_init(&swaynag.seats);
 
 	struct swaynag_button *button_close =
 		calloc(sizeof(struct swaynag_button), 1);

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -437,8 +437,6 @@ void swaynag_setup(struct swaynag *swaynag) {
 	}
 
 	swaynag->scale = 1;
-	wl_list_init(&swaynag->outputs);
-	wl_list_init(&swaynag->seats);
 
 	struct wl_registry *registry = wl_display_get_registry(swaynag->display);
 	wl_registry_add_listener(registry, &registry_listener, swaynag);


### PR DESCRIPTION
swaynag_destroy is called on all cleanup cases and needs the lists to be valid,
just init them early