### PR TITLE
ci: enable basu on freebsd

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,5 +1,6 @@
 image: freebsd/latest
 packages:
+- devel/basu
 - devel/json-c
 - devel/libevdev
 - devel/meson
@@ -32,7 +33,7 @@ tasks:
     cd subprojects
     ln -s ../../wlroots wlroots
     cd ..
-    meson build
+    meson build -Dtray=enabled -Dsd-bus-provider=basu
 - build: |
     cd sway
     ninja -C build


### PR DESCRIPTION
Avoid swaybar tray growing dependencies not supported by elogind and basu.
https://github.com/swaywm/sway/blob/7c9706de7186f32159f719e3f15fcdc017a13f35/.builds/alpine.yml#L31
https://github.com/swaywm/sway/blob/7c9706de7186f32159f719e3f15fcdc017a13f35/.builds/archlinux.yml#L28
