### PR TITLE
Fix initial modeset

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -425,6 +425,10 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		return false;
 	}
 
+	if (oc && !oc->enabled) {
+		return true;
+	}
+
 	if (config->reloading) {
 		output_damage_whole(output);
 	}
@@ -464,7 +468,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	output->width = output_box->width;
 	output->height = output_box->height;
 
-	if ((!oc || oc->enabled) && !output->configured) {
+	if (!output->configured) {
 		output_configure(output);
 	}
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -345,20 +345,17 @@ static void queue_output_config(struct output_config *oc,
 		return;
 	}
 
-	if (!oc) {
-		sway_log(SWAY_DEBUG, "Turning on output %s", wlr_output->name);
-		wlr_output_enable(wlr_output, true);
+	sway_log(SWAY_DEBUG, "Turning on output %s", wlr_output->name);
+	wlr_output_enable(wlr_output, true);
 
-		if (oc && oc->width > 0 && oc->height > 0) {
-			sway_log(SWAY_DEBUG, "Set %s mode to %dx%d (%f Hz)",
-				wlr_output->name, oc->width, oc->height, oc->refresh_rate);
-			set_mode(wlr_output, oc->width, oc->height,
-				oc->refresh_rate, oc->custom_mode == 1);
-		} else if (!wl_list_empty(&wlr_output->modes)) {
-			struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
-			wlr_output_set_mode(wlr_output, mode);
-		}
-		output->current_mode = wlr_output->pending.mode;
+	if (oc && oc->width > 0 && oc->height > 0) {
+		sway_log(SWAY_DEBUG, "Set %s mode to %dx%d (%f Hz)",
+			wlr_output->name, oc->width, oc->height, oc->refresh_rate);
+		set_mode(wlr_output, oc->width, oc->height,
+			oc->refresh_rate, oc->custom_mode == 1);
+	} else if (!wl_list_empty(&wlr_output->modes)) {
+		struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
+		wlr_output_set_mode(wlr_output, mode);
 	}
 
 	if (oc && (oc->subpixel != WL_OUTPUT_SUBPIXEL_UNKNOWN || config->reloading)) {


### PR DESCRIPTION
An if branch takes care of the case where the output needs to be turned
off (DPMS'ed or disabled). The other branch needs to unconditionally
enable the output.

output->current_mode is already taken care of in apply_config.

Sorry about that, probably made a bad change by mistake after my DRM testing.

Closes: https://github.com/swaywm/sway/issues/5193