### PR TITLE
transaction: Mark client resize immediately ready

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -501,7 +501,7 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 		uint32_t serial) {
 	struct sway_transaction_instruction *instruction =
 		view->container->node.instruction;
-	if (instruction->serial == serial) {
+	if (instruction != NULL && instruction->serial == serial) {
 		set_instruction_ready(instruction);
 	}
 }
@@ -510,7 +510,8 @@ void transaction_notify_view_ready_by_size(struct sway_view *view,
 		int width, int height) {
 	struct sway_transaction_instruction *instruction =
 		view->container->node.instruction;
-	if (instruction->container_state.content_width == width &&
+	if (instruction != NULL &&
+			instruction->container_state.content_width == width &&
 			instruction->container_state.content_height == height) {
 		set_instruction_ready(instruction);
 	}

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -293,6 +293,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 			desktop_damage_view(view);
 			transaction_commit_dirty();
+			transaction_notify_view_ready_by_size(view,
+					new_geo.width, new_geo.height);
 		} else {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -383,6 +383,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 			desktop_damage_view(view);
 			transaction_commit_dirty();
+			transaction_notify_view_ready_by_size(view,
+					new_geo.width, new_geo.height);
 		} else {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		}


### PR DESCRIPTION
If a client commits a new size on its own, we create a transaction for
the resize like any other. However, this involves sending a configure
and waiting for the ack, and wlroots will not send configure events when
there has been no change. This leads to transactions timing out.

Instead, just mark the view ready immediately by size when the client
is already ready, so that we avoid waiting for an ack that will never
come.

Closes: https://github.com/swaywm/sway/issues/5490