### PR TITLE
tree/view: Make foreign-toplevel app_id fallback to class

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -715,10 +715,14 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		input_manager_set_focus(&view->container->node);
 	}
 
-	const char *app_id = view_get_app_id(view);
-	if (app_id != NULL) {
+	const char *app_id;
+	const char *class;
+	if ((app_id = view_get_app_id(view)) != NULL) {
 		wlr_foreign_toplevel_handle_v1_set_app_id(
 				view->foreign_toplevel, app_id);
+	} else if ((class = view_get_class(view)) != NULL) {
+		wlr_foreign_toplevel_handle_v1_set_app_id(
+				view->foreign_toplevel, class);
 	}
 }
 


### PR DESCRIPTION
It is not a part of the foreign-toplevel-management protocol to get the class of a toplevel, only for getting the app_id.
For xwayland clients this is an issue because that means that you cannot identify what application the toplevel refers to which is the point of the app_id property.

By falling back to class when an app_id does not exist solves this problem.

Phoc also uses app_id and class interchangeably in their implementation of foreign-toplevel-management, in fact they always do that and not only for just this protocol
https://source.puri.sm/Librem5/phoc/-/blob/c8d8a4c5440a6c1647b09dbd3bba7999f9cd433c/src/xwayland.c#L236