### PR TITLE
focus: beyond fullscreen when focused explicitly

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -164,6 +164,11 @@ void container_for_each_child(struct sway_container *container,
 		void (*f)(struct sway_container *container, void *data), void *data);
 
 /**
+ * Returns the fullscreen container obstructing this container if it exists.
+ */
+struct sway_container *container_obstructing_fullscreen_container(struct sway_container *container);
+
+/**
  * Returns true if the given container is an ancestor of this container.
  */
 bool container_has_ancestor(struct sway_container *container,

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -377,6 +377,13 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		if (container_is_scratchpad_hidden_or_child(container)) {
 			root_scratchpad_show(container);
 		}
+		// if we are switching to a container under a fullscreen window, we first
+		// need to exit fullscreen so that the newly focused container becomes visible
+		struct sway_container *obstructing = container_obstructing_fullscreen_container(container);
+		if (obstructing) {
+			container_fullscreen_disable(obstructing);
+			arrange_root();
+		}
 		seat_set_focus_container(seat, container);
 		seat_consider_warp_to_focus(seat);
 		container_raise_floating(container);

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1090,25 +1090,14 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 	struct sway_container *container = node->type == N_CONTAINER ?
 		node->sway_container : NULL;
 
-	// Deny setting focus to a view which is hidden by a fullscreen container
-	if (new_workspace && new_workspace->fullscreen && container &&
-			!container_is_fullscreen_or_child(container)) {
-		// Unless it's a transient container
-		if (!container_is_transient_for(container, new_workspace->fullscreen)) {
-			return;
-		}
+	// Deny setting focus to a view which is hidden by a fullscreen container or global
+	if (container && container_obstructing_fullscreen_container(container)) {
+		return;
 	}
+
 	// Deny setting focus to a workspace node when using fullscreen global
 	if (root->fullscreen_global && !container && new_workspace) {
 		return;
-	}
-	// Deny setting focus to a view which is hidden by a fullscreen global
-	if (root->fullscreen_global && container != root->fullscreen_global &&
-				!container_has_ancestor(container, root->fullscreen_global)) {
-		// Unless it's a transient container
-		if (!container_is_transient_for(container, root->fullscreen_global)) {
-			return;
-		}
 	}
 
 	struct sway_output *new_output =

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -418,6 +418,28 @@ void container_for_each_child(struct sway_container *container,
 	}
 }
 
+struct sway_container *container_obstructing_fullscreen_container(struct sway_container *container)
+{
+	struct sway_workspace *workspace = container->pending.workspace;
+
+	if (workspace && workspace->fullscreen && !container_is_fullscreen_or_child(container)) {
+		if (container_is_transient_for(container, workspace->fullscreen)) {
+			return NULL;
+		}
+		return workspace->fullscreen;
+	}
+
+	struct sway_container *fullscreen_global = root->fullscreen_global;
+	if (fullscreen_global && container != fullscreen_global && !container_has_ancestor(container, fullscreen_global)) {
+		if (container_is_transient_for(container, fullscreen_global)) {
+			return NULL;
+		}
+		return fullscreen_global;
+	}
+
+	return NULL;
+}
+
 bool container_has_ancestor(struct sway_container *descendant,
 		struct sway_container *ancestor) {
 	while (descendant) {


### PR DESCRIPTION
When issuing a focus command on a specific container, users expect to proceed it even if is hidden by a fullscreen window.

This matches the behavior of i3.

Reported by @markstos: https://github.com/lbonn/i3-focus-last/issues/5