### PR TITLE
Set _JAVA_AWT_WM_NONREPARENTING in sway.desktop

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Sway
 Comment=An i3-compatible Wayland compositor
-Exec=sway
+Exec=env _JAVA_AWT_WM_NONREPARENTING=1 sway
 Type=Application


### PR DESCRIPTION
Fixes issue #595 .
From what I understand, Java expects non-reparenting WMs to set this environmental variable in order for applications like IntelliJ Idea to work, since it has no way to detect this on its own.