### PR TITLE
input: disable events for map_to_output devices when output not present

### DIFF
--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -44,9 +44,11 @@ void input_manager_configure_xcursor(void);
 
 void input_manager_apply_input_config(struct input_config *input_config);
 
+void input_manager_configure_all_inputs(void);
+
 void input_manager_reset_input(struct sway_input_device *input_device);
 
-void input_manager_reset_all_inputs();
+void input_manager_reset_all_inputs(void);
 
 void input_manager_apply_seat_config(struct seat_config *seat_config);
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -481,14 +481,7 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	// Reconfigure all devices, since input config may have been applied before
 	// this output came online, and some config items (like map_to_output) are
 	// dependent on an output being present.
-	struct sway_input_device *input_device = NULL;
-	wl_list_for_each(input_device, &server.input->devices, link) {
-		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &server.input->seats, link) {
-			seat_configure_device(seat, input_device);
-		}
-	}
-
+	input_manager_configure_all_inputs();
 	return true;
 }
 

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -521,6 +521,22 @@ static void retranslate_keysyms(struct input_config *input_config) {
 	}
 }
 
+static void input_manager_configure_input(
+		struct sway_input_device *input_device) {
+	sway_input_configure_libinput_device(input_device);
+	struct sway_seat *seat = NULL;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		seat_configure_device(seat, input_device);
+	}
+}
+
+void input_manager_configure_all_inputs(void) {
+	struct sway_input_device *input_device = NULL;
+	wl_list_for_each(input_device, &server.input->devices, link) {
+		input_manager_configure_input(input_device);
+	}
+}
+
 void input_manager_apply_input_config(struct input_config *input_config) {
 	struct sway_input_device *input_device = NULL;
 	bool wildcard = strcmp(input_config->identifier, "*") == 0;
@@ -531,11 +547,7 @@ void input_manager_apply_input_config(struct input_config *input_config) {
 		if (strcmp(input_device->identifier, input_config->identifier) == 0
 				|| wildcard
 				|| type_matches) {
-			sway_input_configure_libinput_device(input_device);
-			struct sway_seat *seat = NULL;
-			wl_list_for_each(seat, &server.input->seats, link) {
-				seat_configure_device(seat, input_device);
-			}
+			input_manager_configure_input(input_device);
 		}
 	}
 
@@ -550,7 +562,7 @@ void input_manager_reset_input(struct sway_input_device *input_device) {
 	}
 }
 
-void input_manager_reset_all_inputs() {
+void input_manager_reset_all_inputs(void) {
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &server.input->devices, link) {
 		input_manager_reset_input(input_device);
@@ -567,7 +579,6 @@ void input_manager_reset_all_inputs() {
 		}
 	}
 }
-
 
 void input_manager_apply_seat_config(struct seat_config *seat_config) {
 	sway_log(SWAY_DEBUG, "applying seat config for seat %s", seat_config->name);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -266,6 +266,11 @@ void output_disable(struct sway_output *output) {
 	output->current_mode = NULL;
 
 	arrange_root();
+
+	// Reconfigure all devices, since devices with map_to_output directives for
+	// an output that goes offline should stop sending events as long as the
+	// output remains offline.
+	input_manager_configure_all_inputs();
 }
 
 void output_begin_destroy(struct sway_output *output) {


### PR DESCRIPTION
Fixes #3449.

---

Tested with a pointer device, since I do not have a libinput recent enough to contain https://gitlab.freedesktop.org/libinput/libinput/-/commit/0d06bfc4e27bf4a56a7f34b3f20c4a61570e765c.