### PR TITLE
config/output: reconfigure input devices on new output

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -388,6 +388,17 @@ static void queue_output_config(struct output_config *oc,
 			oc->adaptive_sync);
 		wlr_output_enable_adaptive_sync(wlr_output, oc->adaptive_sync == 1);
 	}
+
+	// Reconfigure all devices, since input config may have been applied before
+	// this output came online, and some config items (like map_to_output) are
+	// dependent on an output being present.
+	struct sway_input_device *input_device = NULL;
+	wl_list_for_each(input_device, &server.input->devices, link) {
+		struct sway_seat *seat = NULL;
+		wl_list_for_each(seat, &server.input->seats, link) {
+			seat_configure_device(seat, input_device);
+		}
+	}
 }
 
 bool apply_output_config(struct output_config *oc, struct sway_output *output) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -652,6 +652,8 @@ static void seat_apply_input_config(struct sway_seat *seat,
 		}
 		struct sway_output *output = output_by_name_or_id(mapped_to_output);
 		if (!output) {
+			sway_log(SWAY_DEBUG, "Requested output %s for device %s isn't present",
+				mapped_to_output, sway_device->input_device->identifier);
 			return;
 		}
 		wlr_cursor_map_input_to_output(seat->cursor->cursor,
@@ -701,7 +703,7 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 }
 
 static void seat_configure_switch(struct sway_seat *seat,
-        struct sway_seat_device *seat_device) {
+		struct sway_seat_device *seat_device) {
 	if (!seat_device->switch_device) {
 		sway_switch_create(seat, seat_device);
 	}


### PR DESCRIPTION
Some input rules, like `map_to_output`, are dependent on a specific
screen being present. This currently does not work for hotplugged
outputs, or outputs that are processed after the input device is
initially probed.

This commit fixes both cases, by reconfiguring inputs on each output
addition.

Fixes #5231.