### PR TITLE
seat: use default output mapping if there is no input config

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -660,17 +660,16 @@ static void seat_apply_input_config(struct sway_seat *seat,
 		struct sway_seat_device *sway_device) {
 	struct input_config *ic =
 		input_device_get_config(sway_device->input_device);
-	if (ic == NULL) {
-		return;
-	}
 
 	sway_log(SWAY_DEBUG, "Applying input config to %s",
 		sway_device->input_device->identifier);
 
-	const char *mapped_to_output = ic->mapped_to_output;
-	struct wlr_box *mapped_to_region = ic->mapped_to_region;
+	const char *mapped_to_output = ic == NULL ? NULL : ic->mapped_to_output;
+	struct wlr_box *mapped_to_region = ic == NULL ? NULL : ic->mapped_to_region;
+	enum input_config_mapped_to mapped_to =
+		ic == NULL ? MAPPED_TO_DEFAULT : ic->mapped_to;
 
-	switch (ic->mapped_to) {
+	switch (mapped_to) {
 	case MAPPED_TO_DEFAULT:
 		mapped_to_output = sway_device->input_device->wlr_device->output_name;
 		if (mapped_to_output == NULL) {


### PR DESCRIPTION
This causes sway to use the default output mapping for input device even when there is no applicable input config.

The motivation here is to fix #5638, in which pointer coordinates in individual Wayland backed outputs are incorrectly interpreted as in the coordinate space of the abstract output plane. With this commit each pointer is mapped to it's own output which fixes the offset.