### PR TITLE
Wayland socket-based labels for criteria

### DIFF
--- a/include/sway/client_label.h
+++ b/include/sway/client_label.h
@@ -1,0 +1,4 @@
+#include <wayland-server-core.h>
+
+char* wl_client_label_get(struct wl_client *client);
+void wl_client_label_set(struct wl_client *client, char* label);

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -304,4 +304,6 @@ sway_cmd cmd_ipc_cmd;
 sway_cmd cmd_ipc_events;
 sway_cmd cmd_ipc_event_cmd;
 
+sway_cmd cmd_sandbox_socket;
+
 #endif

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -294,6 +294,7 @@ struct workspace_config {
 
 struct bar_config {
 	char *swaybar_command;
+	char *swaybar_label;
 	struct wl_client *client;
 	struct wl_listener client_destroy;
 
@@ -454,6 +455,7 @@ enum xwayland_mode {
  */
 struct sway_config {
 	char *swaynag_command;
+	char *swaynag_label;
 	struct swaynag_instance swaynag_config_errors;
 	list_t *symbols;
 	list_t *modes;
@@ -493,6 +495,7 @@ struct sway_config {
 
 	// swaybg
 	char *swaybg_command;
+	char *swaybg_label;
 	struct wl_client *swaybg_client;
 	struct wl_listener swaybg_client_destroy;
 

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -34,6 +34,7 @@ struct criteria {
 	struct pattern *shell;
 	struct pattern *app_id;
 	struct pattern *con_mark;
+	struct pattern *cli_label;
 	uint32_t con_id; // internal ID
 #if HAVE_XWAYLAND
 	struct pattern *class;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -232,6 +232,8 @@ const char *view_get_class(struct sway_view *view);
 
 const char *view_get_instance(struct sway_view *view);
 
+const char *view_get_conn_label(struct sway_view *view);
+
 uint32_t view_get_x11_window_id(struct sway_view *view);
 
 uint32_t view_get_x11_parent_id(struct sway_view *view);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -80,6 +80,7 @@ static struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "sandbox_socket", cmd_sandbox_socket },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/bar/swaybar_command.c
+++ b/sway/commands/bar/swaybar_command.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700 // for strdup
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"
@@ -5,11 +6,22 @@
 
 struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
 	struct cmd_results *error = NULL;
+	char *new_label = NULL;
 	if ((error = checkarg(argc, "swaybar_command", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	if (strcmp(argv[0], "--label") == 0) {
+		if ((error = checkarg(argc, "swaybar_command", EXPECTED_AT_LEAST, 3))) {
+			return error;
+		}
+		new_label = strdup(argv[1]);
+		argv += 2;
+		argc -= 2;
+	}
 	free(config->current_bar->swaybar_command);
 	config->current_bar->swaybar_command = join_args(argv, argc);
+	free(config->current_bar->swaybar_label);
+	config->current_bar->swaybar_label = new_label;
 	sway_log(SWAY_DEBUG, "Using custom swaybar command: %s",
 			config->current_bar->swaybar_command);
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -2,16 +2,20 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <signal.h>
+#include "sway/client_label.h"
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/workspace.h"
 #include "log.h"
 #include "stringop.h"
+#include "util.h"
 
 struct cmd_results *cmd_exec_validate(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -26,14 +30,39 @@ struct cmd_results *cmd_exec_validate(int argc, char **argv) {
 
 struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	struct cmd_results *error = NULL;
+	bool use_wl_socket = false;
+	int skip_argc = 0;
 	char *tmp = NULL;
-	if (strcmp(argv[0], "--no-startup-id") == 0) {
-		sway_log(SWAY_INFO, "exec switch '--no-startup-id' not supported, ignored.");
-		--argc; ++argv;
-		if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
-			return error;
+	char *label = NULL;
+
+	while (skip_argc < argc && strncmp(argv[skip_argc], "--", 2) == 0) {
+		if (strcmp(argv[skip_argc], "--no-startup-id") == 0) {
+			sway_log(SWAY_INFO, "exec switch '--no-startup-id' not supported, ignored.");
+			skip_argc++;
+		} else if (strcmp(argv[skip_argc], "--use-wayland-socket") == 0) {
+			use_wl_socket = true;
+			skip_argc++;
+		} else if (strcmp(argv[skip_argc], "--label") == 0) {
+			skip_argc++;
+			if (skip_argc >= argc)
+				return cmd_results_new(CMD_INVALID, "--label requires an argument");
+			label = argv[skip_argc];
+			skip_argc++;
+		} else if (strcmp(argv[skip_argc], "--") == 0) {
+			skip_argc++;
+			break;
+		} else {
+			return cmd_results_new(CMD_INVALID, "Unknown switch %s", argv[skip_argc]);
 		}
 	}
+	if ((error = checkarg(argc - skip_argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	argc -= skip_argc;
+	argv += skip_argc;
+
+	if (label)
+		use_wl_socket = true;
 
 	if (argc == 1 && (argv[0][0] == '\'' || argv[0][0] == '"')) {
 		tmp = strdup(argv[0]);
@@ -54,6 +83,17 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 		sway_log(SWAY_ERROR, "Unable to create pipe for fork");
 	}
 
+	int sockets[2];
+	struct wl_client* client = NULL;
+	if (use_wl_socket) {
+		if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+			sway_log_errno(SWAY_ERROR, "socketpair failed in exec");
+			use_wl_socket = false;
+		} else {
+			sway_set_cloexec(sockets[0], true);
+		}
+	}
+
 	pid_t pid, child;
 	// Fork process
 	if ((pid = fork()) == 0) {
@@ -63,6 +103,15 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 		sigemptyset(&set);
 		sigprocmask(SIG_SETMASK, &set, NULL);
 		close(fd[0]);
+		if (use_wl_socket) {
+			close(sockets[0]);
+			sway_set_cloexec(sockets[1], false);
+
+			char wayland_socket_str[16];
+			snprintf(wayland_socket_str, sizeof(wayland_socket_str),
+					"%d", sockets[1]);
+			setenv("WAYLAND_SOCKET", wayland_socket_str, true);
+		}
 		if ((child = fork()) == 0) {
 			close(fd[1]);
 			execl("/bin/sh", "/bin/sh", "-c", cmd, (void *)NULL);
@@ -77,9 +126,17 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	} else if (pid < 0) {
 		close(fd[0]);
 		close(fd[1]);
+		if (use_wl_socket) {
+			close(sockets[0]);
+			close(sockets[1]);
+		}
 		return cmd_results_new(CMD_FAILURE, "fork() failed");
 	}
 	close(fd[1]); // close write
+	if (use_wl_socket) {
+		close(sockets[1]);
+		client = wl_client_create(server.wl_display, sockets[0]);
+	}
 	ssize_t s = 0;
 	while ((size_t)s < sizeof(pid_t)) {
 		s += read(fd[0], ((uint8_t *)&child) + s, sizeof(pid_t) - s);
@@ -92,6 +149,10 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 		root_record_workspace_pid(child);
 	} else {
 		return cmd_results_new(CMD_FAILURE, "Second fork() failed");
+	}
+
+	if (client && label) {
+		wl_client_label_set(client, strdup(label));
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/sandbox_socket.c
+++ b/sway/commands/sandbox_socket.c
@@ -1,0 +1,147 @@
+#define _XOPEN_SOURCE 700 // for strdup
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <wayland-server-core.h>
+#include "sway/client_label.h"
+#include "sway/commands.h"
+#include "sway/tree/container.h"
+#include "sway/tree/view.h"
+#include "list.h"
+#include "log.h"
+#include "util.h"
+
+struct sandbox_socket {
+	char* path;
+	struct wl_event_source *src;
+	int fd;
+	char* label;
+};
+
+static list_t *sandbox_sockets;
+
+static int fd_accept(int srv_fd, uint32_t mask, void *data) {
+	struct sandbox_socket *sock = data;
+
+	int cli_fd = accept(srv_fd, NULL, NULL);
+	if (cli_fd < 0) {
+		if (errno == EINTR || errno == ECONNABORTED || errno == EAGAIN || errno == EWOULDBLOCK) {
+			return 1;
+		} else {
+			int i;
+			wl_event_source_remove(sock->src);
+			unlink(sock->path);
+			free(sock->path);
+			close(srv_fd);
+			for(i = 0; i < sandbox_sockets->length; ++i) {
+				if (sock != sandbox_sockets->items[i])
+					continue;
+				list_del(sandbox_sockets, i);
+				break;
+			}
+			free(sock);
+			return 0;
+		}
+	}
+
+	sway_set_cloexec(cli_fd, true);
+	struct wl_client* client = wl_client_create(server.wl_display, cli_fd);
+	if (client) {
+		wl_client_label_set(client, strdup(sock->label));
+	} else {
+		close(cli_fd);
+	}
+
+	return 1;
+}
+
+struct cmd_results *cmd_sandbox_socket(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "sandbox_socket", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+
+	if (!sandbox_sockets)
+		sandbox_sockets = create_list();
+
+	char* op = argv[0];
+
+	if (strcmp(op, "create") == 0) {
+		struct sockaddr_un name = {};
+		char* label = NULL;
+		int i = 1;
+		while (i < argc) {
+			if (strcmp(argv[i], "--label") == 0) {
+				if (i + 1 >= argc)
+					return cmd_results_new(CMD_INVALID, "--label requires an argument");
+				label = argv[i + 1];
+				i += 2;
+			} else if (strcmp(argv[i], "--") == 0) {  // after this any argument should be treated as positional
+				++i;
+				break;
+			} else if (strncmp(argv[i], "-", 1) == 0) {
+				return cmd_results_new(CMD_INVALID, "Unknown option to sandbox_socket");
+			} else {
+				break;  // end of options, now only positional arguments
+			}
+		}
+
+		if ((error = checkarg(argc, "sandbox_socket", EXPECTED_EQUAL_TO, i + 1))) {
+			return error;
+		}
+		char *path = argv[i];
+		size_t path_len = strlen(path) + 1;
+
+		if (path_len > sizeof(name.sun_path)) {
+			return cmd_results_new(CMD_INVALID, "Invalid socket path: %s", path);
+		}
+		unlink(path);
+
+		name.sun_family = AF_UNIX;
+		memcpy(name.sun_path, path, path_len);
+		size_t name_len = offsetof(struct sockaddr_un, sun_path) + path_len;
+
+		int srv_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		if (srv_fd < 0 ||
+				!sway_set_cloexec(srv_fd, true) ||
+				fcntl(srv_fd, F_SETFL, O_NONBLOCK) != 0 ||
+				bind(srv_fd, (struct sockaddr *)&name, name_len) != 0 ||
+				listen(srv_fd, 5) != 0) {
+			close(srv_fd);
+			return cmd_results_new(CMD_FAILURE, "Error creating socket: %s", strerror(errno));
+		}
+
+		struct sandbox_socket *sock = calloc(1, sizeof(*sock));
+		sock->path = strdup(path);
+		sock->src = wl_event_loop_add_fd(server.wl_event_loop, srv_fd, WL_EVENT_READABLE, fd_accept, sock);
+		sock->fd = srv_fd;
+		if (label)
+			sock->label = strdup(label);
+
+		list_add(sandbox_sockets, sock);
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	} else if (strcmp(op, "delete") == 0) {
+		char* path = argv[1];
+		int i;
+		for(i = 0; i < sandbox_sockets->length; ++i) {
+			struct sandbox_socket *sock = sandbox_sockets->items[i];
+			if (strcmp(sock->path, path) == 0) {
+				wl_event_source_remove(sock->src);
+				unlink(path);
+				close(sock->fd);
+				free(sock->path);
+				free(sock->label);
+				free(sock);
+				list_del(sandbox_sockets, i);
+				return cmd_results_new(CMD_SUCCESS, NULL);
+			}
+		}
+		return cmd_results_new(CMD_FAILURE, "sandbox_socket: %s not found", path);
+	} else {
+		return cmd_results_new(CMD_INVALID, "Unknown command sandbox_socket %s", op);
+	}
+}

--- a/sway/commands/swaybg_command.c
+++ b/sway/commands/swaybg_command.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700 // for strdup
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"
@@ -5,12 +6,23 @@
 
 struct cmd_results *cmd_swaybg_command(int argc, char **argv) {
 	struct cmd_results *error = NULL;
+	char *new_label = NULL;
 	if ((error = checkarg(argc, "swaybg_command", EXPECTED_AT_LEAST, 1))) {
 		return error;
+	}
+	if (strcmp(argv[0], "--label") == 0) {
+		if ((error = checkarg(argc, "swaybg_command", EXPECTED_AT_LEAST, 3))) {
+			return error;
+		}
+		new_label = strdup(argv[1]);
+		argv += 2;
+		argc -= 2;
 	}
 
 	free(config->swaybg_command);
 	config->swaybg_command = NULL;
+	free(config->swaybg_label);
+	config->swaybg_label = new_label;
 
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {

--- a/sway/commands/swaynag_command.c
+++ b/sway/commands/swaynag_command.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700 // for strdup
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"
@@ -5,12 +6,23 @@
 
 struct cmd_results *cmd_swaynag_command(int argc, char **argv) {
 	struct cmd_results *error = NULL;
+	char *new_label = NULL;
 	if ((error = checkarg(argc, "swaynag_command", EXPECTED_AT_LEAST, 1))) {
 		return error;
+	}
+	if (strcmp(argv[0], "--label") == 0) {
+		if ((error = checkarg(argc, "swaynag_command", EXPECTED_AT_LEAST, 3))) {
+			return error;
+		}
+		new_label = strdup(argv[1]);
+		argv += 2;
+		argc -= 2;
 	}
 
 	free(config->swaynag_command);
 	config->swaynag_command = NULL;
+	free(config->swaynag_label);
+	config->swaynag_label = new_label;
 
 	char *new_command = join_args(argv, argc);
 	if (strcmp(new_command, "-") != 0) {

--- a/sway/config.c
+++ b/sway/config.c
@@ -161,6 +161,8 @@ void free_config(struct sway_config *config) {
 	free(config->font);
 	free(config->swaybg_command);
 	free(config->swaynag_command);
+	free(config->swaybg_label);
+	free(config->swaynag_label);
 	free((char *)config->current_config_path);
 	free((char *)config->current_config);
 	keysym_translation_state_destroy(config->keysym_translation_state);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -10,6 +10,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wordexp.h>
+#include "sway/client_label.h"
 #include "sway/config.h"
 #include "sway/input/keyboard.h"
 #include "sway/output.h"
@@ -37,6 +38,7 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->hidden_state);
 	free(bar->status_command);
 	free(bar->swaybar_command);
+	free(bar->swaybar_label);
 	free(bar->font);
 	free(bar->separator_symbol);
 	if (bar->bindings) {
@@ -203,6 +205,10 @@ static void invoke_swaybar(struct bar_config *bar) {
 	if (bar->client == NULL) {
 		sway_log_errno(SWAY_ERROR, "wl_client_create failed");
 		return;
+	}
+
+	if (bar->swaybar_label) {
+		wl_client_label_set(bar->client, strdup(bar->swaybar_label));
 	}
 
 	bar->client_destroy.notify = handle_swaybar_client_destroy;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output.h>
+#include "sway/client_label.h"
 #include "sway/config.h"
 #include "sway/input/cursor.h"
 #include "sway/output.h"
@@ -688,6 +689,10 @@ static bool _spawn_swaybg(char **command) {
 	if (config->swaybg_client == NULL) {
 		sway_log_errno(SWAY_ERROR, "wl_client_create failed");
 		return false;
+	}
+
+	if (config->swaybg_label) {
+		wl_client_label_set(config->swaybg_client, strdup(config->swaybg_label));
 	}
 
 	config->swaybg_client_destroy.notify = handle_swaybg_client_destroy;

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -20,6 +20,7 @@ bool criteria_is_empty(struct criteria *criteria) {
 		&& !criteria->shell
 		&& !criteria->app_id
 		&& !criteria->con_mark
+		&& !criteria->cli_label
 		&& !criteria->con_id
 #if HAVE_XWAYLAND
 		&& !criteria->class
@@ -93,6 +94,7 @@ void criteria_destroy(struct criteria *criteria) {
 	pattern_destroy(criteria->window_role);
 #endif
 	pattern_destroy(criteria->con_mark);
+	pattern_destroy(criteria->cli_label);
 	free(criteria->workspace);
 	free(criteria->cmdlist);
 	free(criteria->raw);
@@ -234,6 +236,26 @@ static bool criteria_matches_view(struct criteria *criteria,
 			break;
 		case PATTERN_PCRE:
 			if (regex_cmp(app_id, criteria->app_id->regex) != 0) {
+				return false;
+			}
+			break;
+		}
+	}
+
+	if (criteria->cli_label) {
+		const char *cli_label = view_get_conn_label(view);
+		if (!cli_label) {
+			return false;
+		}
+
+		switch (criteria->cli_label->match_type) {
+		case PATTERN_FOCUSED:
+			if (focused && lenient_strcmp(cli_label, view_get_conn_label(focused))) {
+				return false;
+			}
+			break;
+		case PATTERN_PCRE:
+			if (regex_cmp(cli_label, criteria->cli_label->regex) != 0) {
 				return false;
 			}
 			break;
@@ -452,6 +474,7 @@ enum criteria_token {
 	T_APP_ID,
 	T_CON_ID,
 	T_CON_MARK,
+	T_CLI_LABEL,
 	T_FLOATING,
 #if HAVE_XWAYLAND
 	T_CLASS,
@@ -477,6 +500,8 @@ static enum criteria_token token_from_name(char *name) {
 		return T_CON_ID;
 	} else if (strcmp(name, "con_mark") == 0) {
 		return T_CON_MARK;
+	} else if (strcmp(name, "cli_label") == 0) {
+		return T_CLI_LABEL;
 #if HAVE_XWAYLAND
 	} else if (strcmp(name, "class") == 0) {
 		return T_CLASS;
@@ -552,6 +577,9 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		break;
 	case T_CON_MARK:
 		pattern_create(&criteria->con_mark, value);
+		break;
+	case T_CLI_LABEL:
+		pattern_create(&criteria->cli_label, value);
 		break;
 #if HAVE_XWAYLAND
 	case T_CLASS:

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/edges.h>
 #include "log.h"
+#include "sway/client_label.h"
 #include "sway/decoration.h"
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"
@@ -537,4 +538,48 @@ void handle_xdg_shell_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&xdg_surface->events.destroy, &xdg_shell_view->destroy);
 
 	xdg_surface->data = xdg_shell_view;
+}
+
+struct wl_client_label {
+	struct wl_listener listener;
+	char* label;
+};
+
+static void wl_client_label_notify_fn(struct wl_listener *listener, void *data) {
+	// struct wl_client *client = data;
+	struct wl_client_label *label = wl_container_of(listener, label, listener);
+	free(label->label);
+	free(label);
+}
+
+char *wl_client_label_get(struct wl_client *client) {
+	struct wl_listener *label_l =
+		wl_client_get_destroy_listener(client, wl_client_label_notify_fn);
+	if (!label_l) {
+		return NULL;
+	}
+	struct wl_client_label *label_s = wl_container_of(label_l, label_s, listener);
+	return label_s->label;
+}
+
+void wl_client_label_set(struct wl_client *client, char* label) {
+	struct wl_listener *label_l =
+		wl_client_get_destroy_listener(client, wl_client_label_notify_fn);
+	struct wl_client_label *label_s;
+	if (label_l) {
+		label_s = wl_container_of(label_l, label_s, listener);
+		free(label_s->label);
+	} else if (label == NULL) {
+		return;
+	} else {
+		label_s = calloc(1, sizeof(*label_s));
+		if (label_s == NULL) {
+			sway_log(SWAY_ERROR, "Allocation failed");
+			free(label);
+			return;
+		}
+		label_s->listener.notify = wl_client_label_notify_fn;
+		wl_client_add_destroy_listener(client, &label_s->listener);
+	}
+	label_s->label = label;
 }

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -490,6 +490,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "app_id",
 			app_id ? json_object_new_string(app_id) : NULL);
 
+	const char *label = view_get_conn_label(c->view);
+	json_object_object_add(object, "cli_label",
+			label ? json_object_new_string(label) : NULL);
+
 	bool visible = view_is_visible(c->view);
 	json_object_object_add(object, "visible", json_object_new_boolean(visible));
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -85,6 +85,7 @@ sway_sources = files(
 	'commands/reload.c',
 	'commands/rename.c',
 	'commands/resize.c',
+	'commands/sandbox_socket.c',
 	'commands/scratchpad.c',
 	'commands/seat.c',
 	'commands/seat/attach.c',

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -8,6 +8,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include "log.h"
+#include "sway/client_label.h"
+#include "sway/config.h"
 #include "sway/server.h"
 #include "sway/swaynag.h"
 #include "util.h"
@@ -54,6 +56,10 @@ bool swaynag_spawn(const char *swaynag_command,
 	if (swaynag->client == NULL) {
 		sway_log_errno(SWAY_ERROR, "wl_client_create failed");
 		goto failed;
+	}
+
+	if (config->swaynag_label) {
+		wl_client_label_set(swaynag->client, strdup(config->swaynag_label));
 	}
 
 	swaynag->client_destroy.notify = handle_swaynag_client_destroy;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -13,6 +13,7 @@
 #endif
 #include "list.h"
 #include "log.h"
+#include "sway/client_label.h"
 #include "sway/criteria.h"
 #include "sway/commands.h"
 #include "sway/desktop.h"
@@ -105,6 +106,21 @@ const char *view_get_class(struct sway_view *view) {
 const char *view_get_instance(struct sway_view *view) {
 	if (view->impl->get_string_prop) {
 		return view->impl->get_string_prop(view, VIEW_PROP_INSTANCE);
+	}
+	return NULL;
+}
+
+const char *view_get_conn_label(struct sway_view *view) {
+	switch (view->type) {
+	case SWAY_VIEW_XDG_SHELL:;
+		struct wl_client *client =
+			wl_resource_get_client(view->surface->resource);
+		return wl_client_label_get(client);
+#if HAVE_XWAYLAND
+	case SWAY_VIEW_XWAYLAND:;
+		// Is this concept useful in xwayland?
+		break;
+#endif
 	}
 	return NULL;
 }


### PR DESCRIPTION
This is (an improved version of) the labelling part of https://github.com/swaywm/sway/pull/5675, which is useful alone (as @ony mentioned).  There is currently no support for handling Xwayland sockets (and I'm not sure it would make sense to do so; at least none of the current methods for setting labels would support X).  Since this isn't a feature that i3 could support (due to i3 not being the display server) and is similar to an existing sway-only feature (matching pid in criteria), I don't think i3 compatibility is relevant.

Labels are distinct from marks because multiple windows and clients can have a single label, otherwise they are similar in concept.  This merge request does not contain a way to set a label on an existing client, but that could be added later if it is useful.

Example that launches two terminals on different workspaces as part of sway startup:
```
assign [cli_label=wks1] workspace 1
assign [cli_label=wks2] workspace 2
exec --label wks1 $term
exec --label wks2 $term
```