### PR TITLE
view: fix surface_new_subsurface use-after-free

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -949,6 +949,7 @@ void view_child_destroy(struct sway_view_child *child) {
 	wl_list_remove(&child->surface_commit.link);
 	wl_list_remove(&child->surface_destroy.link);
 	wl_list_remove(&child->view_unmap.link);
+	wl_list_remove(&child->surface_new_subsurface.link);
 
 	if (child->impl && child->impl->destroy) {
 		child->impl->destroy(child);


### PR DESCRIPTION
Hopefully fixes #5321. I tried reproducing #5309 this morning but got the other crash instead. 

Previously I could somewhat sporadically crash either FF77 or sway by middle clicking. After the patch I tried spamming middle click for a little while and wasn't able to crash either, but I don't have a 100% reliable reproduction method to test with.

Asan seems to indicate the problem was a surface_new_subsurface listener remaining after the popup was destroyed, and in my debug output just before the abort I also have a "New xdg_shell popup" message every 16~17ms it seems which is probably related to whatever triggers the crash. (1 every frame for some reason? My middle mouse button is a bit jank which might cause that, I don't know.)

Small patch, but a first attempt with Asan. PTAL.