### PR TITLE
text_input: Only send surrounding_text and content_type if supported

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -92,13 +92,18 @@ static void relay_send_im_state(struct sway_input_method_relay *relay,
 		return;
 	}
 	// TODO: only send each of those if they were modified
-	wlr_input_method_v2_send_surrounding_text(input_method,
-		input->current.surrounding.text, input->current.surrounding.cursor,
-		input->current.surrounding.anchor);
+	if (input->active_features & WLR_TEXT_INPUT_V3_FEATURE_SURROUNDING_TEXT) {
+		wlr_input_method_v2_send_surrounding_text(input_method,
+			input->current.surrounding.text, input->current.surrounding.cursor,
+			input->current.surrounding.anchor);
+	}
 	wlr_input_method_v2_send_text_change_cause(input_method,
 		input->current.text_change_cause);
-	wlr_input_method_v2_send_content_type(input_method,
-		input->current.content_type.hint, input->current.content_type.purpose);
+	if (input->active_features & WLR_TEXT_INPUT_V3_FEATURE_CONTENT_TYPE) {
+		wlr_input_method_v2_send_content_type(input_method,
+			input->current.content_type.hint,
+			input->current.content_type.purpose);
+	}
 	wlr_input_method_v2_send_done(input_method);
 	// TODO: pass intent, display popup size
 }


### PR DESCRIPTION
Allows the input method to detect if these are not supported.
~~Depends on https://github.com/swaywm/wlroots/pull/2735~~