### PR TITLE
swaybar: ensure correct init order for status_line

### DIFF
--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -413,10 +413,6 @@ bool bar_setup(struct swaybar *bar, const char *socket_path) {
 	if (!ipc_initialize(bar)) {
 		return false;
 	}
-	if (bar->config->status_command) {
-		bar->status = status_line_init(bar->config->status_command);
-		bar->status->bar = bar;
-	}
 
 	bar->display = wl_display_connect(NULL);
 	if (!bar->display) {
@@ -443,6 +439,11 @@ bool bar_setup(struct swaybar *bar, const char *socket_path) {
 		pointer->cursor_surface =
 			wl_compositor_create_surface(bar->compositor);
 		assert(pointer->cursor_surface);
+	}
+
+	if (bar->config->status_command) {
+		bar->status = status_line_init(bar->config->status_command);
+		bar->status->bar = bar;
 	}
 
 #if HAVE_TRAY

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#include <assert.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <json.h>
@@ -153,6 +154,8 @@ struct status_line *status_line_init(char *cmd) {
 		exit(1);
 	}
 
+	assert(!getenv("WAYLAND_SOCKET") && "display must be initialized before "
+		" starting `status-command`; WAYLAND_SOCKET should not be set");
 	status->pid = fork();
 	if (status->pid == 0) {
 		dup2(pipe_read_fd[1], STDOUT_FILENO);


### PR DESCRIPTION
    `$WAYLAND_SOCKET` is unset by `wl_display_connect` after it has
    successfully connected to the wayland socket.
    
    However, subprocesses spawned by swaybar (status-command) don't have
    access to waybar's fds as $WAYLAND_SOCKET is O_CLOEXEC. This means any
    status command which itself tries to connect to wayland will fail if
    this environment variable is set.
    
    Reorder display and status-command initialization so that this variable
    is not set and add an assert so we can enforce this invariant in future.