### PR TITLE
tiling_resize: abandon resize if a sibling con dies

### DIFF
--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -107,6 +107,9 @@ static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 	if (e->con == con) {
 		seatop_begin_default(seat);
 	}
+	if (e->h_sib == con || e->v_sib == con) {
+		seatop_begin_default(seat);
+	}
 }
 
 static const struct sway_seatop_impl seatop_impl = {


### PR DESCRIPTION
Fixes #5746 

It would be possible not to abandon the resize if we want by calculating which containers will become the new siblings and setting the resize hints on those. I started writing that patch but then I thought "who cares?" It doesn't seem like a sibling container closing during a tiling resize will be a common case and the user can easily just restart the resize themselves.

If you care, let me know and I'll get back to writing that patch. Otherwise, here's the easy fix.