### PR TITLE
container: Fix NULL pointer dereference

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1358,7 +1358,9 @@ void container_detach(struct sway_container *child) {
 		// We may have removed the last tiling child from the workspace. If the
 		// workspace layout was e.g. tabbed, then at this point it may be just
 		// H[]. So, reset it to the default (e.g. T[]) for next time.
-		if (!old_workspace->tiling->length) {
+		// But if we are evacuating a workspace with only sticky floating
+		// containers, the workspace will already be detached from the output.
+		if (old_workspace->output && !old_workspace->tiling->length) {
 			old_workspace->layout =
 				output_get_default_layout(old_workspace->output);
 		}


### PR DESCRIPTION
Reset the workspace layout to the output's default only if the workspace
is actually attached to an output.

Fixes #5762