### PR TITLE
input: Only commit transactions when necessary

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/keyboard.h"
 #include "sway/ipc-server.h"
@@ -642,6 +643,8 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	if (success) {
 		ipc_event_binding(binding);
 	}
+
+	transaction_commit_dirty();
 }
 
 /**

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -20,7 +20,6 @@
 #include "util.h"
 #include "sway/commands.h"
 #include "sway/desktop.h"
-#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/tablet.h"
@@ -383,7 +382,6 @@ static void handle_pointer_motion_relative(
 
 	pointer_motion(cursor, e->time_msec, e->device, e->delta_x, e->delta_y,
 			e->unaccel_dx, e->unaccel_dy);
-	transaction_commit_dirty();
 }
 
 static void handle_pointer_motion_absolute(
@@ -401,7 +399,6 @@ static void handle_pointer_motion_absolute(
 	double dy = ly - cursor->cursor->y;
 
 	pointer_motion(cursor, event->time_msec, event->device, dx, dy, dx, dy);
-	transaction_commit_dirty();
 }
 
 void dispatch_cursor_button(struct sway_cursor *cursor,
@@ -431,7 +428,6 @@ static void handle_pointer_button(struct wl_listener *listener, void *data) {
 	cursor_handle_activity_from_device(cursor, event->device);
 	dispatch_cursor_button(cursor, event->device,
 			event->time_msec, event->button, event->state);
-	transaction_commit_dirty();
 }
 
 void dispatch_cursor_axis(struct sway_cursor *cursor,
@@ -444,7 +440,6 @@ static void handle_pointer_axis(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_axis *event = data;
 	cursor_handle_activity_from_device(cursor, event->device);
 	dispatch_cursor_axis(cursor, event);
-	transaction_commit_dirty();
 }
 
 static void handle_pointer_frame(struct wl_listener *listener, void *data) {
@@ -495,7 +490,6 @@ static void handle_touch_down(struct wl_listener *listener, void *data) {
 		dispatch_cursor_button(cursor, event->device, event->time_msec,
 				BTN_LEFT, WLR_BUTTON_PRESSED);
 		wlr_seat_pointer_notify_frame(wlr_seat);
-		transaction_commit_dirty();
 	}
 }
 
@@ -512,7 +506,6 @@ static void handle_touch_up(struct wl_listener *listener, void *data) {
 			dispatch_cursor_button(cursor, event->device, event->time_msec,
 					BTN_LEFT, WLR_BUTTON_RELEASED);
 			wlr_seat_pointer_notify_frame(wlr_seat);
-			transaction_commit_dirty();
 		}
 	} else {
 		wlr_seat_touch_notify_up(wlr_seat, event->time_msec, event->touch_id);
@@ -553,7 +546,6 @@ static void handle_touch_motion(struct wl_listener *listener, void *data) {
 			dx = lx - cursor->cursor->x;
 			dy = ly - cursor->cursor->y;
 			pointer_motion(cursor, event->time_msec, event->device, dx, dy, dx, dy);
-			transaction_commit_dirty();
 		}
 	} else if (surface) {
 		wlr_seat_touch_notify_motion(wlr_seat, event->time_msec,
@@ -639,8 +631,6 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 		wlr_tablet_v2_tablet_tool_notify_proximity_out(tool->tablet_v2_tool);
 		pointer_motion(cursor, time_msec, input_device->wlr_device, dx, dy, dx, dy);
 	}
-
-	transaction_commit_dirty();
 }
 
 static void handle_tool_axis(struct wl_listener *listener, void *data) {
@@ -720,7 +710,6 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 		dispatch_cursor_button(cursor, event->device, event->time_msec,
 			BTN_LEFT, WLR_BUTTON_RELEASED);
 		wlr_seat_pointer_notify_frame(cursor->seat->wlr_seat);
-		transaction_commit_dirty();
 	} else if (!surface || !wlr_surface_accepts_tablet_v2(tablet_v2, surface)) {
 		// If we started holding the tool tip down on a surface that accepts
 		// tablet v2, we should notify that surface if it gets released over a
@@ -733,7 +722,6 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 			dispatch_cursor_button(cursor, event->device, event->time_msec,
 				BTN_LEFT, WLR_BUTTON_PRESSED);
 			wlr_seat_pointer_notify_frame(cursor->seat->wlr_seat);
-			transaction_commit_dirty();
 		}
 	} else {
 		seatop_tablet_tool_tip(seat, sway_tool, event->time_msec, event->state);
@@ -820,7 +808,6 @@ static void handle_tool_button(struct wl_listener *listener, void *data) {
 			break;
 		}
 		wlr_seat_pointer_notify_frame(cursor->seat->wlr_seat);
-		transaction_commit_dirty();
 		return;
 	}
 

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -9,7 +9,6 @@
 #include <wlr/types/wlr_keyboard_group.h>
 #include <xkbcommon/xkbcommon-names.h>
 #include "sway/commands.h"
-#include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/seat.h"
@@ -500,7 +499,6 @@ static void handle_key_event(struct sway_keyboard *keyboard,
 		}
 	}
 
-	transaction_commit_dirty();
 
 	free(device_identifier);
 }
@@ -587,7 +585,6 @@ static int handle_keyboard_repeat(void *data) {
 
 		seat_execute_command(keyboard->seat_device->sway_seat,
 				keyboard->repeat_binding);
-		transaction_commit_dirty();
 	}
 	return 0;
 }

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -5,6 +5,7 @@
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/tree/view.h"
+#include "sway/desktop/transaction.h"
 #include "log.h"
 
 struct seatop_down_event {
@@ -107,4 +108,5 @@ void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
 	seat->seatop_data = e;
 
 	container_raise_floating(con);
+	transaction_commit_dirty();
 }

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <wlr/types/wlr_cursor.h>
 #include "sway/desktop.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 
@@ -15,6 +16,7 @@ static void finalize_move(struct sway_seat *seat) {
 	// We "move" the container to its own location
 	// so it discovers its output again.
 	container_floating_move_to(e->con, e->con->x, e->con->y);
+	transaction_commit_dirty();
 
 	seatop_begin_default(seat);
 }
@@ -40,6 +42,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	desktop_damage_whole_container(e->con);
 	container_floating_move_to(e->con, cursor->x - e->dx, cursor->y - e->dy);
 	desktop_damage_whole_container(e->con);
+	transaction_commit_dirty();
 }
 
 static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
@@ -74,6 +77,7 @@ void seatop_begin_move_floating(struct sway_seat *seat,
 	seat->seatop_data = e;
 
 	container_raise_floating(con);
+	transaction_commit_dirty();
 
 	cursor_set_image(cursor, "grab", NULL);
 	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -3,6 +3,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/edges.h>
 #include "sway/desktop.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
@@ -214,6 +215,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	} else {
 		handle_motion_prethreshold(seat);
 	}
+	transaction_commit_dirty();
 }
 
 static bool is_parallel(enum sway_container_layout layout,
@@ -294,6 +296,7 @@ static void finalize_move(struct sway_seat *seat) {
 		arrange_workspace(new_ws);
 	}
 
+	transaction_commit_dirty();
 	seatop_begin_default(seat);
 }
 
@@ -348,6 +351,7 @@ void seatop_begin_move_tiling_threshold(struct sway_seat *seat,
 	seat->seatop_data = e;
 
 	container_raise_floating(con);
+	transaction_commit_dirty();
 	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }
 

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -2,6 +2,7 @@
 #include <limits.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/tree/arrange.h"
@@ -27,6 +28,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	if (seat->cursor->pressed_button_count == 0) {
 		container_set_resizing(con, false);
 		arrange_container(con); // Send configure w/o resizing hint
+		transaction_commit_dirty();
 		seatop_begin_default(seat);
 	}
 }
@@ -133,6 +135,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	con->content_height += relative_grow_height;
 
 	arrange_container(con);
+	transaction_commit_dirty();
 }
 
 static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
@@ -176,6 +179,7 @@ void seatop_begin_resize_floating(struct sway_seat *seat,
 
 	container_set_resizing(con, true);
 	container_raise_floating(con);
+	transaction_commit_dirty();
 
 	const char *image = edge == WLR_EDGE_NONE ?
 		"se-resize" : wlr_xcursor_get_resize_name(edge);

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -2,6 +2,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/edges.h>
 #include "sway/commands.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/tree/arrange.h"
@@ -67,6 +68,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 				arrange_workspace(e->v_con->workspace);
 			}
 		}
+		transaction_commit_dirty();
 		seatop_begin_default(seat);
 	}
 }
@@ -99,6 +101,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	if (amount_y != 0) {
 		container_resize_tiled(e->v_con, e->edge_y, amount_y);
 	}
+	transaction_commit_dirty();
 }
 
 static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
@@ -158,5 +161,6 @@ void seatop_begin_resize_tiling(struct sway_seat *seat,
 	seat->seatop_impl = &seatop_impl;
 	seat->seatop_data = e;
 
+	transaction_commit_dirty();
 	wlr_seat_pointer_notify_clear_focus(seat->wlr_seat);
 }

--- a/sway/input/switch.c
+++ b/sway/input/switch.c
@@ -1,5 +1,4 @@
 #include "sway/config.h"
-#include "sway/desktop/transaction.h"
 #include "sway/input/switch.h"
 #include <wlr/types/wlr_idle.h>
 #include "log.h"
@@ -61,9 +60,6 @@ static void execute_binding(struct sway_switch *sway_switch) {
 		seat_execute_command(seat, dummy_binding);
 		free(dummy_binding);
 	}
-
-	transaction_commit_dirty();
-
 }
 
 static void handle_switch_toggle(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
There is no need to check for transactions at the end of every user
input, as the vast majority of input will not issue transactions. This
implementation can also hide where changes are made without an
appropriate transaction commit, as a future unrelated input would issue
the commit instead.

Instead, commit transactions in places where changes are made or are
likely to be made.