### PR TITLE
input/pointer: update cursor activity after updating button counts

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -378,7 +378,6 @@ void dispatch_cursor_button(struct sway_cursor *cursor,
 static void handle_pointer_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, button);
 	struct wlr_event_pointer_button *event = data;
-	cursor_handle_activity(cursor, event->device);
 
 	if (event->state == WLR_BUTTON_PRESSED) {
 		cursor->pressed_button_count++;
@@ -390,6 +389,7 @@ static void handle_pointer_button(struct wl_listener *listener, void *data) {
 		}
 	}
 
+	cursor_handle_activity(cursor, event->device);
 	dispatch_cursor_button(cursor, event->device,
 			event->time_msec, event->button, event->state);
 	transaction_commit_dirty();


### PR DESCRIPTION
Otherwise, Sway will not re-hide a cursor after the last button has been
released.

Needed alongside afa890e to fix #5679.

/cc @Emantor -- <del>I had tested #5681 by scrolling, which worked correctly
after that patch.</del> Looking a bit deeper into this, this was regressed by 82c439c4f116b36d7d171bcc923b50ead59b4ab2 ([diff](https://github.com/swaywm/sway/commit/82c439c4f116b36d7d171bcc923b50ead59b4ab2#diff-40846134db734aabaf9eb9e98bccab5eL358-L375)),
so just reverting that bit of the patch (which is what this PR does) fixes the issue
by itself.

I think afa890e8e9f10667a56e896a114bf81fbc3ff54a still makes sense, though.