### PR TITLE
input/cursor: keep reference to cursor in constraint

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -111,6 +111,7 @@ struct sway_seat {
 };
 
 struct sway_pointer_constraint {
+	struct sway_cursor *cursor;
 	struct wlr_pointer_constraint_v1 *constraint;
 
 	struct wl_listener set_region;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -833,9 +833,7 @@ static void handle_pointer_constraint_set_region(struct wl_listener *listener,
 		void *data) {
 	struct sway_pointer_constraint *sway_constraint =
 		wl_container_of(listener, sway_constraint, set_region);
-	struct wlr_pointer_constraint_v1 *constraint = data;
-	struct sway_seat *seat = constraint->seat->data;
-	struct sway_cursor *cursor = seat->cursor;
+	struct sway_cursor *cursor = sway_constraint->cursor;
 
 	cursor->active_confine_requires_warp = true;
 }
@@ -1248,8 +1246,7 @@ void handle_constraint_destroy(struct wl_listener *listener, void *data) {
 	struct sway_pointer_constraint *sway_constraint =
 		wl_container_of(listener, sway_constraint, destroy);
 	struct wlr_pointer_constraint_v1 *constraint = data;
-	struct sway_seat *seat = constraint->seat->data;
-	struct sway_cursor *cursor = seat->cursor;
+	struct sway_cursor *cursor = sway_constraint->cursor;
 
 	wl_list_remove(&sway_constraint->set_region.link);
 	wl_list_remove(&sway_constraint->destroy.link);
@@ -1273,6 +1270,7 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data) {
 
 	struct sway_pointer_constraint *sway_constraint =
 		calloc(1, sizeof(struct sway_pointer_constraint));
+	sway_constraint->cursor = seat->cursor;
 	sway_constraint->constraint = constraint;
 
 	sway_constraint->set_region.notify = handle_pointer_constraint_set_region;


### PR DESCRIPTION
`set_region` accepts a `NULL` `*data`, so we can't use it to reference the constraint and find the cursor through its seat.

Fixes #5386.

/cc @emersion, sorry about that, don't know how this didn't fail during my testing...

I've tested this PR with:

```
$ wlroots/build/examples/pointer-constraints confine persistent disjoint-region
```

...and clicked a couple of times to observe `set_region` calls while running with ASan.

An alternative fix is in wlroots, but I recall we didn't want to add a non-`NULL` data parameter to `set_region` yet.

```diff
diff --git a/include/wlr/types/wlr_pointer_constraints_v1.h b/include/wlr/types/wlr_pointer_constraints_v1.h
index 0c49e3bf..d99b92f7 100644
--- a/include/wlr/types/wlr_pointer_constraints_v1.h
+++ b/include/wlr/types/wlr_pointer_constraints_v1.h
@@ -60,6 +60,8 @@ struct wlr_pointer_constraint_v1 {
                /**
                 * Called when a pointer constraint's region is updated,
                 * post-surface-commit.
+                *
+                * data: struct wlr_pointer_constraint_v1 *
                 */
                struct wl_signal set_region;
                struct wl_signal destroy;
diff --git a/types/wlr_pointer_constraints_v1.c b/types/wlr_pointer_constraints_v1.c
index eca45984..36c0a359 100644
--- a/types/wlr_pointer_constraints_v1.c
+++ b/types/wlr_pointer_constraints_v1.c
@@ -129,7 +129,7 @@ static void pointer_constraint_commit(
        }
 
        if (updated_region) {
-               wlr_signal_emit_safe(&constraint->events.set_region, NULL);
+               wlr_signal_emit_safe(&constraint->events.set_region, constraint);
        }
 }
```