### PR TITLE
Add no_titlebars command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -160,6 +160,7 @@ sway_cmd cmd_opacity;
 sway_cmd cmd_new_float;
 sway_cmd cmd_new_window;
 sway_cmd cmd_no_focus;
+sway_cmd cmd_no_titlebars;
 sway_cmd cmd_output;
 sway_cmd cmd_permit;
 sway_cmd cmd_popup_during_fullscreen;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -511,6 +511,7 @@ struct sway_config {
 
 	bool tiling_drag;
 	int tiling_drag_threshold;
+	bool no_titlebars;
 
 	bool smart_gaps;
 	int gaps_inner;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -78,6 +78,7 @@ static struct cmd_handler handlers[] = {
 	{ "new_float", cmd_new_float },
 	{ "new_window", cmd_new_window },
 	{ "no_focus", cmd_no_focus },
+	{ "no_titlebars", cmd_no_titlebars },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
 	{ "seat", cmd_seat },

--- a/sway/commands/no_titlebars.c
+++ b/sway/commands/no_titlebars.c
@@ -1,0 +1,24 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+#include "sway/tree/container.h"
+#include "log.h"
+#include "stringop.h"
+#include "util.h"
+
+struct cmd_results *cmd_no_titlebars(int argc, char **argv) {
+	struct cmd_results *error = checkarg(argc, "no_titlebars", EXPECTED_EQUAL_TO, 1);
+
+	if (error) {
+		return error;
+	}
+
+	config->no_titlebars = parse_boolean(argv[0], config->no_titlebars);
+
+	arrange_root();
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+

--- a/sway/config.c
+++ b/sway/config.c
@@ -266,6 +266,7 @@ static void config_defaults(struct sway_config *config) {
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
+	config->no_titlebars = false;
 
 	config->smart_gaps = false;
 	config->gaps_inner = 0;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -659,6 +659,9 @@ static void render_titlebar(struct sway_output *output,
 static void render_top_border(struct sway_output *output,
 		pixman_region32_t *output_damage, struct sway_container *con,
 		struct border_colors *colors) {
+	if (config->no_titlebars) {
+		return;
+	}
 	struct sway_container_state *state = &con->current;
 	if (!state->border_top) {
 		return;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -79,6 +79,7 @@ sway_sources = files(
 	'commands/new_float.c',
 	'commands/new_window.c',
 	'commands/no_focus.c',
+	'commands/no_titlebars.c',
 	'commands/nop.c',
 	'commands/output.c',
 	'commands/popup_during_fullscreen.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -639,6 +639,9 @@ The default colors are:
 	may make it unnecessarily hard to tell which window originally raised the
 	event. This option allows to set a _timeout_ in ms to delay the urgency hint reset.
 
+*no_titlebars* enable|disable|toggle
+	Do not render titlebars
+
 *titlebar_border_thickness* <thickness>
 	Thickness of the titlebar border in pixels
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -617,7 +617,11 @@ void container_update_representation(struct sway_container *con) {
 }
 
 size_t container_titlebar_height(void) {
-	return config->font_height + config->titlebar_v_padding * 2;
+	if (config->no_titlebars) {
+		return 0;
+	} else {
+		return config->font_height + config->titlebar_v_padding * 2;
+	}
 }
 
 void floating_calculate_constraints(int *min_width, int *max_width,


### PR DESCRIPTION
I think a lot of people only use a small number of windows in each workspace and can remember which windows they have in each workspace so don't need the dedicated titlebar space.

I know this is something the i3 maintainers are not interested in so it probably won't fit the sway philosophy either. Several people are asking for it so I figured I'd open this PR at least so that people can find the code if they need it. Feel free to close.