### PR TITLE
Add note on quoting to swaymsg manpage

### DIFF
--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -44,12 +44,18 @@ _swaymsg_ [options...] [message]
 	The message is a sway command (the same commands you can bind to keybindings
 	in your sway config file). It will be executed immediately.
 
-	See **sway**(5) for a list of commands.
+	See *sway*(5) for a list of commands.
 
-	Tip: If you are proving a command that contains a leading hyphen (_-_),
-	insert two hyphens (_--_) before the command to signal to swaymsg not to
-	parse anything beyond that point as an option. For example, use
-	_swaymsg -- mark --add test_ instead of _swaymsg mark --add test_
+	Tips:
+	- Command expansion is performed twice: once by swaymsg, and again by sway.
+	  If you have quoted multi-word strings in your command, enclose the entire
+	  command in single-quotes. For example, use
+	  _swaymsg 'output "Foobar Display" enable'_ instead of
+	  _swaymsg output "Foobar Display" enable_.
+	- If you are proving a command that contains a leading hyphen (_-_), insert
+	  two hyphens (_--_) before the command to signal to swaymsg not to parse
+	  anything beyond that point as an option. For example, use
+	  _swaymsg -- mark --add test_ instead of _swaymsg mark --add test_.
 
 *get\_workspaces*
 	Gets a JSON-encoded list of workspaces and their status.


### PR DESCRIPTION
Argument expansion happens twice when sending commands through `swaymsg`, leading to confusing behavior like #5531 . This PR adds a note to the swaymsg manpage to clarify.

I'm not sure that it's sufficient... may be better to add one on sway-output as well, since that's a common place to see multi-word strings as a single argument (display identifiers).

Closes #5531 . 