### PR TITLE
Revert removal of the raise_floating directive

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -131,6 +131,7 @@ sway_cmd cmd_floating_modifier;
 sway_cmd cmd_floating_scroll;
 sway_cmd cmd_focus;
 sway_cmd cmd_focus_follows_mouse;
+sway_cmd cmd_raise_floating;
 sway_cmd cmd_focus_on_window_activation;
 sway_cmd cmd_focus_wrapping;
 sway_cmd cmd_font;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -500,6 +500,7 @@ struct sway_config {
 	enum focus_follows_mouse_mode focus_follows_mouse;
 	enum mouse_warping_mode mouse_warping;
 	enum focus_wrapping_mode focus_wrapping;
+	bool raise_floating;
 	bool active;
 	bool failed;
 	bool reloading;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -80,6 +80,7 @@ static struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "raise_floating", cmd_raise_floating },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/raise_floating.c
+++ b/sway/commands/raise_floating.c
@@ -1,0 +1,14 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_raise_floating(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "raise_floating", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	config->raise_floating =
+		parse_boolean(argv[0], config->raise_floating);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -254,6 +254,7 @@ static void config_defaults(struct sway_config *config) {
 
 	// Flags
 	config->focus_follows_mouse = FOLLOWS_YES;
+	config->raise_floating = false;
 	config->mouse_warping = WARP_OUTPUT;
 	config->focus_wrapping = WRAP_YES;
 	config->validating = false;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1184,6 +1184,11 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 		}
 	}
 
+	// If we've focused a floating container, bring it to the front.
+	if (container && config->raise_floating) {
+		container_raise_floating(container);
+	}
+
 	if (new_output_last_ws) {
 		workspace_consider_destroy(new_output_last_ws);
 	}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -56,6 +56,7 @@ sway_sources = files(
 	'commands/floating_modifier.c',
 	'commands/focus.c',
 	'commands/focus_follows_mouse.c',
+	'commands/raise_floating.c',
 	'commands/focus_on_window_activation.c',
 	'commands/focus_wrapping.c',
 	'commands/font.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -678,6 +678,11 @@ The default colors are:
 	devices. A list of input device names may be obtained via *swaymsg -t
 	get_inputs*.
 
+*raise\_floating* yes|no
+	Controls the behaviour of floating windows. A _yes_ (the default) will
+	raise windows on gaining focus. A _no_ will only raise floating windows
+	by clicking anywhere in the window.
+
 *seat* <seat> <seat-subcommands...>
 	For details on seat subcommands, see *sway-input*(5).
 


### PR DESCRIPTION
This pull request reverts commit b9b1b0e5662f8e3dbbfa9bb09dd4f69aac9c2db0, and therefore pull request #2888. The reason being that with some panels that list windows (such as `wf-panel`), focusing on a window won't raise it up front, which is weird.

However, this pull request also sets the default value for `raise_floating` to `false`, to not break existing setups that expect the old behavior.