### PR TITLE
swaymsg: use 3 digits for fractional part of the refresh rate

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -214,7 +214,7 @@ static void pretty_print_output(json_object *o) {
 	if (json_object_get_boolean(active)) {
 		printf(
 			"Output %s '%s %s %s'%s\n"
-			"  Current mode: %dx%d @ %f Hz\n"
+			"  Current mode: %dx%d @ %.3f Hz\n"
 			"  Position: %d,%d\n"
 			"  Scale factor: %f\n"
 			"  Scale filter: %s\n"
@@ -228,7 +228,7 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_boolean(focused) ? " (focused)" : "",
 			json_object_get_int(width),
 			json_object_get_int(height),
-			(float)json_object_get_int(refresh) / 1000,
+			(double)json_object_get_int(refresh) / 1000,
 			json_object_get_int(x), json_object_get_int(y),
 			json_object_get_double(scale),
 			json_object_get_string(scale_filter),
@@ -265,9 +265,9 @@ static void pretty_print_output(json_object *o) {
 			json_object_object_get_ex(mode, "height", &mode_height);
 			json_object_object_get_ex(mode, "refresh", &mode_refresh);
 
-			printf("    %dx%d @ %f Hz\n", json_object_get_int(mode_width),
+			printf("    %dx%d @ %.3f Hz\n", json_object_get_int(mode_width),
 				json_object_get_int(mode_height),
-				(float)json_object_get_int(mode_refresh) / 1000);
+				(double)json_object_get_int(mode_refresh) / 1000);
 		}
 	}
 


### PR DESCRIPTION
The fractional part of the real number we want to represent never has more than 3 decimal digits, so use 3 decimal digits of precision.

e.g. 'swaymsg -t get_outputs' would show a refresh rate of 59934 mHz
as 59.933998 Hz, now correctly as 59.934 Hz.

It was previously cast as a float, probably because that's how the output_config represents it, but printf only prints doubles anyway so that seems kind of pointless.