### PR TITLE
More readable code

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -283,7 +283,7 @@ int main(int argc, char **argv) {
 		}
 		switch (c) {
 		case 'h': // help
-			fprintf(stdout, "%s", usage);
+			printf("%s", usage);
 			exit(EXIT_SUCCESS);
 			break;
 		case 'c': // config
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
 			allow_unsupported_gpu = 1;
 			break;
 		case 'v': // version
-			fprintf(stdout, "sway version " SWAY_VERSION "\n");
+			printf("sway version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'V': // verbose
@@ -311,7 +311,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'p': ; // --get-socketpath
 			if (getenv("SWAYSOCK")) {
-				fprintf(stdout, "%s\n", getenv("SWAYSOCK"));
+				printf("%s\n", getenv("SWAYSOCK"));
 				exit(EXIT_SUCCESS);
 			} else {
 				fprintf(stderr, "sway socket not detected.\n");


### PR DESCRIPTION
Put more reasonable variable names instead of just one char.
Changed fprintf(stdout, ...) to printf(...) because its more readable and it is basically the same.