### PR TITLE
build: make completions respect install prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -264,6 +264,9 @@ if get_option('bash-completions')
 	)
 	if bash_comp.found()
 		bash_install_dir = bash_comp.get_pkgconfig_variable('completionsdir')
+		if not bash_install_dir.startswith(prefix)
+			bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')
+		endif
 	else
 		bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')
 	endif
@@ -279,6 +282,9 @@ if get_option('fish-completions')
 	)
 	if fish_comp.found()
 		fish_install_dir = fish_comp.get_pkgconfig_variable('completionsdir')
+		if not fish_install_dir.startswith(prefix)
+			fish_install_dir = join_paths(datadir, 'fish', 'vendor_completions.d')
+		endif
 	else
 		fish_install_dir = join_paths(datadir, 'fish', 'vendor_completions.d')
 	endif


### PR DESCRIPTION
paths straight from pkgconfig will sometimes be outside of the users
build prefix, we should never try to install anything outside of that
directory.

filter the value obtained from pkgconfig and use some fallback if it
is not inside

----
There might be a cleaner way of doing that, but I didn't manage to split the if e.g. something like the following fails because bash_install_dir isn't defined if it didn't get in first loop and meson doesn't see to have lazy evaluation?
@ascent12 might have a better idea, happy to change it as long as we respect prefix.

```meson
        if bash_comp.found()
                bash_install_dir = bash_comp.get_pkgconfig_variable('completionsdir')
        endif
        if not bash_comp.found() or not bash_install_dir.startswith(prefix)
                bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')
        endif
```