### PR TITLE
Fix #5643, #5064: rounding issues in floating-point -> integer conversions

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -105,8 +105,8 @@ static bool get_surface_box(struct surface_iterator_data *data,
 		data->rotation);
 
 	struct wlr_box box = {
-		.x = data->ox + _sx,
-		.y = data->oy + _sy,
+		.x = floor(data->ox + _sx),
+		.y = floor(data->oy + _sy),
 		.width = sw,
 		.height = sh,
 	};

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -346,8 +346,8 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 	if (state->border_left) {
 		memcpy(&color, colors->child_border, sizeof(float) * 4);
 		premultiply_alpha(color, con->alpha);
-		box.x = state->x;
-		box.y = state->content_y;
+		box.x = floor(state->x);
+		box.y = floor(state->content_y);
 		box.width = state->border_thickness;
 		box.height = state->content_height;
 		scale_box(&box, output_scale);
@@ -365,8 +365,8 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
 		}
 		premultiply_alpha(color, con->alpha);
-		box.x = state->content_x + state->content_width;
-		box.y = state->content_y;
+		box.x = floor(state->content_x + state->content_width);
+		box.y = floor(state->content_y);
 		box.width = state->border_thickness;
 		box.height = state->content_height;
 		scale_box(&box, output_scale);
@@ -380,8 +380,8 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
 		}
 		premultiply_alpha(color, con->alpha);
-		box.x = state->x;
-		box.y = state->content_y + state->content_height;
+		box.x = floor(state->x);
+		box.y = floor(state->content_y + state->content_height);
 		box.width = state->width;
 		box.height = state->border_thickness;
 		scale_box(&box, output_scale);
@@ -662,8 +662,8 @@ static void render_top_border(struct sway_output *output,
 	// Child border - top edge
 	memcpy(&color, colors->child_border, sizeof(float) * 4);
 	premultiply_alpha(color, con->alpha);
-	box.x = state->x;
-	box.y = state->y;
+	box.x = floor(state->x);
+	box.y = floor(state->y);
 	box.width = state->width;
 	box.height = state->border_thickness;
 	scale_box(&box, output_scale);
@@ -718,8 +718,8 @@ static void render_containers_linear(struct sway_output *output,
 			}
 
 			if (state->border == B_NORMAL) {
-				render_titlebar(output, damage, child, state->x,
-						state->y, state->width, colors,
+				render_titlebar(output, damage, child, floor(state->x),
+						floor(state->y), state->width, colors,
 						title_texture, marks_texture);
 			} else if (state->border == B_PIXEL) {
 				render_top_border(output, damage, child, colors);
@@ -773,7 +773,7 @@ static void render_containers_tabbed(struct sway_output *output,
 			marks_texture = child->marks_unfocused;
 		}
 
-		int x = cstate->x + tab_width * i;
+		int x = floor(cstate->x + tab_width * i);
 
 		// Make last tab use the remaining width of the parent
 		if (i == parent->children->length - 1) {
@@ -886,8 +886,8 @@ static void render_container(struct sway_output *output,
 	struct parent_data data = {
 		.layout = con->current.layout,
 		.box = {
-			.x = con->current.x,
-			.y = con->current.y,
+			.x = floor(con->current.x),
+			.y = floor(con->current.y),
 			.width = con->current.width,
 			.height = con->current.height,
 		},
@@ -903,8 +903,8 @@ static void render_workspace(struct sway_output *output,
 	struct parent_data data = {
 		.layout = ws->current.layout,
 		.box = {
-			.x = ws->current.x,
-			.y = ws->current.y,
+			.x = floor(ws->current.x),
+			.y = floor(ws->current.y),
 			.width = ws->current.width,
 			.height = ws->current.height,
 		},
@@ -938,8 +938,8 @@ static void render_floating_container(struct sway_output *soutput,
 		}
 
 		if (con->current.border == B_NORMAL) {
-			render_titlebar(soutput, damage, con, con->current.x,
-					con->current.y, con->current.width, colors,
+			render_titlebar(soutput, damage, con, floor(con->current.x),
+					floor(con->current.y), con->current.width, colors,
 					title_texture, marks_texture);
 		} else if (con->current.border == B_PIXEL) {
 			render_top_border(soutput, damage, con, colors);


### PR DESCRIPTION
Currently, various floating-point expressions involving the coordinates of borders, title bars and content surfaces are directly assigned to integers, and so they are rounded towards zero.

This results in off-by-one distances between these elements when the signs of their coordinates differ.

The glitches are easier to see with semitransparent borders and title bars, where one can see that they can overlap with the content surface when it enters an area with a negative coordinate. 

Fixed by wrapping these expressions with a call to floor before the assignment.