### PR TITLE
Add debug symbol stack trace note to ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-If you are using the nvidia proprietary driver for any reason, you have two choices:
+If you are using the Nvidia proprietary driver for any reason, you have two choices:
 
 1. Uninstall it and use nouveau instead
 2. Use X11+i3 and close your browser tab
 
 If `lsmod | grep nvidia | wc -l` shows anything other than zero, your bug report is not welcome here.
 
-Additionally, problems with Firefox are almost certainly Firefox bugs, not sway bugs. Start by submitting your issue to the Firefox bugzilla and come back here only after they confirm otherwise.
+Additionally, problems with Firefox are almost certainly Firefox bugs, not sway bugs. Start by submitting your issue to the Firefox Bugzilla and come back here only after they confirm otherwise.
 
 Otherwise, please include the following four components in your bug report: sway version, debug log, configuration (if applicable), and an explanation of steps taken to reproduce the issue. If sway crashes, also include a stack trace.
 
@@ -42,3 +42,5 @@ If you use systemd, you should be able to open the coredump of the most recent c
     coredumpctl gdb sway
 
 And then type `bt full` to obtain the stack trace.
+
+If the lines mentioning sway/wlroots have "??" for the location, your binaries were built without debug symbols, and the stack trace is unlikely to be useful. You can find instructions to compile sway from source [here](https://github.com/swaywm/sway/wiki/Development-Setup#compiling-as-a-subproject). Note that debug symbols are included in Meson builds by default.


### PR DESCRIPTION
In reading through issues I've noticed that the first developer response is often "you don't have debug symbols". Hopefully including this information in the issue template can help save a round-trip :smiley: 