### PR TITLE
swaybar: Fallback to focused_statusline instead of statusline on focused output

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -269,7 +269,9 @@ static uint32_t render_status_block(cairo_t *cairo,
 	}
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_move_to(cairo, offset, (int)floor(text_y));
-	uint32_t color = block->color_set ? block->color : config->colors.statusline;
+	uint32_t color = output->focused ?
+		config->colors.focused_statusline : config->colors.statusline;
+	color = block->color_set ? block->color : color;
 	color = block->urgent ? config->colors.urgent_workspace.text : color;
 	cairo_set_source_u32(cairo, color);
 	pango_printf(cairo, config->font, output->scale,


### PR DESCRIPTION
Fixes #5940 