### PR TITLE
input: implement xdg_toplevel interactive resize hints

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -219,6 +219,8 @@ void container_floating_resize_and_center(struct sway_container *con);
 
 void container_floating_set_default_size(struct sway_container *con);
 
+void container_set_resizing(struct sway_container *con, bool resizing);
+
 void container_set_floating(struct sway_container *container, bool enable);
 
 void container_set_geometry_from_content(struct sway_container *con);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -43,6 +43,7 @@ struct sway_view_impl {
 	void (*set_activated)(struct sway_view *view, bool activated);
 	void (*set_tiled)(struct sway_view *view, bool tiled);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
+	void (*set_resizing)(struct sway_view *view, bool resizing);
 	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -185,6 +185,14 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	wlr_xdg_toplevel_set_fullscreen(surface, fullscreen);
 }
 
+static void set_resizing(struct sway_view *view, bool resizing) {
+	if (xdg_shell_view_from_view(view) == NULL) {
+		return;
+	}
+	struct wlr_xdg_surface *surface = view->wlr_xdg_surface;
+	wlr_xdg_toplevel_set_resizing(surface, resizing);
+}
+
 static bool wants_floating(struct sway_view *view) {
 	struct wlr_xdg_toplevel *toplevel = view->wlr_xdg_surface->toplevel;
 	struct wlr_xdg_toplevel_state *state = &toplevel->current;
@@ -260,6 +268,7 @@ static const struct sway_view_impl view_impl = {
 	.set_activated = set_activated,
 	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
+	.set_resizing = set_resizing,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
 	.for_each_popup = for_each_popup,

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -21,7 +21,12 @@ struct seatop_resize_floating_event {
 static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		struct wlr_input_device *device, uint32_t button,
 		enum wlr_button_state state) {
+	struct seatop_resize_floating_event *e = seat->seatop_data;
+	struct sway_container *con = e->con;
+
 	if (seat->cursor->pressed_button_count == 0) {
+		container_set_resizing(con, false);
+		arrange_container(con); // Send configure w/o resizing hint
 		seatop_begin_default(seat);
 	}
 }
@@ -170,6 +175,7 @@ void seatop_begin_resize_floating(struct sway_seat *seat,
 	seat->seatop_impl = &seatop_impl;
 	seat->seatop_data = e;
 
+	container_set_resizing(con, true);
 	container_raise_floating(con);
 
 	const char *image = edge == WLR_EDGE_NONE ?

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -746,6 +746,28 @@ void container_floating_set_default_size(struct sway_container *con) {
 	free(box);
 }
 
+
+/**
+ * Indicate to clients in this container that they are participating in (or
+ * have just finished) an interactive resize
+ */
+void container_set_resizing(struct sway_container *con, bool resizing) {
+	if (!con) {
+		return;
+	}
+
+	if (con->view) {
+		if (con->view->impl->set_resizing) {
+			con->view->impl->set_resizing(con->view, resizing);
+		}
+	} else {
+		for (int i = 0; i < con->children->length; ++i ) {
+			struct sway_container *child = con->children->items[i];
+			container_set_resizing(child, resizing);
+		}
+	}
+}
+
 void container_set_floating(struct sway_container *container, bool enable) {
 	if (container_is_floating(container) == enable) {
 		return;


### PR DESCRIPTION
This PR implements interactive resize hints for xdg_toplevels by setting the resize state on all clients participating in an interactive resize. Should resolve #5411. The issues made it sounds ambiguous, but by my reading of xdg-shell.xml clients _should_ receive a non-resizing configure at the end:

> xdg_toplevel resize request:
> [...]
> After the resize is completed, the client will receive another "configure" event without the resize state.

these resizes don't involve the request, but I think it makes sense.

I made a little test client that turns green when resize hint is set, gif below. PTAL.

![output](https://user-images.githubusercontent.com/12577529/86734681-075b5c80-bfe7-11ea-936f-622a65b17ccb.gif)