### PR TITLE
swaybar: allow status line cleanup to proceed when hidden

### DIFF
--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -185,6 +185,7 @@ struct status_line *status_line_init(char *cmd) {
 
 void status_line_free(struct status_line *status) {
 	status_line_close_fds(status);
+	kill(status->pid, status->cont_signal);
 	kill(status->pid, SIGTERM);
 	waitpid(status->pid, NULL, 0);
 	if (status->protocol == PROTOCOL_I3BAR) {


### PR DESCRIPTION
`determine_bar_visibility` stops and starts the status command process according to the bar’s visibility. If the bar was hidden during teardown, teardown would stall while waiting for the stopped status command process to exit.

This resumes a stopped status command during teardown and allows, for example, sway to reload or quit without leaving a swaybar instance behind each time.

Fixes #5536.