### PR TITLE
commands/move: fix crash when moving sphsc child

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -537,7 +537,8 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 	struct sway_node *focus = seat_get_focus(seat);
 
 	// move container
-	if (container->scratchpad) {
+	if (container_is_scratchpad_hidden_or_child(container)) {
+		container_detach(container);
 		root_scratchpad_show(container);
 	}
 	switch (destination->type) {


### PR DESCRIPTION
Fixes #5707.

Yet another bug with scratchpad hidden split containers. Children of sphsc need to be shown before we move them. This change also stops calling root_scratchpad_show for non-hidden scratchpad containers, but afaict that's redundant anyway so the behavior should be the same.