### PR TITLE
Fix layer shell subsurface use after free

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -48,6 +48,7 @@ struct sway_layer_subsurface {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 	struct wl_listener commit;
+	struct wl_listener layer_surface_destroy;
 };
 
 struct sway_output;


### PR DESCRIPTION
This occurs when a layer surface is destroyed , prompting an unmap event for all its children subsurfaces (if it has any). Since this happens after the parent surface is destroyed, any pointers to it become dangling.

A better approach might be to make wlroots unmap the children subsurfaces _before_ the parent is freed, but I couldn't figure out any easy way to do that.

To test this, start gtk-layer-demo, open the popover, and kill the process with the popover still open. 