### PR TITLE
seat/dnd: Support null drag icon surfaces

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -470,31 +470,29 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
 	wl_signal_add(&wlr_drag->events.destroy, &drag->destroy);
 
 	struct wlr_drag_icon *wlr_drag_icon = wlr_drag->icon;
-	if (wlr_drag_icon == NULL) {
-		return;
+	if (wlr_drag_icon != NULL) {
+		struct sway_drag_icon *icon = calloc(1, sizeof(struct sway_drag_icon));
+		if (icon == NULL) {
+			sway_log(SWAY_ERROR, "Allocation failed");
+			return;
+		}
+		icon->seat = seat;
+		icon->wlr_drag_icon = wlr_drag_icon;
+		wlr_drag_icon->data = icon;
+
+		icon->surface_commit.notify = drag_icon_handle_surface_commit;
+		wl_signal_add(&wlr_drag_icon->surface->events.commit, &icon->surface_commit);
+		icon->unmap.notify = drag_icon_handle_unmap;
+		wl_signal_add(&wlr_drag_icon->events.unmap, &icon->unmap);
+		icon->map.notify = drag_icon_handle_map;
+		wl_signal_add(&wlr_drag_icon->events.map, &icon->map);
+		icon->destroy.notify = drag_icon_handle_destroy;
+		wl_signal_add(&wlr_drag_icon->events.destroy, &icon->destroy);
+
+		wl_list_insert(&root->drag_icons, &icon->link);
+
+		drag_icon_update_position(icon);
 	}
-
-	struct sway_drag_icon *icon = calloc(1, sizeof(struct sway_drag_icon));
-	if (icon == NULL) {
-		sway_log(SWAY_ERROR, "Allocation failed");
-		return;
-	}
-	icon->seat = seat;
-	icon->wlr_drag_icon = wlr_drag_icon;
-	wlr_drag_icon->data = icon;
-
-	icon->surface_commit.notify = drag_icon_handle_surface_commit;
-	wl_signal_add(&wlr_drag_icon->surface->events.commit, &icon->surface_commit);
-	icon->unmap.notify = drag_icon_handle_unmap;
-	wl_signal_add(&wlr_drag_icon->events.unmap, &icon->unmap);
-	icon->map.notify = drag_icon_handle_map;
-	wl_signal_add(&wlr_drag_icon->events.map, &icon->map);
-	icon->destroy.notify = drag_icon_handle_destroy;
-	wl_signal_add(&wlr_drag_icon->events.destroy, &icon->destroy);
-
-	wl_list_insert(&root->drag_icons, &icon->link);
-
-	drag_icon_update_position(icon);
 	seatop_begin_default(seat);
 }
 


### PR DESCRIPTION
As per the Wayland spec [1]:

> The icon surface is an optional (can be NULL) surface that provides an
> icon to be moved around with the cursor.

However, as of now Sway "start_drag" signal handler does not starts the
DND session unless a non-NULL drag icons is provided. This patch fixes
it by skipping handling of the drag icon if it is null.

Fixes #5509

[1] https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_data_device

Signed-off-by: Nick Diego Yamane <nickdiego@igalia.com>