### PR TITLE
Introduce list_for_each utility macro

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -27,6 +27,11 @@ void list_swap(list_t *list, int src, int dest);
 // move item to end of list
 void list_move_to_end(list_t *list, void *item);
 
+#define list_for_each(e, list)											\
+	for (__typeof__(e) *p = (__typeof__(e) *) (list)->items, (e) = *p;	\
+			(void **) p < ((list)->items + (list)->length);				\
+			p++, (e) = *p)
+
 /* Calls `free` for each item in the list, then frees the list.
  * Do not use this to free lists of primitives or items that require more
  * complicated deallocation code.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -294,8 +294,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 					cmd_results_new(CMD_FAILURE, "No matching node."));
 		} else {
 			struct cmd_results *fail_res = NULL;
-			for (int i = 0; i < containers->length; ++i) {
-				struct sway_container *container = containers->items[i];
+			struct sway_container *container;
+			list_for_each(container, containers) {
 				set_config_node(&container->node);
 				struct cmd_results *res = handler->handle(argc-1, argv+1);
 				if (res->status == CMD_SUCCESS) {
@@ -527,8 +527,8 @@ void free_cmd_results(struct cmd_results *results) {
 
 char *cmd_results_to_json(list_t *res_list) {
 	json_object *result_array = json_object_new_array();
-	for (int i = 0; i < res_list->length; ++i) {
-		struct cmd_results *results = res_list->items[i];
+	struct cmd_results *results;
+	list_for_each(results, res_list) {
 		json_object *root = json_object_new_object();
 		json_object_object_add(root, "success",
 				json_object_new_boolean(results->status == CMD_SUCCESS));

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -59,8 +59,8 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 
 	char *id = NULL;
 	if (strcmp(argv[0], "id") != 0 && is_subcommand(argv[1])) {
-		for (int i = 0; i < config->bars->length; ++i) {
-			struct bar_config *item = config->bars->items[i];
+		struct bar_config *item;
+		list_for_each(item, config->bars) {
 			if (strcmp(item->id, argv[0]) == 0) {
 				sway_log(SWAY_DEBUG, "Selecting bar: %s", argv[0]);
 				config->current_bar = item;

--- a/sway/commands/bar/hidden_state.c
+++ b/sway/commands/bar/hidden_state.c
@@ -58,8 +58,8 @@ struct cmd_results *bar_cmd_hidden_state(int argc, char **argv) {
 		error = bar_set_hidden_state(config->current_bar, state);
 	} else {
 		const char *id = argc == 2 ? argv[1] : NULL;
-		for (int i = 0; i < config->bars->length; ++i) {
-			struct bar_config *bar = config->bars->items[i];
+		struct bar_config *bar;
+		list_for_each(bar, config->bars) {
 			if (id) {
 				if (strcmp(id, bar->id) == 0) {
 					error = bar_set_hidden_state(bar, state);

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -17,8 +17,8 @@ struct cmd_results *bar_cmd_id(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "id cannot be 'id'");
 	}
 	// check if id is used by a previously defined bar
-	for (int i = 0; i < config->bars->length; ++i) {
-		struct bar_config *find = config->bars->items[i];
+	struct bar_config *find;
+	list_for_each(find, config->bars) {
 		if (strcmp(name, find->id) == 0 && config->current_bar != find) {
 			return cmd_results_new(CMD_FAILURE,
 					"Id '%s' already defined for another bar. Id unchanged (%s).",

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -62,8 +62,8 @@ struct cmd_results *bar_cmd_mode(int argc, char **argv) {
 		error = bar_set_mode(config->current_bar, mode);
 	} else {
 		const char *id = argc == 2 ? argv[1] : NULL;
-		for (int i = 0; i < config->bars->length; ++i) {
-			struct bar_config *bar = config->bars->items[i];
+		struct bar_config *bar;
+		list_for_each(bar, config->bars) {
 			if (id) {
 				if (strcmp(id, bar->id) == 0) {
 					error = bar_set_mode(bar, mode);

--- a/sway/commands/bar/modifier.c
+++ b/sway/commands/bar/modifier.c
@@ -13,18 +13,19 @@ struct cmd_results *bar_cmd_modifier(int argc, char **argv) {
 	uint32_t mod = 0;
 	if (strcmp(argv[0], "none") != 0) {
 		list_t *split = split_string(argv[0], "+");
-		for (int i = 0; i < split->length; ++i) {
+		char *name;
+		list_for_each(name, split) {
 			uint32_t tmp_mod;
-			if ((tmp_mod = get_modifier_mask_by_name(split->items[i])) > 0) {
+			if ((tmp_mod = get_modifier_mask_by_name(name)) > 0) {
 				mod |= tmp_mod;
-			} else if (strcmp(split->items[i], "none") == 0) {
+			} else if (strcmp(name, "none") == 0) {
 				error = cmd_results_new(CMD_INVALID,
 						"none cannot be used along with other modifiers");
 				list_free_items_and_destroy(split);
 				return error;
 			} else {
 				error = cmd_results_new(CMD_INVALID,
-					"Unknown modifier '%s'", (char *)split->items[i]);
+					"Unknown modifier '%s'", name);
 				list_free_items_and_destroy(split);
 				return error;
 			}

--- a/sway/commands/client.c
+++ b/sway/commands/client.c
@@ -47,8 +47,8 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	if (config->active) {
 		root_for_each_container(rebuild_textures_iterator, NULL);
 
-		for (int i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
+		struct sway_output *output;
+		list_for_each(output, root->outputs) {
 			output_damage_whole(output);
 		}
 	}

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -17,8 +17,8 @@ static void rebuild_textures_iterator(struct sway_container *con, void *data) {
 static void do_reload(void *data) {
 	// store bar ids to check against new bars for barconfig_update events
 	list_t *bar_ids = create_list();
-	for (int i = 0; i < config->bars->length; ++i) {
-		struct bar_config *bar = config->bars->items[i];
+	struct bar_config *bar;
+	list_for_each(bar, config->bars) {
 		list_add(bar_ids, strdup(bar->id));
 	}
 
@@ -32,10 +32,10 @@ static void do_reload(void *data) {
 
 	load_swaybars();
 
-	for (int i = 0; i < config->bars->length; ++i) {
-		struct bar_config *bar = config->bars->items[i];
-		for (int j = 0; j < bar_ids->length; ++j) {
-			if (strcmp(bar->id, bar_ids->items[j]) == 0) {
+	list_for_each(bar, config->bars) {
+		char *bar_id;
+		list_for_each(bar_id, bar_ids) {
+			if (strcmp(bar->id, bar_id) == 0) {
 				ipc_event_barconfig_update(bar);
 				break;
 			}

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -26,8 +26,8 @@ struct cmd_results *cmd_show_marks(int argc, char **argv) {
 		root_for_each_container(rebuild_marks_iterator, NULL);
 	}
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_damage_whole(output);
 	}
 

--- a/sway/commands/title_align.c
+++ b/sway/commands/title_align.c
@@ -21,8 +21,8 @@ struct cmd_results *cmd_title_align(int argc, char **argv) {
 				"Expected 'title_align left|center|right'");
 	}
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_damage_whole(output);
 	}
 

--- a/sway/commands/titlebar_border_thickness.c
+++ b/sway/commands/titlebar_border_thickness.c
@@ -19,8 +19,8 @@ struct cmd_results *cmd_titlebar_border_thickness(int argc, char **argv) {
 
 	config->titlebar_border_thickness = value;
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		struct sway_workspace *ws = output_get_active_workspace(output);
 		if (!sway_assert(ws, "Expected output to have a workspace")) {
 			return cmd_results_new(CMD_FAILURE,

--- a/sway/commands/titlebar_padding.c
+++ b/sway/commands/titlebar_padding.c
@@ -30,8 +30,8 @@ struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
 	config->titlebar_v_padding = v_value;
 	config->titlebar_h_padding = h_value;
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		arrange_workspace(output_get_active_workspace(output));
 		output_damage_whole(output);
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -59,26 +59,30 @@ static void free_mode(struct sway_mode *mode) {
 	}
 	free(mode->name);
 	if (mode->keysym_bindings) {
-		for (int i = 0; i < mode->keysym_bindings->length; i++) {
-			free_sway_binding(mode->keysym_bindings->items[i]);
+		struct sway_binding *binding;
+		list_for_each(binding, mode->keysym_bindings) {
+			free_sway_binding(binding);
 		}
 		list_free(mode->keysym_bindings);
 	}
 	if (mode->keycode_bindings) {
-		for (int i = 0; i < mode->keycode_bindings->length; i++) {
-			free_sway_binding(mode->keycode_bindings->items[i]);
+		struct sway_binding *binding;
+		list_for_each(binding, mode->keycode_bindings) {
+			free_sway_binding(binding);
 		}
 		list_free(mode->keycode_bindings);
 	}
 	if (mode->mouse_bindings) {
-		for (int i = 0; i < mode->mouse_bindings->length; i++) {
-			free_sway_binding(mode->mouse_bindings->items[i]);
+		struct sway_binding *binding;
+		list_for_each(binding, mode->mouse_bindings) {
+			free_sway_binding(binding);
 		}
 		list_free(mode->mouse_bindings);
 	}
 	if (mode->switch_bindings) {
-		for (int i = 0; i < mode->switch_bindings->length; i++) {
-			free_switch_binding(mode->switch_bindings->items[i]);
+		struct sway_switch_binding *binding;
+		list_for_each(binding, mode->switch_bindings) {
+			free_switch_binding(binding);
 		}
 		list_free(mode->switch_bindings);
 	}

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -264,8 +264,8 @@ void load_swaybar(struct bar_config *bar) {
 }
 
 void load_swaybars(void) {
-	for (int i = 0; i < config->bars->length; ++i) {
-		struct bar_config *bar = config->bars->items[i];
+	struct bar_config *bar;
+	list_for_each(bar, config->bars) {
 		load_swaybar(bar);
 	}
 }

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -175,8 +175,8 @@ static bool validate_xkb_merge(struct input_config *dest,
 
 static bool validate_wildcard_on_all(struct input_config *wildcard,
 		char **error) {
-	for (int i = 0; i < config->input_configs->length; i++) {
-		struct input_config *ic = config->input_configs->items[i];
+	struct input_config *ic;
+	list_for_each(ic, config->input_configs) {
 		if (strcmp(wildcard->identifier, ic->identifier) != 0) {
 			sway_log(SWAY_DEBUG, "Validating xkb merge of * on %s",
 					ic->identifier);
@@ -186,8 +186,7 @@ static bool validate_wildcard_on_all(struct input_config *wildcard,
 		}
 	}
 
-	for (int i = 0; i < config->input_type_configs->length; i++) {
-		struct input_config *ic = config->input_type_configs->items[i];
+	list_for_each(ic, config->input_type_configs) {
 		sway_log(SWAY_DEBUG, "Validating xkb merge of * config on %s",
 				ic->identifier);
 		if (!validate_xkb_merge(ic, wildcard, error)) {
@@ -199,16 +198,15 @@ static bool validate_wildcard_on_all(struct input_config *wildcard,
 }
 
 static void merge_wildcard_on_all(struct input_config *wildcard) {
-	for (int i = 0; i < config->input_configs->length; i++) {
-		struct input_config *ic = config->input_configs->items[i];
+	struct input_config *ic;
+	list_for_each(ic, config->input_configs) {
 		if (strcmp(wildcard->identifier, ic->identifier) != 0) {
 			sway_log(SWAY_DEBUG, "Merging input * config on %s", ic->identifier);
 			merge_input_config(ic, wildcard);
 		}
 	}
 
-	for (int i = 0; i < config->input_type_configs->length; i++) {
-		struct input_config *ic = config->input_type_configs->items[i];
+	list_for_each(ic, config->input_type_configs) {
 		sway_log(SWAY_DEBUG, "Merging input * config on %s", ic->identifier);
 		merge_input_config(ic, wildcard);
 	}
@@ -216,8 +214,8 @@ static void merge_wildcard_on_all(struct input_config *wildcard) {
 
 static bool validate_type_on_existing(struct input_config *type_wildcard,
 		char **error) {
-	for (int i = 0; i < config->input_configs->length; i++) {
-		struct input_config *ic = config->input_configs->items[i];
+	struct input_config *ic;
+	list_for_each(ic, config->input_configs) {
 		if (ic->input_type == NULL) {
 			continue;
 		}
@@ -234,8 +232,8 @@ static bool validate_type_on_existing(struct input_config *type_wildcard,
 }
 
 static void merge_type_on_existing(struct input_config *type_wildcard) {
-	for (int i = 0; i < config->input_configs->length; i++) {
-		struct input_config *ic = config->input_configs->items[i];
+	struct input_config *ic;
+	list_for_each(ic, config->input_configs) {
 		if (ic->input_type == NULL) {
 			continue;
 		}
@@ -284,8 +282,8 @@ struct input_config *store_input_config(struct input_config *ic,
 	}
 
 	if (!current && !wildcard && !type && set_input_type(ic)) {
-		for (i = 0; i < config->input_type_configs->length; i++) {
-			struct input_config *tc = config->input_type_configs->items[i];
+		struct input_config *tc;
+		list_for_each(tc, config->input_type_configs) {
 			if (strcmp(ic->input_type, tc->identifier + 5) == 0) {
 				current = new_input_config(ic->identifier);
 				current->input_type = ic->input_type;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -126,8 +126,8 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 }
 
 static void merge_wildcard_on_all(struct output_config *wildcard) {
-	for (int i = 0; i < config->output_configs->length; i++) {
-		struct output_config *oc = config->output_configs->items[i];
+	struct output_config *oc;
+	list_for_each(oc, config->output_configs) {
 		if (strcmp(wildcard->name, oc->name) != 0) {
 			sway_log(SWAY_DEBUG, "Merging output * config on %s", oc->name);
 			merge_output_config(oc, wildcard);

--- a/sway/desktop/desktop.c
+++ b/sway/desktop/desktop.c
@@ -4,8 +4,8 @@
 
 void desktop_damage_surface(struct wlr_surface *surface, double lx, double ly,
 		bool whole) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		struct wlr_box *output_box = wlr_output_layout_get_box(
 			root->output_layout, output->wlr_output);
 		output_damage_surface(output, lx - output_box->x,
@@ -14,15 +14,15 @@ void desktop_damage_surface(struct wlr_surface *surface, double lx, double ly,
 }
 
 void desktop_damage_whole_container(struct sway_container *con) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_damage_whole_container(output, con);
 	}
 }
 
 void desktop_damage_box(struct wlr_box *box) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_damage_box(output, box);
 	}
 }

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -235,8 +235,8 @@ void arrange_layers(struct sway_output *output) {
 
 static struct sway_layer_surface *find_mapped_layer_by_client(
 		struct wl_client *client, struct wlr_output *ignore_output) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		if (output->wlr_output == ignore_output) {
 			continue;
 		}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -31,8 +31,8 @@
 #include "sway/tree/workspace.h"
 
 struct sway_output *output_by_name_or_id(const char *name_or_id) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		char identifier[128];
 		output_get_identifier(identifier, sizeof(identifier), output);
 		if (strcasecmp(identifier, name_or_id) == 0
@@ -370,9 +370,8 @@ static void output_for_each_surface(struct sway_output *output,
 
 		// TODO: Show transient containers for fullscreen global
 		if (fullscreen_con == workspace->current.fullscreen) {
-			for (int i = 0; i < workspace->current.floating->length; ++i) {
-				struct sway_container *floater =
-					workspace->current.floating->items[i];
+			struct sway_container *floater;
+			list_for_each(floater, workspace->current.floating) {
 				if (container_is_transient_for(floater, fullscreen_con)) {
 					for_each_surface_container_iterator(floater, &data);
 				}
@@ -515,9 +514,8 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
-	for (int i = 0; i < workspace->current.floating->length; ++i) {
-		struct sway_container *floater =
-			workspace->current.floating->items[i];
+	struct sway_container *floater;
+	list_for_each(floater, workspace->current.floating) {
 		if (container_is_transient_for(floater, view->container)) {
 			return false;
 		}

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -697,9 +697,8 @@ static void render_container(struct sway_output *output,
  */
 static void render_containers_linear(struct sway_output *output,
 		pixman_region32_t *damage, struct parent_data *parent) {
-	for (int i = 0; i < parent->children->length; ++i) {
-		struct sway_container *child = parent->children->items[i];
-
+	struct sway_container *child;
+	list_for_each(child, parent->children) {
 		if (child->view) {
 			struct sway_view *view = child->view;
 			struct border_colors *colors;
@@ -960,15 +959,15 @@ static void render_floating_container(struct sway_output *soutput,
 
 static void render_floating(struct sway_output *soutput,
 		pixman_region32_t *damage) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
-		for (int j = 0; j < output->current.workspaces->length; ++j) {
-			struct sway_workspace *ws = output->current.workspaces->items[j];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
+		struct sway_workspace *ws;
+		list_for_each(ws, output->current.workspaces) {
 			if (!workspace_is_visible(ws)) {
 				continue;
 			}
-			for (int k = 0; k < ws->current.floating->length; ++k) {
-				struct sway_container *floater = ws->current.floating->items[k];
+			struct sway_container *floater;
+			list_for_each(floater, ws->current.floating) {
 				if (floater->fullscreen_mode != FULLSCREEN_NONE) {
 					continue;
 				}

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -125,8 +125,8 @@ const char *input_device_get_type(struct sway_input_device *device) {
 static void apply_input_type_config(struct sway_input_device *input_device) {
 	const char *device_type = input_device_get_type(input_device);
 	struct input_config *type_config = NULL;
-	for (int i = 0; i < config->input_type_configs->length; i++) {
-		struct input_config *ic = config->input_type_configs->items[i];
+	struct input_config *ic;
+	list_for_each(ic, config->input_type_configs) {
 		if (strcmp(ic->identifier + 5, device_type) == 0) {
 			type_config = ic;
 			break;

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -588,8 +588,8 @@ static int handle_keyboard_repeat(void *data) {
 }
 
 static void determine_bar_visibility(uint32_t modifiers) {
-	for (int i = 0; i < config->bars->length; ++i) {
-		struct bar_config *bar = config->bars->items[i];
+	struct bar_config *bar;
+	list_for_each(bar, config->bars) {
 		if (bar->modifier == 0) {
 			continue;
 		}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -928,8 +928,8 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 		}
 	}
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *sway_output = root->outputs->items[i];
+	struct sway_output *sway_output;
+	list_for_each(sway_output, root->outputs) {
 		struct wlr_output *output = sway_output->wlr_output;
 		bool result =
 			wlr_xcursor_manager_load(seat->cursor->xcursor_manager,
@@ -1210,8 +1210,8 @@ void seat_set_exclusive_client(struct sway_seat *seat,
 		seat->exclusive_client = client;
 		// Triggers a refocus of the topmost surface layer if necessary
 		// TODO: Make layer surface focus per-output based on cursor position
-		for (int i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
+		struct sway_output *output;
+		list_for_each(output, root->outputs) {
 			arrange_layers(output);
 		}
 		return;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -715,38 +715,36 @@ json_object *ipc_json_describe_node(struct sway_node *node) {
 
 json_object *ipc_json_describe_node_recursive(struct sway_node *node) {
 	json_object *object = ipc_json_describe_node(node);
-	int i;
 
 	json_object *children = json_object_new_array();
 	switch (node->type) {
 	case N_ROOT:
 		json_object_array_add(children,
 				ipc_json_describe_scratchpad_output());
-		for (i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
+		struct sway_output *output;
+		list_for_each(output, root->outputs) {
 			json_object_array_add(children,
 					ipc_json_describe_node_recursive(&output->node));
 		}
 		break;
-	case N_OUTPUT:
-		for (i = 0; i < node->sway_output->workspaces->length; ++i) {
-			struct sway_workspace *ws = node->sway_output->workspaces->items[i];
+	case N_OUTPUT:;
+		struct sway_workspace *ws;
+		list_for_each(ws, node->sway_output->workspaces) {
 			json_object_array_add(children,
 					ipc_json_describe_node_recursive(&ws->node));
 		}
 		break;
-	case N_WORKSPACE:
-		for (i = 0; i < node->sway_workspace->tiling->length; ++i) {
-			struct sway_container *con = node->sway_workspace->tiling->items[i];
+	case N_WORKSPACE:;
+		struct sway_container *con;
+		list_for_each(con, node->sway_workspace->tiling) {
 			json_object_array_add(children,
 					ipc_json_describe_node_recursive(&con->node));
 		}
 		break;
 	case N_CONTAINER:
 		if (node->sway_container->children) {
-			for (i = 0; i < node->sway_container->children->length; ++i) {
-				struct sway_container *child =
-					node->sway_container->children->items[i];
+			struct sway_container *child;
+			list_for_each(child, node->sway_container->children) {
 				json_object_array_add(children,
 						ipc_json_describe_node_recursive(&child->node));
 			}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -668,8 +668,8 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 	case IPC_GET_OUTPUTS:
 	{
 		json_object *outputs = json_object_new_array();
-		for (int i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
+		struct sway_output *output;
+		list_for_each(output, root->outputs) {
 			json_object *output_json = ipc_json_describe_node(&output->node);
 
 			// override the default focused indicator because it's set
@@ -686,7 +686,6 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 			json_object_object_add(output_json, "subpixel_hinting", json_object_new_string(subpixel));
 			json_object_array_add(outputs, output_json);
 		}
-		struct sway_output *output;
 		wl_list_for_each(output, &root->all_outputs, link) {
 			if (!output->enabled && output != root->noop_output) {
 				json_object_array_add(outputs,
@@ -829,8 +828,8 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 		if (!buf[0]) {
 			// Send list of configured bar IDs
 			json_object *bars = json_object_new_array();
-			for (int i = 0; i < config->bars->length; ++i) {
-				struct bar_config *bar = config->bars->items[i];
+			struct bar_config *bar;
+			list_for_each(bar, config->bars) {
 				json_object_array_add(bars, json_object_new_string(bar->id));
 			}
 			const char *json_string = json_object_to_json_string(bars);

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -22,8 +22,8 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 	// is currently occupied
 	int new_children = 0;
 	double current_width_fraction = 0;
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	struct sway_container *child;
+	list_for_each(child, children) {
 		current_width_fraction += child->width_fraction;
 		if (child->width_fraction <= 0) {
 			new_children += 1;
@@ -32,8 +32,7 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 
 	// Calculate each height fraction
 	double total_width_fraction = 0;
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	list_for_each(child, children) {
 		if (child->width_fraction <= 0) {
 			if (current_width_fraction <= 0) {
 				child->width_fraction = 1.0;
@@ -47,14 +46,13 @@ static void apply_horiz_layout(list_t *children, struct wlr_box *parent) {
 		total_width_fraction += child->width_fraction;
 	}
 	// Normalize width fractions so the sum is 1.0
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	list_for_each(child, children) {
 		child->width_fraction /= total_width_fraction;
 	}
 
 	// Calculate gap size
 	double inner_gap = 0;
-	struct sway_container *child = children->items[0];
+	child = children->items[0];
 	struct sway_workspace *ws = child->workspace;
 	if (ws) {
 		inner_gap = ws->gaps_inner;
@@ -189,8 +187,8 @@ static void apply_stacked_layout(list_t *children, struct wlr_box *parent) {
 	if (!children->length) {
 		return;
 	}
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	struct sway_container *child;
+	list_for_each(child, children) {
 		int parent_offset = child->view ?  0 :
 			container_titlebar_height() * children->length;
 		child->x = parent->x;
@@ -201,8 +199,8 @@ static void apply_stacked_layout(list_t *children, struct wlr_box *parent) {
 }
 
 static void arrange_floating(list_t *floating) {
-	for (int i = 0; i < floating->length; ++i) {
-		struct sway_container *floater = floating->items[i];
+	struct sway_container *floater;
+	list_for_each(floater, floating) {
 		arrange_container(floater);
 	}
 }
@@ -229,8 +227,8 @@ static void arrange_children(list_t *children,
 	}
 
 	// Recurse into child containers
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	struct sway_container *child;
+	list_for_each(child, children) {
 		arrange_container(child);
 	}
 }
@@ -275,8 +273,8 @@ void arrange_workspace(struct sway_workspace *workspace) {
 	double diff_x = workspace->x - prev_x;
 	double diff_y = workspace->y - prev_y;
 	if (!first_arrange && (diff_x != 0 || diff_y != 0)) {
-		for (int i = 0; i < workspace->floating->length; ++i) {
-			struct sway_container *floater = workspace->floating->items[i];
+		struct sway_container *floater;
+		list_for_each(floater, workspace->floating) {
 			container_floating_translate(floater, diff_x, diff_y);
 			double center_x = floater->x + floater->width / 2;
 			double center_y = floater->y + floater->height / 2;
@@ -318,8 +316,8 @@ void arrange_output(struct sway_output *output) {
 	output->width = output_box->width;
 	output->height = output_box->height;
 
-	for (int i = 0; i < output->workspaces->length; ++i) {
-		struct sway_workspace *workspace = output->workspaces->items[i];
+	struct sway_workspace *workspace;
+	list_for_each(workspace, output->workspaces) {
 		arrange_workspace(workspace);
 	}
 }
@@ -343,8 +341,8 @@ void arrange_root(void) {
 		fs->height = root->height;
 		arrange_container(fs);
 	} else {
-		for (int i = 0; i < root->outputs->length; ++i) {
-			struct sway_output *output = root->outputs->items[i];
+		struct sway_output *output;
+		list_for_each(output, root->outputs) {
 			arrange_output(output);
 		}
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -154,8 +154,8 @@ struct sway_container *container_find_child(struct sway_container *container,
 	if (!container->children) {
 		return NULL;
 	}
-	for (int i = 0; i < container->children->length; ++i) {
-		struct sway_container *child = container->children->items[i];
+	struct sway_container *child;
+	list_for_each(child, container->children) {
 		if (test(child, data)) {
 			return child;
 		}
@@ -272,8 +272,8 @@ static struct sway_container *container_at_linear(struct sway_node *parent,
 		double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	list_t *children = node_get_children(parent);
-	for (int i = 0; i < children->length; ++i) {
-		struct sway_container *child = children->items[i];
+	struct sway_container *child;
+	list_for_each(child, children) {
 		struct sway_container *container =
 			tiling_container_at(&child->node, lx, ly, surface, sx, sy);
 		if (container) {
@@ -409,8 +409,8 @@ void container_for_each_child(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data),
 		void *data) {
 	if (container->children)  {
-		for (int i = 0; i < container->children->length; ++i) {
-			struct sway_container *child = container->children->items[i];
+		struct sway_container *child;
+		list_for_each(child, container->children) {
 			f(child, data);
 			container_for_each_child(child, f, data);
 		}
@@ -429,8 +429,8 @@ bool container_has_ancestor(struct sway_container *descendant,
 }
 
 void container_damage_whole(struct sway_container *container) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_damage_whole_container(output, container);
 	}
 }
@@ -853,8 +853,8 @@ void container_floating_translate(struct sway_container *con,
 	con->content_y += y_amount;
 
 	if (con->children) {
-		for (int i = 0; i < con->children->length; ++i) {
-			struct sway_container *child = con->children->items[i];
+		struct sway_container *child;
+		list_for_each(child, con->children) {
 			container_floating_translate(child, x_amount, y_amount);
 		}
 	}
@@ -1153,8 +1153,8 @@ void container_discover_outputs(struct sway_container *con) {
 	};
 	struct sway_output *old_output = container_get_effective_output(con);
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		struct wlr_box output_box;
 		output_get_box(output, &output_box);
 		struct wlr_box intersection;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -68,8 +68,8 @@ static void restore_workspaces(struct sway_output *output) {
 		// outside of the output's bounds, do the same as the output layout has
 		// likely changed and the maximum size needs to be checked and the
 		// floater re-centered
-		for (int i = 0; i < ws->floating->length; i++) {
-			struct sway_container *floater = ws->floating->items[i];
+		struct sway_container *floater;
+		list_for_each(floater, ws->floating) {
 			if (floater->width == 0 || floater->height == 0 ||
 					floater->width > output->width ||
 					floater->height > output->height ||

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -342,22 +342,22 @@ void root_remove_workspace_pid(pid_t pid) {
 
 void root_for_each_workspace(void (*f)(struct sway_workspace *ws, void *data),
 		void *data) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_for_each_workspace(output, f, data);
 	}
 }
 
 void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 		void *data) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		output_for_each_container(output, f, data);
 	}
 
 	// Scratchpad
-	for (int i = 0; i < root->scratchpad->length; ++i) {
-		struct sway_container *container = root->scratchpad->items[i];
+	struct sway_container *container;
+	list_for_each(container, root->scratchpad) {
 		if (container_is_scratchpad_hidden(container)) {
 			f(container, data);
 			container_for_each_child(container, f, data);
@@ -365,16 +365,16 @@ void root_for_each_container(void (*f)(struct sway_container *con, void *data),
 	}
 
 	// Saved workspaces
-	for (int i = 0; i < root->noop_output->workspaces->length; ++i) {
-		struct sway_workspace *ws = root->noop_output->workspaces->items[i];
+	struct sway_workspace *ws;
+	list_for_each(ws, root->noop_output->workspaces) {
 		workspace_for_each_container(ws, f, data);
 	}
 }
 
 struct sway_output *root_find_output(
 		bool (*test)(struct sway_output *output, void *data), void *data) {
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		if (test(output, data)) {
 			return output;
 		}
@@ -385,8 +385,8 @@ struct sway_output *root_find_output(
 struct sway_workspace *root_find_workspace(
 		bool (*test)(struct sway_workspace *ws, void *data), void *data) {
 	struct sway_workspace *result = NULL;
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		if ((result = output_find_workspace(output, test, data))) {
 			return result;
 		}
@@ -397,16 +397,16 @@ struct sway_workspace *root_find_workspace(
 struct sway_container *root_find_container(
 		bool (*test)(struct sway_container *con, void *data), void *data) {
 	struct sway_container *result = NULL;
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	list_for_each(output, root->outputs) {
 		if ((result = output_find_container(output, test, data))) {
 			return result;
 		}
 	}
 
 	// Scratchpad
-	for (int i = 0; i < root->scratchpad->length; ++i) {
-		struct sway_container *container = root->scratchpad->items[i];
+	struct sway_container *container;
+	list_for_each(container, root->scratchpad) {
 		if (container_is_scratchpad_hidden(container)) {
 			if (test(container, data)) {
 				return container;
@@ -418,8 +418,8 @@ struct sway_container *root_find_container(
 	}
 
 	// Saved workspaces
-	for (int i = 0; i < root->noop_output->workspaces->length; ++i) {
-		struct sway_workspace *ws = root->noop_output->workspaces->items[i];
+	struct sway_workspace *ws;
+	list_for_each(ws, root->noop_output->workspaces) {
 		if ((result = workspace_find_container(ws, test, data))) {
 			return result;
 		}

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -21,8 +21,8 @@
 #include "util.h"
 
 struct workspace_config *workspace_find_config(const char *ws_name) {
-	for (int i = 0; i < config->workspace_configs->length; ++i) {
-		struct workspace_config *wsc = config->workspace_configs->items[i];
+	struct workspace_config *wsc;
+	list_for_each(wsc, config->workspace_configs) {
 		if (strcmp(wsc->workspace, ws_name) == 0) {
 			return wsc;
 		}
@@ -496,8 +496,8 @@ bool workspace_is_empty(struct sway_workspace *ws) {
 		return false;
 	}
 	// Sticky views are not considered to be part of this workspace
-	for (int i = 0; i < ws->floating->length; ++i) {
-		struct sway_container *floater = ws->floating->items[i];
+	struct sway_container *floater;
+	list_for_each(floater, ws->floating) {
 		if (!floater->is_sticky) {
 			return false;
 		}
@@ -588,14 +588,13 @@ void workspace_detect_urgent(struct sway_workspace *workspace) {
 void workspace_for_each_container(struct sway_workspace *ws,
 		void (*f)(struct sway_container *con, void *data), void *data) {
 	// Tiling
-	for (int i = 0; i < ws->tiling->length; ++i) {
-		struct sway_container *container = ws->tiling->items[i];
+	struct sway_container *container;
+	list_for_each(container, ws->tiling) {
 		f(container, data);
 		container_for_each_child(container, f, data);
 	}
 	// Floating
-	for (int i = 0; i < ws->floating->length; ++i) {
-		struct sway_container *container = ws->floating->items[i];
+	list_for_each(container, ws->floating) {
 		f(container, data);
 		container_for_each_child(container, f, data);
 	}
@@ -605,8 +604,8 @@ struct sway_container *workspace_find_container(struct sway_workspace *ws,
 		bool (*test)(struct sway_container *con, void *data), void *data) {
 	struct sway_container *result = NULL;
 	// Tiling
-	for (int i = 0; i < ws->tiling->length; ++i) {
-		struct sway_container *child = ws->tiling->items[i];
+	struct sway_container *child;
+	list_for_each(child, ws->tiling) {
 		if (test(child, data)) {
 			return child;
 		}
@@ -615,8 +614,7 @@ struct sway_container *workspace_find_container(struct sway_workspace *ws,
 		}
 	}
 	// Floating
-	for (int i = 0; i < ws->floating->length; ++i) {
-		struct sway_container *child = ws->floating->items[i];
+	list_for_each(child, ws->floating) {
 		if (test(child, data)) {
 			return child;
 		}


### PR DESCRIPTION
This PR introduces a `list_for_each` macro to make dealing with `list_t` more ergonomic (and less prone to swapping indices). It's based off `wl_array_for_each` from `wayland-util.h`, modified to accommodate `list_t`'s indirection.

Some existing places that I thought could benefit from the readability have been ported over, but this was best-effort and there are probably places that I've missed.

Alternative syntax possible here would be e.g.

```c
list_for_each(struct sway_container *child, container->children) {
    ...
}
```

which is one line shorter, but not symmetric with `wl_list_for_each`.