### PR TITLE
xwayland: support views that change override-redirect status

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -162,6 +162,7 @@ struct sway_xwayland_view {
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
+	struct wl_listener override_redirect;
 };
 
 struct sway_xwayland_unmanaged {
@@ -176,6 +177,7 @@ struct sway_xwayland_unmanaged {
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener destroy;
+	struct wl_listener override_redirect;
 };
 #endif
 struct sway_view_child;


### PR DESCRIPTION
This fixes https://github.com/swaywm/sway/issues/4600 by destroying the view and recreating it with the correct type (same as this Wayfire patch https://github.com/WayfireWM/wayfire/pull/706 )

I have tested with the Warframe launcher and Dark Souls 3, which both work fine with this.