### PR TITLE
swaybar: support StatusNotifierItem ToolTip

### DIFF
--- a/include/swaybar/tray/item.h
+++ b/include/swaybar/tray/item.h
@@ -52,6 +52,9 @@ struct swaybar_sni {
 	bool item_is_menu;
 	char *menu;
 	struct swaybar_sni_tool_tip *tool_tip;
+	char *title;
+	char *category;
+	char *id;
 	char *icon_theme_path; // non-standard KDE property
 
 	struct wl_list slots; // swaybar_sni_slot::link

--- a/include/swaybar/tray/item.h
+++ b/include/swaybar/tray/item.h
@@ -14,6 +14,13 @@ struct swaybar_pixmap {
 	unsigned char pixels[];
 };
 
+struct swaybar_sni_tool_tip {
+	char *icon_name;
+	list_t *icon_pixmap; // struct swaybar_pixmap *
+	char *title;
+	char *description; // can contain HTML subset <b><i><u><a href=""><img src=" alt="">, see https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/Markup/
+};
+
 struct swaybar_sni_slot {
 	struct wl_list link; // swaybar_sni::slots
 	struct swaybar_sni *sni;
@@ -44,6 +51,7 @@ struct swaybar_sni {
 	list_t *attention_icon_pixmap; // struct swaybar_pixmap *
 	bool item_is_menu;
 	char *menu;
+	struct swaybar_sni_tool_tip *tool_tip;
 	char *icon_theme_path; // non-standard KDE property
 
 	struct wl_list slots; // swaybar_sni_slot::link

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -303,7 +303,7 @@ static void wl_pointer_frame(void *data, struct wl_pointer *wl_pointer) {
 	for (uint32_t axis = 0; axis < 2; ++axis) {
 		if (seat->axis[axis].discrete_steps) {
 			for (uint32_t step = 0; step < seat->axis[axis].discrete_steps; ++step) {
-				// Honestly, it would probabyl make sense to pass in
+				// Honestly, it would probably make sense to pass in
 				// 'seat->axis[axis].value / seat->axis[axi].discrete_steps' here,
 				// but it's only used to check whether it's positive or negative
 				// so I don't think it's worth the risk of rounding errors.

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -43,12 +43,13 @@ static int read_pixmap(sd_bus_message *msg, struct swaybar_sni *sni,
 
 	if (sd_bus_message_at_end(msg, 0)) {
 		sway_log(SWAY_DEBUG, "%s %s no. of icons = 0", sni->watcher_id, prop);
-		return ret;
+		goto finish;
 	}
 
 	list_t *pixmaps = create_list();
 	if (!pixmaps) {
-		return -12; // -ENOMEM
+		ret = -12; // -ENOMEM
+		goto finish;
 	}
 
 	while (!sd_bus_message_at_end(msg, 0)) {
@@ -93,7 +94,7 @@ static int read_pixmap(sd_bus_message *msg, struct swaybar_sni *sni,
 	}
 
 	if (pixmaps->length < 1) {
-		sway_log(SWAY_DEBUG, "%s %s no. of icons = 0", sni->watcher_id, prop);
+		sway_log(SWAY_ERROR, "%s %s no. of icons = 0", sni->watcher_id, prop);
 		goto error;
 	}
 
@@ -102,9 +103,11 @@ static int read_pixmap(sd_bus_message *msg, struct swaybar_sni *sni,
 	sway_log(SWAY_DEBUG, "%s %s no. of icons = %d", sni->watcher_id, prop,
 			pixmaps->length);
 
-	return ret;
+	goto finish;
 error:
 	list_free_items_and_destroy(pixmaps);
+finish:
+	sd_bus_message_exit_container(msg);
 	return ret;
 }
 


### PR DESCRIPTION
This is some work I started while investigating tool-tip support for d-bus menu in #5161.

**The updates to the d-bus message parsing logic are the most interesting thing here.**  I've not tested since rebasing but the branch builds and runs but I know it does not fully function because the paint logic is naive.  Someone more familiar with the Wayland spec or wlroots should be able to nudge this in the right direction; I think it requires an additional surface like the tray uses for popups.

As well, this isn't the kind of support I was after; not many applications use SNI's ToolTip, and instead I just want to update #5161 to paint the application names and/or (icon) descriptions in bordered boxes when hovering on the icons.