### PR TITLE
swaynag: Use position from wl_pointer.enter

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -178,6 +178,8 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct swaynag_seat *seat = data;
 	struct swaynag_pointer *pointer = &seat->pointer;
+	pointer->x = wl_fixed_to_int(surface_x);
+	pointer->y = wl_fixed_to_int(surface_y);
 	pointer->serial = serial;
 	update_cursor(seat);
 }


### PR DESCRIPTION
Only wl_pointer.motion was used to update pointer position, which would
cause issues if the pointer was not moved prior to wl_pointer.button.

This also fixes touch input through wl_pointer emulation, which fires
wl_pointer.button immediately after wl_pointer.enter.

Closes: https://github.com/swaywm/sway/issues/5991