### PR TITLE
input/tablet: query tablet focused surface for cursor image check

### DIFF
--- a/sway/input/tablet.c
+++ b/sway/input/tablet.c
@@ -106,8 +106,7 @@ static void handle_tablet_tool_set_cursor(struct wl_listener *listener, void *da
 	}
 
 	struct wl_client *focused_client = NULL;
-	struct wlr_surface *focused_surface =
-		cursor->seat->wlr_seat->pointer_state.focused_surface;
+	struct wlr_surface *focused_surface = tool->tablet_v2_tool->focused_surface;
 	if (focused_surface != NULL) {
 		focused_client = wl_resource_get_client(focused_surface->resource);
 	}


### PR DESCRIPTION
`handle_tablet_tool_set_cursor` was copied from input/cursor.c's
`handle_request_set_cursor`, but the focused surface check was not
adjusted appropriately.

Fixes #5257.