### PR TITLE
Don't transfer focus to NULL node on touch

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -408,7 +408,9 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 				event->touch_id, sx, sy);
 	}
 
-	seat_set_focus(seat, focused_node);
+	if (focused_node) {
+		seat_set_focus(seat, focused_node);
+	}
 }
 
 static void handle_touch_up(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Fixes #5185

The issue is fixed when checking for NULL already, but I think the N_WORKSPACE check also makes sense.

Edit: removed the workspace part as proposed by emersion.