### PR TITLE
output: remove damage listeners in damage destroy

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -742,6 +742,10 @@ static void damage_handle_destroy(struct wl_listener *listener, void *data) {
 		return;
 	}
 	output_disable(output);
+
+	wl_list_remove(&output->damage_destroy.link);
+	wl_list_remove(&output->damage_frame.link);
+
 	transaction_commit_dirty();
 }
 
@@ -785,8 +789,6 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&output->transform.link);
 	wl_list_remove(&output->scale.link);
 	wl_list_remove(&output->present.link);
-	wl_list_remove(&output->damage_destroy.link);
-	wl_list_remove(&output->damage_frame.link);
 
 	transaction_commit_dirty();
 


### PR DESCRIPTION
Instead of removing the destroy listeners in the output destroy, remove
them in the damage destroy handler. Fixes the following use after free:
```
  ==646625==ERROR: AddressSanitizer: heap-use-after-free on address 0x61200017cab8 at pc 0x0000004f8f29 bp 0x7ffdf465ad30 sp 0x7ffdf465ad20
  WRITE of size 8 at 0x61200017cab8 thread T0

      #0 0x4f8f28 in wl_list_remove ../common/list.c:181
      #1 0x43dd24 in handle_destroy ../sway/desktop/output.c:790
  (`wl_list_remove(&output->damage_destroy.link);` here, 214e3030e1dce master branch)
      #2 0x7f0e573a1c93 in wlr_signal_emit_safe ../util/signal.c:29
      #3 0x7f0e57390954 in wlr_output_destroy ../types/wlr_output.c:365
      #4 0x7f0e5735e37f in backend_destroy ../backend/x11/backend.c:128
      #5 0x7f0e57348147 in wlr_backend_destroy ../backend/backend.c:47
      #6 0x7f0e57356f75 in multi_backend_destroy ../backend/multi/backend.c:54
      #7 0x7f0e5735710e in handle_display_destroy ../backend/multi/backend.c:107
      #8 0x7f0e573f23e4 in wl_display_destroy (/lib64/libwayland-server.so.0+0x93e4)
      #9 0x42f0b2 in server_fini ../sway/server.c:177
      #10 0x42dd01 in main ../sway/main.c:414
      #11 0x7f0e570f7041 in __libc_start_main (/lib64/libc.so.6+0x27041)
      #12 0x40e3bd in _start (/opt/wayland/bin/sway+0x40e3bd)

  0x61200017cab8 is located 120 bytes inside of 320-byte region [0x61200017ca40,0x61200017cb80)
  freed by thread T0 here:
      #0 0x7f0e57aa9357 in __interceptor_free (/lib64/libasan.so.6+0xb0357)
      #1 0x7f0e5738b877 in wlr_output_damage_destroy ../types/wlr_output_damage.c:143
      #2 0x7f0e5738b2b9 in output_handle_destroy ../types/wlr_output_damage.c:13
      #3 0x7f0e573a1c93 in wlr_signal_emit_safe ../util/signal.c:29
      #4 0x7f0e57390954 in wlr_output_destroy ../types/wlr_output.c:365
      #5 0x7f0e5735e37f in backend_destroy ../backend/x11/backend.c:128
      #6 0x7f0e57348147 in wlr_backend_destroy ../backend/backend.c:47
      #7 0x7f0e57356f75 in multi_backend_destroy ../backend/multi/backend.c:54
      #8 0x7f0e5735710e in handle_display_destroy ../backend/multi/backend.c:107
      #9 0x7f0e573f23e4 in wl_display_destroy (/lib64/libwayland-server.so.0+0x93e4)

  previously allocated by thread T0 here:
      #0 0x7f0e57aa9887 in __interceptor_calloc (/lib64/libasan.so.6+0xb0887)
      #1 0x7f0e5738b532 in wlr_output_damage_create ../types/wlr_output_damage.c:91
      #2 0x43e4a7 in handle_new_output ../sway/desktop/output.c:875
      #3 0x7f0e573a1c93 in wlr_signal_emit_safe ../util/signal.c:29
      #4 0x7f0e57357261 in new_output_reemit ../backend/multi/backend.c:143
      #5 0x7f0e573a1c93 in wlr_signal_emit_safe ../util/signal.c:29
      #6 0x7f0e5736030a in wlr_x11_output_create ../backend/x11/output.c:253
      #7 0x7f0e5735e309 in backend_start ../backend/x11/backend.c:113
      #8 0x7f0e573480fb in wlr_backend_start ../backend/backend.c:36
      #9 0x7f0e57356e61 in multi_backend_start ../backend/multi/backend.c:31
      #10 0x7f0e573480fb in wlr_backend_start ../backend/backend.c:36
      #11 0x42f4ba in server_start ../sway/server.c:205
      #12 0x42dbd7 in main ../sway/main.c:394
      #13 0x7f0e570f7041 in __libc_start_main (/lib64/libc.so.6+0x27041)
```
Fixes #5158

Draft because I can't currently test. Could you give this a try @martinetd?