### PR TITLE
tiling_drag: emit window move ipc events

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -5,6 +5,7 @@
 #include "sway/desktop.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
+#include "sway/ipc-server.h"
 #include "sway/output.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/node.h"
@@ -261,6 +262,7 @@ static void finalize_move(struct sway_seat *seat) {
 				container_split(target, new_layout);
 			}
 			container_add_sibling(target, con, after);
+			ipc_event_window(con, "move");
 		}
 	} else {
 		// Target is a workspace which requires splitting


### PR DESCRIPTION
At the moment moving windows with the tiling drag feature doesn't emit ipc events, but I think it probably should.

It looks like the swap command doesn't currently emit a window move event, so I've just added a window move event to the actual move action of a tiling drag, not the swap.