### PR TITLE
input/tablet: simplify parameter plumbing for tablet references

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -21,7 +21,7 @@ struct sway_seatop_impl {
 	void (*pointer_axis)(struct sway_seat *seat,
 			struct wlr_event_pointer_axis *event);
 	void (*rebase)(struct sway_seat *seat, uint32_t time_msec);
-	void (*tablet_tool_motion)(struct sway_seat *seat, struct sway_tablet *tablet,
+	void (*tablet_tool_motion)(struct sway_seat *seat,
 			struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
 	void (*end)(struct sway_seat *seat);
 	void (*unref)(struct sway_seat *seat, struct sway_container *con);
@@ -269,8 +269,7 @@ void seatop_pointer_axis(struct sway_seat *seat,
 		struct wlr_event_pointer_axis *event);
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet *tablet, struct sway_tablet_tool *tool,
-		uint32_t time_msec, double dx, double dy);
+		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
 
 void seatop_rebase(struct sway_seat *seat, uint32_t time_msec);
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1464,10 +1464,9 @@ void seatop_pointer_axis(struct sway_seat *seat,
 }
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet *tablet, struct sway_tablet_tool *tool,
-		uint32_t time_msec, double dx, double dy) {
+		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
 	if (seat->seatop_impl->tablet_tool_motion) {
-		seat->seatop_impl->tablet_tool_motion(seat, tablet, tool, time_msec, dx, dy);
+		seat->seatop_impl->tablet_tool_motion(seat, tool, time_msec, dx, dy);
 	} else {
 		seatop_pointer_motion(seat, time_msec, dx, dy);
 	}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -475,8 +475,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 }
 
 static void handle_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet *tablet, struct sway_tablet_tool *tool,
-		uint32_t time_msec, double dx, double dy) {
+		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 
@@ -492,7 +491,7 @@ static void handle_tablet_tool_motion(struct sway_seat *seat,
 	if (surface) {
 		if (seat_is_input_allowed(seat, surface)) {
 			wlr_tablet_v2_tablet_tool_notify_proximity_in(tool->tablet_v2_tool,
-				tablet->tablet_v2, surface);
+				tool->tablet->tablet_v2, surface);
 			wlr_tablet_v2_tablet_tool_notify_motion(tool->tablet_v2_tool, sx, sy);
 		}
 	} else {


### PR DESCRIPTION
This is a small cleanup commit for removing `sway_tablet` parameters
from functions that already accept `sway_tablet_tool`, since the tablet
reference can be accessed through `tool->tablet`. This makes it
unmistakable that the tablet is tied to a given tool, and removes
any doubt that an unassociated tablet reference can be passed in.