### PR TITLE
Automatically map built-in touchscreens/tablets to built-in panels 

### DIFF
--- a/include/sway/input/libinput.h
+++ b/include/sway/input/libinput.h
@@ -6,4 +6,6 @@ void sway_input_configure_libinput_device(struct sway_input_device *device);
 
 void sway_input_reset_libinput_device(struct sway_input_device *device);
 
+bool sway_libinput_device_is_builtin(struct sway_input_device *device);
+
 #endif

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ libinput = dependency('libinput', version: '>=1.6.0')
 xcb = dependency('xcb', required: get_option('xwayland'))
 drm_full = dependency('libdrm') # only needed for drm_fourcc.h
 drm = drm_full.partial_dependency(compile_args: true, includes: true)
+libudev = dependency('libudev')
 bash_comp = dependency('bash-completion', required: false)
 fish_comp = dependency('fish', required: false)
 math = cc.find_library('m')

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -208,6 +208,7 @@ sway_deps = [
 	jsonc,
 	libevdev,
 	libinput,
+	libudev,
 	math,
 	pango,
 	pcre,

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -111,6 +111,9 @@ The following commands may only be used in the configuration file.
 	Maps inputs from this device to the specified output. Only meaningful if the
 	device is a pointer, touch, or drawing tablet device.
 
+	The wildcard _\*_ can be used to map the input device to the whole desktop
+	layout.
+
 *input* <identifier> map_to_region <X> <Y> <width> <height>
 	Maps inputs from this device to the specified region of the global output
 	layout. Only meaningful if the device is a pointer, touch, or drawing tablet


### PR DESCRIPTION
Detect whether an output is built-in via its type. Detect whether
a touchscreen/tablet is built-in via its ID_PATH property.