### PR TITLE
config/output: reconfigure input devices after full output init

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -388,17 +388,6 @@ static void queue_output_config(struct output_config *oc,
 			oc->adaptive_sync);
 		wlr_output_enable_adaptive_sync(wlr_output, oc->adaptive_sync == 1);
 	}
-
-	// Reconfigure all devices, since input config may have been applied before
-	// this output came online, and some config items (like map_to_output) are
-	// dependent on an output being present.
-	struct sway_input_device *input_device = NULL;
-	wl_list_for_each(input_device, &server.input->devices, link) {
-		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &server.input->seats, link) {
-			seat_configure_device(seat, input_device);
-		}
-	}
 }
 
 bool apply_output_config(struct output_config *oc, struct sway_output *output) {
@@ -487,6 +476,17 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		sway_log(SWAY_DEBUG, "Set %s max render time to %d",
 			oc->name, oc->max_render_time);
 		output->max_render_time = oc->max_render_time;
+	}
+
+	// Reconfigure all devices, since input config may have been applied before
+	// this output came online, and some config items (like map_to_output) are
+	// dependent on an output being present.
+	struct sway_input_device *input_device = NULL;
+	wl_list_for_each(input_device, &server.input->devices, link) {
+		struct sway_seat *seat = NULL;
+		wl_list_for_each(seat, &server.input->seats, link) {
+			seat_configure_device(seat, input_device);
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Previously in 3de1a39, it "worked by accident" in my testing since the
display being used in `map_to_output` was initialized first (the map
would not be applied because the display hadn't actually come online
yet), and was followed by a second display (at which point the map would
get applied for the first display).

Replacing a monitor with another one surfaced this bug.

Refs #5231