### PR TITLE
tree/view: fix segfault in view_update_title

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1171,7 +1171,7 @@ void view_update_title(struct sway_view *view, bool force) {
 
 	ipc_event_window(view->container, "title");
 
-	if (view->foreign_toplevel) {
+	if (view->foreign_toplevel && title) {
 		wlr_foreign_toplevel_handle_v1_set_title(view->foreign_toplevel, title);
 	}
 }


### PR DESCRIPTION
xdg-shell doesn't allow clients to set the title to NULL, so we
shouldn't need to call wlr_foreign_toplevel_handle_v1_set_title with an
empty string to reset the old one.

Closes: https://github.com/swaywm/sway/issues/5488