### PR TITLE
Delay refocus until after arranging nodes

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -97,8 +97,6 @@ void container_begin_destroy(struct sway_container *con) {
 		container_fullscreen_disable(con);
 	}
 
-	wl_signal_emit(&con->node.events.destroy, &con->node);
-
 	container_end_mouse_operation(con);
 
 	con->node.destroying = true;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -844,6 +844,7 @@ void view_unmap(struct sway_view *view) {
 		seat_consider_warp_to_focus(seat);
 	}
 
+	wl_signal_emit(&view->container->node.events.destroy, &view->container->node);
 	transaction_commit_dirty();
 	view->surface = NULL;
 }


### PR DESCRIPTION
fixes #5873
    
i3 determines focus after it arranges its nodes, so the ipc events that follow have the newly updated window geometry.
