### PR TITLE
config: fix unfocused text color

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -309,7 +309,7 @@ static void config_defaults(struct sway_config *config) {
 
 	color_to_rgba(config->border_colors.unfocused.border, 0x333333FF);
 	color_to_rgba(config->border_colors.unfocused.background, 0x222222FF);
-	color_to_rgba(config->border_colors.unfocused.text, 0x88888888);
+	color_to_rgba(config->border_colors.unfocused.text, 0x888888FF);
 	color_to_rgba(config->border_colors.unfocused.indicator, 0x292D2EFF);
 	color_to_rgba(config->border_colors.unfocused.child_border, 0x222222FF);
 


### PR DESCRIPTION
This color, both in i3 and as described in sway(5), defaults to #888888.
However, the actual default also has an alpha of 88 instead of FF,
meaning it ends up significantly darker than intended.