### PR TITLE
Enable variable override using /etc/sway/config-vars.d/

### DIFF
--- a/config.in
+++ b/config.in
@@ -20,6 +20,11 @@ set $term alacritty
 # on the original workspace that the command was run on.
 set $menu dmenu_path | dmenu | xargs swaymsg exec --
 
+#### Variable override
+#
+# Files in this directory can be used to override variables
+include /etc/sway/config-vars.d/*
+
 ### Output configuration
 #
 # Default wallpaper (more resolutions are available in @datadir@/backgrounds/sway/)


### PR DESCRIPTION
We use this in Debian to allow other packages to override default variables- I thought that this maybe also helps other distributors. (Based on this change it would be great to also define the wallpaper path using a variable defined in the variables section)