### PR TITLE
Fix swaynag off-by-one issues in button positions

### DIFF
--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -184,8 +184,8 @@ static uint32_t render_button(cairo_t *cairo, struct swaynag *swaynag,
 		return ideal_surface_height;
 	}
 
-	button->x = *x - border - text_width - padding * 2 + 1;
-	button->y = (int)(ideal_height - text_height) / 2 - padding + 1;
+	button->x = *x - border - text_width - padding * 2;
+	button->y = (int)(ideal_height - text_height) / 2 - padding;
 	button->width = text_width + padding * 2;
 	button->height = text_height + padding * 2;
 


### PR DESCRIPTION
Button positions are off in both the x and y directions.

This can be easily seen if we set the thickness of button borders to 1 and set all the other margins, paddings, border thicknesses and button gaps to 0. For example:

[warning]
font=Source Code Pro 18px
edge=top
text=d8dee9
border=00FFFF
border-bottom=4c566a
background=4c566a
button-background=4c566a
border-bottom-size=0
button-border-size=1
button-padding=0
message-padding=0
details-border-size=0
button-gap=0
button-dismiss-gap=0
button-margin-right=0

Then, in the y direction, there is an one-pixel gap between the top of swaynag and the top button borders, while the bottom button borders are invisible. In the x direction, the right border of the dismiss button is invisible, while the borders of adjacent buttons overlap by one pixel.

Fixed by removing the explicit one-pixel offsets in the assignment statements for button->x and button-y in the render_button function.

I tested before and after the change with different fonts, scale factors of 0.5, 1 and 2 and various margin / border / gap settings.