### PR TITLE
Improve resize transactions

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -105,7 +105,6 @@ struct sway_container {
 	// refuses to resize to the content dimensions then it can be smaller.
 	// These are in layout coordinates.
 	double surface_x, surface_y;
-	double surface_width, surface_height;
 
 	enum sway_fullscreen_mode fullscreen_mode;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -55,6 +55,13 @@ struct sway_view_impl {
 	void (*destroy)(struct sway_view *view);
 };
 
+struct sway_saved_buffer {
+	struct wlr_client_buffer *buffer;
+	int x, y;
+	int width, height;
+	struct wl_list link; // sway_view::saved_buffers
+};
+
 struct sway_view {
 	enum sway_view_type type;
 	const struct sway_view_impl *impl;
@@ -64,9 +71,6 @@ struct sway_view {
 	struct sway_xdg_decoration *xdg_decoration;
 
 	pid_t pid;
-
-	double saved_x, saved_y;
-	int saved_width, saved_height;
 
 	// The size the view would want to be if it weren't tiled.
 	// Used when changing a view from tiled to floating.
@@ -80,8 +84,7 @@ struct sway_view {
 	bool allow_request_urgent;
 	struct wl_event_source *urgent_timer;
 
-	struct wlr_client_buffer *saved_buffer;
-	int saved_buffer_width, saved_buffer_height;
+	struct wl_list saved_buffers; // sway_saved_buffer::link
 
 	// The geometry for whatever the client is committing, regardless of
 	// transaction state. Updated on every commit.

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -171,8 +171,8 @@ void output_view_for_each_surface(struct sway_output *output,
 			- view->geometry.x,
 		.oy = view->container->surface_y - output->ly
 			- view->geometry.y,
-		.width = view->container->surface_width,
-		.height = view->container->surface_height,
+		.width = view->container->current.content_width,
+		.height = view->container->current.content_height,
 		.rotation = 0, // TODO
 	};
 
@@ -191,8 +191,8 @@ void output_view_for_each_popup(struct sway_output *output,
 			- view->geometry.x,
 		.oy = view->container->surface_y - output->ly
 			- view->geometry.y,
-		.width = view->container->surface_width,
-		.height = view->container->surface_height,
+		.width = view->container->current.content_width,
+		.height = view->container->current.content_height,
 		.rotation = 0, // TODO
 	};
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -511,7 +511,7 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
-	if (view->saved_buffer) {
+	if (!wl_list_empty(&view->saved_buffers)) {
 		return false;
 	}
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -255,20 +255,20 @@ static void apply_container_state(struct sway_container *container,
 	// the container. This is important for fullscreen views which
 	// refuse to resize to the size of the output.
 	if (view && view->surface) {
-		if (view->surface->current.width < container->width) {
-			container->surface_x = container->content_x +
-				(container->content_width - view->surface->current.width) / 2;
+		if (view->geometry.width < container->current.content_width) {
+			container->surface_x = container->current.content_x +
+				(container->current.content_width - view->geometry.width) / 2;
 		} else {
-			container->surface_x = container->content_x;
+			container->surface_x = container->current.content_x;
 		}
-		if (view->surface->current.height < container->height) {
-			container->surface_y = container->content_y +
-				(container->content_height - view->surface->current.height) / 2;
+		if (view->geometry.height < container->current.content_height) {
+			container->surface_y = container->current.content_y +
+				(container->current.content_height - view->geometry.height) / 2;
 		} else {
-			container->surface_y = container->content_y;
+			container->surface_y = container->current.content_y;
 		}
-		container->surface_width = view->surface->current.width;
-		container->surface_height = view->surface->current.height;
+		container->surface_width = container->current.content_width;
+		container->surface_height = container->current.content_height;
 	}
 
 	if (!container->node.destroying) {

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -267,8 +267,6 @@ static void apply_container_state(struct sway_container *container,
 		} else {
 			container->surface_y = container->current.content_y;
 		}
-		container->surface_width = container->current.content_width;
-		container->surface_height = container->current.content_height;
 	}
 
 	if (!container->node.destroying) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -284,7 +284,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		wlr_xdg_surface_get_geometry(xdg_surface, &new_geo);
 
 		if ((new_geo.width != view->geometry.width ||
-					new_geo.height != view->geometry.height)) {
+					new_geo.height != view->geometry.height ||
+					new_geo.x != view->geometry.x ||
+					new_geo.y != view->geometry.y)) {
 			// The view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -282,10 +282,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	} else {
 		struct wlr_box new_geo;
 		wlr_xdg_surface_get_geometry(xdg_surface, &new_geo);
-		struct sway_container *con = view->container;
 
-		if ((new_geo.width != con->surface_width ||
-					new_geo.height != con->surface_height)) {
+		if ((new_geo.width != view->geometry.width ||
+					new_geo.height != view->geometry.height)) {
 			// The view has unexpectedly sent a new size
 			desktop_damage_view(view);
 			view_update_size(view, new_geo.width, new_geo.height);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -355,10 +355,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	} else {
 		struct wlr_box new_geo;
 		get_geometry(view, &new_geo);
-		struct sway_container *con = view->container;
 
-		if ((new_geo.width != con->surface_width ||
-					new_geo.height != con->surface_height)) {
+		if ((new_geo.width != view->geometry.width ||
+					new_geo.height != view->geometry.height)) {
 			// The view has unexpectedly sent a new size
 			// eg. The Firefox "Save As" dialog when downloading a file
 			desktop_damage_view(view);

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -357,7 +357,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		get_geometry(view, &new_geo);
 
 		if ((new_geo.width != view->geometry.width ||
-					new_geo.height != view->geometry.height)) {
+					new_geo.height != view->geometry.height ||
+					new_geo.x != view->geometry.x ||
+					new_geo.y != view->geometry.y)) {
 			// The view has unexpectedly sent a new size
 			// eg. The Firefox "Save As" dialog when downloading a file
 			desktop_damage_view(view);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -737,8 +737,6 @@ void view_update_size(struct sway_view *view, int width, int height) {
 		con->surface_x = fmax(con->surface_x, con->content_x);
 		con->surface_y = fmax(con->surface_y, con->content_y);
 	}
-	con->surface_width = width;
-	con->surface_height = height;
 }
 
 static const struct sway_view_child_impl subsurface_impl;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -730,8 +730,6 @@ void view_update_size(struct sway_view *view, int width, int height) {
 	if (container_is_floating(con)) {
 		con->content_width = width;
 		con->content_height = height;
-		con->current.content_width = width;
-		con->current.content_height = height;
 		container_set_geometry_from_content(con);
 	} else {
 		con->surface_x = con->content_x + (con->content_width - width) / 2;


### PR DESCRIPTION
This PR contains a few improvements to the resizing logic:

1. Save all view buffers, including subsurfaces, rather than only the main surface. Fixes subsurfaces disappearing during resize.
2. Ensure that "current" geometry is not trashed, and is used when appropriate. Fixes border/titlebar and content disagreeing on dimensions during resize.
3. Update centering logic to account for complete and current dimensions. Fixes positioning during resize, especially with CSDs.
4. Remove bogus dimensions being tracked on the container state that was no longer useful.