### PR TITLE
render: scale titlebars correctly when straddling outputs

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -518,6 +518,10 @@ static void render_titlebar(struct sway_output *output,
 		struct wlr_box texture_box;
 		wlr_texture_get_size(title_texture,
 			&texture_box.width, &texture_box.height);
+
+		float title_scale = container_get_effective_output(con)->wlr_output->scale;
+		texture_box.width = texture_box.width * output_scale / title_scale;
+		texture_box.height = texture_box.height * output_scale / title_scale;
 		ob_title_width = texture_box.width;
 
 		// The title texture might be shorter than the config->font_height,


### PR DESCRIPTION
When a container straddles multiple outputs, the title bar is only rendered
at the scale of the "effective" output. If the title bar straddles onto
another output with a different scale factor, it was drawn at the wrong size.

In this commit, we take into consideration the scale the title was rendered
at and scale it accordingly so that it appears at the right size on the other
outputs.

This fixes #6054.