### PR TITLE
config/output: don't change output state before commit

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -36,7 +36,7 @@ struct sway_output {
 	// last applied mode when the output is DPMS'ed
 	struct wlr_output_mode *current_mode;
 
-	bool enabled, configured;
+	bool enabling, enabled;
 	list_t *workspaces;
 
 	struct sway_output_state current;
@@ -98,7 +98,7 @@ struct sway_output *all_output_by_name_or_id(const char *name_or_id);
 
 void output_sort_workspaces(struct sway_output *output);
 
-void output_configure(struct sway_output *output);
+void output_enable(struct sway_output *output);
 
 void output_disable(struct sway_output *output);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -844,7 +844,7 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 static void handle_mode(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, mode);
-	if (!output->configured && !output->enabled) {
+	if (!output->enabled && !output->enabling) {
 		struct output_config *oc = find_output_config(output);
 		if (output->wlr_output->current_mode != NULL &&
 				(!oc || oc->enabled)) {
@@ -857,7 +857,7 @@ static void handle_mode(struct wl_listener *listener, void *data) {
 		}
 		return;
 	}
-	if (!output->enabled || !output->configured) {
+	if (!output->enabled) {
 		return;
 	}
 	arrange_layers(output);
@@ -869,7 +869,7 @@ static void handle_mode(struct wl_listener *listener, void *data) {
 
 static void handle_transform(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, transform);
-	if (!output->enabled || !output->configured) {
+	if (!output->enabled) {
 		return;
 	}
 	arrange_layers(output);
@@ -886,7 +886,7 @@ static void update_textures(struct sway_container *con, void *data) {
 
 static void handle_scale(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, scale);
-	if (!output->enabled || !output->configured) {
+	if (!output->enabled) {
 		return;
 	}
 	arrange_layers(output);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -99,8 +99,8 @@ struct sway_node *node_at_coords(
 		return NULL;
 	}
 	struct sway_output *output = wlr_output->data;
-	if (!output || !output->configured) {
-		// output is being destroyed or is being configured
+	if (!output || !output->enabled) {
+		// output is being destroyed or is being enabled
 		return NULL;
 	}
 	double ox = lx, oy = ly;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -110,12 +110,12 @@ struct sway_output *output_create(struct wlr_output *wlr_output) {
 	return output;
 }
 
-void output_configure(struct sway_output *output) {
-	if (!sway_assert(!output->configured, "output is already configured")) {
+void output_enable(struct sway_output *output) {
+	if (!sway_assert(!output->enabled, "output is already enabled")) {
 		return;
 	}
 	struct wlr_output *wlr_output = output->wlr_output;
-	output->configured = true;
+	output->enabled = true;
 	list_add(root->outputs, output);
 
 	restore_workspaces(output);
@@ -262,7 +262,6 @@ void output_disable(struct sway_output *output) {
 	list_del(root->outputs, index);
 
 	output->enabled = false;
-	output->configured = false;
 	output->current_mode = NULL;
 
 	arrange_root();


### PR DESCRIPTION
Previously, we called output_disable prior to wlr_output_commit. This
mutates Sway's output state before the output commit actually succeeds.
This results in Sway's state getting out-of-sync with wlroots'.

An alternative fix [1] was to revert the changes made by output_disable
in case of failure. This is a little complicated. Instead, this patch
makes it so Sway's internal state is never changed before a successful
wlr_output commit.

We had two output flags: enabled and configured. However enabled was set
prior to the output becoming enabled, and was used to prevent the output
event handlers (specifically, the mode handler) from calling
apply_output_config again (infinite loop).

Rename enabled to enabling and use it exclusively for this purpose.
Rename configured to enabled, because that's what it really means.

[1]: https://github.com/swaywm/sway/pull/5521

Closes: https://github.com/swaywm/sway/issues/5483

cc @RedSoxFan 