### PR TITLE
swaynag: sway_abort on failure to properly register

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -445,7 +445,10 @@ void swaynag_setup(struct swaynag *swaynag) {
 
 	struct wl_registry *registry = wl_display_get_registry(swaynag->display);
 	wl_registry_add_listener(registry, &registry_listener, swaynag);
-	wl_display_roundtrip(swaynag->display);
+	if (wl_display_roundtrip(swaynag->display) < 0) {
+		sway_abort("failed to register with the wayland display");
+	}
+
 	assert(swaynag->compositor && swaynag->layer_shell && swaynag->shm);
 
 	while (swaynag->querying_outputs > 0) {


### PR DESCRIPTION
In case `wl_display_roundtrip` returns an error after registering for
events, print an more user-friendly error message and exit.

Previously, if the build did not have assertions enabled, this would
likely result in a segfault. With assertions enabled, it's not user
friendly to terminate with internal implementation information.

As discussed with @kennylevinsen 