### PR TITLE
Rework split, layout, workspace_layout, and move commands to work like i3

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -374,4 +374,17 @@ bool container_is_sticky(struct sway_container *con);
 
 bool container_is_sticky_or_child(struct sway_container *con);
 
+/**
+ * This will destroy pairs of redundant H/V splits
+ * e.g. H[V[H[app app]] app] -> H[app app app]
+ * The middle "V[H[" are eliminated by a call to container_squash
+ * on the V[ con. It's grandchildren are added to it's parent.
+ *
+ * This function is roughly equivalent to i3's tree_flatten here:
+ * https://github.com/i3/i3/blob/1f0c628cde40cf87371481041b7197344e0417c6/src/tree.c#L651
+ *
+ * Returns the number of new containers added to the parent
+ */
+int container_squash(struct sway_container *con);
+
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -116,6 +116,13 @@ struct sway_container *workspace_add_tiling(struct sway_workspace *workspace,
 void workspace_add_floating(struct sway_workspace *workspace,
 		struct sway_container *con);
 
+/**
+ * Adds a tiling container to the workspace without considering
+ * the workspace_layout, so the con will not be split.
+ */
+void workspace_insert_tiling_direct(struct sway_workspace *workspace,
+		struct sway_container *con, int index);
+
 struct sway_container *workspace_insert_tiling(struct sway_workspace *workspace,
 		struct sway_container *con, int index);
 
@@ -133,5 +140,13 @@ void workspace_get_box(struct sway_workspace *workspace, struct wlr_box *box);
 size_t workspace_num_tiling_views(struct sway_workspace *ws);
 
 size_t workspace_num_sticky_containers(struct sway_workspace *ws);
+
+/**
+ * workspace_squash is container_flatten in the reverse
+ * direction. Instead of eliminating redundant splits that are
+ * parents of the target container, it eliminates pairs of
+ * redundant H/V splits that are children of the workspace.
+ */
+void workspace_squash(struct sway_workspace *workspace);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -110,13 +110,13 @@ void workspace_unwrap_children(struct sway_workspace *ws,
 
 void workspace_detach(struct sway_workspace *workspace);
 
-void workspace_add_tiling(struct sway_workspace *workspace,
+struct sway_container *workspace_add_tiling(struct sway_workspace *workspace,
 		struct sway_container *con);
 
 void workspace_add_floating(struct sway_workspace *workspace,
 		struct sway_container *con);
 
-void workspace_insert_tiling(struct sway_workspace *workspace,
+struct sway_container *workspace_insert_tiling(struct sway_workspace *workspace,
 		struct sway_container *con, int index);
 
 void workspace_remove_gaps(struct sway_workspace *ws);

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -162,6 +162,12 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 			}
 			container->layout = new_layout;
 			container_update_representation(container);
+		} else if (config->handler_context.container) {
+			// i3 avoids changing workspace layouts with a new container
+			// https://github.com/i3/i3/blob/3cd1c45eba6de073bc4300eebb4e1cc1a0c4479a/src/con.c#L1817
+			container = workspace_wrap_children(workspace);
+			container->layout = new_layout;
+			container_update_representation(container);
 		} else {
 			if (old_layout != L_TABBED && old_layout != L_STACKED) {
 				workspace->prev_split_layout = old_layout;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -309,16 +309,6 @@ static bool container_move_in_direction(struct sway_container *container,
 		return false;
 	}
 
-	// If container is in a split container by itself, move out of the split
-	if (container->parent) {
-		struct sway_container *old_parent = container->parent;
-		struct sway_container *new_parent =
-			container_flatten(container->parent);
-		if (new_parent != old_parent) {
-			return true;
-		}
-	}
-
 	// Look for a suitable *container* sibling or parent.
 	// The below loop stops once we hit the workspace because current->parent
 	// is NULL for the topmost containers in a workspace.
@@ -721,10 +711,18 @@ static struct cmd_results *cmd_move_in_direction(
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
 	struct sway_workspace *old_ws = container->workspace;
+	struct sway_container *old_parent = container->parent;
 
 	if (!container_move_in_direction(container, direction)) {
 		// Container didn't move
 		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+
+	// clean-up, destroying parents if the container was the last child
+	if (old_parent) {
+		container_reap_empty(old_parent);
+	} else if (old_ws) {
+		workspace_consider_destroy(old_ws);
 	}
 
 	struct sway_workspace *new_ws = container->workspace;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -133,6 +133,7 @@ static void container_move_to_container_from_direction(
 			}
 			container->width = container->height = 0;
 			container->width_fraction = container->height_fraction = 0;
+			workspace_squash(destination->workspace);
 		}
 		return;
 	}
@@ -145,6 +146,7 @@ static void container_move_to_container_from_direction(
 		container_insert_child(destination, container, index);
 		container->width = container->height = 0;
 		container->width_fraction = container->height_fraction = 0;
+		workspace_squash(destination->workspace);
 		return;
 	}
 
@@ -396,6 +398,7 @@ static bool container_move_in_direction(struct sway_container *container,
 		if (old_parent) {
 			container_reap_empty(old_parent);
 		}
+		workspace_squash(container->workspace);
 		return true;
 	}
 }

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -276,11 +276,12 @@ static void workspace_rejigger(struct sway_workspace *ws,
 		return;
 	}
 	container_detach(child);
-	workspace_wrap_children(ws);
+	struct sway_container *new_parent = workspace_wrap_children(ws);
 
 	int index =
 		move_dir == WLR_DIRECTION_LEFT || move_dir == WLR_DIRECTION_UP ? 0 : 1;
 	workspace_insert_tiling(ws, child, index);
+	container_flatten(new_parent);
 	ws->layout =
 		move_dir == WLR_DIRECTION_LEFT || move_dir == WLR_DIRECTION_RIGHT ?
 		L_HORIZ : L_VERT;
@@ -340,11 +341,8 @@ static bool container_move_in_direction(struct sway_container *container,
 							container_insert_child(current->parent, container,
 									index + (offs < 0 ? 0 : 1));
 						} else {
-							struct sway_workspace *ws = current->workspace;
-							workspace_insert_tiling(ws,
-								container_split(container,
-									output_get_default_layout(ws->output)),
-								index + (offs < 0 ? 0 : 1));
+							workspace_insert_tiling(current->workspace, container,
+									index + (offs < 0 ? 0 : 1));
 						}
 						return true;
 					}

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -395,6 +395,8 @@ static bool container_move_in_direction(struct sway_container *container,
 			workspace_insert_tiling(ancestor->workspace, container,
 					index + (offs < 0 ? 0 : 1));
 		}
+		ancestor->height = ancestor->width = 0;
+		ancestor->height_fraction = ancestor->width_fraction = 0;
 		if (old_parent) {
 			container_reap_empty(old_parent);
 		}

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -23,10 +23,6 @@ static struct cmd_results *do_split(int layout) {
 		workspace_split(ws, layout);
 	}
 
-	if (con && con->parent && con->parent->parent) {
-		container_flatten(con->parent->parent);
-	}
-
 	if (root->fullscreen_global) {
 		arrange_root();
 	} else {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -350,19 +350,20 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 		return;
 	}
 
+	struct sway_container *container = view->container;
 	if (e->fullscreen && e->output && e->output->data) {
 		struct sway_output *output = e->output->data;
 		struct sway_workspace *ws = output_get_active_workspace(output);
-		if (ws && !container_is_scratchpad_hidden(view->container)) {
-			if (container_is_floating(view->container)) {
-				workspace_add_floating(ws, view->container);
+		if (ws && !container_is_scratchpad_hidden(container)) {
+			if (container_is_floating(container)) {
+				workspace_add_floating(ws, container);
 			} else {
-				workspace_add_tiling(ws, view->container);
+				container = workspace_add_tiling(ws, container);
 			}
 		}
 	}
 
-	container_set_fullscreen(view->container, e->fullscreen);
+	container_set_fullscreen(container, e->fullscreen);
 
 	arrange_root();
 	transaction_commit_dirty();

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -247,7 +247,7 @@ static void finalize_move(struct sway_seat *seat) {
 
 	// Moving container into empty workspace
 	if (target_node->type == N_WORKSPACE && edge == WLR_EDGE_NONE) {
-		workspace_add_tiling(new_ws, con);
+		con = workspace_add_tiling(new_ws, con);
 	} else if (target_node->type == N_CONTAINER) {
 		// Moving container before/after another
 		struct sway_container *target = target_node->sway_container;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -89,7 +89,7 @@ The following commands may only be used in the configuration file.
 	_swaynag\_command -_
 
 *workspace_layout* default|stacking|tabbed
-	Specifies the initial layout for new workspaces.
+	Specifies the initial layout for new containers in an empty workspace.
 
 *xwayland* enable|disable|force
 	Enables or disables Xwayland support, which allows X11 applications to be

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1355,16 +1355,6 @@ void container_detach(struct sway_container *child) {
 		container_update_representation(old_parent);
 		node_set_dirty(&old_parent->node);
 	} else if (old_workspace) {
-		// We may have removed the last tiling child from the workspace. If the
-		// workspace layout was e.g. tabbed, then at this point it may be just
-		// H[]. So, reset it to the default (e.g. T[]) for next time.
-		// But if we are evacuating a workspace with only sticky floating
-		// containers, the workspace will already be detached from the output.
-		if (old_workspace->output && !old_workspace->tiling->length) {
-			old_workspace->layout =
-				output_get_default_layout(old_workspace->output);
-		}
-
 		workspace_update_representation(old_workspace);
 		node_set_dirty(&old_workspace->node);
 	}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -804,9 +804,10 @@ void container_set_floating(struct sway_container *container, bool enable) {
 			container->width = reference->width;
 			container->height = reference->height;
 		} else {
-			workspace_add_tiling(workspace, container);
-			container->width = workspace->width;
-			container->height = workspace->height;
+			struct sway_container *other =
+				workspace_add_tiling(workspace, container);
+			other->width = workspace->width;
+			other->height = workspace->height;
 		}
 		if (container->view) {
 			view_set_tiled(container->view, true);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -395,9 +395,6 @@ void output_get_box(struct sway_output *output, struct wlr_box *box) {
 
 enum sway_container_layout output_get_default_layout(
 		struct sway_output *output) {
-	if (config->default_layout != L_NONE) {
-		return config->default_layout;
-	}
 	if (config->default_orientation != L_NONE) {
 		return config->default_orientation;
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -732,10 +732,11 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 		ws = seat_get_last_known_workspace(seat);
 	}
 
+	struct sway_container *container = view->container;
 	if (target_sibling) {
-		container_add_sibling(target_sibling, view->container, 1);
+		container_add_sibling(target_sibling, container, 1);
 	} else if (ws) {
-		workspace_add_tiling(ws, view->container);
+		container = workspace_add_tiling(ws, container);
 	}
 	ipc_event_window(view->container, "new");
 
@@ -759,26 +760,26 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 
 	if (config->popup_during_fullscreen == POPUP_LEAVE &&
-			view->container->workspace &&
-			view->container->workspace->fullscreen &&
-			view->container->workspace->fullscreen->view) {
-		struct sway_container *fs = view->container->workspace->fullscreen;
+			container->workspace &&
+			container->workspace->fullscreen &&
+			container->workspace->fullscreen->view) {
+		struct sway_container *fs = container->workspace->fullscreen;
 		if (view_is_transient_for(view, fs->view)) {
 			container_set_fullscreen(fs, false);
 		}
 	}
 
 	view_update_title(view, false);
-	container_update_representation(view->container);
+	container_update_representation(container);
 
 	if (fullscreen) {
 		container_set_fullscreen(view->container, true);
 		arrange_workspace(view->container->workspace);
 	} else {
-		if (view->container->parent) {
-			arrange_container(view->container->parent);
-		} else if (view->container->workspace) {
-			arrange_workspace(view->container->workspace);
+		if (container->parent) {
+			arrange_container(container->parent);
+		} else if (container->workspace) {
+			arrange_workspace(container->workspace);
 		}
 	}
 


### PR DESCRIPTION
EDIT: Hijacking top comment b/c this PR is barely related to what it started as anyway

Hey you. Lurker. Please test.

---
Fix #5755 

This is intended to match i3's behavior here:

https://github.com/i3/i3/blob/3cd1c45eba6de073bc4300eebb4e1cc1a0c4479a/src/tree.c#L354