### PR TITLE
input: rename pointer handlers to be unambiguous

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -16,9 +16,10 @@ struct sway_seatop_impl {
 	void (*button)(struct sway_seat *seat, uint32_t time_msec,
 			struct wlr_input_device *device, uint32_t button,
 			enum wlr_button_state state);
-	void (*motion)(struct sway_seat *seat, uint32_t time_msec,
+	void (*pointer_motion)(struct sway_seat *seat, uint32_t time_msec,
 			double dx, double dy);
-	void (*axis)(struct sway_seat *seat, struct wlr_event_pointer_axis *event);
+	void (*pointer_axis)(struct sway_seat *seat,
+			struct wlr_event_pointer_axis *event);
 	void (*rebase)(struct sway_seat *seat, uint32_t time_msec);
 	void (*tablet_tool_motion)(struct sway_seat *seat, struct sway_tablet *tablet,
 			struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
@@ -261,14 +262,15 @@ void seatop_button(struct sway_seat *seat, uint32_t time_msec,
 /**
  * dx and dy are distances relative to previous position.
  */
-void seatop_motion(struct sway_seat *seat, uint32_t time_msec,
+void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy);
+
+void seatop_pointer_axis(struct sway_seat *seat,
+		struct wlr_event_pointer_axis *event);
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
 		struct sway_tablet *tablet, struct sway_tablet_tool *tool,
 		uint32_t time_msec, double dx, double dy);
-
-void seatop_axis(struct sway_seat *seat, struct wlr_event_pointer_axis *event);
 
 void seatop_rebase(struct sway_seat *seat, uint32_t time_msec);
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -321,7 +321,7 @@ static void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 
 	wlr_cursor_move(cursor->cursor, device, dx, dy);
 
-	seatop_motion(cursor->seat, time_msec, dx, dy);
+	seatop_pointer_motion(cursor->seat, time_msec, dx, dy);
 }
 
 static void handle_pointer_motion_relative(
@@ -383,7 +383,7 @@ static void handle_pointer_button(struct wl_listener *listener, void *data) {
 
 void dispatch_cursor_axis(struct sway_cursor *cursor,
 		struct wlr_event_pointer_axis *event) {
-	seatop_axis(cursor->seat, event);
+	seatop_pointer_axis(cursor->seat, event);
 }
 
 static void handle_pointer_axis(struct wl_listener *listener, void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1449,16 +1449,17 @@ void seatop_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-void seatop_motion(struct sway_seat *seat, uint32_t time_msec,
+void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
-	if (seat->seatop_impl->motion) {
-		seat->seatop_impl->motion(seat, time_msec, dx, dy);
+	if (seat->seatop_impl->pointer_motion) {
+		seat->seatop_impl->pointer_motion(seat, time_msec, dx, dy);
 	}
 }
 
-void seatop_axis(struct sway_seat *seat, struct wlr_event_pointer_axis *event) {
-	if (seat->seatop_impl->axis) {
-		seat->seatop_impl->axis(seat, event);
+void seatop_pointer_axis(struct sway_seat *seat,
+		struct wlr_event_pointer_axis *event) {
+	if (seat->seatop_impl->pointer_axis) {
+		seat->seatop_impl->pointer_axis(seat, event);
 	}
 }
 
@@ -1468,7 +1469,7 @@ void seatop_tablet_tool_motion(struct sway_seat *seat,
 	if (seat->seatop_impl->tablet_tool_motion) {
 		seat->seatop_impl->tablet_tool_motion(seat, tablet, tool, time_msec, dx, dy);
 	} else {
-		seatop_motion(seat, time_msec, dx, dy);
+		seatop_pointer_motion(seat, time_msec, dx, dy);
 	}
 }
 

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -405,9 +405,9 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	seat_pointer_notify_button(seat, time_msec, button, state);
 }
 
-/*----------------------------------\
- * Functions used by handle_motion  /
- *--------------------------------*/
+/*------------------------------------------\
+ * Functions used by handle_pointer_motion  /
+ *----------------------------------------*/
 
 static void check_focus_follows_mouse(struct sway_seat *seat,
 		struct seatop_default_event *e, struct sway_node *hovered_node) {
@@ -439,7 +439,7 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 	}
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
@@ -510,9 +510,9 @@ static void handle_tablet_tool_motion(struct sway_seat *seat,
 	e->previous_node = node;
 }
 
-/*--------------------------------\
- * Functions used by handle_axis  /
- *------------------------------*/
+/*----------------------------------------\
+ * Functions used by handle_pointer_axis  /
+ *--------------------------------------*/
 
 static uint32_t wl_axis_to_button(struct wlr_event_pointer_axis *event) {
 	switch (event->orientation) {
@@ -526,7 +526,7 @@ static uint32_t wl_axis_to_button(struct wlr_event_pointer_axis *event) {
 	}
 }
 
-static void handle_axis(struct sway_seat *seat,
+static void handle_pointer_axis(struct sway_seat *seat,
 		struct wlr_event_pointer_axis *event) {
 	struct sway_input_device *input_device =
 		event->device ? event->device->data : NULL;
@@ -648,8 +648,8 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 
 static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
-	.motion = handle_motion,
-	.axis = handle_axis,
+	.pointer_motion = handle_pointer_motion,
+	.pointer_axis = handle_pointer_axis,
 	.tablet_tool_motion = handle_tablet_tool_motion,
 	.rebase = handle_rebase,
 	.allow_set_cursor = true,

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -12,7 +12,7 @@ struct seatop_down_event {
 	double ref_con_lx, ref_con_ly; // container's x/y at start of op
 };
 
-static void handle_axis(struct sway_seat *seat,
+static void handle_pointer_axis(struct sway_seat *seat,
 		struct wlr_event_pointer_axis *event) {
 	struct sway_input_device *input_device =
 		event->device ? event->device->data : NULL;
@@ -36,7 +36,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_down_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
@@ -57,9 +57,9 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 }
 
 static const struct sway_seatop_impl seatop_impl = {
-	.axis = handle_axis,
 	.button = handle_button,
-	.motion = handle_motion,
+	.pointer_motion = handle_pointer_motion,
+	.pointer_axis = handle_pointer_axis,
 	.unref = handle_unref,
 	.allow_set_cursor = true,
 };

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -23,7 +23,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_move_floating_event *e = seat->seatop_data;
 	struct wlr_cursor *cursor = seat->cursor->cursor;
@@ -41,7 +41,7 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 
 static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
-	.motion = handle_motion,
+	.pointer_motion = handle_pointer_motion,
 	.unref = handle_unref,
 };
 

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -206,7 +206,7 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 	desktop_damage_box(&e->drop_box);
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_move_tiling_event *e = seat->seatop_data;
 	if (e->threshold_reached) {
@@ -250,7 +250,6 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	if (!swap) {
 		container_detach(con);
 	}
-
 
 	// Moving container into empty workspace
 	if (target_node->type == N_WORKSPACE && edge == WLR_EDGE_NONE) {
@@ -315,7 +314,7 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 
 static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
-	.motion = handle_motion,
+	.pointer_motion = handle_pointer_motion,
 	.unref = handle_unref,
 	.render = handle_render,
 };

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -25,7 +25,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_resize_floating_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
@@ -131,7 +131,7 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 
 static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
-	.motion = handle_motion,
+	.pointer_motion = handle_pointer_motion,
 	.unref = handle_unref,
 };
 

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -27,7 +27,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_motion(struct sway_seat *seat, uint32_t time_msec,
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		double dx, double dy) {
 	struct seatop_resize_tiling_event *e = seat->seatop_data;
 	int amount_x = 0;
@@ -67,7 +67,7 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 
 static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
-	.motion = handle_motion,
+	.pointer_motion = handle_pointer_motion,
 	.unref = handle_unref,
 };
 


### PR DESCRIPTION
This commit renames `motion` and `axis` handlers to `pointer_motion` and
`pointer_axis`, respectively, to disambiguate them from their tablet
(and future touch) handlers. `button` is left as-is, as it is generic
across input devices.