### PR TITLE
Implement moving tablet v2 surfaces by pen input

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -273,6 +273,13 @@ void container_set_fullscreen(struct sway_container *con,
 void container_fullscreen_disable(struct sway_container *con);
 
 /**
+ * Walk up the container tree branch starting at the given container, and return
+ * its earliest ancestor.
+ */
+struct sway_container *container_toplevel_ancestor(
+		struct sway_container *container);
+
+/**
  * Return true if the container is floating, or a child of a floating split
  * container.
  */

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -338,10 +338,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		if (button == btn_move && (mod_pressed || on_titlebar)) {
 			seat_set_focus_container(seat,
 					seat_get_focus_inactive_view(seat, &cont->node));
-			while (cont->parent) {
-				cont = cont->parent;
-			}
-			seatop_begin_move_floating(seat, cont);
+			seatop_begin_move_floating(seat, container_toplevel_ancestor(cont));
 			return;
 		}
 	}
@@ -359,10 +356,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		uint32_t btn_resize = config->floating_mod_inverse ?
 			BTN_LEFT : BTN_RIGHT;
 		if (mod_pressed && button == btn_resize) {
-			struct sway_container *floater = cont;
-			while (floater->parent) {
-				floater = floater->parent;
-			}
+			struct sway_container *floater = container_toplevel_ancestor(cont);
 			edge = 0;
 			edge |= cursor->cursor->x > floater->x + floater->width / 2 ?
 				WLR_EDGE_RIGHT : WLR_EDGE_LEFT;

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -235,6 +235,13 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 			return;
 		}
 
+		// Handle moving a tiling container
+		if (config->tiling_drag && mod_pressed && !is_floating_or_child &&
+				cont->fullscreen_mode == FULLSCREEN_NONE) {
+			seatop_begin_move_tiling(seat, cont);
+			return;
+		}
+
 		seatop_begin_down(seat, node->sway_container, time_msec, sx, sy);
 	}
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1108,11 +1108,17 @@ void container_set_fullscreen(struct sway_container *con,
 	}
 }
 
-bool container_is_floating_or_child(struct sway_container *container) {
+struct sway_container *container_toplevel_ancestor(
+		struct sway_container *container) {
 	while (container->parent) {
 		container = container->parent;
 	}
-	return container_is_floating(container);
+
+	return container;
+}
+
+bool container_is_floating_or_child(struct sway_container *container) {
+	return container_is_floating(container_toplevel_ancestor(container));
 }
 
 bool container_is_fullscreen_or_child(struct sway_container *container) {
@@ -1537,10 +1543,7 @@ void container_update_marks_textures(struct sway_container *con) {
 
 void container_raise_floating(struct sway_container *con) {
 	// Bring container to front by putting it at the end of the floating list.
-	struct sway_container *floater = con;
-	while (floater->parent) {
-		floater = floater->parent;
-	}
+	struct sway_container *floater = container_toplevel_ancestor(con);
 	if (container_is_floating(floater) && floater->workspace) {
 		list_move_to_end(floater->workspace->floating, floater);
 		node_set_dirty(&floater->workspace->node);
@@ -1552,8 +1555,6 @@ bool container_is_scratchpad_hidden(struct sway_container *con) {
 }
 
 bool container_is_scratchpad_hidden_or_child(struct sway_container *con) {
-	while (con->parent) {
-		con = con->parent;
-	}
+	con = container_toplevel_ancestor(con);
 	return con->scratchpad && !con->workspace;
 }


### PR DESCRIPTION
Closes #5293.

This PR "cheats" a bit since tool tips on container titlebars/edges actually go through pointer emulation, so we don't need to implement resizing logic in the tool tip seatop.