### PR TITLE
seat: Refocus seat when wlr_drag is destroyed

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -64,6 +64,12 @@ struct sway_drag_icon {
 	struct wl_listener destroy;
 };
 
+struct sway_drag {
+	struct sway_seat *seat;
+	struct wlr_drag *wlr_drag;
+	struct wl_listener destroy;
+};
+
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct sway_cursor *cursor;


### PR DESCRIPTION
wlr_drag installs grabs for the full duration of the drag, leading to
the drag target not being focused when the drag ends. This leads to
unexpected focus behavior, especially for the keyboard which requires
toggling focus away and back to set.

We can only fix the focus once the grabs are released, so refocus the
seat when the wlr_drag destroy event is received.

Closes: https://github.com/swaywm/sway/issues/5116

Depends on: https://github.com/swaywm/wlroots/pull/2306