### PR TITLE
Restrict floating corners command line option (wip)

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -15,6 +15,8 @@
 #include "sway/input/tablet.h"
 #include "sway/tree/root.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
+#include <wlr/util/edges.h>
+
 
 // TODO: Refactor this shit
 
@@ -473,6 +475,7 @@ struct sway_config {
 	bool floating_mod_inverse;
 	uint32_t dragging_key;
 	uint32_t resizing_key;
+    enum wlr_edges resizing_corner;
 	char *floating_scroll_up_cmd;
 	char *floating_scroll_down_cmd;
 	char *floating_scroll_left_cmd;

--- a/sway/commands/resizing_corner.c
+++ b/sway/commands/resizing_corner.c
@@ -1,0 +1,31 @@
+#include "strings.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/keyboard.h"
+
+struct cmd_results *cmd_resizing_corner(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "resizing_corner", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+    // Corresponds to WLR bitmasks (see edges.h)
+    if (strcasecmp(argv[1], "all") == 0) {
+      config->resizing_corner = WLR_EDGE_NONE;
+    } else if (strcasecmp(argv[1], "topright") == 0) {
+      config->resizing_corner = WLR_EDGE_TOP & WLR_EDGE_RIGHT;
+    } else if (strcasecmp(argv[1], "bottomright") == 0) {
+      config->resizing_corner = WLR_EDGE_BOTTOM & WLR_EDGE_RIGHT;
+    } else if (strcasecmp(argv[1], "bottomleft") == 0) {
+      config->resizing_corner = WLR_EDGE_BOTTOM & WLR_EDGE_LEFT;
+    } else if (strcasecmp(argv[1], "topleft") == 0) {
+      config->resizing_corner = WLR_EDGE_TOP & WLR_EDGE_LEFT;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+				"Usage: resizing_corner [topright|bottomright|bottomleft|topleft|all]");
+	}
+
+	config->resizing_corner = corner;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -228,6 +228,7 @@ static void config_defaults(struct sway_config *config) {
 	config->floating_mod_inverse = false;
 	config->dragging_key = BTN_LEFT;
 	config->resizing_key = BTN_RIGHT;
+	config->resizing_corner = 0;
 
 	if (!(config->floating_scroll_up_cmd = strdup(""))) goto cleanup;
 	if (!(config->floating_scroll_down_cmd = strdup(""))) goto cleanup;

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -34,7 +34,12 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_resize_floating_event *e = seat->seatop_data;
 	struct sway_container *con = e->con;
-	enum wlr_edges edge = e->edge;
+    enum wlr_edges edge;
+    if(config->resizing_corner){
+      edge = config->resizing_corner;
+    } else {
+      edge = e->edge;
+    }
 	struct sway_cursor *cursor = seat->cursor;
 
 	// The amount the mouse has moved since the start of the resize operation


### PR DESCRIPTION
This is definitely going to need some help, but you can see where I'm going with this.  Idea is to allow emulation of xmonad-style resizing behavior (e.g., always keep top-left corner static, resize at bottom-right corner).