### PR TITLE
output: Revert implementation of evacuate_sticky()

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -152,18 +152,21 @@ void output_enable(struct sway_output *output) {
 	arrange_root();
 }
 
-static void evacuate_sticky(struct sway_container *con, void *data) {
-	if (container_is_floating(con) && con->is_sticky) {
-		struct sway_workspace *new_ws = data;
-		if (!sway_assert(new_ws, "Expected workspace to not be null")) {
-			return;
-		}
-		container_detach(con);
-		workspace_add_floating(new_ws, con);
-		container_handle_fullscreen_reparent(con);
-		container_floating_move_to_center(con);
-		ipc_event_window(con, "move");
+static void evacuate_sticky(struct sway_workspace *old_ws,
+		struct sway_output *new_output) {
+	struct sway_workspace *new_ws = output_get_active_workspace(new_output);
+	if (!sway_assert(new_ws, "New output does not have a workspace")) {
+		return;
 	}
+	while(old_ws->floating->length) {
+		struct sway_container *sticky = old_ws->floating->items[0];
+		container_detach(sticky);
+		workspace_add_floating(new_ws, sticky);
+		container_handle_fullscreen_reparent(sticky);
+		container_floating_move_to_center(sticky);
+		ipc_event_window(sticky, "move");
+	}
+	workspace_detect_urgent(new_ws);
 }
 
 static void output_evacuate(struct sway_output *output) {
@@ -198,10 +201,9 @@ static void output_evacuate(struct sway_output *output) {
 		if (workspace_is_empty(workspace)) {
 			// If the new output has an active workspace (the noop output may
 			// not have one), move all sticky containers to it
-			if (new_output_ws) {
-				workspace_for_each_container(workspace, evacuate_sticky,
-					new_output_ws);
-				workspace_detect_urgent(new_output_ws);
+			if (new_output_ws &&
+					workspace_num_sticky_containers(workspace) > 0) {
+				evacuate_sticky(workspace, new_output);
 			}
 
 			if (workspace_num_sticky_containers(workspace) == 0) {


### PR DESCRIPTION
The function evacuate_sticky() was changed in commit 32788a93 to be used
by workspace_for_each_container() to make the code more readable. But I
overlooked that it is not safe to use workspace_for_each_container() to
remove container from a workspace. This commit restores the previous
implementation for evacuate_sticky().