### PR TITLE
scdoc: unbindcode --input-device, not input-device

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -745,7 +745,7 @@ The default colors are:
 	input device will be unbound.
 
 	*unbindcode* [--whole-window] [--border] [--exclude-titlebar] [--release] \
-[--locked] [input-device=<device>] <code>
+[--locked] [--input-device=<device>] <code>
 	is also available for unbinding with key/button codes instead of key/button names.
 
 *unmark* [<identifier>]


### PR DESCRIPTION
Apparently, there's a typo in Sway's man page where `input-device` of
`unbindcode` command has no dashes.