### PR TITLE
input/keyboard: wlr_keyboard_group enter and leave

### DIFF
--- a/include/sway/input/keyboard.h
+++ b/include/sway/input/keyboard.h
@@ -75,6 +75,8 @@ struct sway_keyboard_group {
 	struct sway_seat_device *seat_device;
 	struct wl_listener keyboard_key;
 	struct wl_listener keyboard_modifiers;
+	struct wl_listener enter;
+	struct wl_listener leave;
 	struct wl_list link; // sway_seat::keyboard_groups
 };
 


### PR DESCRIPTION
Fixes #4975 
Requires swaywm/wlroots#2229

This adds support for wlr_keyboard_group's enter and leave events. The
enter event just updates the keyboard's state. The leave event updates
the keyboard's state and if the surface was notified of a press event
for the key code, then it is notified of a key release.