### PR TITLE
input/cursor: reset event source after unhide

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -299,6 +299,7 @@ void cursor_unhide(struct sway_cursor *cursor) {
 		cursor_set_image(cursor, image, cursor->image_client);
 	}
 	cursor_rebase(cursor);
+	wl_event_source_timer_update(cursor->hide_source, cursor_get_timeout(cursor));
 }
 
 static void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1482,7 +1482,6 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	}
 	if (seat->cursor->hidden){
 		cursor_unhide(seat->cursor);
-		wl_event_source_timer_update(seat->cursor->hide_source, cursor_get_timeout(seat->cursor));
 	}
 }
 


### PR DESCRIPTION
Reset the event source after unhiding the cursor, to ensure that the
timeout starts after showing the cursor. Also remove the open coded
variant in seat_consider_warp_to_focus().

Fixes #5679