### PR TITLE
Test output before direct scan-out

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -548,10 +548,14 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
+	wlr_output_attach_buffer(wlr_output, &surface->buffer->base);
+	if (!wlr_output_test(wlr_output)) {
+		return false;
+	}
+
 	wlr_presentation_surface_sampled_on_output(server.presentation, surface,
 		wlr_output);
 
-	wlr_output_attach_buffer(wlr_output, &surface->buffer->base);
 	return wlr_output_commit(wlr_output);
 }
 


### PR DESCRIPTION
This avoids some log spam.

Eventually when we wire up the atomic test commit this will take care of
the other log spam referenced below.

References: https://github.com/swaywm/sway/pull/5010
References: https://github.com/swaywm/wlroots/issues/2181
Closes: https://github.com/swaywm/wlroots/issues/2532