### PR TITLE
Take window borders into account when resizing floating windows

### DIFF
--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -73,6 +73,12 @@ static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
 		height = fmax(view_min_height, fmin(height, view_max_height));
 	}
 
+	struct sway_container_state *state = &con->current;
+	width += state->border_thickness * 2;
+	height += config->titlebar_border_thickness * 2;
+	height += container_titlebar_height();
+	height += config->titlebar_v_padding;
+
 	// Recalculate these, in case we hit a min/max limit
 	grow_width = width - e->ref_width;
 	grow_height = height - e->ref_height;


### PR DESCRIPTION

Otherwise the borders can be resized to smaller than the minimum window size like this:

![float_resize_bug](https://user-images.githubusercontent.com/680052/80166180-a1615a80-85dd-11ea-83a3-f8d947ebabc5.png)
