### PR TITLE
swaynag: allow specifying more buttons which execute and dismiss

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -53,6 +53,7 @@ struct swaynag_button {
 	int width;
 	int height;
 	bool terminal;
+	bool dismiss;
 };
 
 struct swaynag_details {

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -52,6 +52,8 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 	static struct option opts[] = {
 		{"button", required_argument, NULL, 'b'},
 		{"button-no-terminal", required_argument, NULL, 'B'},
+		{"button-dismiss", required_argument, NULL, 'z'},
+		{"button-dismiss-no-terminal", required_argument, NULL, 'Z'},
 		{"config", required_argument, NULL, 'c'},
 		{"debug", no_argument, NULL, 'd'},
 		{"edge", required_argument, NULL, 'e'},
@@ -90,6 +92,11 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			"be defined.\n"
 		"  -B, --button-no-terminal <text> <action>  Like --button, but does"
 			"not run the action in a terminal.\n"
+		"  -z, --button-dismiss <text> <action>  Create a button with text that "
+			"dismisses swaynag, and executes action in a terminal when pressed. "
+			"Multiple buttons can be defined.\n"
+		"  -Z, --button-dismiss-no-terminal <text> <action>  Like "
+			"--button-dismiss, but does not run the action in a terminal.\n"
 		"  -c, --config <path>           Path to config file.\n"
 		"  -d, --debug                   Enable debugging.\n"
 		"  -e, --edge top|bottom         Set the edge to use.\n"
@@ -120,13 +127,15 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 
 	optind = 1;
 	while (1) {
-		int c = getopt_long(argc, argv, "b:B:c:de:f:hlL:m:o:s:t:v", opts, NULL);
+		int c = getopt_long(argc, argv, "b:B:z:Z:c:de:f:hlL:m:o:s:t:v", opts, NULL);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 'b': // Button
 		case 'B': // Button (No Terminal)
+		case 'z': // Button (Dismiss)
+		case 'Z': // Button (Dismiss, No Terminal)
 			if (swaynag) {
 				if (optind >= argc) {
 					fprintf(stderr, "Missing action for button %s\n", optarg);
@@ -138,6 +147,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 				button->type = SWAYNAG_ACTION_COMMAND;
 				button->action = strdup(argv[optind]);
 				button->terminal = c == 'b';
+				button->dismiss = c == 'z' || c == 'Z';
 				list_add(swaynag->buttons, button);
 			}
 			optind++;

--- a/swaynag/swaynag.1.scd
+++ b/swaynag/swaynag.1.scd
@@ -21,6 +21,19 @@ _swaynag_ [options...]
 	_action_ will be run directly instead of in a terminal. Multiple buttons
 	can be defined by providing the flag multiple times.
 
+*-z, --button-dismiss* <text> <action>
+	Create a button with the text _text_ that executes _action_ when pressed,
+	and dismisses swaynag. If the environment variable _TERMINAL_ is set,
+	_action_ will be run inside the terminal. Otherwise, it will fallback to
+	running directly. Multiple buttons can be defined by providing the flag
+	multiple times.
+
+*-Z, --button-dismiss-no-terminal* <text> <action>
+	Create a button with the text _text_ that executes _action_ when pressed,
+	and dismisses swaynag. _action_ will be run directly instead of in a
+	terminal. Multiple buttons can be defined by providing the flag multiple
+	times.
+
 *-c, --config* <path>
 	The config file to use. By default, the following paths are checked:
 	_$HOME/.swaynag/config_, _$XDG\_CONFIG\_HOME/swaynag/config_, and

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -76,6 +76,11 @@ static void swaynag_button_execute(struct swaynag *swaynag,
 			}
 			_exit(EXIT_SUCCESS);
 		}
+
+		if (button->dismiss) {
+			swaynag->run_display = false;
+		}
+
 		if (waitpid(pid, NULL, 0) < 0) {
 			sway_log_errno(SWAY_DEBUG, "waitpid failed");
 		}


### PR DESCRIPTION
I don't love -z / -Z, but I figure this patch is far from being
accepted for other reasons too.