### PR TITLE
Prevent script to crash on lockscreen

### DIFF
--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -15,8 +15,13 @@ def on_window_focus(inactive_opacity, ipc, event):
     global prev_focused
     global prev_workspace
 
+    focused_workspace = ipc.get_tree().find_focused()
+
+    if focused_workspace == None:
+        return
+
     focused = event.container
-    workspace = ipc.get_tree().find_focused().workspace().num
+    workspace = focused_workspace.workspace().num
 
     if focused.id != prev_focused.id:  # https://github.com/swaywm/sway/issues/2859
         focused.command("opacity 1")


### PR DESCRIPTION
When running swaylock, no workspace is focused, so the script `inactive-windows-transparency.py` fails with the following stacktrace:

```
'NoneType' object has no attribute 'workspace'
Traceback (most recent call last):
  File "/home/pat/.config/sway/bin/opacity", line 64, in <module>
    ipc.main()
  File "/usr/lib/python3.9/site-packages/i3ipc/connection.py", line 514, in main
    raise loop_exception
  File "/usr/lib/python3.9/site-packages/i3ipc/connection.py", line 497, in main
    while not self._event_socket_poll():
  File "/usr/lib/python3.9/site-packages/i3ipc/connection.py", line 477, in _event_socket_poll
    raise e
  File "/usr/lib/python3.9/site-packages/i3ipc/connection.py", line 474, in _event_socket_poll
    self._pubsub.emit(event_name, event)
  File "/usr/lib/python3.9/site-packages/i3ipc/_private/pubsub.py", line 28, in emit
    s['handler'](self.conn, data)
  File "/home/pat/.config/sway/bin/opacity", line 19, in on_window_focus
    workspace = ipc.get_tree().find_focused().workspace().num
AttributeError: 'NoneType' object has no attribute 'workspace'
```