### PR TITLE
swaynag: exit on wl_display_roundtrip error

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -444,7 +444,11 @@ void swaynag_setup(struct swaynag *swaynag) {
 	assert(swaynag->compositor && swaynag->layer_shell && swaynag->shm);
 
 	while (swaynag->querying_outputs > 0) {
-		wl_display_roundtrip(swaynag->display);
+		if (wl_display_roundtrip(swaynag->display) < 0) {
+			sway_log(SWAY_ERROR, "Error during outputs init.");
+			swaynag_destroy(swaynag);
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	if (!swaynag->output && swaynag->type->output) {


### PR DESCRIPTION
fixes loop when sway closes the socket in the middle of querying outputs,
see #5138.

(in my opinion doesn't close it, because I'd like to understand why sway closes the socket, this probably just hides the problem but is good to have anyway)