### PR TITLE
protocols: update wlr-layer-shell-unstable-v1

### DIFF
--- a/protocols/wlr-layer-shell-unstable-v1.xml
+++ b/protocols/wlr-layer-shell-unstable-v1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="wlr_layer_shell_v1_unstable_v1">
+<protocol name="wlr_layer_shell_unstable_v1">
   <copyright>
     Copyright © 2017 Drew DeVault
 
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="3">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -82,17 +82,27 @@
       <entry name="top" value="2"/>
       <entry name="overlay" value="3"/>
     </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="3">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
       environment.
 
-      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
-      is double-buffered, and will be applied at the time wl_surface.commit of
-      the corresponding wl_surface is called.
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
     </description>
 
     <request name="set_size">
@@ -115,7 +125,7 @@
     <request name="set_anchor">
       <description summary="configures the anchor point of the surface">
         Requests that the compositor anchor the surface to the specified edges
-        and corners. If two orthoginal edges are specified (e.g. 'top' and
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
         'left'), then the anchor point will be the intersection of the edges
         (e.g. the top left corner of the output); otherwise the anchor point
         will be centered on that edge, or in the center if none is specified.
@@ -127,19 +137,24 @@
 
     <request name="set_exclusive_zone">
       <description summary="configures the exclusive geometry of this surface">
-        Requests that the compositor avoids occluding an area of the surface
-        with other surfaces. The compositor's use of this information is
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
         implementation-dependent - do not assume that this region will not
         actually be occluded.
 
-        A positive value is only meaningful if the surface is anchored to an
-        edge, rather than a corner. The zone is the number of surface-local
-        coordinates from the edge that are considered exclusive.
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
 
         Surfaces that do not wish to have an exclusive zone may instead specify
         how they should interact with surfaces that do. If set to zero, the
         surface indicates that it would like to be moved to avoid occluding
-        surfaces with a positive excluzive zone. If set to -1, the surface
+        surfaces with a positive exclusive zone. If set to -1, the surface
         indicates that it would not like to be moved to accommodate for other
         surfaces, and the compositor should extend it all the way to the edges
         it is anchored to.
@@ -281,5 +296,16 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
   </interface>
 </protocol>


### PR DESCRIPTION
Hidden visibility (via `WL_PRIVATE`) doesn't seem to have an effect during static linking. When there're multiple copies the linker doesn't know when to use each definition, so bundled wlroots may end up using protocols/libserver_protos.a.

Fixes https://github.com/swaywm/sway/issues/5515
