### PR TITLE
[WIP]: Fix atomic transactions

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -1,6 +1,10 @@
 #ifndef _SWAY_TRANSACTION_H
 #define _SWAY_TRANSACTION_H
 #include <stdint.h>
+#include "sway/output.h"
+#include "sway/tree/container.h"
+#include "sway/tree/workspace.h"
+
 
 /**
  * Transactions enable us to perform atomic layout updates.
@@ -19,7 +23,25 @@
  * create and commits a transaction from the dirty containers.
  */
 
-struct sway_transaction_instruction;
+struct sway_transaction {
+	struct wl_event_source *timer;
+	list_t *instructions;   // struct sway_transaction_instruction *
+	size_t num_waiting;
+	size_t num_configures;
+	struct timespec commit_time;
+};
+
+struct sway_transaction_instruction {
+	struct sway_transaction *transaction;
+	struct sway_node *node;
+	union {
+		struct sway_output_state output_state;
+		struct sway_workspace_state workspace_state;
+		struct sway_container_state container_state;
+	};
+	uint32_t serial;
+};
+
 struct sway_view;
 
 /**

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -18,25 +18,6 @@
 #include "list.h"
 #include "log.h"
 
-struct sway_transaction {
-	struct wl_event_source *timer;
-	list_t *instructions;   // struct sway_transaction_instruction *
-	size_t num_waiting;
-	size_t num_configures;
-	struct timespec commit_time;
-};
-
-struct sway_transaction_instruction {
-	struct sway_transaction *transaction;
-	struct sway_node *node;
-	union {
-		struct sway_output_state output_state;
-		struct sway_workspace_state workspace_state;
-		struct sway_container_state container_state;
-	};
-	uint32_t serial;
-};
-
 static struct sway_transaction *transaction_create(void) {
 	struct sway_transaction *transaction =
 		calloc(1, sizeof(struct sway_transaction));


### PR DESCRIPTION
This is a first pass at #5848 which reserves the new transaction for "unexpected" resizes.

It's not working perfectly. In cases like #5750 I can (sometimes?) see a transaction timing out before the border is corrected. I'm not sure what's happening here b/c as I understand it the final transaction should have no clients to wait for in the first place.