### PR TITLE
Implement foreign toplevel fullscreen

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -101,6 +101,7 @@ struct sway_view {
 	struct wl_listener foreign_activate_request;
 	struct wl_listener foreign_fullscreen_request;
 	struct wl_listener foreign_close_request;
+	struct wl_listener foreign_destroy;
 
 	bool destroying;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -99,6 +99,7 @@ struct sway_view {
 
 	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel;
 	struct wl_listener foreign_activate_request;
+	struct wl_listener foreign_fullscreen_request;
 	struct wl_listener foreign_close_request;
 
 	bool destroying;

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -978,6 +978,10 @@ static void set_fullscreen_iterator(struct sway_container *con, void *data) {
 	if (con->view->impl->set_fullscreen) {
 		bool *enable = data;
 		con->view->impl->set_fullscreen(con->view, *enable);
+		if (con->view->foreign_toplevel) {
+			wlr_foreign_toplevel_handle_v1_set_fullscreen(
+				con->view->foreign_toplevel, *enable);
+		}
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -670,6 +670,17 @@ static void handle_foreign_close_request(
 	view_close(view);
 }
 
+static void handle_foreign_destroy(
+		struct wl_listener *listener, void *data) {
+	struct sway_view *view = wl_container_of(
+			listener, view, foreign_destroy);
+
+	wl_list_remove(&view->foreign_activate_request.link);
+	wl_list_remove(&view->foreign_fullscreen_request.link);
+	wl_list_remove(&view->foreign_close_request.link);
+	wl_list_remove(&view->foreign_destroy.link);
+}
+
 void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 			  bool fullscreen, struct wlr_output *fullscreen_output,
 			  bool decoration) {
@@ -709,6 +720,9 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	view->foreign_close_request.notify = handle_foreign_close_request;
 	wl_signal_add(&view->foreign_toplevel->events.request_close,
 			&view->foreign_close_request);
+	view->foreign_destroy.notify = handle_foreign_destroy;
+	wl_signal_add(&view->foreign_toplevel->events.destroy,
+			&view->foreign_destroy);
 
 	// If we're about to launch the view into the floating container, then
 	// launch it as a tiled view in the root of the workspace instead.


### PR DESCRIPTION
This pull adds support for the foreign toplevel fullscreen event and request.

By event I mean that previously FTM would not indicate the fullscreen state as set on fullscreen views, so the first commit fixes it to indicate the fullscreen state for fullscreen views.

The second commit handles the FTM set_fullscreen request. It doesn't comply with the output hint, since it's not necessary and I don't have an easy way to test multi-output stuff on my laptop anway. PTAL.