### PR TITLE
desktop/output: Disable head if mode is NULL

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -816,7 +816,7 @@ static void update_output_manager_config(struct sway_server *server) {
 		struct wlr_box *output_box = wlr_output_layout_get_box(
 			root->output_layout, output->wlr_output);
 		// We mark the output enabled even if it is switched off by DPMS
-		config_head->state.enabled = output->enabled;
+		config_head->state.enabled = output->current_mode != NULL && output->enabled;
 		config_head->state.mode = output->current_mode;
 		if (output_box) {
 			config_head->state.x = output_box->x;


### PR DESCRIPTION
wlr_output_configuration_head_v1_create normally fills out the head
"enabled" field to match the wlr_output state. We overwrite this to also
set the head as enabled if it is only turned off with DPMS.

However, in some cases we may not have a mode for this display, in which
case setting it as enabled will lead to a segfault later on. Therefore,
enabled conditional on the presence of a mode.

Fixes: https://github.com/swaywm/wlroots/issues/2199