### PR TITLE
Update sway-bar manpage to reflect default config

### DIFF
--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -93,7 +93,7 @@ runtime.
 	status lines using the i3bar JSON protocol.
 
 *position* top|bottom
-	Sets position of the bar. Default is _bottom_.
+	Sets position of the bar. Default is _top_.
 
 *separator_symbol* <symbol>
 	Specifies the separator symbol to separate blocks on the bar.


### PR DESCRIPTION
Default bar position in current version `1.5-5ae4f650` is `top` https://github.com/swaywm/sway/blob/master/config.in#L204