### PR TITLE
commands/focus: force container warp when fulfilling `focus mode_toggle`

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -110,7 +110,7 @@ void cursor_set_image_surface(struct sway_cursor *cursor,
 		struct wl_client *client);
 
 void cursor_warp_to_container(struct sway_cursor *cursor,
-	struct sway_container *container);
+	struct sway_container *container, bool force);
 
 void cursor_warp_to_workspace(struct sway_cursor *cursor,
 		struct sway_workspace *workspace);

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -268,7 +268,16 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 	}
 	if (new_focus) {
 		seat_set_focus_container(seat, new_focus);
-		seat_consider_warp_to_focus(seat);
+
+		// If we're on the floating layer and the floating container area
+		// overlaps the position on the tiling layer that would be warped to,
+		// `seat_consider_warp_to_focus` would decide not to warp, but we need
+		// to anyway.
+		if (config->mouse_warping == WARP_CONTAINER) {
+			cursor_warp_to_container(seat->cursor, new_focus, true);
+		} else {
+			seat_consider_warp_to_focus(seat);
+		}
 	} else {
 		return cmd_results_new(CMD_FAILURE,
 				"Failed to find a %s container in workspace",

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -280,12 +280,16 @@ void cursor_handle_activity(struct sway_cursor *cursor,
 
 	enum sway_input_idle_source idle_source = idle_source_from_device(device);
 	seat_idle_notify_activity(cursor->seat, idle_source);
-	if (cursor->hidden && idle_source != IDLE_SOURCE_TOUCH) {
+	if (idle_source != IDLE_SOURCE_TOUCH) {
 		cursor_unhide(cursor);
 	}
 }
 
 void cursor_unhide(struct sway_cursor *cursor) {
+	if (!cursor->hidden) {
+		return;
+	}
+
 	cursor->hidden = false;
 	if (cursor->image_surface) {
 		cursor_set_image_surface(cursor,
@@ -1115,18 +1119,19 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 
 /**
  * Warps the cursor to the middle of the container argument.
- * Does nothing if the cursor is already inside the container.
- * If container is NULL, returns without doing anything.
+ * Does nothing if the cursor is already inside the container and `force` is
+ * false. If container is NULL, returns without doing anything.
  */
 void cursor_warp_to_container(struct sway_cursor *cursor,
-		struct sway_container *container) {
+		struct sway_container *container, bool force) {
 	if (!container) {
 		return;
 	}
 
 	struct wlr_box box;
 	container_get_box(container, &box);
-	if (wlr_box_contains_point(&box, cursor->cursor->x, cursor->cursor->y)) {
+	if (!force && wlr_box_contains_point(&box, cursor->cursor->x,
+			cursor->cursor->y)) {
 		return;
 	}
 
@@ -1134,6 +1139,7 @@ void cursor_warp_to_container(struct sway_cursor *cursor,
 	double y = container->y + container->height / 2.0;
 
 	wlr_cursor_warp(cursor->cursor, NULL, x, y);
+	cursor_unhide(cursor);
 }
 
 /**
@@ -1150,6 +1156,7 @@ void cursor_warp_to_workspace(struct sway_cursor *cursor,
 	double y = workspace->y + workspace->height / 2.0;
 
 	wlr_cursor_warp(cursor->cursor, NULL, x, y);
+	cursor_unhide(cursor);
 }
 
 uint32_t get_mouse_bindsym(const char *name, char **error) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1477,12 +1477,9 @@ void seat_consider_warp_to_focus(struct sway_seat *seat) {
 	}
 
 	if (focus->type == N_CONTAINER) {
-		cursor_warp_to_container(seat->cursor, focus->sway_container);
+		cursor_warp_to_container(seat->cursor, focus->sway_container, false);
 	} else {
 		cursor_warp_to_workspace(seat->cursor, focus->sway_workspace);
-	}
-	if (seat->cursor->hidden){
-		cursor_unhide(seat->cursor);
 	}
 }
 


### PR DESCRIPTION
This commit switches focusing behavior to force a warp when executing
`focus mode_toggle`.

Fixes #5772.