### PR TITLE
input: remove motion deltas from seatop callbacks

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -16,13 +16,12 @@ struct sway_seatop_impl {
 	void (*button)(struct sway_seat *seat, uint32_t time_msec,
 			struct wlr_input_device *device, uint32_t button,
 			enum wlr_button_state state);
-	void (*pointer_motion)(struct sway_seat *seat, uint32_t time_msec,
-			double dx, double dy);
+	void (*pointer_motion)(struct sway_seat *seat, uint32_t time_msec);
 	void (*pointer_axis)(struct sway_seat *seat,
 			struct wlr_event_pointer_axis *event);
 	void (*rebase)(struct sway_seat *seat, uint32_t time_msec);
 	void (*tablet_tool_motion)(struct sway_seat *seat,
-			struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
+			struct sway_tablet_tool *tool, uint32_t time_msec);
 	void (*tablet_tool_tip)(struct sway_seat *seat, struct sway_tablet_tool *tool,
 			uint32_t time_msec, enum wlr_tablet_tool_tip_state state);
 	void (*end)(struct sway_seat *seat);
@@ -269,11 +268,7 @@ void seatop_button(struct sway_seat *seat, uint32_t time_msec,
 		struct wlr_input_device *device, uint32_t button,
 		enum wlr_button_state state);
 
-/**
- * dx and dy are distances relative to previous position.
- */
-void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy);
+void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec);
 
 void seatop_pointer_axis(struct sway_seat *seat,
 		struct wlr_event_pointer_axis *event);
@@ -283,7 +278,7 @@ void seatop_tablet_tool_tip(struct sway_seat *seat,
 		enum wlr_tablet_tool_tip_state state);
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy);
+		struct sway_tablet_tool *tool, uint32_t time_msec);
 
 void seatop_rebase(struct sway_seat *seat, uint32_t time_msec);
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -333,7 +333,7 @@ static void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 
 	wlr_cursor_move(cursor->cursor, device, dx, dy);
 
-	seatop_pointer_motion(cursor->seat, time_msec, dx, dy);
+	seatop_pointer_motion(cursor->seat, time_msec);
 }
 
 static void handle_pointer_motion_relative(
@@ -595,7 +595,7 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 	if (!cursor->simulating_pointer_from_tool_tip &&
 			((surface && wlr_surface_accepts_tablet_v2(tablet->tablet_v2, surface)) ||
 				wlr_tablet_tool_v2_has_implicit_grab(tool->tablet_v2_tool))) {
-		seatop_tablet_tool_motion(seat, tool, time_msec, dx, dy);
+		seatop_tablet_tool_motion(seat, tool, time_msec);
 	} else {
 		wlr_tablet_v2_tablet_tool_notify_proximity_out(tool->tablet_v2_tool);
 		pointer_motion(cursor, time_msec, input_device->wlr_device, dx, dy, dx, dy);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1500,10 +1500,9 @@ void seatop_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	if (seat->seatop_impl->pointer_motion) {
-		seat->seatop_impl->pointer_motion(seat, time_msec, dx, dy);
+		seat->seatop_impl->pointer_motion(seat, time_msec);
 	}
 }
 
@@ -1523,11 +1522,11 @@ void seatop_tablet_tool_tip(struct sway_seat *seat,
 }
 
 void seatop_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
+		struct sway_tablet_tool *tool, uint32_t time_msec) {
 	if (seat->seatop_impl->tablet_tool_motion) {
-		seat->seatop_impl->tablet_tool_motion(seat, tool, time_msec, dx, dy);
+		seat->seatop_impl->tablet_tool_motion(seat, tool, time_msec);
 	} else {
-		seatop_pointer_motion(seat, time_msec, dx, dy);
+		seatop_pointer_motion(seat, time_msec);
 	}
 }
 

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -557,8 +557,7 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 	}
 }
 
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 
@@ -592,7 +591,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
 }
 
 static void handle_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
+		struct sway_tablet_tool *tool, uint32_t time_msec) {
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -37,8 +37,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_down_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
 	if (seat_is_input_allowed(seat, con->view->surface)) {
@@ -60,7 +59,7 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 }
 
 static void handle_tablet_tool_motion(struct sway_seat *seat,
-		struct sway_tablet_tool *tool, uint32_t time_msec, double dx, double dy) {
+		struct sway_tablet_tool *tool, uint32_t time_msec) {
 	struct seatop_down_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
 	if (seat_is_input_allowed(seat, con->view->surface)) {

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -34,8 +34,7 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 		finalize_move(seat);
 	}
 }
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_move_floating_event *e = seat->seatop_data;
 	struct wlr_cursor *cursor = seat->cursor->cursor;
 	desktop_damage_whole_container(e->con);

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -207,8 +207,7 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 	desktop_damage_box(&e->drop_box);
 }
 
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_move_tiling_event *e = seat->seatop_data;
 	if (e->threshold_reached) {
 		handle_motion_postthreshold(seat);

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -31,8 +31,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_resize_floating_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
 	enum wlr_edges edge = e->edge;

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -71,8 +71,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 }
 
-static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec,
-		double dx, double dy) {
+static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_resize_tiling_event *e = seat->seatop_data;
 	int amount_x = 0;
 	int amount_y = 0;


### PR DESCRIPTION
Straightforward cleanup, they haven't been used for a while.