### PR TITLE
 commands/move: unwrap workspace container on move to new workspace 

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -105,6 +105,9 @@ struct sway_container *workspace_find_container(struct sway_workspace *ws,
  */
 struct sway_container *workspace_wrap_children(struct sway_workspace *ws);
 
+void workspace_unwrap_children(struct sway_workspace *ws,
+		struct sway_container *wrap);
+
 void workspace_detach(struct sway_workspace *workspace);
 
 void workspace_add_tiling(struct sway_workspace *workspace,

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -208,9 +208,13 @@ static void container_move_to_workspace(struct sway_container *container,
 		}
 	} else {
 		container_detach(container);
-		container->width = container->height = 0;
-		container->width_fraction = container->height_fraction = 0;
-		workspace_add_tiling(workspace, container);
+		if (workspace_is_empty(workspace) && container->children) {
+			workspace_unwrap_children(workspace, container);
+		} else {
+			container->width = container->height = 0;
+			container->width_fraction = container->height_fraction = 0;
+			workspace_add_tiling(workspace, container);
+		}
 		container_update_representation(container);
 	}
 	if (container->view) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -641,6 +641,21 @@ struct sway_container *workspace_wrap_children(struct sway_workspace *ws) {
 	return middle;
 }
 
+void workspace_unwrap_children(struct sway_workspace *ws,
+		struct sway_container *wrap) {
+	if (!sway_assert(workspace_is_empty(ws),
+			"target workspace must be empty")) {
+		return;
+	}
+
+	ws->layout = wrap->layout;
+	while (wrap->children->length) {
+		struct sway_container *child = wrap->children->items[0];
+		container_detach(child);
+		workspace_add_tiling(ws, child);
+	}
+}
+
 void workspace_detach(struct sway_workspace *workspace) {
 	struct sway_output *output = workspace->output;
 	int index = list_find(output->workspaces, workspace);


### PR DESCRIPTION
If moving e.g. `T[app app]` into a new workspace with
`workspace_layout tabbed`, then post-`arrange_workspace` the tree in
that workspace will be `T[T[app app]]`. This still happens with
horizontal or vertical workspace layout, but is less visible since those
containers have no decorations.

Fixes #5426.