### PR TITLE
Include sway-session.target

### DIFF
--- a/contrib/sway-session.target
+++ b/contrib/sway-session.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=sway session
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target

--- a/contrib/sway-session.target
+++ b/contrib/sway-session.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=sway session
+Documentation=man:systemd.special(7)
 BindsTo=graphical-session.target
 Wants=graphical-session-pre.target
 After=graphical-session-pre.target


### PR DESCRIPTION
In order to keep the discussion focused: this PR is NOT about [running sway as a systemd service](https://github.com/swaywm/sway/issues/5160) 🙂 

`sway` can run on many OS, some of which use `systemd` for service management, like Arch Linux. 

On those OS it is needed to organize dependencies and startup order, for example some services should only start in a graphical session, but not in tty, and should stop when graphical session ends.

For this particular task, `systemd` itself created a standard `graphical-session.target`, which as per [their description](https://github.com/systemd/systemd/commit/c92fcc4f4375b0) acts as a dynamic alias for any concrete graphical user session (so a service that must only run in a graphical session would declare a dependency on this virtual target).

According to this design, `graphical-session.target` itself should not and cannot be started directly, instead every WM should provide its own `.target` that "implements" this interface.

[sway wiki](https://github.com/swaywm/sway/wiki/Systemd-integration) contains the definition of `sway-session.target` and instructions for users on where to put it, however given that `systemd` is popular, I propose to include `sway-session.target` directly in the repo. This would help consolidating the effort and share best-practices between people who run OS with `systemd` and who compile `sway` (for themselves or especially as part of creating `sway` distro packages), as they would additionally copy this `.target` (the same one!) to a proper location as part of `sway` package, instead of users having to do so.

- Having this `.target` present in sway repo has nothing to do with how `sway` itself is being launched.
- Having this `.target` installed on an end-user's computer does not change any behavior in itself, users still need to start and stop it themselves.
    - Although this can be further assisted by distro packagers to create a config file that users can just source in their own sway config _if they want to_ and get proper systemd integration that works on their distro, [here](https://github.com/archlinux/svntogit-community/blob/packages/sway/trunk/50-systemd-user.conf) is an example from Arch package, I will add `systemctl --user start sway-session.target` to that file.

Looking forward to your feedback 🙂 