### PR TITLE
output: use suggested position for output by default

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -45,6 +45,7 @@ struct sway_output {
 	struct wl_listener commit;
 	struct wl_listener mode;
 	struct wl_listener available_modes;
+	struct wl_listener suggested_position;
 	struct wl_listener present;
 	struct wl_listener damage_destroy;
 	struct wl_listener damage_frame;

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -44,6 +44,7 @@ struct sway_output {
 	struct wl_listener destroy;
 	struct wl_listener commit;
 	struct wl_listener mode;
+	struct wl_listener available_modes;
 	struct wl_listener present;
 	struct wl_listener damage_destroy;
 	struct wl_listener damage_frame;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -872,6 +872,17 @@ static void handle_mode(struct wl_listener *listener, void *data) {
 	update_output_manager_config(output->server);
 }
 
+static void handle_available_modes(struct wl_listener *listener, void *data) {
+	struct sway_output *output = wl_container_of(listener, output, available_modes);
+	struct output_config *oc = find_output_config(output);
+	apply_output_config(oc, output);
+	free_output_config(oc);
+
+	transaction_commit_dirty();
+
+	update_output_manager_config(output->server);
+}
+
 static void update_textures(struct sway_container *con, void *data) {
 	container_update_title_textures(con);
 	container_update_marks_textures(con);
@@ -928,6 +939,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->commit.notify = handle_commit;
 	wl_signal_add(&wlr_output->events.mode, &output->mode);
 	output->mode.notify = handle_mode;
+	wl_signal_add(&wlr_output->events.available_modes, &output->available_modes);
+	output->available_modes.notify = handle_available_modes;
 	wl_signal_add(&wlr_output->events.present, &output->present);
 	output->present.notify = handle_present;
 	wl_signal_add(&output->damage->events.frame, &output->damage_frame);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -883,6 +883,17 @@ static void handle_available_modes(struct wl_listener *listener, void *data) {
 	update_output_manager_config(output->server);
 }
 
+static void handle_suggested_position(struct wl_listener *listener, void *data) {
+	struct sway_output *output = wl_container_of(listener, output, suggested_position);
+	struct output_config *oc = find_output_config(output);
+	apply_output_config(oc, output);
+	free_output_config(oc);
+
+	transaction_commit_dirty();
+
+	update_output_manager_config(output->server);
+}
+
 static void update_textures(struct sway_container *con, void *data) {
 	container_update_title_textures(con);
 	container_update_marks_textures(con);
@@ -941,6 +952,8 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->mode.notify = handle_mode;
 	wl_signal_add(&wlr_output->events.available_modes, &output->available_modes);
 	output->available_modes.notify = handle_available_modes;
+	wl_signal_add(&wlr_output->events.suggested_position, &output->suggested_position);
+	output->suggested_position.notify = handle_suggested_position;
 	wl_signal_add(&wlr_output->events.present, &output->present);
 	output->present.notify = handle_present;
 	wl_signal_add(&output->damage->events.frame, &output->damage_frame);


### PR DESCRIPTION
Depends on and includes https://github.com/swaywm/sway/pull/5942 (could also be independently rebased onto master)

Depends on wlroots API: https://github.com/swaywm/wlroots/pull/2629

Some virtualised outputs provide a suggested position which indicates the relative position of the outputs in the host WM. This change uses these positions for outputs with no configured position.