### PR TITLE
 hiding the cursor and sending a touch event are swapped 

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -364,9 +364,9 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 
 	// TODO: fall back to cursor simulation if client has not bound to touch
 	if (seat_is_input_allowed(seat, surface)) {
+		cursor_hide(cursor);
 		wlr_seat_touch_notify_down(wlr_seat, surface, event->time_msec,
 				event->touch_id, sx, sy);
-		cursor_hide(cursor);
 	}
 
 	seat_set_focus(seat, focused_node);


### PR DESCRIPTION
As discussed in swaywm/sway#5145 a more logical solution is to perform cursor hide/leave before emitting a touch down event instead of after.