### PR TITLE
transaction: stop matching X transactions by geometry

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -37,15 +37,6 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 		uint32_t serial);
 
 /**
- * Notify the transaction system that a view is ready for the new layout, but
- * identifying the instruction by geometry rather than by serial.
- *
- * This is used by xwayland views, as they don't have serials.
- */
-void transaction_notify_view_ready_by_geometry(struct sway_view *view,
-		double x, double y, int width, int height);
-
-/**
  * Unconditionally notify the transaction system that a view is ready for the
  * new layout.
  */

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -519,19 +519,6 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 	}
 }
 
-void transaction_notify_view_ready_by_geometry(struct sway_view *view,
-		double x, double y, int width, int height) {
-	struct sway_transaction_instruction *instruction =
-		view->container->node.instruction;
-	if (instruction != NULL &&
-			(int)instruction->container_state.content_x == (int)x &&
-			(int)instruction->container_state.content_y == (int)y &&
-			instruction->container_state.content_width == width &&
-			instruction->container_state.content_height == height) {
-		set_instruction_ready(instruction);
-	}
-}
-
 void transaction_notify_view_ready_immediately(struct sway_view *view) {
 	struct sway_transaction_instruction *instruction =
 			view->container->node.instruction;


### PR DESCRIPTION
JetBrains IDEs really keep providing the most pathological cases for
Xwayland...

The "Search everywhere" dialog can be resized, but it responds to a
configure request with a configure notify including double the growth in
width.

So, if the user drags the left edge by 5px, we send Xwayland a configure
request based off the current geometry, -5px on the x axis, and +5px
width. JetBrains IDEs then respond with -5px on the x axis, and +10px
width.

Presumably they do this to keep the dialog symmetric. Still, it breaks
Sway because we match commits to transactions by geometry, so any
resizes of the "Search everywhere" dialog will cause Sway's transactions
to time out.

Instead, we can just assume that the first commit following a
transaction is in response to that transaction. This is obviously
race-y, but I don't think we can do anything particularly smarter in the
face of crazy applications.