### PR TITLE
input/tablet: add seatop_down entry for tablet input

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -23,6 +23,8 @@ struct sway_seatop_impl {
 	void (*rebase)(struct sway_seat *seat, uint32_t time_msec);
 	void (*tablet_tool_motion)(struct sway_seat *seat,
 			struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
+	void (*tablet_tool_tip)(struct sway_seat *seat, struct sway_tablet_tool *tool,
+			uint32_t time_msec, enum wlr_tablet_tool_tip_state state);
 	void (*end)(struct sway_seat *seat);
 	void (*unref)(struct sway_seat *seat, struct sway_container *con);
 	void (*render)(struct sway_seat *seat, struct sway_output *output,
@@ -267,6 +269,10 @@ void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 
 void seatop_pointer_axis(struct sway_seat *seat,
 		struct wlr_event_pointer_axis *event);
+
+void seatop_tablet_tool_tip(struct sway_seat *seat,
+		struct sway_tablet_tool *tool, uint32_t time_msec,
+		enum wlr_tablet_tool_tip_state state);
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
 		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1476,6 +1476,14 @@ void seatop_pointer_axis(struct sway_seat *seat,
 	}
 }
 
+void seatop_tablet_tool_tip(struct sway_seat *seat,
+		struct sway_tablet_tool *tool, uint32_t time_msec,
+		enum wlr_tablet_tool_tip_state state) {
+	if (seat->seatop_impl->tablet_tool_tip) {
+		seat->seatop_impl->tablet_tool_tip(seat, tool, time_msec, state);
+	}
+}
+
 void seatop_tablet_tool_motion(struct sway_seat *seat,
 		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
 	if (seat->seatop_impl->tablet_tool_motion) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -198,6 +198,25 @@ static void state_add_button(struct seatop_default_event *e, uint32_t button) {
  * Functions used by handle_button  /
  *--------------------------------*/
 
+static void handle_tablet_tool_tip(struct sway_seat *seat,
+		struct sway_tablet_tool *tool, uint32_t time_msec,
+		enum wlr_tablet_tool_tip_state state) {
+	if (state != WLR_TABLET_TOOL_TIP_DOWN) {
+		return;
+	}
+
+	struct sway_cursor *cursor = seat->cursor;
+
+	struct wlr_surface *surface = NULL;
+	double sx, sy;
+	struct sway_node *node = node_at_coords(seat,
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+
+	if (surface && node && node->type == N_CONTAINER) {
+		seatop_begin_down(seat, node->sway_container, time_msec, sx, sy);
+	}
+}
+
 static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		struct wlr_input_device *device, uint32_t button,
 		enum wlr_button_state state) {
@@ -649,6 +668,7 @@ static const struct sway_seatop_impl seatop_impl = {
 	.button = handle_button,
 	.pointer_motion = handle_pointer_motion,
 	.pointer_axis = handle_pointer_axis,
+	.tablet_tool_tip = handle_tablet_tool_tip,
 	.tablet_tool_motion = handle_tablet_tool_motion,
 	.rebase = handle_rebase,
 	.allow_set_cursor = true,


### PR DESCRIPTION
Depends on https://github.com/swaywm/wlroots/pull/2158.

Currently, when tablet input exits a window during an implicit grab, it
passes focus to another window.

For instance, this is problematic when trying to drag a scrollbar, and
exiting the window &mdash; the scrollbar motion stops. Additionally,
without `focus_follows_mouse no`, the tablet passes focus to whatever
surface it goes over regardless of if there is an active implicit grab.

If the tablet is over a surface that does not bind tablet handlers, sway
will fall back to pointer emulation, and all of this works fine. It
probably should have consistent behavior between emulated and
not-emulated input, though.

This commit adds a condition for entering `seatop_down` when a tablet's
tool tip goes down, and exiting when it goes up. Since events won't be
routed through `seatop_default`, this prevents windows losing focus during
implicit grabs.

Closes #5302.

Some more logic should be refactored into these new handlers, but I feel
that is best left outside the scope of this PR.