### PR TITLE
tree/container: use L_NONE for parent layout of floating container

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1225,12 +1225,18 @@ void container_discover_outputs(struct sway_container *con) {
 }
 
 enum sway_container_layout container_parent_layout(struct sway_container *con) {
+	if (container_is_floating(con)) {
+		return L_NONE;
+	}
+
 	if (con->parent) {
 		return con->parent->layout;
 	}
+
 	if (con->workspace) {
 		return con->workspace->layout;
 	}
+
 	return L_NONE;
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1258,8 +1258,7 @@ bool view_is_visible(struct sway_view *view) {
 	struct sway_container *con = view->container;
 	while (con) {
 		enum sway_container_layout layout = container_parent_layout(con);
-		if ((layout == L_TABBED || layout == L_STACKED)
-				&& !container_is_floating(con)) {
+		if (layout == L_TABBED || layout == L_STACKED) {
 			struct sway_node *parent = con->parent ?
 				&con->parent->node : &con->workspace->node;
 			if (seat_get_active_tiling_child(seat, parent) != &con->node) {


### PR DESCRIPTION
The parent of a floating container is technically the workspace, but it
is incorrect to say that the parent layout of a floating container is
that of the workspace.

For instance, if the workspace layout is tabbed, a floating container
should not (and does not) show tab decorations. However, prior to this
commit, querying its parent layout would nonetheless return `L_TABBED`.

Fixes #5782.