### PR TITLE
desktop: output: Scale custom output refresh rate

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -996,7 +996,8 @@ static void output_manager_apply(struct sway_server *server,
 		} else {
 			oc->width = config_head->state.custom_mode.width;
 			oc->height = config_head->state.custom_mode.height;
-			oc->refresh_rate = config_head->state.custom_mode.refresh;
+			oc->refresh_rate =
+				config_head->state.custom_mode.refresh / 1000.f;
 		}
 		oc->x = config_head->state.x;
 		oc->y = config_head->state.y;


### PR DESCRIPTION
This fixes an issue with wlr-output-management causing the frame rate to
jump to 60000 Hz when setting a custom mode.