### PR TITLE
Use new wlroots API for clearing keyboard/pointer focus during grabs

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -645,7 +645,7 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 
 	struct sway_seat *seat;
 	wl_list_for_each(seat, &server.input->seats, link) {
-		wlr_seat_pointer_clear_focus(seat->wlr_seat);
+		wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 		cursor_rebase(seat->cursor);
 	}
 }

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -236,7 +236,7 @@ void cursor_update_image(struct sway_cursor *cursor,
 static void cursor_hide(struct sway_cursor *cursor) {
 	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	cursor->hidden = true;
-	wlr_seat_pointer_clear_focus(cursor->seat->wlr_seat);
+	wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
 }
 
 static int hide_notify(void *data) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -698,7 +698,7 @@ static void seat_configure_keyboard(struct sway_seat *seat,
 	struct sway_node *focus = seat_get_focus(seat);
 	if (focus && node_is_view(focus)) {
 		// force notify reenter to pick up the new configuration
-		wlr_seat_keyboard_clear_focus(seat->wlr_seat);
+		wlr_seat_keyboard_notify_clear_focus(seat->wlr_seat);
 		seat_keyboard_notify_enter(seat, focus->sway_container->view->surface);
 	}
 }
@@ -963,7 +963,7 @@ static void send_unfocus(struct sway_container *con, void *data) {
 // Unfocus the container and any children (eg. when leaving `focus parent`)
 static void seat_send_unfocus(struct sway_node *node, struct sway_seat *seat) {
 	sway_cursor_constrain(seat->cursor, NULL);
-	wlr_seat_keyboard_clear_focus(seat->wlr_seat);
+	wlr_seat_keyboard_notify_clear_focus(seat->wlr_seat);
 	if (node->type == N_WORKSPACE) {
 		workspace_for_each_container(node->sway_workspace, send_unfocus, seat);
 	} else {
@@ -1230,7 +1230,7 @@ void seat_set_exclusive_client(struct sway_seat *seat,
 	}
 	if (seat->wlr_seat->pointer_state.focused_client) {
 		if (seat->wlr_seat->pointer_state.focused_client->client != client) {
-			wlr_seat_pointer_clear_focus(seat->wlr_seat);
+			wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 		}
 	}
 	struct timespec now;

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -460,8 +460,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 		}
 	} else {
 		cursor_update_image(cursor, node);
-		wlr_seat_pointer_notify_enter(seat->wlr_seat, NULL, 0, 0);
-		wlr_seat_pointer_clear_focus(seat->wlr_seat);
+		wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 	}
 
 	struct sway_drag_icon *drag_icon;
@@ -640,8 +639,7 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 		}
 	} else {
 		cursor_update_image(cursor, e->previous_node);
-		wlr_seat_pointer_notify_enter(seat->wlr_seat, NULL, 0, 0);
-		wlr_seat_pointer_clear_focus(seat->wlr_seat);
+		wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 	}
 }
 

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -65,5 +65,5 @@ void seatop_begin_move_floating(struct sway_seat *seat,
 	container_raise_floating(con);
 
 	cursor_set_image(cursor, "grab", NULL);
-	wlr_seat_pointer_clear_focus(seat->wlr_seat);
+	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -336,7 +336,7 @@ void seatop_begin_move_tiling_threshold(struct sway_seat *seat,
 	seat->seatop_data = e;
 
 	container_raise_floating(con);
-	wlr_seat_pointer_clear_focus(seat->wlr_seat);
+	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }
 
 void seatop_begin_move_tiling(struct sway_seat *seat,

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -175,5 +175,5 @@ void seatop_begin_resize_floating(struct sway_seat *seat,
 	const char *image = edge == WLR_EDGE_NONE ?
 		"se-resize" : wlr_xcursor_get_resize_name(edge);
 	cursor_set_image(seat->cursor, image, NULL);
-	wlr_seat_pointer_clear_focus(seat->wlr_seat);
+	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -106,5 +106,5 @@ void seatop_begin_resize_tiling(struct sway_seat *seat,
 	seat->seatop_impl = &seatop_impl;
 	seat->seatop_data = e;
 
-	wlr_seat_pointer_clear_focus(seat->wlr_seat);
+	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }


### PR DESCRIPTION
We are not allowed to do what we did in #5222 and pass a `NULL` surface wlr_seat_pointer_notify_enter(), and it's causing crashes when an xdg-shell popup is active (see #5294 and swaywm/wlroots#2161).

Instead, solve #5220 using the new wlroots API introduced in swaywm/wlroots#2217.