### PR TITLE
In container_split, set a floating container's view to tiled

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1413,6 +1413,13 @@ struct sway_container *container_split(struct sway_container *child,
 	struct sway_seat *seat = input_manager_get_default_seat();
 	bool set_focus = (seat_get_focus(seat) == &child->node);
 
+	if (container_is_floating(child) && child->view) {
+		view_set_tiled(child->view, true);
+		if (child->view->using_csd) {
+			child->border = child->saved_border;
+		}
+	}
+
 	struct sway_container *cont = container_create(NULL);
 	cont->width = child->width;
 	cont->height = child->height;


### PR DESCRIPTION
Currently, when a floating container with a view is split and children are added to it, the new views are rendered as tiled, while the first view stays in floating style.

Here this is addressed by setting the view to tiled as soon as the container is split, by duplicating the "view part" of the logic in container_set_floating(..., false). Since the new container of the view is no longer considered floating, it makes sense to set the view to tiling at this point.

The view would have to be set back to floating if it was possible to "unsplit" the container (see "split none" when it gets implemented).