### PR TITLE
Add a secondary headless backend

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -29,6 +29,8 @@ struct sway_server {
 
 	struct wlr_backend *backend;
 	struct wlr_backend *noop_backend;
+	// secondary headless backend used for creating virtual outputs on-the-fly
+	struct wlr_backend *headless_backend;
 
 	struct wlr_compositor *compositor;
 	struct wl_listener compositor_new_surface;


### PR DESCRIPTION
This allows the create_output command to work on DRM too.

Depends on ~~https://github.com/swaywm/wlroots/pull/2111~~, ~~https://github.com/swaywm/sway/pull/5215~~ and ~~https://github.com/swaywm/wlroots/pull/2063~~

cc @any1