### PR TITLE
commands/move: fix single-split escaping on move

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -311,9 +311,10 @@ static bool container_move_in_direction(struct sway_container *container,
 
 	// If container is in a split container by itself, move out of the split
 	if (container->parent) {
+		struct sway_container *old_parent = container->parent;
 		struct sway_container *new_parent =
 			container_flatten(container->parent);
-		if (new_parent != container->parent) {
+		if (new_parent != old_parent) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Prior to this commit, having a layout like `T[app1 V[app2]]`, focusing
`app2`, and then doing `move left` would result in `T[app2 app1]`. Now, the
resulting layout is `T[app1 app2]`, which matches i3 behavior.

`container_flatten` updates `container->parent`, meaning that the
existing check would never be true.