### PR TITLE
readme: use references for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # sway
 
-[**English**](https://github.com/swaywm/sway/blob/master/README.md#sway--) - [日本語](https://github.com/swaywm/sway/blob/master/README.ja.md#sway--) - [Français](https://github.com/swaywm/sway/blob/master/README.fr.md#sway--) - [Українська](https://github.com/swaywm/sway/blob/master/README.uk.md#sway--) - [Español](https://github.com/swaywm/sway/blob/master/README.es.md#sway--) - [Polski](https://github.com/swaywm/sway/blob/master/README.pl.md#sway--) - [中文-简体](https://github.com/swaywm/sway/blob/master/README.zh-CN.md#sway--) - [Deutsch](https://github.com/swaywm/sway/blob/master/README.de.md#sway--) - [Nederlands](https://github.com/swaywm/sway/blob/master/README.nl.md#sway--) - [Русский](https://github.com/swaywm/sway/blob/master/README.ru.md#sway--)- [中文-繁體](https://github.com/swaywm/sway/blob/master/README.zh-TW.md#sway--) - [Português](https://github.com/swaywm/sway/blob/master/README.pt.md#sway--) - [Danish](https://github.com/swaywm/sway/blob/master/README.dk.md#sway--) - [한국어](https://github.com/swaywm/sway/blob/master/README.ko.md#sway--) - [Română](https://github.com/swaywm/sway/blob/master/README.ro.md#sway--)
+**[English][en]** - [日本語][ja] - [Français][fr] - [Українська][uk] - [Español][es] - [Polski][pl] - [中文-简体][zh-CN] - [Deutsch][de] - [Nederlands][nl] - [Русский][ru] - [中文-繁體][zh-TW] - [Português][pt] - [Danish][dk] - [한국어][ko] - [Română][ro]
 
-sway is an [i3](https://i3wm.org/)-compatible [Wayland](http://wayland.freedesktop.org/) compositor.
-Read the [FAQ](https://github.com/swaywm/sway/wiki). Join the [IRC
-channel](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway on
-irc.freenode.net).
+sway is an [i3]-compatible [Wayland] compositor. Read the [FAQ]. Join the
+[IRC channel] \(#sway on irc.freenode.net).
 
 If you'd like to support sway development, please contribute to [SirCmpwn's
-Patreon page](https://patreon.com/sircmpwn).
+Patreon page].
 
 ## Release Signatures
 
-Releases are signed with [E88F5E48](https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48)
-and published [on GitHub](https://github.com/swaywm/sway/releases).
+Releases are signed with [E88F5E48] and published [on GitHub][GitHub releases].
 
 ## Installation
 
@@ -27,12 +24,13 @@ channel or shoot an email to sir@cmpwn.com for advice.
 
 ### Compiling from Source
 
-Check out [this wiki page](https://github.com/swaywm/sway/wiki/Development-Setup) if you want to build the HEAD of sway and wlroots for testing or development.
+Check out [this wiki page][Development setup] if you want to build the HEAD of
+sway and wlroots for testing or development.
 
 Install dependencies:
 
 * meson \*
-* [wlroots](https://github.com/swaywm/wlroots)
+* [wlroots]
 * wayland
 * wayland-protocols \*
 * pcre
@@ -40,7 +38,7 @@ Install dependencies:
 * pango
 * cairo
 * gdk-pixbuf2 (optional: system tray)
-* [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*
+* [scdoc] (optional: man pages) \*
 * git (optional: version info) \*
 
 _\*Compile-time dep_
@@ -68,3 +66,29 @@ Run `man 5 sway` for information on the configuration.
 
 Run `sway` from a TTY. Some display managers may work but are not supported by
 sway (gdm is known to work fairly well).
+
+[en]: https://github.com/swaywm/sway#readme
+[ja]: https://github.com/swaywm/sway/blob/master/README.ja.md
+[fr]: https://github.com/swaywm/sway/blob/master/README.fr.md
+[uk]: https://github.com/swaywm/sway/blob/master/README.uk.md
+[es]: https://github.com/swaywm/sway/blob/master/README.es.md
+[pl]: https://github.com/swaywm/sway/blob/master/README.pl.md
+[zh-CN]: https://github.com/swaywm/sway/blob/master/README.zh-CN.md
+[de]: https://github.com/swaywm/sway/blob/master/README.de.md
+[nl]: https://github.com/swaywm/sway/blob/master/README.nl.md
+[ru]: https://github.com/swaywm/sway/blob/master/README.ru.md
+[zh-TW]: https://github.com/swaywm/sway/blob/master/README.zh-TW.md
+[pt]: https://github.com/swaywm/sway/blob/master/README.pt.md
+[dk]: https://github.com/swaywm/sway/blob/master/README.dk.md
+[ko]: https://github.com/swaywm/sway/blob/master/README.ko.md
+[ro]: https://github.com/swaywm/sway/blob/master/README.ro.md
+[i3]: https://i3wm.org/
+[Wayland]: http://wayland.freedesktop.org/
+[FAQ]: https://github.com/swaywm/sway/wiki
+[IRC channel]: http://webchat.freenode.net/?channels=sway&uio=d4
+[SirCmpwn's Patreon page]: https://patreon.com/sircmpwn
+[E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
+[GitHub releases]: https://github.com/swaywm/sway/releases
+[Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup
+[wlroots]: https://github.com/swaywm/wlroots
+[scdoc]: https://git.sr.ht/~sircmpwn/scdoc


### PR DESCRIPTION
This avoids cluttering the README text with URLs.

[GitHub's rendered diff](https://github.com/swaywm/sway/pull/5894/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) can help making sure the links didn't change. I simplified the language links, removing a broken anchor.