### PR TITLE
Fix X11 clients getting stuck minimized

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -147,6 +147,7 @@ struct sway_xwayland_view {
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
 	struct wl_listener request_maximize;
+	struct wl_listener request_minimize;
 	struct wl_listener request_configure;
 	struct wl_listener request_fullscreen;
 	struct wl_listener request_activate;


### PR DESCRIPTION
Usually it should be enough to simply not grant a client's
minimize request, however some applications (Steam, fullscreen
games in Wine) don't wait for the compositor and minimize anyway,
getting them stuck in an unrecoverable state.
Restoring them immediately lead to heavy flickering ( https://streamable.com/imhyj7 ) when unfocused
on my test application (Earth Defense Force 5 via Steam), so it's
preferable to grant their request without actually minimizing and
then restoring them once they are in focus again.

Should fix https://github.com/swaywm/sway/issues/4324