### PR TITLE
Fix #5696: add ',' and ';' to escape characters for config

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -202,6 +202,14 @@ int unescape_string(char *string) {
 				string[i - 1] = '?';
 				string[i] = '\0';
 				break;
+			case ',':
+				string[i - 1] = ',';
+				string[i] = '\0';
+				break;
+			case ';':
+				string[i - 1] = ';';
+				string[i] = '\0';
+				break;
 			case 'x':
 				{
 					unsigned char c = 0;


### PR DESCRIPTION
Closes #5696 

Adds ',' and ';' as characters that can be unescaped by common/stringop.c:unescape_string. I doubt this breaks any functionality unless someone tried intentionally. 

This seems to be a workaround for a larger issue of command seperators in config files don't consider if they are in quotes or not, but I'm not sure how to approach that issue currently.