### PR TITLE
Add support for wlr_output_test

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -691,6 +691,8 @@ void merge_output_config(struct output_config *dst, struct output_config *src);
 
 bool apply_output_config(struct output_config *oc, struct sway_output *output);
 
+bool test_output_config(struct output_config *oc, struct sway_output *output);
+
 struct output_config *store_output_config(struct output_config *oc);
 
 struct output_config *find_output_config(struct sway_output *output);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -504,9 +504,7 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 	wlr_presentation_surface_sampled_on_output(server.presentation, surface,
 		wlr_output);
 
-	if (!wlr_output_attach_buffer(wlr_output, &surface->buffer->base)) {
-		return false;
-	}
+	wlr_output_attach_buffer(wlr_output, &surface->buffer->base);
 	return wlr_output_commit(wlr_output);
 }
 


### PR DESCRIPTION
This depends on https://github.com/swaywm/wlroots/pull/2097.

To test, use [wlr-randr](https://github.com/emersion/wlr-randr)'s `--dryrun` mode to perform an invalid output configuration change. For instance, use the Wayland backend and try to disable an output:

```
wlr-randr --dryrun --output WL-1 --off
```

This should fail (the Wayland backend doesn't support disabling outputs). Prior to this PR, this always succeeded.