### PR TITLE
Fix for_window criteria and mouse button bindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -559,7 +559,7 @@ struct sway_config {
 		struct sway_node *node;
 		struct sway_container *container;
 		struct sway_workspace *workspace;
-		bool using_criteria;
+		bool node_overridden; // True if the node is selected by means other than focus
 		struct {
 			int argc;
 			char **argv;

--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -105,12 +105,12 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Scratchpad is empty");
 	}
 
-	if (config->handler_context.using_criteria) {
+	if (config->handler_context.node_overridden) {
 		struct sway_container *con = config->handler_context.container;
 
 		// If the container is in a floating split container,
 		// operate on the split container instead of the child.
-		if (container_is_floating_or_child(con)) {
+		if (con && container_is_floating_or_child(con)) {
 			while (con->pending.parent) {
 				con = con->pending.parent;
 			}
@@ -118,8 +118,9 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 
 		// If using criteria, this command is executed for every container which
 		// matches the criteria. If this container isn't in the scratchpad,
-		// we'll just silently return a success.
-		if (!con->scratchpad) {
+		// we'll just silently return a success. The same is true if the
+		// overridden node is not a container.
+		if (!con || !con->scratchpad) {
 			return cmd_results_new(CMD_SUCCESS, NULL);
 		}
 		scratchpad_toggle_container(con);

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -21,7 +21,7 @@ static void remove_all_marks_iterator(struct sway_container *con, void *data) {
 struct cmd_results *cmd_unmark(int argc, char **argv) {
 	// Determine the container
 	struct sway_container *con = NULL;
-	if (config->handler_context.using_criteria) {
+	if (config->handler_context.node_overridden) {
 		con = config->handler_context.container;
 	}
 


### PR DESCRIPTION
Previously, the special case handling of scratchpad and unmark commands
was (probably accidentally) limited to criteria directly handled in the
execute_command function. This would exclude: 1. for_window criteria, as
these are handled externally for views and 2. and mouse bindings which
select target the node currently under the mouse cursor.

As a concrete example `for_window [app_id="foobar"] move scratchpad,
scratchpad show` would show (or hide due to the toggling functionality)
another window from the scratchpad, instead of showing the window with
app_id "foobar".

This commit replaces the "using_criteria" flag with "node_overridden"
with the more general notion of signifying that the node (and
container/workspace) in the current command handler context of the sway
config is not defined by the currently focused node, but instead
overridden by other means, i.e., criteria or mouse position.

## Test plan
### for_window criteria:

Choose two applications `$app1` and `$app2` with respective app ids `$appid1` and `$appid2`. Add the following to your sway config:

```
for_window [app_id="$appid1"] move scratchpad, scratchpad show
for_window [app_id="$appid2"] move scratchpad, scratchpad show
bindsym $somekey $app1
bindsym $otherkey $app2
```

Press `$somekey`. `$app1` will be started, moved to scratchpad and then shown.
Then press `$otherkey`. `$app2` will be started and moved to scratchpad. Now the behaviour diverges:

#### master:
`$app1` will be hidden (because the criterion of the second config line of above is not applied to the `scratchpad show`).

#### with this patch:
`$app2` will be shown as expected.

### mouse button bindings:

In your sway config:
```
focus_follows_mouse no
bindsym --whole-window $mod+button2 scratchpad show
```

Again, choose two applications (`$app1`, `$app2`), move them to scratchpad, show them both on your desktop.
Now focus `$app1`, but move your mouse over onto the window of `$app2` and press `$mod` + middle mouse button.

master:
`$app1` will be hidden (since the container override of the button command is not propagated to `scratchpad show`).

with this patch:
`$app2` will be hidden as expected.
