### PR TITLE
Add last_focused timestamp to containers

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -52,6 +52,7 @@ struct sway_container_state {
 
 	struct sway_container *focused_inactive_child;
 	bool focused;
+	struct timespec last_focused;
 
 	enum sway_container_border border;
 	int border_thickness;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -152,6 +152,13 @@ static void copy_container_state(struct sway_container *container,
 
 	struct sway_seat *seat = input_manager_current_seat();
 	state->focused = seat_get_focus(seat) == &container->node;
+	if (state->focused) {
+		struct timespec ts;
+		timespec_get(&ts, TIME_UTC);
+		state->last_focused = ts;
+	} else {
+		state->last_focused = container->current.last_focused;
+	}
 
 	if (!container->view) {
 		struct sway_node *focus =

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -634,6 +634,12 @@ static void ipc_json_describe_container(struct sway_container *c, json_object *o
 
 	json_object_object_add(object, "marks", marks);
 
+	char last_focused[14];
+	sprintf(last_focused, "%ld%03ld",
+		c->current.last_focused.tv_sec,
+		c->current.last_focused.tv_nsec / 1000000);
+	json_object_object_add(object, "last_focused", json_object_new_string(last_focused));
+
 	if (c->view) {
 		ipc_json_describe_view(c, object);
 	}


### PR DESCRIPTION
A new field `struct timespec last_focused` is added to the `sway_container_state` struct holding a UNIX timestamp telling when this container last gained focus.  This timestamp is added to the IPC `get_tree` JSON output.

The rationale is that it allows users writing their own container manipulation scripts (e.g., window switchers) to sort containers by last-recently-used order.