### PR TITLE
container: set fullscreen mode before attempting focus

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -994,6 +994,7 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 	bool enable = true;
 	set_fullscreen_iterator(con, &enable);
 	container_for_each_child(con, set_fullscreen_iterator, &enable);
+	con->fullscreen_mode = FULLSCREEN_WORKSPACE;
 
 	con->saved_x = con->x;
 	con->saved_y = con->y;
@@ -1017,7 +1018,6 @@ static void container_fullscreen_workspace(struct sway_container *con) {
 		}
 	}
 
-	con->fullscreen_mode = FULLSCREEN_WORKSPACE;
 	container_end_mouse_operation(con);
 	ipc_event_window(con, "fullscreen_mode");
 }


### PR DESCRIPTION
Fixes #5905

Previously the new fullscreen container would fail to focus because of a check for "obscured by fullscreen view" in seat_set_focus, but the container here is itself the fullscreen view. Thats a bug in it's own right, and it incidentally fixes the crash.

The crash happens because when the scratchpad window is dismissed the focus logic again fails to re-set focus to the previous focus behind the newly fullscreened view (so the scratchpad hidden window retains focus, a guaranteed crash).

Aside:
In my experience, focused scratchpad windows are a common source of fatal crashes in sway. I think the \*set_focus\* functions really ought to return a bool or maybe a pointer to the node they focused so the caller can do something intelligent when it fails to find a proper focus. We should never be sending focused containers to the scratchpad.