### PR TITLE
Smart borders fix: always show borders for floating containers

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -280,7 +280,8 @@ void view_autoconfigure(struct sway_view *view) {
 			(config->hide_edge_borders_smart == ESMART_NO_GAPS &&
 			!gaps_to_edge(view));
 		if (smart) {
-			bool show_border = !view_is_only_visible(view);
+			bool show_border = container_is_floating_or_child(con) ||
+				!view_is_only_visible(view);
 			con->border_left &= show_border;
 			con->border_right &= show_border;
 			con->border_top &= show_border;


### PR DESCRIPTION
Currently, in view_autoconfigure, the only condition for show_border
is !view_is_only_visible. view_is_only_visible does not cross the
boundary between the workspace's tiling and floating lists and does not
differentiate between them.

The result is, that in a workspace with zero or more tiling containers
and a single floating container, the floating container will lose its
borders as soon as it is split, provided that a only one view is visible
within the floating container.

To test the current behaviour, enable smart borders and open a single floating container
and split the container. It will lose its borders unless a sibling is created
and the layout is either horizontal or vertical. Opening a second floating
container will restore the borders.

Fixed by adjusting the condition for show_borders.