### PR TITLE
Clip surfaces to container

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -395,7 +395,7 @@ struct sway_container *container_at(struct sway_workspace *workspace,
 	}
 	// Tiling (focused)
 	if (focus && focus->view && !is_floating) {
-		if ((c = surface_at_view(focus, lx, ly, surface, sx, sy))) {
+		if ((c = view_container_at(&focus->node, lx, ly, surface, sx, sy))) {
 			return c;
 		}
 	}


### PR DESCRIPTION
This draft PR attempts to clip surfaces to their configured size if applicable.

Works by clamping box dimensions to the view size with fmin. Maybe we could just use the view width/height instead and flat out ignore the surface dimensions.

## TODO
- [X] ~~Squeeze toplevels (unintentional feature)~~ fixed
- [X] Clip toplevels
- [X] Verify transformations (tested 90 degrees at least)
- [X] Verify layer shell/xwayland/popups