### PR TITLE
input/pointer: send pointer enter event on confine warp

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -791,6 +791,8 @@ static void check_constraint_region(struct sway_cursor *cursor) {
 				wlr_cursor_warp_closest(cursor->cursor, NULL,
 					sx + con->content_x - view->geometry.x,
 					sy + con->content_y - view->geometry.y);
+
+				cursor_rebase(cursor);
 			}
 		}
 	}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -637,6 +637,7 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 	if (surface) {
 		if (seat_is_input_allowed(seat, surface)) {
 			wlr_seat_pointer_notify_enter(seat->wlr_seat, surface, sx, sy);
+			wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
 		}
 	} else {
 		cursor_update_image(cursor, e->previous_node);


### PR DESCRIPTION
The spec has this to say about sending events on confine creation:

 > Whenever the confinement is activated, it is guaranteed that the
surface the pointer is confined to will already have received pointer
focus and that the pointer will be within the region passed to the
request creating this object.

...and on region update:

> If warped, a wl_pointer.motion event will be emitted, but no
wp_relative_pointer.relative_motion event.

Prior to this patch, sway did neither, and updated the hardware cursor
position without notifying the underlying surface until the next motion
event. This led to inconsistent results, especially in applications that
draw their own software cursor.

([Related SDL patch.](https://bugzilla.libsdl.org/show_bug.cgi?id=5151))