### PR TITLE
Handle SIGINT

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -367,6 +367,7 @@ int main(int argc, char **argv) {
 
 	// handle SIGTERM signals
 	signal(SIGTERM, sig_handler);
+	signal(SIGINT, sig_handler);
 
 	// prevent ipc from crashing sway
 	signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
Gracefully exit on SIGINT, like we do for SIGTERM.