### PR TITLE
desktop/transaction: log transaction commit attempts

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -439,6 +439,15 @@ static void transaction_commit(struct sway_transaction *transaction) {
 					instruction->container_state.content_height);
 			++transaction->num_waiting;
 
+			sway_log(SWAY_DEBUG, "Transaction %p[%d]: configure view %p to %dx%d+%d+%d, serial %d",
+					transaction, i, node->sway_container->view,
+					(int)instruction->container_state.content_width,
+					(int)instruction->container_state.content_height,
+					(int)instruction->container_state.content_x,
+					(int)instruction->container_state.content_y,
+					instruction->serial
+			);
+
 			// From here on we are rendering a saved buffer of the view, which
 			// means we can send a frame done event to make the client redraw it
 			// as soon as possible. Additionally, this is required if a view is
@@ -514,8 +523,17 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 		uint32_t serial) {
 	struct sway_transaction_instruction *instruction =
 		view->container->node.instruction;
-	if (instruction != NULL && instruction->serial == serial) {
-		set_instruction_ready(instruction);
+	if (instruction != NULL) {
+		if (instruction->serial == serial) {
+			sway_log(SWAY_DEBUG,
+				"Transaction %p: view %p acked serial %d",
+				instruction->transaction, view, serial);
+			set_instruction_ready(instruction);
+		} else {
+			sway_log(SWAY_DEBUG,
+				"Transaction %p: view %p acked serial %d, was expecting %d",
+				instruction->transaction, view, serial, instruction->serial);
+		}
 	}
 }
 
@@ -523,12 +541,23 @@ void transaction_notify_view_ready_by_geometry(struct sway_view *view,
 		double x, double y, int width, int height) {
 	struct sway_transaction_instruction *instruction =
 		view->container->node.instruction;
-	if (instruction != NULL &&
-			(int)instruction->container_state.content_x == (int)x &&
-			(int)instruction->container_state.content_y == (int)y &&
-			instruction->container_state.content_width == width &&
-			instruction->container_state.content_height == height) {
-		set_instruction_ready(instruction);
+	if (instruction != NULL) {
+		int txn_x = (int)instruction->container_state.content_x;
+		int txn_y = (int)instruction->container_state.content_y;
+		int txn_width = instruction->container_state.content_width;
+		int txn_height = instruction->container_state.content_height;
+		if (txn_x == (int)x && txn_y == (int)y &&
+				txn_width == width && txn_height == height) {
+			sway_log(SWAY_DEBUG,
+				"Transaction %p: view %p acked geometry %dx%d+%d+%d",
+				instruction->transaction, view, width, height, (int)x, (int)y);
+			set_instruction_ready(instruction);
+		} else {
+			sway_log(SWAY_DEBUG,
+				"Transaction %p: view %p acked geometry %dx%d+%d+%d, was expecting %dx%d+%d+%d",
+				instruction->transaction, view, width, height, (int)x, (int)y,
+				txn_width, txn_height, txn_x, txn_y);
+		}
 	}
 }
 
@@ -536,6 +565,8 @@ void transaction_notify_view_ready_immediately(struct sway_view *view) {
 	struct sway_transaction_instruction *instruction =
 			view->container->node.instruction;
 	if (instruction != NULL) {
+		sway_log(SWAY_DEBUG, "Transaction %p: view %p marked ready",
+			instruction->transaction, view);
 		set_instruction_ready(instruction);
 	}
 }


### PR DESCRIPTION
This information is helpful when debugging transaction timeout issues.

Some examples:

* successful multi-instruction transaction

```
00:01:37.624 [sway/desktop/transaction.c:428] Transaction 0x55a1f581e5e0 committing with 9 instructions
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[1]: configure view 0x55a1f58621c0 to 1257x1357+2091+586, serial 689
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[2]: configure view 0x55a1f55b5aa0 to 1257x1357+1456+597, serial 690
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[3]: configure view 0x55a1f58e63b0 to 1257x1357+1456+597, serial 691
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[4]: configure view 0x55a1f5823620 to 1257x1357+1456+597, serial 692
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[5]: configure view 0x55a1f5895740 to 1257x1357+1456+597, serial 693
00:01:37.624 [sway/desktop/transaction.c:449] Transaction 0x55a1f581e5e0[7]: configure view 0x55a1f59033d0 to 1257x1357+2727+597, serial 694
00:01:37.625 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f59033d0 acked serial 694
00:01:37.625 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f55b5aa0 acked serial 690
00:01:37.678 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f5823620 acked serial 692
00:01:37.692 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f5895740 acked serial 693
00:01:37.715 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f58621c0 acked serial 689
00:01:37.719 [sway/desktop/transaction.c:530] Transaction 0x55a1f581e5e0: view 0x55a1f58e63b0 acked serial 691
00:01:37.719 [sway/desktop/transaction.c:514] Transaction 0x55a1f581e5e0 is ready
```

* transaction from a JetBrains IDE timing out

```
00:01:53.181 [sway/desktop/transaction.c:428] Transaction 0x55fac9d04730 committing with 1 instructions
00:01:53.181 [sway/desktop/transaction.c:449] Transaction 0x55fac9d04730[0]: configure view 0x55fac9cf49f0 to 974x1114+2233+708, serial 0
00:01:53.201 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 976x1114+2234+708, was expecting 974x1114+2233+708
00:01:53.220 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 924x1114+2258+708, was expecting 974x1114+2233+708
00:01:53.238 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 884x1114+2274+708, was expecting 974x1114+2233+708
00:01:53.255 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 884x1114+2293+708, was expecting 974x1114+2233+708
00:01:53.267 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 850x1114+2306+708, was expecting 974x1114+2233+708
00:01:53.286 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 825x1114+2307+708, was expecting 974x1114+2233+708
00:01:53.293 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 825x1114+2307+708, was expecting 974x1114+2233+708
00:01:53.349 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 814x1114+2313+708, was expecting 974x1114+2233+708
00:01:53.366 [sway/desktop/transaction.c:559] Transaction 0x55fac9d04730: view 0x55fac9cf49f0 acked geometry 814x1114+2316+708, was expecting 974x1114+2233+708
00:01:53.389 [sway/desktop/transaction.c:389] Transaction 0x55fac9d04730 timed out (1 waiting)
```

(this is the Sway bug from https://github.com/swaywm/sway/pull/5745)