### PR TITLE
Add views idle inhibition status in get_tree output

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -29,6 +29,9 @@ struct sway_idle_inhibitor_v1 {
 	struct wl_listener destroy;
 };
 
+bool sway_idle_inhibit_v1_is_active(
+	struct sway_idle_inhibitor_v1 *inhibitor);
+
 void sway_idle_inhibit_v1_check_active(
 	struct sway_idle_inhibit_manager_v1 *manager);
 
@@ -36,6 +39,9 @@ void sway_idle_inhibit_v1_user_inhibitor_register(struct sway_view *view,
 		enum sway_idle_inhibit_mode mode);
 
 struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
+		struct sway_view *view);
+
+struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_application_inhibitor_for_view(
 		struct sway_view *view);
 
 void sway_idle_inhibit_v1_user_inhibitor_destroy(

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -230,6 +230,8 @@ void view_get_constraints(struct sway_view *view, double *min_width,
 uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 	int height);
 
+bool view_inhibit_idle(struct sway_view *view);
+
 /**
  * Whether or not the view is the only visible view in its tree. If the view
  * is tiling, there may be floating views. If the view is floating, there may

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -77,6 +77,19 @@ struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
 	return NULL;
 }
 
+struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_application_inhibitor_for_view(
+		struct sway_view *view) {
+	struct sway_idle_inhibitor_v1 *inhibitor;
+	wl_list_for_each(inhibitor, &server.idle_inhibit_manager_v1->inhibitors,
+			link) {
+		if (inhibitor->view == view &&
+				inhibitor->mode == INHIBIT_IDLE_APPLICATION) {
+			return inhibitor;
+		}
+	}
+	return NULL;
+}
+
 void sway_idle_inhibit_v1_user_inhibitor_destroy(
 		struct sway_idle_inhibitor_v1 *inhibitor) {
 	if (!inhibitor) {
@@ -89,7 +102,7 @@ void sway_idle_inhibit_v1_user_inhibitor_destroy(
 	destroy_inhibitor(inhibitor);
 }
 
-static bool check_active(struct sway_idle_inhibitor_v1 *inhibitor) {
+bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 	switch (inhibitor->mode) {
 	case INHIBIT_IDLE_APPLICATION:
 		// If there is no view associated with the inhibitor, assume visible
@@ -122,7 +135,7 @@ void sway_idle_inhibit_v1_check_active(
 	struct sway_idle_inhibitor_v1 *inhibitor;
 	bool inhibited = false;
 	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
-		if ((inhibited = check_active(inhibitor))) {
+		if ((inhibited = sway_idle_inhibit_v1_is_active(inhibitor))) {
 			break;
 		}
 	}

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -379,6 +379,14 @@ node and will have the following properties:
 |- shell
 :  string
 :  (Only views) The shell of the view, such as _xdg\_shell_ or _xwayland_
+|- inhibit_idle
+:  boolean
+:  (Only views) Whether the view is inhibiting the idle state
+|- idle_inhibitors
+:  object
+:  (Only views) An object containing the state of the _application_ and _user_ idle inhibitors.
+    _application_ can be _enabled_ or _none_.
+    _user_ can be _focus_, _fullscreen_, _open_, _visible_ or _none_.
 |- window
 :  integer
 :  (Only xwayland views) The X11 window ID for the xwayland view
@@ -676,6 +684,11 @@ node and will have the following properties:
 							"app_id": null,
 							"visible": true,
 							"shell": "xwayland",
+							"inhibit_idle": true,
+							"idle_inhibitors": {
+								"application": "none",
+								"user": "visible",
+							},
 							"window_properties": {
 								"class": "URxvt",
 								"instance": "urxvt",
@@ -731,6 +744,11 @@ node and will have the following properties:
 							"app_id": "termite",
 							"visible": true,
 							"shell": "xdg_shell",
+							"inhibit_idle": false,
+							"idle_inhibitors": {
+								"application": "none",
+								"user": "fullscreen",
+							},
 							"nodes": [
 							]
 						}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -17,6 +17,7 @@
 #include "sway/commands.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/cursor.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
@@ -161,6 +162,29 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 		return view->impl->configure(view, lx, ly, width, height);
 	}
 	return 0;
+}
+
+bool view_inhibit_idle(struct sway_view *view) {
+	struct sway_idle_inhibitor_v1 *user_inhibitor =
+		sway_idle_inhibit_v1_user_inhibitor_for_view(view);
+
+	struct sway_idle_inhibitor_v1 *application_inhibitor =
+		sway_idle_inhibit_v1_application_inhibitor_for_view(view);
+
+	if (!user_inhibitor && !application_inhibitor) {
+		return false;
+	}
+
+	if (!user_inhibitor) {
+		return sway_idle_inhibit_v1_is_active(application_inhibitor);
+	}
+
+	if (!application_inhibitor) {
+		return sway_idle_inhibit_v1_is_active(user_inhibitor);
+	}
+
+	return sway_idle_inhibit_v1_is_active(user_inhibitor)
+		|| sway_idle_inhibit_v1_is_active(application_inhibitor);
 }
 
 bool view_is_only_visible(struct sway_view *view) {


### PR DESCRIPTION
Fixes #5286

Following command is an example of scripting to determine whether any view is currently inhibiting the idle state.
Exits with 0 if idle is inhibited, >0 otherwise.
```
swaymsg -t get_tree |
jq -e 'recurse(.floating_nodes[]?,.nodes[]?) | select(.inhibit_idle == true)' > /dev/null
```