### PR TITLE
Check the output state for recorded workspaces

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -270,7 +270,16 @@ found:
 			sway_log(SWAY_DEBUG,
 					"Creating workspace %s for pid %d because it disappeared",
 					pw->workspace, pid);
-			ws = workspace_create(pw->output, pw->workspace);
+
+			struct sway_output *output = pw->output;
+			if (pw->output && !pw->output->enabled) {
+				sway_log(SWAY_DEBUG,
+						"Workspace output %s is disabled, trying another one",
+						pw->output->wlr_output->name);
+				output = NULL;
+			}
+
+			ws = workspace_create(output, pw->workspace);
 		}
 
 		pid_workspace_destroy(pw);


### PR DESCRIPTION
Steps to reproduce:
1. Run a process that takes some time to open a view (e.g. a bash script runs on workspace 2 and sleeps for a few seconds before executing something else).
2. Disable the output on which the process started.

In this case Sway re-creates the workspace on the disabled output. If you go to workspace 2 after that, there appears one more workspace 2 on the enabled output.