### PR TITLE
input/seatop_default: consider fullscreen views to have no edges

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -73,6 +73,9 @@ static enum wlr_edges find_edge(struct sway_container *cont,
 			cont->border == B_CSD) {
 		return WLR_EDGE_NONE;
 	}
+	if (cont->fullscreen_mode) {
+		return WLR_EDGE_NONE;
+	}
 
 	enum wlr_edges edge = 0;
 	if (cursor->cursor->x < cont->x + cont->border_thickness) {


### PR DESCRIPTION
Previously, `find_edge` on a single fullscreen view would occasionally
return an edge rather than `WLR_EDGE_NONE`*. This would trigger entry
into `seatop_resize_tiling`, which doesn't have meaning for a fullscreen
view.

The result was that the fullscreen container hitbox was considered to be
that of where it'd be if it were tiling, so most clicks would not go
through.

Fixes #5792.

\* I suspect this to be due to floating point imprecision in `find_edge`,
but I didn't dig too deeply.