### PR TITLE
transactions: Amend pending transactions

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -23,6 +23,8 @@
 #include "sway/xwayland.h"
 #endif
 
+struct sway_transaction;
+
 struct sway_server {
 	struct wl_display *wl_display;
 	struct wl_event_loop *wl_event_loop;
@@ -85,8 +87,22 @@ struct sway_server {
 	struct wlr_text_input_manager_v3 *text_input;
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 
+	// The timeout for transactions, after which a transaction is applied
+	// regardless of readiness.
 	size_t txn_timeout_ms;
-	list_t *transactions;
+
+	// Stores a transaction after it has been committed, but is waiting for
+	// views to ack the new dimensions before being applied. A queued
+	// transaction is frozen and must not have new instructions added to it.
+	struct sway_transaction *queued_transaction;
+
+	// Stores a pending transaction that will be committed once the existing
+	// queued transaction is applied and freed. The pending transaction can be
+	// updated with new instructions as needed.
+	struct sway_transaction *pending_transaction;
+
+	// Stores the nodes that have been marked as "dirty" and will be put into
+	// the pending transaction.
 	list_t *dirty_nodes;
 };
 

--- a/sway/server.c
+++ b/sway/server.c
@@ -199,7 +199,6 @@ bool server_init(struct sway_server *server) {
 	}
 
 	server->dirty_nodes = create_list();
-	server->transactions = create_list();
 
 	server->input = input_manager_create(server);
 	input_manager_get_default_seat(); // create seat0
@@ -215,7 +214,6 @@ void server_fini(struct sway_server *server) {
 	wl_display_destroy_clients(server->wl_display);
 	wl_display_destroy(server->wl_display);
 	list_free(server->dirty_nodes);
-	list_free(server->transactions);
 }
 
 bool server_start(struct sway_server *server) {


### PR DESCRIPTION
The transaction system contains a necessary optimization where a popped
transaction is combined with later, similar transactions. This breaks
the chronological order of states, and can lead to desynchronized
geometries.

To fix this, we replace the queue with only 2 transactions: current and
pending. If a pending transaction exists, it is updated with new state
instead of creating additional transactions.

As we never have more than a single waiting transaction, we no longer
need the queue optimization that is causing problems.

Closes: https://github.com/swaywm/sway/issues/6012