### PR TITLE
input/cursor: don't send wl_pointer.motion event on pointer unlock warp

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1244,6 +1244,10 @@ static void warp_to_constraint_cursor_hint(struct sway_cursor *cursor) {
 		double ly = sy + con->content_y - view->geometry.y;
 
 		wlr_cursor_warp(cursor->cursor, NULL, lx, ly);
+
+		// Warp the pointer as well, so that on the next pointer rebase we don't
+		// send an unexpected synthetic motion event to clients.
+		wlr_seat_pointer_warp(constraint->seat, sx, sy);
 	}
 }
 


### PR DESCRIPTION
On warping to a cursor hint, update the pointer position we track as well, so that on the next pointer rebase we don't send an unexpected synthetic motion event to clients.

Fixes #5405.

---

Refs https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/20, awaiting clarification on that end but figured I should bring up a patch for testing/review earlier. I don't have any games/applications that require this patch, so it hasn't been tested by me (hoping to get someone affected by the issue to give it a shot).

If the plan is to tag Sway 1.5 in the near-ish future, I think we should either (temporarily) revert https://github.com/swaywm/sway/commit/6ea45395c70939a6d855736cabfe75ad9cf4a0ae or apply something along the lines of this patch. The slight cosmetic improvement https://github.com/swaywm/sway/commit/6ea45395c70939a6d855736cabfe75ad9cf4a0ae provides (+ making clicks post-`swaymsg cursor move` click the right location) is probably not worth breaking applications that rely on not seeing a motion event post-unlock.

(Tacking onto 1.5 milestone so that it doesn't get lost.)