### PR TITLE
cursor: arm cursor hide timer immediately

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1041,6 +1041,8 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 
 	cursor->hide_source = wl_event_loop_add_timer(server.wl_event_loop,
 			hide_notify, cursor);
+	wl_event_source_timer_update(
+			cursor->hide_source, cursor_get_timeout(cursor));
 
 	wl_list_init(&cursor->image_surface_destroy.link);
 	cursor->image_surface_destroy.notify = handle_image_surface_destroy;


### PR DESCRIPTION
According to the wayland docs, wayland timers are disarmed on creation.
This leads to the cursor not being hidden if there is no activity after
creation, since the timer is armed on activity, but not at creation.
Arm the timer after creation to ensure the cursor is hidden even if
there is no cursor activity after creation.

Fixes #5684