### PR TITLE
input/keyboard: fix Group# bindings for keyboard groups

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -626,10 +626,12 @@ static void handle_modifier_event(struct sway_keyboard *keyboard) {
 		determine_bar_visibility(modifiers);
 	}
 
-	if (wlr_device->keyboard->modifiers.group != keyboard->effective_layout &&
-			!wlr_keyboard_group_from_wlr_keyboard(wlr_device->keyboard)) {
+	if (wlr_device->keyboard->modifiers.group != keyboard->effective_layout) {
 		keyboard->effective_layout = wlr_device->keyboard->modifiers.group;
-		ipc_event_input("xkb_layout", keyboard->seat_device->input_device);
+
+		if (!wlr_keyboard_group_from_wlr_keyboard(wlr_device->keyboard)) {
+			ipc_event_input("xkb_layout", keyboard->seat_device->input_device);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #5800 

The keyboard group's effective keyboard layout was never being changed
due to a condition that incorrectly preventing it from being performed.
The IPC event that follows the change was correctly being prevented.