### PR TITLE
output: simplify layer surface iteration

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -206,40 +206,20 @@ void output_layer_for_each_surface(struct sway_output *output,
 	wl_list_for_each(layer_surface, layer_surfaces, link) {
 		struct wlr_layer_surface_v1 *wlr_layer_surface_v1 =
 			layer_surface->layer_surface;
-		output_surface_for_each_surface(output, wlr_layer_surface_v1->surface,
-			layer_surface->geo.x, layer_surface->geo.y, iterator,
-			user_data);
-
-		struct wlr_xdg_popup *state;
-		wl_list_for_each(state, &wlr_layer_surface_v1->popups, link) {
-			struct wlr_xdg_surface *popup = state->base;
-			if (!popup->configured) {
-				continue;
-			}
-
-			double popup_sx, popup_sy;
-			popup_sx = layer_surface->geo.x +
-				popup->popup->geometry.x - popup->geometry.x;
-			popup_sy = layer_surface->geo.y +
-				popup->popup->geometry.y - popup->geometry.y;
-
-			struct wlr_surface *surface = popup->surface;
-
-			struct surface_iterator_data data = {
-				.user_iterator = iterator,
-				.user_data = user_data,
-				.output = output,
-				.view = NULL,
-				.ox = popup_sx,
-				.oy = popup_sy,
-				.width = surface->current.width,
-				.height = surface->current.height,
-				.rotation = 0,
-			};
-
-			wlr_xdg_surface_for_each_surface(
-					popup, output_for_each_surface_iterator, &data);
-		}
+		struct wlr_surface *surface = wlr_layer_surface_v1->surface;
+		struct surface_iterator_data data = {
+			.user_iterator = iterator,
+			.user_data = user_data,
+			.output = output,
+			.view = NULL,
+			.ox = layer_surface->geo.x,
+			.oy = layer_surface->geo.y,
+			.width = surface->current.width,
+			.height = surface->current.height,
+			.rotation = 0,
+		};
+		wlr_layer_surface_v1_for_each_surface(wlr_layer_surface_v1,
+			output_for_each_surface_iterator, &data);
 	}
 }
 
@@ -264,37 +244,20 @@ void output_layer_for_each_popup_surface(struct sway_output *output,
 	wl_list_for_each(layer_surface, layer_surfaces, link) {
 		struct wlr_layer_surface_v1 *wlr_layer_surface_v1 =
 			layer_surface->layer_surface;
-
-		struct wlr_xdg_popup *state;
-		wl_list_for_each(state, &wlr_layer_surface_v1->popups, link) {
-			struct wlr_xdg_surface *popup = state->base;
-			if (!popup->configured) {
-				continue;
-			}
-
-			double popup_sx, popup_sy;
-			popup_sx = layer_surface->geo.x +
-				popup->popup->geometry.x - popup->geometry.x;
-			popup_sy = layer_surface->geo.y +
-				popup->popup->geometry.y - popup->geometry.y;
-
-			struct wlr_surface *surface = popup->surface;
-
-			struct surface_iterator_data data = {
-				.user_iterator = iterator,
-				.user_data = user_data,
-				.output = output,
-				.view = NULL,
-				.ox = popup_sx,
-				.oy = popup_sy,
-				.width = surface->current.width,
-				.height = surface->current.height,
-				.rotation = 0,
-			};
-
-			wlr_xdg_surface_for_each_surface(
-					popup, output_for_each_surface_iterator, &data);
-		}
+		struct wlr_surface *surface = wlr_layer_surface_v1->surface;
+		struct surface_iterator_data data = {
+			.user_iterator = iterator,
+			.user_data = user_data,
+			.output = output,
+			.view = NULL,
+			.ox = layer_surface->geo.x,
+			.oy = layer_surface->geo.y,
+			.width = surface->current.width,
+			.height = surface->current.height,
+			.rotation = 0,
+		};
+		wlr_layer_surface_v1_for_each_popup_surface(wlr_layer_surface_v1,
+			output_for_each_surface_iterator, &data);
 	}
 }
 


### PR DESCRIPTION
Note that now data.{width,height} are set to the layer surface's size, not to an xdg_surface's. Not sure if it's important, but it seems to work correctly anyway.