### PR TITLE
input/cursor: rename `simulated_tool_tip_down` to be more accurate

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -58,7 +58,7 @@ struct sway_cursor {
 	struct wl_listener tool_tip;
 	struct wl_listener tool_proximity;
 	struct wl_listener tool_button;
-	bool simulated_tool_tip_down;
+	bool simulating_pointer_from_tool_tip;
 	uint32_t tool_buttons;
 
 	struct wl_listener request_set_cursor;


### PR DESCRIPTION
This is a tiny cleanup commit that renames `simulated_tool_tip_down` to
`simulating_pointer_from_tool_tip`, making it match
`simulating_pointer_from_touch` (that was added later and had more
discussion on naming).

This is a better name since it makes it clear that it's the *pointer*
that's being simulated, not the tool tip.