### PR TITLE
layer-shell: implement on-demand keyboard interactivity

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -211,7 +211,8 @@ void arrange_layers(struct sway_output *output) {
 	for (size_t i = 0; i < nlayers; ++i) {
 		wl_list_for_each_reverse(layer,
 				&output->layers[layers_above_shell[i]], link) {
-			if (layer->layer_surface->current.keyboard_interactive &&
+			if (layer->layer_surface->current.keyboard_interactive ==
+					ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE &&
 					layer->layer_surface->mapped) {
 				topmost = layer;
 				break;
@@ -227,7 +228,8 @@ void arrange_layers(struct sway_output *output) {
 		if (topmost != NULL) {
 			seat_set_focus_layer(seat, topmost->layer_surface);
 		} else if (seat->focused_layer &&
-				!seat->focused_layer->current.keyboard_interactive) {
+				seat->focused_layer->current.keyboard_interactive !=
+				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE) {
 			seat_set_focus_layer(seat, NULL);
 		}
 	}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -365,8 +365,12 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	if (surface && wlr_surface_is_layer_surface(surface)) {
 		struct wlr_layer_surface_v1 *layer =
 			wlr_layer_surface_v1_from_wlr_surface(surface);
-		if (layer->current.keyboard_interactive) {
+		if (layer->current.keyboard_interactive ==
+				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE) {
 			seat_set_focus_layer(seat, layer);
+		} else if (layer->current.keyboard_interactive ==
+				ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND) {
+			seat_set_focus_surface(seat, surface, true);
 		}
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;


### PR DESCRIPTION
I'm still not sure if the approach with `seat_set_focus_surface` is right but on-demand surface is definitely not expected to set `seat->focused_layer`.

Basic cases tested with gtk-layer-demo:
 * [x] xdg toplevel + layer-surface/top/on-demand:
   Input focus can be switched between the surfaces
 * [x] xdg toplevel + layer-surface/top/on-demand + layer-surface/top/exclusive:
   Focus can be switched between two layer surfaces. xdg surface does not get focus
 * [ ] xdg toplevel + layer-surface/top/on-demand + layer-surface/overlay/exclusive:
   Contrary to my expectations, both layer surfaces can get focus. xdg surface is still ignored
 * [ ] focus_follows_mouse: keyboard focus is released on wl_pointer.leave; keyboard focus is not received on wl_pointer.enter. The code for that is still missing.
 * [ ] return keyboard focus after destroying on-demand layer surface:
     That part is definitely buggy. There's no keyboard focus after destroying on-demand layer surface.