### PR TITLE
Reload Command loads config file in order of priority described in man pages

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -500,6 +500,7 @@ struct sway_config {
 	struct side_gaps gaps_outer;
 
 	list_t *config_chain;
+	bool user_config_path;
 	const char *current_config_path;
 	const char *current_config;
 	int current_config_line_number;

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -22,7 +22,12 @@ static void do_reload(void *data) {
 		list_add(bar_ids, strdup(bar->id));
 	}
 
-	if (!load_main_config(config->current_config_path, true, false)) {
+	const char *path = NULL;
+	if (config->user_config_path) {
+		path = config->current_config_path;
+	}
+
+	if (!load_main_config(path, true, false)) {
 		sway_log(SWAY_ERROR, "Error(s) reloading config");
 		list_free_items_and_destroy(bar_ids);
 		return;
@@ -55,7 +60,12 @@ struct cmd_results *cmd_reload(int argc, char **argv) {
 		return error;
 	}
 
-	if (!load_main_config(config->current_config_path, true, true)) {
+	const char *path = NULL;
+	if (config->user_config_path) {
+		path = config->current_config_path;
+	}
+
+	if (!load_main_config(path, true, true)) {
 		return cmd_results_new(CMD_FAILURE, "Error(s) reloading config.");
 	}
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -447,6 +447,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		}
 	}
 
+	config->user_config_path = file ? true : false;
 	config->current_config_path = path;
 	list_add(config->config_chain, real_path);
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -272,7 +272,9 @@ set|plus|minus <amount>
 	optional comment argument is ignored, but logged for debugging purposes.
 
 *reload*
-	Reloads the sway config file and applies any changes.
+	Reloads the sway config file and applies any changes. The config file is
+	located at path specified by the command line arguments when started,
+	otherwise according to the priority stated in *sway*(1).
 
 *rename workspace* [<old_name>] to <new_name>
 	Rename either <old_name> or the focused workspace to the <new_name>


### PR DESCRIPTION
Reload Command now loads config file with most priority instead of currently loaded config file