### PR TITLE
cursor: update hide timer during config apply

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1041,8 +1041,6 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 
 	cursor->hide_source = wl_event_loop_add_timer(server.wl_event_loop,
 			hide_notify, cursor);
-	wl_event_source_timer_update(
-			cursor->hide_source, cursor_get_timeout(cursor));
 
 	wl_list_init(&cursor->image_surface_destroy.link);
 	cursor->image_surface_destroy.notify = handle_image_surface_destroy;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -722,6 +722,8 @@ static void seat_configure_pointer(struct sway_seat *seat,
 	wlr_cursor_attach_input_device(seat->cursor->cursor,
 		sway_device->input_device->wlr_device);
 	seat_apply_input_config(seat, sway_device);
+	wl_event_source_timer_update(
+			seat->cursor->hide_source, cursor_get_timeout(seat->cursor));
 }
 
 static void seat_configure_keyboard(struct sway_seat *seat,


### PR DESCRIPTION
We can't arm the timer during cursor creation since the config may not
be ready yet. Instead arm the timer while applying the input
configuration, cursor_get_timeout() can now handle this even if the
configuration is not ready yet:

Return NULL in calls to seat_get_config*() if the config is not
initialized yet. This is required since we try to retrieve the hide
timeout from the cursor config, even if the config is not initialized.

Return 0 if we can't find any input configuration. This is okay even if
a timeout is configured, since the config will reapply the seat
configuration after load and sets up the correct timer with the correct
timeout.

Fixes #5686