### PR TITLE
 criteria: fix crash when comparing NULL properties

### DIFF
--- a/common/stringop.c
+++ b/common/stringop.c
@@ -64,7 +64,7 @@ char *lenient_strncat(char *dest, const char *src, size_t len) {
 }
 
 // strcmp that also handles null pointers.
-int lenient_strcmp(char *a, char *b) {
+int lenient_strcmp(const char *a, const char *b) {
 	if (a == b) {
 		return 0;
 	} else if (!a) {

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -12,7 +12,7 @@ char *lenient_strcat(char *dest, const char *src);
 char *lenient_strncat(char *dest, const char *src, size_t len);
 
 // strcmp that also handles null pointers.
-int lenient_strcmp(char *a, char *b);
+int lenient_strcmp(const char *a, const char *b);
 
 // Simply split a string with delims, free with `list_free_items_and_destroy`
 list_t *split_string(const char *str, const char *delims);

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -188,7 +188,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 		switch (criteria->title->match_type) {
 		case PATTERN_FOCUSED:
-			if (focused && strcmp(title, view_get_title(focused))) {
+			if (focused && lenient_strcmp(title, view_get_title(focused))) {
 				return false;
 			}
 			break;
@@ -228,7 +228,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 		switch (criteria->app_id->match_type) {
 		case PATTERN_FOCUSED:
-			if (focused && strcmp(app_id, view_get_app_id(focused))) {
+			if (focused && lenient_strcmp(app_id, view_get_app_id(focused))) {
 				return false;
 			}
 			break;
@@ -260,7 +260,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 		switch (criteria->class->match_type) {
 		case PATTERN_FOCUSED:
-			if (focused && strcmp(class, view_get_class(focused))) {
+			if (focused && lenient_strcmp(class, view_get_class(focused))) {
 				return false;
 			}
 			break;


### PR DESCRIPTION
_Copy of the main commit message:_

For each following combinations of criteria & command below, the command would
crash sway without the fix.
It's particular about the __focused__ criteria, where the view matches part of
the criteria but not the focused app, leading to a failure when calling
`strcmp` with NULL.

"xterm" is a non-wayland app (X11) and "kitty" is. Both are terminals.

    # "class" is specific to X11
    # The view is X11 (xterm) leading to the criteria checking for the
    # focused app's class, leading to a crash
    for_window [class="__focused__"] floating enable
    exec kitty -e xterm

    # Similarly, crash as the focused app (xterm) has no app_id when the view has one
    for_window [app_id="__focused__"] floating enable
    exec xterm -e kitty

    # If the view has a title but not the focused app: NULL title will crash criteria checking
    for_window [title="__focused__"] floating enable
    exec xterm -title "" -e xterm

**EDIT:** Applied more fixes as suggested