### PR TITLE
swaybar: multiply min_width by the output scale

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -174,8 +174,8 @@ static uint32_t render_status_block(cairo_t *cairo,
 				output->scale, block->markup, "%s", block->min_width_str);
 		block->min_width = w;
 	}
-	if (width < block->min_width) {
-		width = block->min_width;
+	if (width < block->min_width * output->scale) {
+		width = block->min_width * output->scale;
 	}
 
 	double block_width = width;
@@ -329,8 +329,8 @@ static void predict_status_block_pos(cairo_t *cairo,
 				output->scale, block->markup, "%s", block->min_width_str);
 		block->min_width = w;
 	}
-	if (width < block->min_width) {
-		width = block->min_width;
+	if (width < block->min_width * output->scale) {
+		width = block->min_width * output->scale;
 	}
 
 	uint32_t ideal_height = text_height + ws_vertical_padding * 2;


### PR DESCRIPTION
This is useful for mixed-DPI configurations to make the bar look the same on all outputs.