### PR TITLE
Document required '\n' in swaybar-protocol

### DIFF
--- a/swaybar/swaybar-protocol.7.scd
+++ b/swaybar/swaybar-protocol.7.scd
@@ -8,10 +8,10 @@ swaybar-protocol - JSON status line protocol for swaybar
 
 swaybar defines the following JSON protocol to specify what information is
 displayed in the status line on the right side of swaybar. The protocol
-comprises a header, that is a JSON object, followed by an infinite JSON
-array that represents the information to display. All communication is done by
-writing the status line to standard output and reading events from standard
-input.
+comprises a header, that is a JSON object, followed by a newline (*0x0A*),
+followed by an infinite JSON array that represents the information to display.
+All communication is done by writing the status line to standard output and
+reading events from standard input.
 
 # HEADER
 


### PR DESCRIPTION
The following statusbar output is not considered by sway to be following
the swaybar-protocol:

    {"version":1}[[{"full_text":"2.89","urgent":false}],

However this one is:

    {"version":1}\n[[{"full_text":"2.89","urgent":false}],

Both outputs contain a header with the required values and an unfinished
array of objects with the required values, but the first one is showed
verbatim.