### PR TITLE
input/seatop_default: properly notify pointer leave

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -219,6 +219,7 @@ static void cursor_do_rebase(struct sway_cursor *cursor, uint32_t time_msec,
 	}
 
 	if (surface == NULL) {
+		wlr_seat_pointer_notify_enter(wlr_seat, NULL, 0, 0);
 		wlr_seat_pointer_clear_focus(wlr_seat);
 	}
 }


### PR DESCRIPTION
Currently, clients receive wl_data_device::leave events only when the
pointer enters another surface, which leads to issues, such as #5220.
This happens because wlr_seat_pointer_notify_enter() is called when
handling motion events only for non-NULL surfaces.

Fixes #5220