### PR TITLE
common/util: fix get_current_time_msec returning microseconds

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -1,14 +1,20 @@
 #define _POSIX_C_SOURCE 200809L
 #include <ctype.h>
-#include <float.h>
 #include <fcntl.h>
 #include <math.h>
+#include <time.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <wayland-server-protocol.h>
 #include "log.h"
 #include "util.h"
+
+uint32_t get_current_time_msec(void) {
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return now.tv_sec * 1000 + now.tv_nsec / 1000000;
+}
 
 int wrap(int i, int max) {
 	return ((i % max) + max) % max;

--- a/include/util.h
+++ b/include/util.h
@@ -6,7 +6,13 @@
 #include <wayland-server-protocol.h>
 
 /**
- * Wrap i into the range [0, max[
+ * Get the current time, in milliseconds.
+ */
+
+uint32_t get_current_time_msec(void);
+
+/**
+ * Wrap i into the range [0, max]
  */
 int wrap(int i, int max);
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -4,8 +4,6 @@
 #include <libevdev/libevdev.h>
 #include <linux/input-event-codes.h>
 #include <errno.h>
-#include <float.h>
-#include <limits.h>
 #include <strings.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_cursor.h>
@@ -13,9 +11,9 @@
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/region.h>
-#include "list.h"
-#include "log.h"
 #include "config.h"
+#include "log.h"
+#include "util.h"
 #include "sway/commands.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
@@ -24,18 +22,11 @@
 #include "sway/input/tablet.h"
 #include "sway/layers.h"
 #include "sway/output.h"
-#include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
-
-static uint32_t get_current_time_msec(void) {
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-	return now.tv_nsec / 1000;
-}
 
 static struct wlr_surface *layer_surface_at(struct sway_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {


### PR DESCRIPTION
This commit makes `get_current_time_msec` correctly return milliseconds
as opposed to microseconds. It also considers the value of `tv_sec`, so
we don't lose occasionally go back in time by one second. Finally, the
function is moved into `util.c` so that it can be reused elsewhere
without having to consider these pitfalls.