### PR TITLE
build: make completions respect install prefixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -263,7 +263,10 @@ if get_option('bash-completions')
 		'completions/bash/swaymsg',
 	)
 	if bash_comp.found()
-		bash_install_dir = bash_comp.get_pkgconfig_variable('completionsdir')
+		bash_install_dir = bash_comp.get_pkgconfig_variable(
+			'completionsdir',
+			define_variable: ['datadir', datadir]
+		)
 	else
 		bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')
 	endif
@@ -278,7 +281,10 @@ if get_option('fish-completions')
 		'completions/fish/swaynag.fish',
 	)
 	if fish_comp.found()
-		fish_install_dir = fish_comp.get_pkgconfig_variable('completionsdir')
+		fish_install_dir = fish_comp.get_pkgconfig_variable(
+			'completionsdir',
+			define_variable: ['datadir', datadir]
+		)
 	else
 		fish_install_dir = join_paths(datadir, 'fish', 'vendor_completions.d')
 	endif


### PR DESCRIPTION
Tell pkgconfig about prefix and datadir as required in the .pc files, so
if the prefix isn't standard nothing is installed outside of it.

For fish, this requires https://github.com/fish-shell/fish-shell/pull/6778

Fixes swaywm/swaybg#13