### PR TITLE
[RFC] Add each view's shell to JSON description

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -493,6 +493,8 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 	json_object_object_add(object, "max_render_time", json_object_new_int(c->view->max_render_time));
 
+	json_object_object_add(object, "shell", json_object_new_string(view_get_shell(c->view)));
+
 #if HAVE_XWAYLAND
 	if (c->view->type == SWAY_VIEW_XWAYLAND) {
 		json_object_object_add(object, "window",

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -376,6 +376,9 @@ node and will have the following properties:
 |- visible
 :  boolean
 :  (Only views) Whether the node is visible
+|- shell
+:  string
+:  (Only views) The shell of the view, such as _xdg\_shell_ or _xwayland_
 |- window
 :  integer
 :  (Only xwayland views) The X11 window ID for the xwayland view
@@ -672,6 +675,7 @@ node and will have the following properties:
 							"pid": 23959,
 							"app_id": null,
 							"visible": true,
+							"shell": "xwayland",
 							"window_properties": {
 								"class": "URxvt",
 								"instance": "urxvt",
@@ -726,6 +730,7 @@ node and will have the following properties:
 							"pid": 25370,
 							"app_id": "termite",
 							"visible": true,
+							"shell": "xdg_shell",
 							"nodes": [
 							]
 						}


### PR DESCRIPTION
This is a criteria you can use to select windows since commit 484cc189e909 ("Add shell criteria token"), but there's no way to query it for an existing window. This exposes its value in the output of `swaymsg -t get_tree`.

I don't know if this makes sense. Regarding criteria, `sway(5)` says "[y]ou may like to use `swaymsg -t get_tree` for finding the values of these properties", but shell isn't currently reported there. Some of the others aren't obviously included either, though, so maybe the man page just needs changing.