### PR TITLE
tray: do not render passive items

### DIFF
--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -461,6 +461,11 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 		sni->target_size = target_size;
 	}
 
+	// Passive
+	if (sni->status && sni->status[0] == 'P') {
+		return 0;
+	}
+
 	int icon_size;
 	cairo_surface_t *icon;
 	if (sni->icon) {


### PR DESCRIPTION
From the spec:

> Passive: The item doesn't convey important information to the user, it can be considered an "idle" status and is likely that **visualizations will chose to hide it**.

https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/#org.freedesktop.statusnotifieritem.status