### PR TITLE
transaction: validate X transaction completions by geometry, not size

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -38,11 +38,17 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 
 /**
  * Notify the transaction system that a view is ready for the new layout, but
- * identifying the instruction by width and height rather than by serial.
+ * identifying the instruction by geometry rather than by serial.
  *
  * This is used by xwayland views, as they don't have serials.
  */
-void transaction_notify_view_ready_by_size(struct sway_view *view,
-		int width, int height);
+void transaction_notify_view_ready_by_geometry(struct sway_view *view,
+		double x, double y, int width, int height);
+
+/**
+ * Unconditionally notify the transaction system that a view is ready for the
+ * new layout.
+ */
+void transaction_notify_view_ready_immediately(struct sway_view *view);
 
 #endif

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -510,13 +510,23 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 	}
 }
 
-void transaction_notify_view_ready_by_size(struct sway_view *view,
-		int width, int height) {
+void transaction_notify_view_ready_by_geometry(struct sway_view *view,
+		double x, double y, int width, int height) {
 	struct sway_transaction_instruction *instruction =
 		view->container->node.instruction;
 	if (instruction != NULL &&
+			(int)instruction->container_state.content_x == (int)x &&
+			(int)instruction->container_state.content_y == (int)y &&
 			instruction->container_state.content_width == width &&
 			instruction->container_state.content_height == height) {
+		set_instruction_ready(instruction);
+	}
+}
+
+void transaction_notify_view_ready_immediately(struct sway_view *view) {
+	struct sway_transaction_instruction *instruction =
+			view->container->node.instruction;
+	if (instruction != NULL) {
 		set_instruction_ready(instruction);
 	}
 }

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -302,8 +302,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 			desktop_damage_view(view);
 			transaction_commit_dirty();
-			transaction_notify_view_ready_by_size(view,
-					new_geo.width, new_geo.height);
+			transaction_notify_view_ready_immediately(view);
 		} else {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -401,8 +401,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 
 	if (view->container->node.instruction) {
 		get_geometry(view, &view->geometry);
-		transaction_notify_view_ready_by_size(view,
-				state->width, state->height);
+		transaction_notify_view_ready_by_geometry(view,
+				xsurface->x, xsurface->y, state->width, state->height);
 	} else {
 		struct wlr_box new_geo;
 		get_geometry(view, &new_geo);
@@ -418,8 +418,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 			desktop_damage_view(view);
 			transaction_commit_dirty();
-			transaction_notify_view_ready_by_size(view,
-					new_geo.width, new_geo.height);
+			transaction_notify_view_ready_by_geometry(view,
+					xsurface->x, xsurface->y, new_geo.width, new_geo.height);
 		} else {
 			memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		}


### PR DESCRIPTION
Xwayland views are aware of their coordinates, so validating transaction
completions should take into account the reported coordinates of the
view. Prior to this commit they didn't, and matching dimensions would
suffice to validate the transaction.

Also introduced `transaction_notify_view_ready_immediately` to support
the fix from d0f7e0f without jumping through hoops to figure out the
geometry of an `xdg_shell` view.