### PR TITLE
Switch to wlr_xdg_surface_for_each_popup_surface

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -124,11 +124,11 @@ void output_layer_for_each_surface(struct sway_output *output,
 	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
-void output_layer_for_each_surface_toplevel(struct sway_output *output,
+void output_layer_for_each_toplevel_surface(struct sway_output *output,
 	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
-void output_layer_for_each_surface_popup(struct sway_output *output,
+void output_layer_for_each_popup_surface(struct sway_output *output,
 	struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 	void *user_data);
 

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -116,7 +116,7 @@ void output_view_for_each_surface(struct sway_output *output,
 	struct sway_view *view, sway_surface_iterator_func_t iterator,
 	void *user_data);
 
-void output_view_for_each_popup(struct sway_output *output,
+void output_view_for_each_popup_surface(struct sway_output *output,
 		struct sway_view *view, sway_surface_iterator_func_t iterator,
 		void *user_data);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -47,7 +47,7 @@ struct sway_view_impl {
 	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
-	void (*for_each_popup)(struct sway_view *view,
+	void (*for_each_popup_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
 	bool (*is_transient_for)(struct sway_view *child,
 			struct sway_view *ancestor);
@@ -297,9 +297,9 @@ void view_for_each_surface(struct sway_view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
 /**
- * Iterate all popups recursively.
+ * Iterate all popup surfaces of a view.
  */
-void view_for_each_popup(struct sway_view *view,
+void view_for_each_popup_surface(struct sway_view *view,
 	wlr_surface_iterator_func_t iterator, void *user_data);
 
 // view implementation

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -243,7 +243,7 @@ void output_layer_for_each_surface(struct sway_output *output,
 	}
 }
 
-void output_layer_for_each_surface_toplevel(struct sway_output *output,
+void output_layer_for_each_toplevel_surface(struct sway_output *output,
 		struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct sway_layer_surface *layer_surface;
@@ -257,7 +257,7 @@ void output_layer_for_each_surface_toplevel(struct sway_output *output,
 }
 
 
-void output_layer_for_each_surface_popup(struct sway_output *output,
+void output_layer_for_each_popup_surface(struct sway_output *output,
 		struct wl_list *layer_surfaces, sway_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct sway_layer_surface *layer_surface;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -179,7 +179,7 @@ void output_view_for_each_surface(struct sway_output *output,
 	view_for_each_surface(view, output_for_each_surface_iterator, &data);
 }
 
-void output_view_for_each_popup(struct sway_output *output,
+void output_view_for_each_popup_surface(struct sway_output *output,
 		struct sway_view *view, sway_surface_iterator_func_t iterator,
 		void *user_data) {
 	struct surface_iterator_data data = {
@@ -196,7 +196,7 @@ void output_view_for_each_popup(struct sway_output *output,
 		.rotation = 0, // TODO
 	};
 
-	view_for_each_popup(view, output_for_each_surface_iterator, &data);
+	view_for_each_popup_surface(view, output_for_each_surface_iterator, &data);
 }
 
 void output_layer_for_each_surface(struct sway_output *output,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -265,24 +265,14 @@ static void render_view_toplevels(struct sway_view *view,
 			render_surface_iterator, &data);
 }
 
-static void render_popup_iterator(struct sway_output *output, struct sway_view *view,
-		struct wlr_surface *surface, struct wlr_box *box, float rotation,
-		void *data) {
-	// Render this popup's surface
-	render_surface_iterator(output, view, surface, box, rotation, data);
-
-	// Render this popup's child toplevels
-	output_surface_for_each_surface(output, surface, box->x, box->y,
-			render_surface_iterator, data);
-}
-
 static void render_view_popups(struct sway_view *view,
 		struct sway_output *output, pixman_region32_t *damage, float alpha) {
 	struct render_data data = {
 		.damage = damage,
 		.alpha = alpha,
 	};
-	output_view_for_each_popup(output, view, render_popup_iterator, &data);
+	output_view_for_each_popup_surface(output, view,
+		render_surface_iterator, &data);
 }
 
 static void render_saved_view(struct sway_view *view,

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -171,7 +171,7 @@ static void render_layer_toplevel(struct sway_output *output,
 		.damage = damage,
 		.alpha = 1.0f,
 	};
-	output_layer_for_each_surface_toplevel(output, layer_surfaces,
+	output_layer_for_each_toplevel_surface(output, layer_surfaces,
 		render_surface_iterator, &data);
 }
 
@@ -181,7 +181,7 @@ static void render_layer_popups(struct sway_output *output,
 		.damage = damage,
 		.alpha = 1.0f,
 	};
-	output_layer_for_each_surface_popup(output, layer_surfaces,
+	output_layer_for_each_popup_surface(output, layer_surfaces,
 		render_surface_iterator, &data);
 }
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -211,12 +211,13 @@ static void for_each_surface(struct sway_view *view,
 		user_data);
 }
 
-static void for_each_popup(struct sway_view *view,
+static void for_each_popup_surface(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	if (xdg_shell_view_from_view(view) == NULL) {
 		return;
 	}
-	wlr_xdg_surface_for_each_popup(view->wlr_xdg_surface, iterator, user_data);
+	wlr_xdg_surface_for_each_popup_surface(view->wlr_xdg_surface, iterator,
+		user_data);
 }
 
 static bool is_transient_for(struct sway_view *child,
@@ -271,7 +272,7 @@ static const struct sway_view_impl view_impl = {
 	.set_resizing = set_resizing,
 	.wants_floating = wants_floating,
 	.for_each_surface = for_each_surface,
-	.for_each_popup = for_each_popup,
+	.for_each_popup_surface = for_each_popup_surface,
 	.is_transient_for = is_transient_for,
 	.close = _close,
 	.close_popups = close_popups,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -449,13 +449,13 @@ void view_for_each_surface(struct sway_view *view,
 	}
 }
 
-void view_for_each_popup(struct sway_view *view,
+void view_for_each_popup_surface(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data) {
 	if (!view->surface) {
 		return;
 	}
-	if (view->impl->for_each_popup) {
-		view->impl->for_each_popup(view, iterator, user_data);
+	if (view->impl->for_each_popup_surface) {
+		view->impl->for_each_popup_surface(view, iterator, user_data);
 	}
 }
 


### PR DESCRIPTION
Instead of calling wlr_xdg_surface_for_each_popup and then
wlr_surface_for_each_surface, use the new for_each_popup_surface helper
introduced in https://github.com/swaywm/wlroots/pull/2609 that does it in one go.