### PR TITLE
Add static+const qualifiers

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -46,8 +46,8 @@ enum expected_args {
 struct cmd_results *checkarg(int argc, const char *name,
 		enum expected_args type, int val);
 
-struct cmd_handler *find_handler(char *line, struct cmd_handler *cmd_handlers,
-		size_t handlers_size);
+const struct cmd_handler *find_handler(char *line,
+		const struct cmd_handler *cmd_handlers, size_t handlers_size);
 
 /**
  * Parse and executes a command.
@@ -68,7 +68,7 @@ struct cmd_results *config_command(char *command, char **new_block);
  * Parse and handle a sub command
  */
 struct cmd_results *config_subcommand(char **argv, int argc,
-		struct cmd_handler *handlers, size_t handlers_size);
+		const struct cmd_handler *handlers, size_t handlers_size);
 /*
  * Parses a command policy rule.
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -42,7 +42,7 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 }
 
 /* Keep alphabetized */
-static struct cmd_handler handlers[] = {
+static const struct cmd_handler handlers[] = {
 	{ "assign", cmd_assign },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },
@@ -98,7 +98,7 @@ static struct cmd_handler handlers[] = {
 };
 
 /* Config-time only commands. Keep alphabetized */
-static struct cmd_handler config_handlers[] = {
+static const struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "include", cmd_include },
 	{ "swaybg_command", cmd_swaybg_command },
@@ -108,7 +108,7 @@ static struct cmd_handler config_handlers[] = {
 };
 
 /* Runtime-only commands. Keep alphabetized */
-static struct cmd_handler command_handlers[] = {
+static const struct cmd_handler command_handlers[] = {
 	{ "border", cmd_border },
 	{ "create_output", cmd_create_output },
 	{ "exit", cmd_exit },
@@ -144,22 +144,22 @@ static int handler_compare(const void *_a, const void *_b) {
 	return strcasecmp(a->command, b->command);
 }
 
-struct cmd_handler *find_handler(char *line, struct cmd_handler *handlers,
-		size_t handlers_size) {
+const struct cmd_handler *find_handler(char *line,
+		const struct cmd_handler *handlers, size_t handlers_size) {
 	if (!handlers || !handlers_size) {
 		return NULL;
 	}
-	struct cmd_handler query = { .command = line };
+	const struct cmd_handler query = { .command = line };
 	return bsearch(&query, handlers,
 			handlers_size / sizeof(struct cmd_handler),
 			sizeof(struct cmd_handler), handler_compare);
 }
 
-static struct cmd_handler *find_handler_ex(char *line,
-		struct cmd_handler *config_handlers, size_t config_handlers_size,
-		struct cmd_handler *command_handlers, size_t command_handlers_size,
-		struct cmd_handler *handlers, size_t handlers_size) {
-	struct cmd_handler *handler = NULL;
+static const struct cmd_handler *find_handler_ex(char *line,
+		const struct cmd_handler *config_handlers, size_t config_handlers_size,
+		const struct cmd_handler *command_handlers, size_t command_handlers_size,
+		const struct cmd_handler *handlers, size_t handlers_size) {
+	const struct cmd_handler *handler = NULL;
 	if (config->reading) {
 		handler = find_handler(line, config_handlers, config_handlers_size);
 	} else if (config->active) {
@@ -168,7 +168,7 @@ static struct cmd_handler *find_handler_ex(char *line,
 	return handler ? handler : find_handler(line, handlers, handlers_size);
 }
 
-static struct cmd_handler *find_core_handler(char *line) {
+static const struct cmd_handler *find_core_handler(char *line) {
 	return find_handler_ex(line, config_handlers, sizeof(config_handlers),
 			command_handlers, sizeof(command_handlers),
 			handlers, sizeof(handlers));
@@ -265,7 +265,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 				}
 			}
 		}
-		struct cmd_handler *handler = find_core_handler(argv[0]);
+		const struct cmd_handler *handler = find_core_handler(argv[0]);
 		if (!handler) {
 			list_add(res_list, cmd_results_new(CMD_INVALID,
 					"Unknown/invalid command '%s'", argv[0]));
@@ -370,7 +370,7 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 
 	// Determine the command handler
 	sway_log(SWAY_INFO, "Config command: %s", exec);
-	struct cmd_handler *handler = find_core_handler(argv[0]);
+	const struct cmd_handler *handler = find_core_handler(argv[0]);
 	if (!handler || !handler->handle) {
 		const char *error = handler
 			? "Command '%s' is shimmed, but unimplemented"
@@ -418,12 +418,12 @@ cleanup:
 }
 
 struct cmd_results *config_subcommand(char **argv, int argc,
-		struct cmd_handler *handlers, size_t handlers_size) {
+		const struct cmd_handler *handlers, size_t handlers_size) {
 	char *command = join_args(argv, argc);
 	sway_log(SWAY_DEBUG, "Subcommand: %s", command);
 	free(command);
 
-	struct cmd_handler *handler = find_handler(argv[0], handlers,
+	const struct cmd_handler *handler = find_handler(argv[0], handlers,
 			handlers_size);
 	if (!handler) {
 		return cmd_results_new(CMD_INVALID,
@@ -453,7 +453,7 @@ struct cmd_results *config_commands_command(char *exec) {
 		goto cleanup;
 	}
 
-	struct cmd_handler *handler = find_handler(cmd, NULL, 0);
+	const struct cmd_handler *handler = find_handler(cmd, NULL, 0);
 	if (!handler && strcmp(cmd, "*") != 0) {
 		results = cmd_results_new(CMD_INVALID,
 			"Unknown/invalid command '%s'", cmd);

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -8,7 +8,7 @@
 #include "log.h"
 
 // Must be in alphabetical order for bsearch
-static struct cmd_handler bar_handlers[] = {
+static const struct cmd_handler bar_handlers[] = {
 	{ "bindcode", bar_cmd_bindcode },
 	{ "binding_mode_indicator", bar_cmd_binding_mode_indicator },
 	{ "bindsym", bar_cmd_bindsym },
@@ -41,7 +41,7 @@ static struct cmd_handler bar_handlers[] = {
 };
 
 // Must be in alphabetical order for bsearch
-static struct cmd_handler bar_config_handlers[] = {
+static const struct cmd_handler bar_config_handlers[] = {
 	{ "id", bar_cmd_id },
 	{ "swaybar_command", bar_cmd_swaybar_command },
 };

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -4,7 +4,7 @@
 #include "util.h"
 
 // Must be in alphabetical order for bsearch
-static struct cmd_handler bar_colors_handlers[] = {
+static const struct cmd_handler bar_colors_handlers[] = {
 	{ "active_workspace", bar_colors_cmd_active_workspace },
 	{ "background", bar_colors_cmd_background },
 	{ "binding_mode", bar_colors_cmd_binding_mode },

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -7,7 +7,7 @@
 #include "stringop.h"
 
 // must be in order for the bsearch
-static struct cmd_handler input_handlers[] = {
+static const struct cmd_handler input_handlers[] = {
 	{ "accel_profile", input_cmd_accel_profile },
 	{ "calibration_matrix", input_cmd_calibration_matrix },
 	{ "click_method", input_cmd_click_method },
@@ -40,7 +40,7 @@ static struct cmd_handler input_handlers[] = {
 };
 
 // must be in order for the bsearch
-static struct cmd_handler input_config_handlers[] = {
+static const struct cmd_handler input_config_handlers[] = {
 	{ "xkb_capslock", input_cmd_xkb_capslock },
 	{ "xkb_numlock", input_cmd_xkb_numlock },
 };

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -9,7 +9,7 @@
 #include "stringop.h"
 
 // Must be in order for the bsearch
-static struct cmd_handler mode_handlers[] = {
+static const struct cmd_handler mode_handlers[] = {
 	{ "bindcode", cmd_bindcode },
 	{ "bindswitch", cmd_bindswitch },
 	{ "bindsym", cmd_bindsym },

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -6,7 +6,7 @@
 #include "log.h"
 
 // must be in order for the bsearch
-static struct cmd_handler output_handlers[] = {
+static const struct cmd_handler output_handlers[] = {
 	{ "adaptive_sync", output_cmd_adaptive_sync },
 	{ "background", output_cmd_background },
 	{ "bg", output_cmd_background },

--- a/sway/commands/seat.c
+++ b/sway/commands/seat.c
@@ -8,13 +8,13 @@
 
 // must be in order for the bsearch
 // these handlers perform actions on the seat
-static struct cmd_handler seat_action_handlers[] = {
+static const struct cmd_handler seat_action_handlers[] = {
 	{ "cursor", seat_cmd_cursor },
 };
 
 // must be in order for the bsearch
 // these handlers alter the seat config
-static struct cmd_handler seat_handlers[] = {
+static const struct cmd_handler seat_handlers[] = {
 	{ "attach", seat_cmd_attach },
 	{ "fallback", seat_cmd_fallback },
 	{ "hide_cursor", seat_cmd_hide_cursor },

--- a/sway/main.c
+++ b/sway/main.c
@@ -245,7 +245,7 @@ static void handle_wlr_log(enum wlr_log_importance importance,
 int main(int argc, char **argv) {
 	static int verbose = 0, debug = 0, validate = 0, allow_unsupported_gpu = 0;
 
-	static struct option long_options[] = {
+	static const struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"config", required_argument, NULL, 'c'},
 		{"validate", no_argument, NULL, 'C'},

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -90,7 +90,7 @@ static void layer_surface_closed(void *_output,
 	swaybar_output_free(output);
 }
 
-struct zwlr_layer_surface_v1_listener layer_surface_listener = {
+static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
 	.configure = layer_surface_configure,
 	.closed = layer_surface_closed,
 };
@@ -230,7 +230,7 @@ static void output_scale(void *data, struct wl_output *wl_output,
 	}
 }
 
-struct wl_output_listener output_listener = {
+static const struct wl_output_listener output_listener = {
 	.geometry = output_geometry,
 	.mode = output_mode,
 	.done = output_done,
@@ -307,7 +307,7 @@ static void xdg_output_handle_description(void *data,
 	}
 }
 
-struct zxdg_output_v1_listener xdg_output_listener = {
+static const struct zxdg_output_v1_listener xdg_output_listener = {
 	.logical_position = xdg_output_handle_logical_position,
 	.logical_size = xdg_output_handle_logical_size,
 	.done = xdg_output_handle_done,

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -339,7 +339,7 @@ static void wl_pointer_axis_discrete(void *data, struct wl_pointer *wl_pointer,
 	seat->axis[axis].discrete_steps += abs(discrete);
 }
 
-static struct wl_pointer_listener pointer_listener = {
+static const struct wl_pointer_listener pointer_listener = {
 	.enter = wl_pointer_enter,
 	.leave = wl_pointer_leave,
 	.motion = wl_pointer_motion,

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
 	char *socket_path = NULL;
 	bool debug = false;
 
-	static struct option long_options[] = {
+	static const struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"version", no_argument, NULL, 'v'},
 		{"socket", required_argument, NULL, 's'},

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -343,7 +343,7 @@ int main(int argc, char **argv) {
 
 	sway_log_init(SWAY_INFO, NULL);
 
-	static struct option long_options[] = {
+	static const struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"monitor", no_argument, NULL, 'm'},
 		{"pretty", no_argument, NULL, 'p'},

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -51,7 +51,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		TO_PADDING_BTN,
 	};
 
-	static struct option opts[] = {
+	static const struct option opts[] = {
 		{"button", required_argument, NULL, 'b'},
 		{"button-no-terminal", required_argument, NULL, 'B'},
 		{"button-dismiss", required_argument, NULL, 'z'},

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -103,7 +103,7 @@ static void layer_surface_closed(void *data,
 	swaynag_destroy(swaynag);
 }
 
-static struct zwlr_layer_surface_v1_listener layer_surface_listener = {
+static const struct zwlr_layer_surface_v1_listener layer_surface_listener = {
 	.configure = layer_surface_configure,
 	.closed = layer_surface_closed,
 };
@@ -124,7 +124,7 @@ static void surface_enter(void *data, struct wl_surface *surface,
 	};
 }
 
-static struct wl_surface_listener surface_listener = {
+static const struct wl_surface_listener surface_listener = {
 	.enter = surface_enter,
 	.leave = nop,
 };
@@ -263,7 +263,7 @@ static void wl_pointer_axis(void *data, struct wl_pointer *wl_pointer,
 	render_frame(swaynag);
 }
 
-static struct wl_pointer_listener pointer_listener = {
+static const struct wl_pointer_listener pointer_listener = {
 	.enter = wl_pointer_enter,
 	.leave = nop,
 	.motion = wl_pointer_motion,
@@ -289,7 +289,7 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	}
 }
 
-const struct wl_seat_listener seat_listener = {
+static const struct wl_seat_listener seat_listener = {
 	.capabilities = seat_handle_capabilities,
 	.name = nop,
 };
@@ -305,7 +305,7 @@ static void output_scale(void *data, struct wl_output *output,
 	}
 }
 
-static struct wl_output_listener output_listener = {
+static const struct wl_output_listener output_listener = {
 	.geometry = nop,
 	.mode = nop,
 	.done = nop,
@@ -327,7 +327,7 @@ static void xdg_output_handle_name(void *data,
 	swaynag_output->swaynag->querying_outputs--;
 }
 
-static struct zxdg_output_v1_listener xdg_output_listener = {
+static const struct zxdg_output_v1_listener xdg_output_listener = {
 	.logical_position = nop,
 	.logical_size = nop,
 	.done = nop,


### PR DESCRIPTION
There are three groups of variables which this PR makes static const.

* Lists of command handlers
* The Wayland request listeners
* The option lists passed to getopt_long

I'm fairly certain that these are all the variables which should be static const; I checked with ``objdump -t `which sway` | grep "\.data" `` to find initialized global (or function static) variables that were not linked as relocatable read-only, and did not find any others which could be fixed.

