### PR TITLE
output: add phys_scale to adjust EDID-reported size

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -282,6 +282,7 @@ sway_cmd output_cmd_dpms;
 sway_cmd output_cmd_enable;
 sway_cmd output_cmd_max_render_time;
 sway_cmd output_cmd_mode;
+sway_cmd output_cmd_phys_scale;
 sway_cmd output_cmd_position;
 sway_cmd output_cmd_scale;
 sway_cmd output_cmd_scale_filter;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -259,6 +259,7 @@ struct output_config {
 	int custom_mode;
 	int x, y;
 	float scale;
+	float phys_scale;
 	enum scale_filter_mode scale_filter;
 	int32_t transform;
 	enum wl_output_subpixel subpixel;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -15,6 +15,7 @@ static struct cmd_handler output_handlers[] = {
 	{ "enable", output_cmd_enable },
 	{ "max_render_time", output_cmd_max_render_time },
 	{ "mode", output_cmd_mode },
+	{ "phys_scale", output_cmd_phys_scale },
 	{ "pos", output_cmd_position },
 	{ "position", output_cmd_position },
 	{ "res", output_cmd_mode },

--- a/sway/commands/output/phys_scale.c
+++ b/sway/commands/output/phys_scale.c
@@ -1,0 +1,22 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+struct cmd_results *output_cmd_phys_scale(int argc, char **argv) {
+	if (!config->handler_context.output_config) {
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
+	}
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, "Missing phys_scale argument.");
+	}
+
+	char *end;
+	config->handler_context.output_config->phys_scale = strtof(*argv, &end);
+	if (*end) {
+		return cmd_results_new(CMD_INVALID, "Invalid scale.");
+	}
+
+	config->handler_context.leftovers.argc = argc - 1;
+	config->handler_context.leftovers.argv = argv + 1;
+	return NULL;
+}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -59,6 +59,7 @@ struct output_config *new_output_config(const char *name) {
 	oc->refresh_rate = -1;
 	oc->custom_mode = -1;
 	oc->x = oc->y = -1;
+	oc->phys_scale = -1;
 	oc->scale = -1;
 	oc->scale_filter = SCALE_FILTER_DEFAULT;
 	oc->transform = -1;
@@ -83,6 +84,9 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 	}
 	if (src->y != -1) {
 		dst->y = src->y;
+	}
+	if (src->phys_scale != -1) {
+		dst->phys_scale = src->phys_scale;
 	}
 	if (src->scale != -1) {
 		dst->scale = src->scale;
@@ -367,6 +371,13 @@ static void queue_output_config(struct output_config *oc,
 	if (oc && oc->transform >= 0) {
 		sway_log(SWAY_DEBUG, "Set %s transform to %d", oc->name, oc->transform);
 		wlr_output_set_transform(wlr_output, oc->transform);
+	}
+
+	if (oc && oc->phys_scale > 0) {
+		wlr_output->phys_width = wlr_output->phys_width * oc->phys_scale;
+		wlr_output->phys_height = wlr_output->phys_height * oc->phys_scale;
+		sway_log(SWAY_DEBUG, "Scaling %s physical sizes by %f to %dx%d mm", oc->name,
+			oc->phys_scale, wlr_output->phys_width, wlr_output->phys_height);
 	}
 
 	// Apply the scale last before the commit, because the scale auto-detection

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -186,6 +186,7 @@ sway_sources = files(
 	'commands/output/enable.c',
 	'commands/output/max_render_time.c',
 	'commands/output/mode.c',
+	'commands/output/phys_scale.c',
 	'commands/output/position.c',
 	'commands/output/scale.c',
 	'commands/output/scale_filter.c',


### PR DESCRIPTION
Some monitors report an invalid size in their EDID.  While sway ignores these sizes (see phys_size_is_aspect_ratio), some other applications do not.  Instead of requiring a change to the monitor, allow specifying a scaling factor in the configuration to bring the physical dimensions in line with reality.

**Note**: Currently this is in terms of the original (EDID-specified) phys_size; it might be useful to just throw that value out and calculate it based on a scaling factor of (square) pixels.