### PR TITLE
Avoid configure events on client-initiated resize

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -51,10 +51,4 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 void transaction_notify_view_ready_by_geometry(struct sway_view *view,
 		double x, double y, int width, int height);
 
-/**
- * Unconditionally notify the transaction system that a view is ready for the
- * new layout.
- */
-void transaction_notify_view_ready_immediately(struct sway_view *view);
-
 #endif

--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -28,6 +28,12 @@ struct sway_view;
  */
 void transaction_commit_dirty(void);
 
+/*
+ * Same as transaction_commit_dirty, but signalling that this is a
+ * client-initiated change has already taken effect.
+ */
+void transaction_commit_dirty_client(void);
+
 /**
  * Notify the transaction system that a view is ready for the new layout.
  *

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -35,6 +35,7 @@ struct sway_transaction_instruction {
 		struct sway_container_state container_state;
 	};
 	uint32_t serial;
+	bool server_request;
 	bool waiting;
 };
 
@@ -165,7 +166,7 @@ static void copy_container_state(struct sway_container *container,
 }
 
 static void transaction_add_node(struct sway_transaction *transaction,
-		struct sway_node *node) {
+		struct sway_node *node, bool server_request) {
 	struct sway_transaction_instruction *instruction = NULL;
 
 	// Check if we have an instruction for this node already, in which case we
@@ -188,9 +189,12 @@ static void transaction_add_node(struct sway_transaction *transaction,
 		}
 		instruction->transaction = transaction;
 		instruction->node = node;
+		instruction->server_request = server_request;
 
 		list_add(transaction->instructions, instruction);
 		node->ntxnrefs++;
+	} else if (server_request) {
+		instruction->server_request = true;
 	}
 
 	switch (node->type) {
@@ -364,6 +368,9 @@ static bool should_configure(struct sway_node *node,
 	if (node->destroying) {
 		return false;
 	}
+	if (!instruction->server_request) {
+		return false;
+	}
 	struct sway_container_state *cstate = &node->sway_container->current;
 	struct sway_container_state *istate = &instruction->container_state;
 #if HAVE_XWAYLAND
@@ -522,7 +529,7 @@ void transaction_notify_view_ready_immediately(struct sway_view *view) {
 	}
 }
 
-void transaction_commit_dirty(void) {
+static void _transaction_commit_dirty(bool server_request) {
 	if (!server.dirty_nodes->length) {
 		return;
 	}
@@ -536,10 +543,18 @@ void transaction_commit_dirty(void) {
 
 	for (int i = 0; i < server.dirty_nodes->length; ++i) {
 		struct sway_node *node = server.dirty_nodes->items[i];
-		transaction_add_node(server.pending_transaction, node);
+		transaction_add_node(server.pending_transaction, node, server_request);
 		node->dirty = false;
 	}
 	server.dirty_nodes->length = 0;
 
 	transaction_commit_pending();
+}
+
+void transaction_commit_dirty(void) {
+	_transaction_commit_dirty(true);
+}
+
+void transaction_commit_dirty_client(void) {
+	_transaction_commit_dirty(false);
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -521,14 +521,6 @@ void transaction_notify_view_ready_by_geometry(struct sway_view *view,
 	}
 }
 
-void transaction_notify_view_ready_immediately(struct sway_view *view) {
-	struct sway_transaction_instruction *instruction =
-			view->container->node.instruction;
-	if (instruction != NULL) {
-		set_instruction_ready(instruction);
-	}
-}
-
 static void _transaction_commit_dirty(bool server_request) {
 	if (!server.dirty_nodes->length) {
 		return;

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -293,7 +293,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			new_geo.y != view->geometry.y;
 
 	if (new_size) {
-		// The view has unexpectedly sent a new size
+		// The client changed its surface size in this commit. For floating
+		// containers, we resize the container to match. For tiling containers,
+		// we only recenter the surface.
 		desktop_damage_view(view);
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -298,8 +298,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
 			view_update_size(view);
-			transaction_commit_dirty();
-			transaction_notify_view_ready_immediately(view);
+			transaction_commit_dirty_client();
 		} else {
 			view_center_surface(view);
 		}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -413,7 +413,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
 			view_update_size(view);
-			transaction_commit_dirty();
+			transaction_commit_dirty_client();
 		} else {
 			view_center_surface(view);
 		}

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -407,8 +407,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			new_geo.y != view->geometry.y;
 
 	if (new_size) {
-		// The view has unexpectedly sent a new size
-		// eg. The Firefox "Save As" dialog when downloading a file
+		// The client changed its surface size in this commit. For floating
+		// containers, we resize the container to match. For tiling containers,
+		// we only recenter the surface.
 		desktop_damage_view(view);
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {


### PR DESCRIPTION
Avoid transactions if a resize is client-initiated.

Closes: https://github.com/swaywm/sway/issues/5857