### PR TITLE
ISSUE_TEMPLATE: the wiki is community maintained

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,8 @@ labels: 'bug'
 - Please do NOT submit bug reports for questions. Ask questions on IRC at #sway on irc.freenode.net.
 - Proprietary graphics drivers, including nvidia, are not supported. Please use the open source equivalents, such as nouveau, if you would like to use Sway.
 - Problems with the Wayland version of Firefox are likely to be Firefox bugs. Start by submitting your issue to the Firefox Bugzilla and come back here only after they confirm otherwise.
+- Please do NOT submit issues for information from the github wiki. The github wiki is community maintained and therefore may contain outdated information, scripts that don't work or osbolete workarounds.
+  If you fix a script or find outdated information, don't hesitate to adjust the wiki page.
 
 ### Please fill out the following:
 - **Sway Version:**


### PR DESCRIPTION
Mention that the github wiki may contain outdated information scripts
and old workarounds and that sway the sway project does not provide
support for it.