### PR TITLE
exec: fix validation during config reload

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -97,6 +97,12 @@ void container_resize_tiled(struct sway_container *parent, uint32_t axis,
 struct sway_container *container_find_resize_parent(struct sway_container *con,
 		uint32_t edge);
 
+/**
+ * Handlers shared by exec and exec_always.
+ */
+sway_cmd cmd_exec_validate;
+sway_cmd cmd_exec_process;
+
 sway_cmd cmd_assign;
 sway_cmd cmd_bar;
 sway_cmd cmd_bindcode;

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -5,12 +5,15 @@
 #include "stringop.h"
 
 struct cmd_results *cmd_exec(int argc, char **argv) {
-	if (!config->active) return cmd_results_new(CMD_DEFER, NULL);
+	struct cmd_results *error = NULL;
+	if ((error = cmd_exec_validate(argc, argv))) {
+		return error;
+	}
 	if (config->reloading) {
 		char *args = join_args(argv, argc);
 		sway_log(SWAY_DEBUG, "Ignoring 'exec %s' due to reload", args);
 		free(args);
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
-	return cmd_exec_always(argc, argv);
+	return cmd_exec_process(argc, argv);
 }

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -13,15 +13,19 @@
 #include "log.h"
 #include "stringop.h"
 
-struct cmd_results *cmd_exec_always(int argc, char **argv) {
+struct cmd_results *cmd_exec_validate(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if (!config->active || config->validating) {
-		return cmd_results_new(CMD_DEFER, NULL);
-	}
 	if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	if (!config->active || config->validating) {
+		return cmd_results_new(CMD_DEFER, NULL);
+	}
+	return error;
+}
 
+struct cmd_results *cmd_exec_process(int argc, char **argv) {
+	struct cmd_results *error = NULL;
 	char *tmp = NULL;
 	if (strcmp(argv[0], "--no-startup-id") == 0) {
 		sway_log(SWAY_INFO, "exec switch '--no-startup-id' not supported, ignored.");
@@ -91,4 +95,12 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results *cmd_exec_always(int argc, char **argv) {
+	struct cmd_results *error;
+	if ((error = cmd_exec_validate(argc, argv))) {
+		return error;
+	}
+	return cmd_exec_process(argc, argv);
 }


### PR DESCRIPTION
Repro steps:
1. Add `exec` (with no arguments) to your config.
2. Reload sway.

Sway crashes with the "argc should be positive" error from `join_args`.

The `exec` command just calls `exec_always`, however a few shared validation checks should be performed before this call.