### PR TITLE
cmd_move: update container representation in sibling swaps

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -120,6 +120,7 @@ static void container_move_to_container_from_direction(
 			int container_index = list_find(siblings, container);
 			int destination_index = list_find(siblings, destination);
 			list_swap(siblings, container_index, destination_index);
+			container_update_representation(container);
 		} else {
 			sway_log(SWAY_DEBUG, "Promoting to sibling of cousin");
 			int offset =


### PR DESCRIPTION
Fixes #5925

Since e95c299f the sibling swap case is handled by container_move_to_container_from_direction which may list_swap instead of inserting the child, so we need a call to update the container repr in this case. Previously container_insert_child handled that.