### PR TITLE
ISSUE_TEMPLATE: note debug logs should be from TTY

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@ If this doesn't work, use:
 
 * Sway Version:
 
-Obtain a debug log like so:
+Obtain a debug log by running the following command from a TTY:
 
     sway -d 2> ~/sway.log
 


### PR DESCRIPTION
It is common for user to attach a debug log from the Wayland backend
because they are running the command from inside of Sway. This just adds
a note that the debug logs should be obtained from a TTY. Anyone who is
actually using the Wayland or X11 backends and submitting an issue
related to them likely is already familiar with how to obtain a debug
log for the appropriate backend.