### PR TITLE
input/seatop_default: release on empty workspace

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -280,7 +280,10 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 
 	// Handle clicking an empty workspace
 	if (node && node->type == N_WORKSPACE) {
-		seat_set_focus(seat, node);
+		if (state == WLR_BUTTON_PRESSED) {
+			seat_set_focus(seat, node);
+		}
+		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;
 	}
 


### PR DESCRIPTION
Instead of handling presses and releases on empty workspaces as setting
focus to the workspace, handle releases by notifying the seat of a
pointer action. This way DnDs are correctly released if the button is
released over an empty workspace.

Fixes #3932