### PR TITLE
desktop/layer_shell: Fix allocation type mismatch

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -429,7 +429,7 @@ static struct sway_layer_subsurface *create_subsurface(
 		struct wlr_subsurface *wlr_subsurface,
 		struct sway_layer_surface *layer_surface) {
 	struct sway_layer_subsurface *subsurface =
-			calloc(1, sizeof(struct sway_layer_surface));
+			calloc(1, sizeof(struct sway_layer_subsurface));
 	if (subsurface == NULL) {
 		return NULL;
 	}


### PR DESCRIPTION
Since `sizeof(struct sway_layer_surface) > sizeof(struct sway_layer_subsurface)`, the allocation size mismatch fixed by this PR is currently not a problem.