### PR TITLE
Allow to disable insecure protocols at compile-time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,8 @@ if get_option('tray').enabled() and not tray_deps_found
 endif
 have_tray = (not get_option('tray').disabled()) and tray_deps_found
 
+use_insecure_protocols = get_option('use-insecure-protocols')
+
 conf_data = configuration_data()
 
 conf_data.set10('HAVE_XWAYLAND', have_xwayland)
@@ -94,6 +96,7 @@ conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
 conf_data.set10('HAVE_SYSTEMD', systemd.found())
 conf_data.set10('HAVE_ELOGIND', elogind.found())
 conf_data.set10('HAVE_TRAY', have_tray)
+conf_data.set10('USE_INSECURE_PROTOCOLS', use_insecure_protocols)
 
 scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
 if scdoc.found()
@@ -283,6 +286,7 @@ summary({
 	'elogind': elogind.found(),
 	'tray': have_tray,
 	'man-pages': scdoc.found(),
+	'use-insecure-protocols': use_insecure_protocols
 }, bool_yn: true)
 
 if not systemd.found() and not elogind.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,4 +6,4 @@ option('xwayland', type: 'feature', value: 'auto', description: 'Enable support 
 option('tray', type: 'feature', value: 'auto', description: 'Enable support for swaybar tray')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybg')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
-option('use-insecure-protocols', type: 'boolean', value: true, description: 'Disable insecure protocols')
+option('use-insecure-protocols', type: 'boolean', value: true, description: 'Enable insecure protocols')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('xwayland', type: 'feature', value: 'auto', description: 'Enable support 
 option('tray', type: 'feature', value: 'auto', description: 'Enable support for swaybar tray')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybg')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
+option('use-insecure-protocols', type: 'boolean', value: true, description: 'Disable insecure protocols')

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -180,7 +180,9 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 
 		seat_keyboard_notify_enter(seat, view->surface);
 		seat_tablet_pads_notify_enter(seat, view->surface);
+#if USE_INSECURE_PROTOCOLS
 		sway_input_method_relay_set_focus(&seat->im_relay, view->surface);
+#endif
 
 		struct wlr_pointer_constraint_v1 *constraint =
 			wlr_pointer_constraints_v1_constraint_for_surface(
@@ -592,7 +594,9 @@ struct sway_seat *seat_create(const char *seat_name) {
 	wl_list_init(&seat->keyboard_groups);
 	wl_list_init(&seat->keyboard_shortcuts_inhibitors);
 
+#if USE_INSECURE_PROTOCOLS
 	sway_input_method_relay_init(seat, &seat->im_relay);
+#endif
 
 	bool first = wl_list_empty(&server.input->seats);
 	wl_list_insert(&server.input->seats, &seat->link);
@@ -1069,7 +1073,9 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 			view_close_popups(last_focus->sway_container->view);
 		}
 		seat_send_unfocus(last_focus, seat);
+#if USE_INSECURE_PROTOCOLS
 		sway_input_method_relay_set_focus(&seat->im_relay, NULL);
+#endif
 		seat->has_focus = false;
 		return;
 	}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -32,7 +32,6 @@ sway_sources = files(
 	'input/seatop_resize_tiling.c',
 	'input/switch.c',
 	'input/tablet.c',
-	'input/text_input.c',
 
 	'config/bar.c',
 	'config/output.c',
@@ -219,6 +218,10 @@ sway_deps = [
 if have_xwayland
 	sway_sources += 'desktop/xwayland.c'
 	sway_deps += xcb
+endif
+
+if use_insecure_protocols
+	sway_sources += 'input/text_input.c'
 endif
 
 executable(

--- a/sway/server.c
+++ b/sway/server.c
@@ -140,13 +140,14 @@ bool server_init(struct sway_server *server) {
 		handle_output_power_manager_set_mode;
 	wl_signal_add(&server->output_power_manager_v1->events.set_mode,
 		&server->output_power_manager_set_mode);
+#if USE_INSECURE_PROTOCOLS
 	server->input_method = wlr_input_method_manager_v2_create(server->wl_display);
 	server->text_input = wlr_text_input_manager_v3_create(server->wl_display);
-	server->foreign_toplevel_manager =
-		wlr_foreign_toplevel_manager_v1_create(server->wl_display);
-
 	wlr_export_dmabuf_manager_v1_create(server->wl_display);
 	wlr_screencopy_manager_v1_create(server->wl_display);
+#endif
+	server->foreign_toplevel_manager =
+		wlr_foreign_toplevel_manager_v1_create(server->wl_display);
 	wlr_data_control_manager_v1_create(server->wl_display);
 	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);


### PR DESCRIPTION
This pull-request is a way to allow build sway without insecure ptotocols, such as text-input (which allow to keylog user input from other windows) or screencopy (which allows any application to capture other apps' windows)
This is just a temporary solution, until proper security model is in place. Also, everything is enabled by default (like it was before this PR)