### PR TITLE
Add layer shell subsurfaces

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -20,6 +20,7 @@ struct sway_layer_surface {
 	struct wl_listener surface_commit;
 	struct wl_listener output_destroy;
 	struct wl_listener new_popup;
+	struct wl_listener new_subsurface;
 
 	struct wlr_box geo;
 	enum zwlr_layer_shell_v1_layer layer;
@@ -37,6 +38,16 @@ struct sway_layer_popup {
 	struct wl_listener destroy;
 	struct wl_listener commit;
 	struct wl_listener new_popup;
+};
+
+struct sway_layer_subsurface {
+	struct wlr_subsurface *wlr_subsurface;
+	struct sway_layer_surface *layer_surface;
+
+	struct wl_listener map;
+	struct wl_listener unmap;
+	struct wl_listener destroy;
+	struct wl_listener commit;
 };
 
 struct sway_output;


### PR DESCRIPTION
Damage subsurfaces created by layer surfaces on map, unmap and
commit. This fixes the flicker of Gtk Popovers.

Can be tested with gtk-layer-demo from https://github.com/wmww/gtk-layer-shell

Fixes #5617