### PR TITLE
cmds:output: fix quoted defs not stripped

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -403,6 +403,8 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 				&& handler->handle != cmd_bindswitch
 				&& handler->handle != cmd_set
 				&& handler->handle != cmd_for_window
+				&& handler->handle != cmd_output
+				&& handler->handle != cmd_input
 				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
 			strip_quotes(argv[i]);
 		}

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -51,6 +51,13 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 		return error;
 	}
 
+	// Commands from config_command() & execute_command() don't handle quotes the same way
+	for (int i = 0; i < argc; ++i) {
+		if (*argv[i] == '\"' || *argv[i] == '\'') {
+			strip_quotes(argv[i]);
+		}
+	}
+
 	sway_log(SWAY_DEBUG, "entering input block: %s", argv[0]);
 
 	config->handler_context.input_config = new_input_config(argv[0]);

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -2,6 +2,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/output.h"
+#include "stringop.h"
 #include "list.h"
 #include "log.h"
 
@@ -37,6 +38,13 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	if (strcasecmp(argv[0], root->noop_output->wlr_output->name) == 0) {
 		return cmd_results_new(CMD_FAILURE,
 				"Refusing to configure the no op output");
+	}
+
+	// Commands from config_command() & execute_command() don't handle quotes the same way
+	for (int i = 0; i < argc; ++i) {
+		if (*argv[i] == '\"' || *argv[i] == '\'') {
+			strip_quotes(argv[i]);
+		}
 	}
 
 	struct output_config *output = NULL;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -615,7 +615,7 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 	wl_list_for_each_safe(sway_output, tmp, &root->all_outputs, link) {
 		char *name = sway_output->wlr_output->name;
 		output_get_identifier(id, sizeof(id), sway_output);
-		if (wildcard || !strcmp(name, oc->name) || !strcmp(id, oc->name)) {
+		if (wildcard || !output_name_cmp(oc, name) || !output_name_cmp(oc, id)) {
 			struct output_config *current = get_output_config(id, sway_output);
 			if (!current) {
 				// No stored output config matched, apply oc directly


### PR DESCRIPTION
Someone found the issue on here: https://www.reddit.com/r/swaywm/comments/kr2b42/use_variable_in_swaymsg/  
After investigating:

With the following config:

    def $abc "wayland wayland "

The following command would fail to be executed:

    swaymsg -- output '$abc' scale 2

The definition `$abc` is replaced with it content, including the quotes,
which fails to match real output names.

We now strip quotes early in the output command.