### PR TITLE
interpret "subpixel none" as CAIRO_ANTIALIAS_GRAY

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -459,8 +459,13 @@ static void update_title_texture(struct sway_container *con,
 	cairo_set_antialias(c, CAIRO_ANTIALIAS_BEST);
 	cairo_font_options_t *fo = cairo_font_options_create();
 	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
-	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
-	cairo_font_options_set_subpixel_order(fo, to_cairo_subpixel_order(output->wlr_output->subpixel));
+	if (output->wlr_output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
+		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
+	} else {
+		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
+		cairo_font_options_set_subpixel_order(fo,
+			to_cairo_subpixel_order(output->wlr_output->subpixel));
+	}
 	cairo_set_font_options(c, fo);
 	get_text_size(c, config->font, &width, NULL, NULL, scale,
 			config->pango_markup, "%s", con->formatted_title);

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -698,8 +698,13 @@ void render_frame(struct swaybar_output *output) {
 	cairo_set_antialias(cairo, CAIRO_ANTIALIAS_BEST);
 	cairo_font_options_t *fo = cairo_font_options_create();
 	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
-	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
-	cairo_font_options_set_subpixel_order(fo, to_cairo_subpixel_order(output->subpixel));
+	if (output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
+		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
+	} else {
+		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
+		cairo_font_options_set_subpixel_order(fo,
+			to_cairo_subpixel_order(output->subpixel));
+	}
 	cairo_set_font_options(cairo, fo);
 	cairo_font_options_destroy(fo);
 	cairo_save(cairo);


### PR DESCRIPTION
Fixes issue #5228. Currently, WL_OUTPUT_SUBPIXEL_NONE is ignored and CAIRO_ANTIALIAS_SUBPIXEL is still set. This commit checks if subpixel is set to none and if so, calls set_antialias with CAIRO_ANTIALIAS_GRAY. This mirrors the functionality in Mako's [PR261](https://github.com/emersion/mako/pull/261).

@progandy brought up that we could alternatively "extend it to 'none' = no antialias, 'gray' = grayscale" and/or read from the fontconfig setup.