### PR TITLE
criteria: Add idle inhibitor criteria

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -24,6 +24,18 @@ struct pattern {
 	pcre *regex;
 };
 
+enum criteria_idle_inhibitor {
+	// implicit: C_IDLE_INHIBITOR_UNSPEC = 0,
+	C_IDLE_INHIBITOR_NONE = 1,
+	C_IDLE_INHIBITOR_APPLICATION,
+	C_IDLE_INHIBITOR_USER,
+	C_IDLE_INHIBITOR_FOCUS,
+	C_IDLE_INHIBITOR_FULLSCREEN,
+	C_IDLE_INHIBITOR_OPEN,
+	C_IDLE_INHIBITOR_VISIBLE,
+	C_IDLE_INHIBITOR_ACTIVE,
+};
+
 struct criteria {
 	enum criteria_type type;
 	char *raw; // entire criteria string (for logging)
@@ -47,6 +59,7 @@ struct criteria {
 	char urgent; // 'l' for latest or 'o' for oldest
 	struct pattern *workspace;
 	pid_t pid;
+	enum criteria_idle_inhibitor idle_inhibitor;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -29,11 +29,17 @@ struct sway_idle_inhibitor_v1 {
 	struct wl_listener destroy;
 };
 
+bool sway_idle_inhibit_v1_inhibitor_check_active(
+		struct sway_idle_inhibitor_v1 *inhibitor);
+
 void sway_idle_inhibit_v1_check_active(
 	struct sway_idle_inhibit_manager_v1 *manager);
 
 void sway_idle_inhibit_v1_user_inhibitor_register(struct sway_view *view,
 		enum sway_idle_inhibit_mode mode);
+
+struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_inhibitor_for_view(
+		struct sway_view *view);
 
 struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
 		struct sway_view *view);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -341,4 +341,9 @@ void view_save_buffer(struct sway_view *view);
 
 bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 
+void view_schedule_criteria_execution_from_wlr_surface(
+		struct wlr_surface *wlr_surface);
+
+void view_schedule_criteria_execution_from_view(struct sway_view *view);
+
 #endif

--- a/sway/commands/inhibit_idle.c
+++ b/sway/commands/inhibit_idle.c
@@ -47,5 +47,7 @@ struct cmd_results *cmd_inhibit_idle(int argc, char **argv) {
 		sway_idle_inhibit_v1_user_inhibitor_register(con->view, mode);
 	}
 
+	view_execute_criteria(con->view);
+
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -870,6 +870,14 @@ The following attributes may be matched with:
 *id*
 	Compare value against the X11 window ID. Must be numeric.
 
+*idle_inhibitor*
+	Matches the state of idle inhibitors on windows. Values can be "none",
+	"application", "user", "focus", "fullscreen", "open", "none", "visible"
+	and "active" and will match windows where no, an application or a user
+	inhibitor is present with the "focus" to "visible" keywords describing
+	the type of user inhibtor to match more closely. "active" matches any
+	inhibitor that is currently preventing idle regardless of type.
+
 *instance*
 	Compare value against the window instance. Can be a regular expression. If
 	value is \_\_focused\_\_, then the window instance must be the same as that

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1175,3 +1175,23 @@ bool view_is_transient_for(struct sway_view *child,
 	return child->impl->is_transient_for &&
 		child->impl->is_transient_for(child, ancestor);
 }
+
+static void view_criteria_execution_view_iterator(
+		struct sway_container *container, void *data) {
+	struct sway_view *view = data;
+
+	if (container->view == view) {
+		view_execute_criteria(container->view);
+	}
+}
+
+static void view_execute_criteria_from_view(void *data) {
+	// here we intentionally go looking for a view matching our argument
+	// because that view might have been freed since
+	root_for_each_container(view_criteria_execution_view_iterator, data);
+}
+
+void view_schedule_criteria_execution_from_view(struct sway_view *view) {
+	wl_event_loop_add_idle(server.wl_event_loop,
+			view_execute_criteria_from_view, view);
+}


### PR DESCRIPTION
Add a criterion that matches idle inhibitors in all their various states
and types. Add call sites at creation and destruction, either via the
protocol or due to command call. This allows to trigger actions based on
idle inhibitor state changes on windows.

Example config combined with keyboard shortcuts inhibitor criterion:

for_window [shortcuts_inhibitor=inactive] title_format !-%title
for_window [shortcuts_inhibitor=active] title_format !+%title
for_window [idle_inhibitor=active] title_format ^%title
for_window [idle_inhibitor=none shortcuts_inhibitor=absent] title_format %title

Signed-off-by: Michael Weiser <michael.weiser@gmx.de>

Particularly useful in concert with criteria reexecution from #5323 to revert and re-apply changes as inhibitors change state.