### PR TITLE
Add missing include

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -23,6 +23,7 @@
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
+#include <wlr/types/wlr_output_power_management_v1.h>
 #include "config.h"
 #include "list.h"
 #include "log.h"


### PR DESCRIPTION
I was wondering if I oversee something, I just wanted to compile sway with debug symbols but could not start it without including `#include <wlr/types/wlr_output_power_management_v1.h>` in `server.c`.

Otherwise I got an error message "undefined symbol wlr_output_power_manager_v1".
