### PR TITLE
readme: link to the development doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ channel or shoot an email to sir@cmpwn.com for advice.
 
 ### Compiling from Source
 
+Check out [this wiki page](https://github.com/swaywm/sway/wiki/Development-Setup) if you want to build the HEAD of sway and wlroots for testing or development.
+
 Install dependencies:
 
 * meson \*


### PR DESCRIPTION
The subproject compilation is the best way to test sway and wlroots but it's hidden. I only found it from comments in issues.