### PR TITLE
swaybar: don't expand separator_block_width if separator is false

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -208,7 +208,7 @@ static uint32_t render_status_block(cairo_t *cairo,
 					output->height < _ideal_surface_height) {
 				return _ideal_surface_height;
 			}
-			if (sep_width > sep_block_width) {
+			if (block->separator && sep_width > sep_block_width) {
 				sep_block_width = sep_width + margin * 2;
 			}
 		}


### PR DESCRIPTION
When swaybar receives the following JSON body

    [
        {
            "full_text": "foo",
            "separator": false,
            "separator_block_width": 0
        },
        {
            "full_text": "bar"
        }
    ]

it should not draw any separator or any space between the two
blocks. However, since swaybar calculates that `separator_block_width`
0 is too small to fit any configured separator, it will override the
`separator_block_width` with some non-zero value. This patch changes
that such that the necessary `separator_block_width` is only expanded if
the block has `separator: true`.

This should be in line to what i3 does, as its documentation of the i3bar
protocol for `separator` states that

> [...] if you disable the separator line, there will still be a gap after the block, 
unless you also use `separator_block_width`.

To reproduce, set your sway bar configuration to

    bar {
      status_command ${HOME}/bar.sh
      separator_symbol |
    }

where `${HOME}/bar.sh` is

    #!/bin/sh
    echo '{"version": 1}'
    echo '['
    echo '[],'
    echo '[{"full_text": "foo", "separator": false, "separator_block_width": 0},{"full_text": "bar"}]'
    sleep infinity

 