### PR TITLE
xdg_shell: schedule configure on maximize requests

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -360,6 +360,11 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 	transaction_commit_dirty();
 }
 
+static void handle_request_maximize(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_surface *surface = data;
+	wlr_xdg_surface_schedule_configure(surface);
+}
+
 static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_move);
@@ -402,6 +407,7 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	wl_list_remove(&xdg_shell_view->commit.link);
 	wl_list_remove(&xdg_shell_view->new_popup.link);
 	wl_list_remove(&xdg_shell_view->request_fullscreen.link);
+	wl_list_remove(&xdg_shell_view->request_maximize.link);
 	wl_list_remove(&xdg_shell_view->request_move.link);
 	wl_list_remove(&xdg_shell_view->request_resize.link);
 	wl_list_remove(&xdg_shell_view->set_title.link);
@@ -449,6 +455,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xdg_shell_view->request_fullscreen.notify = handle_request_fullscreen;
 	wl_signal_add(&xdg_surface->toplevel->events.request_fullscreen,
 			&xdg_shell_view->request_fullscreen);
+
+	xdg_shell_view->request_maximize.notify = handle_request_maximize;
+	wl_signal_add(&xdg_surface->toplevel->events.request_maximize,
+			&xdg_shell_view->request_maximize);
 
 	xdg_shell_view->request_move.notify = handle_request_move;
 	wl_signal_add(&xdg_surface->toplevel->events.request_move,


### PR DESCRIPTION
OK, so I'm pretty sure this is a hack, but hear me out.

I saw some users get caught up about buggy Evince behavior and when searching the old reports found #4593. I think the discussion there is correct, however when I tried to run Evince and reproduce, I can see with `WAYLAND_DEBUG=1 evince` that just before evince hangs (until next configure) it tries `set_maximized`, which obviously shouldn't do anything for a tiled view, BUT sway doesn't send back a configure event. Evince waits until the next configure and continues fine.

Now, I'm pretty sure we're _supposed_ to send one, even if it doesn't do anything, based on the description of set_maximized from the xml:

> After requesting that the surface should be maximized, the compositor
    will respond by emitting a configure event. Whether this configure
    actually sets the window maximized is subject to compositor policies.

I make sway respond with this patch. I can now see sway emit the configure, and it does fix the hang in Evince for me. However I don't think I'm supposed to call `wlr_xdg_surface_schedule_configure` here.

Is this the right behavior? Anyone know a better way to do it?