### PR TITLE
Fix up pointer constraint interaction with tablet input

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -292,16 +292,19 @@ void cursor_unhide(struct sway_cursor *cursor) {
 static void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 		struct wlr_input_device *device, double dx, double dy,
 		double dx_unaccel, double dy_unaccel) {
-	cursor_handle_activity(cursor, IDLE_SOURCE_POINTER);
+	if (device->type == WLR_INPUT_DEVICE_POINTER) {
+		cursor_handle_activity(cursor, IDLE_SOURCE_POINTER);
+	}
 
 	wlr_relative_pointer_manager_v1_send_relative_motion(
 		server.relative_pointer_manager,
 		cursor->seat->wlr_seat, (uint64_t)time_msec * 1000,
 		dx, dy, dx_unaccel, dy_unaccel);
 
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	if (cursor->active_constraint) {
+	// Only apply pointer constraints to real pointer input.
+	if (cursor->active_constraint && device->type == WLR_INPUT_DEVICE_POINTER) {
+		struct wlr_surface *surface = NULL;
+		double sx, sy;
 		node_at_coords(cursor->seat,
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 


### PR DESCRIPTION
Fixes https://github.com/swaywm/sway/issues/5268.

The less-obvious part of this change is in the second commit, with the (unexpected) problem described in its message. By my understanding of the pointer constraint spec this should be correct, but I wouldn't bet on my understanding :)