### PR TITLE
grimshot: unbreak saving with default filename on FreeBSD

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -12,11 +12,20 @@
 ##
 ## See `man 1 grimshot` or `grimshot usage` for further details.
 
-getTargetDirectory() {
+get_target_directory() {
   test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" && \
     . "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
 
   echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+}
+
+get_target_file() {
+  NAME=$(date +%Y%m%d_%H%M%S)
+  DIR=${1:-$(get_target_directory)}
+  while [ -e "$DIR/$NAME$SUFFIX.png" ]; do
+    SUFFIX="_$((i+=1))"
+  done
+  echo "$DIR/$NAME$SUFFIX.png"
 }
 
 NOTIFY=no
@@ -42,7 +51,7 @@ done
 
 ACTION=${1:-usage}
 SUBJECT=${2:-screen}
-FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
+FILE=${3:-$(get_target_file)}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"


### PR DESCRIPTION
Regressed by 61d59180b875. CC @WhyNotHugo

```
$ sh contrib/grimshot save active
date: invalid argument 'ns' for -I
/home/foo/.png
```

`-I` is not in [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html) and not supported by [DragonFly](https://www.dragonflybsd.org/cgi/web-man?command=date&section=1), [NetBSD](https://man.netbsd.org/date.1), [OpenBSD](https://man.openbsd.org/date.1). On [FreeBSD](https://man.freebsd.org/date/1) `-I` [appears](https://svnweb.freebsd.org/changeset/base/337332) since 12.0 (still missing in 11.4) but 13.0 doesn't support `-I ns` (nanoseconds) or `%N`.

Additionally, `-I` uses `:` to separate time which makes such files harder to share with Windows.
