### PR TITLE
common/log: use bright black rather than black for SWAY_DEBUG

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -42,7 +42,7 @@ static const char *verbosity_colors[] = {
 	[SWAY_SILENT] = "",
 	[SWAY_ERROR ] = "\x1B[1;31m",
 	[SWAY_INFO  ] = "\x1B[1;34m",
-	[SWAY_DEBUG ] = "\x1B[1;30m",
+	[SWAY_DEBUG ] = "\x1B[1;90m",
 };
 
 static void timespec_sub(struct timespec *r, const struct timespec *a,


### PR DESCRIPTION
On some terminals under default settings, black is truly rendered as
`#000`, making it unreadable when the background is also black.

Closes #5141.