### PR TITLE
grimshot: fix POSIX compliance

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -14,7 +14,7 @@
 
 getTargetDirectory() {
   test -f ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs && \
-    source ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs
+    . ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs
 
   echo ${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}
 }


### PR DESCRIPTION
`source` is not POSIX compliant, '`.`' is.
https://stackoverflow.com/a/11588629

Take together with #5465 

The reason this didn't bubble up before might be that `/bin/sh` resolves to `/bin/bash` for some people?