### PR TITLE
Issue #5066: Fix saved_border initialization in view_map

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -743,10 +743,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		&view->surface_new_subsurface);
 	view->surface_new_subsurface.notify = view_handle_surface_new_subsurface;
 
-	if (decoration) {
-		view_update_csd_from_client(view, decoration);
-	}
-
 	if (view->impl->wants_floating && view->impl->wants_floating(view)) {
 		view->container->border = config->floating_border;
 		view->container->border_thickness = config->floating_border_thickness;
@@ -755,6 +751,10 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		view->container->border = config->border;
 		view->container->border_thickness = config->border_thickness;
 		view_set_tiled(view, true);
+	}
+
+	if (decoration) {
+		view_update_csd_from_client(view, decoration);
 	}
 
 	if (config->popup_during_fullscreen == POPUP_LEAVE &&


### PR DESCRIPTION
In view_map, the function view_update_csd_from_client is called conditionally before the container's border types are initialized from the configuration. This results in saved_border being initialized inside view_update_csd_from_client from garbage values.

This results in applications that take this path not having their borders restored when set to floating and then back to tiled.

Moved this conditional call just after the next block that initializes the containers borders.

In my system this path is taken by most of the GTK applications I use, including gnome-terminal, nautilus, totem, gnome-calculator and others, vscode, and emersions's hello_wayland example application.

To reproduce the bug, open an application and verify from sway's debug log that the message
`View 0xSOMETHING updated CSD to 1` appears in sway.log.
Then toggle the view to floating and back to tiled. The borders will be set to none.
While floated the borders will be set to csd and saved_border will be none.
You need to not have explicitly set the window's borders from the keyboard
or with criteria.