### PR TITLE
commands/move: maintain workspace_layout when moving

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -271,12 +271,11 @@ static void workspace_rejigger(struct sway_workspace *ws,
 		return;
 	}
 	container_detach(child);
-	struct sway_container *new_parent = workspace_wrap_children(ws);
+	workspace_wrap_children(ws);
 
 	int index =
 		move_dir == WLR_DIRECTION_LEFT || move_dir == WLR_DIRECTION_UP ? 0 : 1;
 	workspace_insert_tiling(ws, child, index);
-	container_flatten(new_parent);
 	ws->layout =
 		move_dir == WLR_DIRECTION_LEFT || move_dir == WLR_DIRECTION_RIGHT ?
 		L_HORIZ : L_VERT;
@@ -345,8 +344,11 @@ static bool container_move_in_direction(struct sway_container *container,
 							container_insert_child(current->parent, container,
 									index + (offs < 0 ? 0 : 1));
 						} else {
-							workspace_insert_tiling(current->workspace, container,
-									index + (offs < 0 ? 0 : 1));
+							struct sway_workspace *ws = current->workspace;
+							workspace_insert_tiling(ws,
+								container_split(container,
+									output_get_default_layout(ws->output)),
+								index + (offs < 0 ? 0 : 1));
 						}
 						return true;
 					}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1329,6 +1329,14 @@ void container_detach(struct sway_container *child) {
 		container_update_representation(old_parent);
 		node_set_dirty(&old_parent->node);
 	} else if (old_workspace) {
+		// We may have removed the last tiling child from the workspace. If the
+		// workspace layout was e.g. tabbed, then at this point it may be just
+		// H[]. So, reset it to the default (e.g. T[]) for next time.
+		if (!old_workspace->tiling->length) {
+			old_workspace->layout =
+				output_get_default_layout(old_workspace->output);
+		}
+
 		workspace_update_representation(old_workspace);
 		node_set_dirty(&old_workspace->node);
 	}


### PR DESCRIPTION
Fixes #5157.

---

I think there are definitely cases I've missed here, but at least Sway does generate compatible layout trees as per the linked issue.