### PR TITLE
meson.build: Fix the version format

### DIFF
--- a/contrib/_incr_version
+++ b/contrib/_incr_version
@@ -1,6 +1,13 @@
 #!/bin/sh -eu
 old_version="$1"
 new_version="$2"
+
+if [ "$new_version" != "${new_version#v}" ]
+then
+	echo "Error: The new version shouldn't be prefixed with a \"v\"." >&2
+	exit 1
+fi
+
 sed -i meson.build -e "s/^	version: .*#release_version/	version: '$new_version', #release_version/g"
 
 printf "Minimum wlroots version? "

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'sway',
 	'c',
-	version: 'v1.5', #release_version
+	version: '1.5', #release_version
 	license: 'MIT',
 	meson_version: '>=0.53.0',
 	default_options: [


### PR DESCRIPTION
cc @ddevault @emersion: I'm not sure about this, but it seems like the "v" was added by accident (if not the code would need to be changed).
Version outputs:
```console
$ # Old
$ sway --version
sway version v1.5
$ swaymsg -rt get_version
{
   "human_readable": "v1.5",
   "variant": "sway",
   "major": 0,
   "minor": 0,
   "patch": 0,
   "loaded_config_file_name": "\/home\/nixos\/.config\/sway\/config"
 }
$ # New
$ sway --version
sway version 1.5
$ swaymsg -rt get_version
{
   "human_readable": "1.5",
   "variant": "sway",
   "major": 1,
   "minor": 5,
   "patch": 0,
   "loaded_config_file_name": "\/home\/nixos\/.config\/sway\/config"
 }
```