### PR TITLE
rephrase swayidle-timout example to improve readability

### DIFF
--- a/config.in
+++ b/config.in
@@ -37,8 +37,7 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 #
 # exec swayidle -w \
 #          timeout 300 'swaylock -f -c 000000' \
-#          timeout 600 'swaymsg "output * dpms off"' \
-#               resume 'swaymsg "output * dpms on"' \
+#          timeout 600 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' \
 #          before-sleep 'swaylock -f -c 000000'
 #
 # This will lock your screen after 300 seconds of inactivity, then turn off


### PR DESCRIPTION
The current configuration of sway contains (as a comment) a call to `swayidle`. However, according to the current manpage of `swayidle`, the command is using an incorrect `resume` flag. This corrects this, so that the `swayidle` example used in the default config is fully functional out-of-the-box.