### PR TITLE
Add check for empty GEOM variable

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -111,6 +111,10 @@ if [ "$ACTION" = "check" ] ; then
   exit
 elif [ "$SUBJECT" = "area" ] ; then
   GEOM=$(slurp -d)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+    exit
+  fi
   WHAT="Area"
 elif [ "$SUBJECT" = "active" ] ; then
   FOCUSED=$(swaymsg -t get_tree | jq -r 'recurse(.nodes[]?, .floating_nodes[]?) | select(.focused)')


### PR DESCRIPTION
In case when slurp is used to select part of screen, if user aborts the selection, grimshot will capture the whole screen instead of exiting. This is fixed with check for empty variable.