### PR TITLE
desktop/render: show indicators for top-level split

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -371,7 +371,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		container_current_parent_layout(con);
 
 	if (state->border_right) {
-		if (con->current.parent && siblings->length == 1 && layout == L_HORIZ) {
+		if (!container_is_floating(con) && siblings->length == 1 && layout == L_HORIZ) {
 			memcpy(&color, colors->indicator, sizeof(float) * 4);
 		} else {
 			memcpy(&color, colors->child_border, sizeof(float) * 4);
@@ -386,7 +386,7 @@ static void render_view(struct sway_output *output, pixman_region32_t *damage,
 	}
 
 	if (state->border_bottom) {
-		if (con->current.parent && siblings->length == 1 && layout == L_VERT) {
+		if (!container_is_floating(con) && siblings->length == 1 && layout == L_VERT) {
 			memcpy(&color, colors->indicator, sizeof(float) * 4);
 		} else {
 			memcpy(&color, colors->child_border, sizeof(float) * 4);


### PR DESCRIPTION
i3 shows indicators for the workspace-level pseudo-split, but Sway does
not, as of b977c02. This commit replaces the floating container check
with a call to `container_is_floating`, which has some more robust
checks in place.

Fixes #5699.