### PR TITLE
set XDG_CURRENT_DESKTOP environment for systemd login

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
https://github.com/emersion/xdg-desktop-portal-wlr requires XDG_CURRENT_DESKTOP to be set, login managers should set it from DesktopNames