### PR TITLE
swaynag: adds option to separately specify the text color for buttons

### DIFF
--- a/include/swaynag/types.h
+++ b/include/swaynag/types.h
@@ -9,6 +9,7 @@ struct swaynag_type {
 	uint32_t anchors;
 
 	// Colors
+	uint32_t button_text;
 	uint32_t button_background;
 	uint32_t background;
 	uint32_t text;

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -39,6 +39,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		TO_COLOR_BORDER_BOTTOM,
 		TO_COLOR_BUTTON,
 		TO_COLOR_TEXT,
+		TO_COLOR_BUTTON_TEXT,
 		TO_THICK_BAR_BORDER,
 		TO_PADDING_MESSAGE,
 		TO_THICK_DET_BORDER,
@@ -72,6 +73,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		{"border-bottom", required_argument, NULL, TO_COLOR_BORDER_BOTTOM},
 		{"button-background", required_argument, NULL, TO_COLOR_BUTTON},
 		{"text", required_argument, NULL, TO_COLOR_TEXT},
+		{"button-text", required_argument, NULL, TO_COLOR_BUTTON_TEXT},
 		{"border-bottom-size", required_argument, NULL, TO_THICK_BAR_BORDER},
 		{"message-padding", required_argument, NULL, TO_PADDING_MESSAGE},
 		{"details-border-size", required_argument, NULL, TO_THICK_DET_BORDER},
@@ -97,33 +99,34 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			"Multiple buttons can be defined.\n"
 		"  -Z, --button-dismiss-no-terminal <text> <action>  Like "
 			"--button-dismiss, but does not run the action in a terminal.\n"
-		"  -c, --config <path>           Path to config file.\n"
-		"  -d, --debug                   Enable debugging.\n"
-		"  -e, --edge top|bottom         Set the edge to use.\n"
-		"  -f, --font <font>             Set the font to use.\n"
-		"  -h, --help                    Show help message and quit.\n"
-		"  -l, --detailed-message        Read a detailed message from stdin.\n"
-		"  -L, --detailed-button <text>  Set the text of the detail button.\n"
-		"  -m, --message <msg>           Set the message text.\n"
-		"  -o, --output <output>         Set the output to use.\n"
-		"  -s, --dismiss-button <text>   Set the dismiss button text.\n"
-		"  -t, --type <type>             Set the message type.\n"
-		"  -v, --version                 Show the version number and quit.\n"
+		"  -c, --config <path>             Path to config file.\n"
+		"  -d, --debug                     Enable debugging.\n"
+		"  -e, --edge top|bottom           Set the edge to use.\n"
+		"  -f, --font <font>               Set the font to use.\n"
+		"  -h, --help                      Show help message and quit.\n"
+		"  -l, --detailed-message          Read a detailed message from stdin.\n"
+		"  -L, --detailed-button <text>    Set the text of the detail button.\n"
+		"  -m, --message <msg>             Set the message text.\n"
+		"  -o, --output <output>           Set the output to use.\n"
+		"  -s, --dismiss-button <text>     Set the dismiss button text.\n"
+		"  -t, --type <type>               Set the message type.\n"
+		"  -v, --version                   Show the version number and quit.\n"
 		"\n"
 		"The following appearance options can also be given:\n"
-		"  --background RRGGBB[AA]       Background color.\n"
-		"  --border RRGGBB[AA]           Border color.\n"
-		"  --border-bottom RRGGBB[AA]    Bottom border color.\n"
-		"  --button-background RRGGBB[AA]           Button background color.\n"
-		"  --text RRGGBB[AA]             Text color.\n"
-		"  --border-bottom-size size     Thickness of the bar border.\n"
-		"  --message-padding padding     Padding for the message.\n"
-		"  --details-border-size size    Thickness for the details border.\n"
-		"  --button-border-size size     Thickness for the button border.\n"
-		"  --button-gap gap              Size of the gap between buttons\n"
-		"  --button-dismiss-gap gap      Size of the gap for dismiss button.\n"
-		"  --button-margin-right margin  Margin from dismiss button to edge.\n"
-		"  --button-padding padding      Padding for the button text.\n";
+		"  --background RRGGBB[AA]         Background color.\n"
+		"  --border RRGGBB[AA]             Border color.\n"
+		"  --border-bottom RRGGBB[AA]      Bottom border color.\n"
+		"  --button-background RRGGBB[AA]  Button background color.\n"
+		"  --text RRGGBB[AA]               Text color.\n"
+		"  --button-text RRGGBB[AA]        Button text color.\n"
+		"  --border-bottom-size size       Thickness of the bar border.\n"
+		"  --message-padding padding       Padding for the message.\n"
+		"  --details-border-size size      Thickness for the details border.\n"
+		"  --button-border-size size       Thickness for the button border.\n"
+		"  --button-gap gap                Size of the gap between buttons\n"
+		"  --button-dismiss-gap gap        Size of the gap for dismiss button.\n"
+		"  --button-margin-right margin    Margin from dismiss button to edge.\n"
+		"  --button-padding padding        Padding for the button text.\n";
 
 	optind = 1;
 	while (1) {
@@ -253,6 +256,11 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		case TO_COLOR_TEXT:  // Text color
 			if (type && !parse_color(optarg, &type->text)) {
 				fprintf(stderr, "Invalid text color: %s", optarg);
+			}
+			break;
+		case TO_COLOR_BUTTON_TEXT:  // Button text color
+			if (type && !parse_color(optarg, &type->button_text)) {
+				fprintf(stderr, "Invalid button text color: %s", optarg);
 			}
 			break;
 		case TO_THICK_BAR_BORDER:  // Bottom border thickness

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -47,7 +47,7 @@ static void render_details_scroll_button(cairo_t *cairo,
 			button->width - (border * 2), button->height - (border * 2));
 	cairo_fill(cairo);
 
-	cairo_set_source_u32(cairo, swaynag->type->text);
+	cairo_set_source_u32(cairo, swaynag->type->button_text);
 	cairo_move_to(cairo, button->x + border + padding,
 			button->y + border + (button->height - text_height) / 2);
 	pango_printf(cairo, swaynag->type->font, swaynag->scale, true,
@@ -199,7 +199,7 @@ static uint32_t render_button(cairo_t *cairo, struct swaynag *swaynag,
 			button->width, button->height);
 	cairo_fill(cairo);
 
-	cairo_set_source_u32(cairo, swaynag->type->text);
+	cairo_set_source_u32(cairo, swaynag->type->button_text);
 	cairo_move_to(cairo, button->x + padding, button->y + padding);
 	pango_printf(cairo, swaynag->type->font, swaynag->scale, true,
 			"%s", button->text);

--- a/swaynag/swaynag.1.scd
+++ b/swaynag/swaynag.1.scd
@@ -97,6 +97,9 @@ _swaynag_ [options...]
 *--text* <RRGGBB[AA]>
 	Set the text color.
 
+*--button-text* <RRGGBB[AA]>
+	Set the button text color.
+
 *--border-bottom-size* <size>
 	Set the thickness of the bottom border.
 

--- a/swaynag/swaynag.5.scd
+++ b/swaynag/swaynag.5.scd
@@ -42,6 +42,9 @@ colors can be set:
 *text=<color>*
 	The color of the text.
 
+*button-text=<color>*
+	The color of the button text.
+
 The following sizing options can also be set:
 
 *border-bottom-size=<size>*

--- a/swaynag/types.c
+++ b/swaynag/types.c
@@ -38,6 +38,7 @@ void swaynag_types_add_default(list_t *types) {
 	type_defaults->button_background = 0x333333FF;
 	type_defaults->background = 0x323232FF;
 	type_defaults->text = 0xFFFFFFFF;
+	type_defaults->button_text = 0xFFFFFFFF;
 	type_defaults->border = 0x222222FF;
 	type_defaults->border_bottom = 0x444444FF;
 	type_defaults->bar_border_thickness = 2;
@@ -54,6 +55,7 @@ void swaynag_types_add_default(list_t *types) {
 	type_error->button_background = 0x680A0AFF;
 	type_error->background = 0x900000FF;
 	type_error->text = 0xFFFFFFFF;
+	type_error->button_text = 0xFFFFFFFF;
 	type_error->border = 0xD92424FF;
 	type_error->border_bottom = 0x470909FF;
 	list_add(types, type_error);
@@ -62,6 +64,7 @@ void swaynag_types_add_default(list_t *types) {
 	type_warning->button_background = 0xFFC100FF;
 	type_warning->background = 0xFFA800FF;
 	type_warning->text = 0x000000FF;
+	type_warning->button_text = 0x000000FF;
 	type_warning->border = 0xAB7100FF;
 	type_warning->border_bottom = 0xAB7100FF;
 	list_add(types, type_warning);
@@ -106,6 +109,11 @@ void swaynag_type_merge(struct swaynag_type *dest, struct swaynag_type *src) {
 	if (src->text > 0) {
 		dest->text = src->text;
 	}
+
+	if (src->button_text > 0) {
+		dest->button_text = src->button_text;
+	}
+
 
 	if (src->border > 0) {
 		dest->border = src->border;


### PR DESCRIPTION
adds the `button_text` option, which allows setting a separate RRGGBB[AA] value for the text color of buttons. If not set, the generic text color is used.

example:
```bash
$ ls -a ~/ | ./swaynag -t warning -m "files in home" -L "show..." -l --text=FF0000 --button-text=000000
```