### PR TITLE
contrib/grimshot: changing the date format used in the filename

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -28,7 +28,7 @@ fi
 
 ACTION=${1:-usage}
 SUBJECT=${2:-screen}
-FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
+FILE=${3:-$(getTargetDirectory)/$(date +"%Y-%m-%dT%H-%M-%S-%3N").png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"


### PR DESCRIPTION
Some tools (like Ms Teams) do not accept some characters like : 
So I propose to change the date format or we could add a parameter option