### PR TITLE
Restrict relative output transforms to runtime changes

### DIFF
--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -59,6 +59,10 @@ struct cmd_results *output_cmd_transform(int argc, char **argv) {
 	config->handler_context.leftovers.argv = argv + 1;
 	if (argc > 1 &&
 			(strcmp(argv[1], "clockwise") == 0 || strcmp(argv[1], "anticlockwise") == 0)) {
+		if (config->reloading) {
+			return cmd_results_new(CMD_INVALID,
+				"Relative transforms cannot be used in the configuration file");
+		}
 		if (!sway_assert(output->name != NULL, "Output config name not set")) {
 			return NULL;
 		}

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -102,7 +102,8 @@ must be separated by one space. For example:
 	to apply a rotation and flip, or "normal" to apply no transform. The
 	rotation is performed clockwise. If a single output is chosen and a
 	rotation direction is specified (_clockwise_ or _anticlockwise_) then the
-	transform is added or subtracted from the current transform.
+	transform is added or subtracted from the current transform (this cannot be
+	used directly in the configuration file).
 
 *output* <name> disable|enable
 	Enables or disables the specified output (all outputs are enabled by


### PR DESCRIPTION
Prevent them from being used in the config file.

This is a breaking config file change.

References: https://github.com/swaywm/sway/issues/5236