### PR TITLE
grimshot: add a pipe mode

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -32,13 +32,13 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window] [FILE]"
+  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window] [FILE|-]"
   echo "  grimshot check"
   echo "  grimshot usage"
   echo ""
   echo "Commands:"
   echo "  copy: Copy the screenshot data into the clipboard."
-  echo "  save: Save the screenshot to a regular file."
+  echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
   echo "  check: Verify if required tools are installed and exit."
   echo "  usage: Show this message and exit."
   echo ""

--- a/contrib/grimshot.1
+++ b/contrib/grimshot.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "grimshot" "1" "2020-12-20"
+.TH "grimshot" "1" "2021-02-23"
 .P
 .SH NAME
 .P
@@ -31,6 +31,7 @@ Show notifications to the user that a screenshot has been taken.\&
 Save the screenshot into a regular file.\& Grimshot will write images
 files to \fBXDG_SCREENSHOTS_DIR\fR if this is set (or defined
 in \fBuser-dirs.\&dir\fR), or otherwise fall back to \fBXDG_PICTURES_DIR\fR.\&
+Set FILE to '-' to pipe the output to STDOUT.\&
 .P
 .RE
 \fBcopy\fR

--- a/contrib/grimshot.1.scd
+++ b/contrib/grimshot.1.scd
@@ -19,6 +19,7 @@ grimshot - a helper for screenshots within sway
 	Save the screenshot into a regular file. Grimshot will write images
 	files to *XDG_SCREENSHOTS_DIR* if this is set (or defined
 	in *user-dirs.dir*), or otherwise fall back to *XDG_PICTURES_DIR*.
+	Set FILE to '-' to pipe the output to STDOUT.
 
 *copy*
 	Copy the screenshot data (as image/png) into the clipboard.


### PR DESCRIPTION
Swappy is a great screenshot annotation tool that expects input in STDIN.

Support tools like that by adding an option to pipe the output to STDOUT.

Example syntax:

     grimshot pipe area | swappy -f -
