### PR TITLE
config/output: correct refresh rate rounding error

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -237,7 +237,10 @@ struct output_config *store_output_config(struct output_config *oc) {
 
 static void set_mode(struct wlr_output *output, int width, int height,
 		float refresh_rate, bool custom) {
-	int mhz = (int)(refresh_rate * 1000);
+	// Not all floating point integers can be represented exactly
+	// as (int)(1000 * mHz / 1000.f)
+	// round() the result to avoid any error
+	int mhz = (int)round(refresh_rate * 1000);
 
 	if (wl_list_empty(&output->modes) || custom) {
 		sway_log(SWAY_DEBUG, "Assigning custom mode to %s", output->name);


### PR DESCRIPTION
When we apply the configured refresh rate in set_mode the mHz value is calculated as:

```c
int mHz = (int) (1000 * refresh_rate)
```

where `refresh_rate` is a float with value `(mHz / 1000.f)`. Well, not all 6-digit integers can be represented as `(int) (1000 * (mHz / 1000.f))`, because the `(int)` cast truncates towards zero.

e.g. 64340 mHz is unrepresentable:

```c
(int) (1000 * (64340 / 1000.f)) == 64339
(int) (1000 * (64341 / 1000.f)) == 64341
```

I find 739 integers ≤ 100000 have this property. The float value is less than the target integer by at most 1/2 the maximum floating-point epsilon on the interval we care about. For 32-bit floats and mHz ≤ 300000 (300Hz), that means 1/64.

So a 1/64 nudge would be enough, but I figure a 1/2 nudge won't hurt. None of the non-representable mHz are near common refresh rates so it's unlikely to cause issues in the first place, but we might as well be right.