### PR TITLE
Adhere to X11 focus requirements

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -785,7 +785,18 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	view_execute_criteria(view);
 
-	if (should_focus(view)) {
+	bool set_focus = should_focus(view);
+
+#if HAVE_XWAYLAND
+	if (wlr_surface_is_xwayland_surface(wlr_surface)) {
+		struct wlr_xwayland_surface *xsurface =
+			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
+    	set_focus = (wlr_xwayland_icccm_input_model(xsurface) !=
+			WLR_ICCCM_INPUT_MODEL_NONE) && set_focus;
+	}
+#endif
+
+	if (set_focus) {
 		input_manager_set_focus(&view->container->node);
 	}
 


### PR DESCRIPTION
When mapping an X11 view the focus state should be retrieved via the
existing mechanisms to determine focus. For certain views if this check
is not completed they will have initial focus when it is undesired.

Relates to swaywm/wlroots#2604