### PR TITLE
swaybar: add NULL check when listing workspaces

### DIFF
--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -360,7 +360,7 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 
 		wl_list_for_each(output, &bar->outputs, link) {
 			const char *ws_output = json_object_get_string(out);
-			if (strcmp(ws_output, output->name) == 0) {
+			if (ws_output != NULL && strcmp(ws_output, output->name) == 0) {
 				struct swaybar_workspace *ws =
 					calloc(1, sizeof(struct swaybar_workspace));
 				ws->num = json_object_get_int(num);


### PR DESCRIPTION
For some reason my version of sway doesn't show workspace names:

    $ swaymsg -t get_outputs
    Output HDMI-A-1 '(null) (null) (null)' (inactive)
    Output HDMI-A-2 '(null) (null) (null)' (inactive)

Which is weird, but it's no reason to crash swaybar. The field is
totally missing from the JSON, so it ends up doing `strcmp(NULL, name)`
which is undefined behavior.