### PR TITLE
text_input: Ignore text_input disable from unfocused windows

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -144,6 +144,10 @@ static void handle_text_input_disable(struct wl_listener *listener,
 		void *data) {
 	struct sway_text_input *text_input = wl_container_of(listener, text_input,
 		text_input_disable);
+	if (text_input->input->focused_surface == NULL) {
+		sway_log(SWAY_DEBUG, "Disabling text input, but no longer focused");
+		return;
+	}
 	relay_disable_text_input(text_input->relay, text_input);
 }
 


### PR DESCRIPTION
Before this commit, there would be cases where focus changes from one
window to another, the new window activates text_input, then the old
window sends a deactivate request, making text_input unfocused
completely.