### PR TITLE
WIP: sway: add titlebar_v_height option 

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -188,6 +188,7 @@ sway_cmd cmd_title_align;
 sway_cmd cmd_title_format;
 sway_cmd cmd_titlebar_border_thickness;
 sway_cmd cmd_titlebar_padding;
+sway_cmd cmd_titlebar_height;
 sway_cmd cmd_unbindcode;
 sway_cmd cmd_unbindswitch;
 sway_cmd cmd_unbindsym;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -492,6 +492,7 @@ struct sway_config {
 	int titlebar_border_thickness;
 	int titlebar_h_padding;
 	int titlebar_v_padding;
+	int titlebar_height;
 	size_t urgent_timeout;
 	enum sway_fowa focus_on_window_activation;
 	enum sway_popup_during_fullscreen popup_during_fullscreen;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -89,6 +89,7 @@ static const struct cmd_handler handlers[] = {
 	{ "tiling_drag_threshold", cmd_tiling_drag_threshold },
 	{ "title_align", cmd_title_align },
 	{ "titlebar_border_thickness", cmd_titlebar_border_thickness },
+	{ "titlebar_height", cmd_titlebar_height },
 	{ "titlebar_padding", cmd_titlebar_padding },
 	{ "unbindcode", cmd_unbindcode },
 	{ "unbindswitch", cmd_unbindswitch },

--- a/sway/commands/titlebar_height.c
+++ b/sway/commands/titlebar_height.c
@@ -1,0 +1,29 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "sway/tree/arrange.h"
+#include "log.h"
+
+struct cmd_results *cmd_titlebar_height(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "titlebar_height", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	char *inv;
+	int value = strtol(argv[0], &inv, 10);
+	if (*inv != '\0' || value < -1 ) {
+		return cmd_results_new(CMD_FAILURE, "Invalid size specified");
+	}
+
+	config->titlebar_height = value;
+
+	for (int i = 0; i < root->outputs->length; ++i) {
+		struct sway_output *output = root->outputs->items[i];
+		arrange_workspace(output_get_active_workspace(output));
+		output_damage_whole(output);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -245,6 +245,7 @@ static void config_defaults(struct sway_config *config) {
 	config->titlebar_border_thickness = 1;
 	config->titlebar_h_padding = 5;
 	config->titlebar_v_padding = 4;
+	config->titlebar_height = -1;
 
 	// floating view
 	config->floating_maximum_width = 0;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -113,6 +113,7 @@ sway_sources = files(
 	'commands/title_format.c',
 	'commands/titlebar_border_thickness.c',
 	'commands/titlebar_padding.c',
+	'commands/titlebar_height.c',
 	'commands/unmark.c',
 	'commands/urgent.c',
 	'commands/workspace.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -649,6 +649,10 @@ The default colors are:
 	should be greater than titlebar_border_thickness. If _vertical_ value is
 	not specified it is set to the _horizontal_ value.
 
+*titlebar_height* <height>
+	Height of the titlebar binded to _height_ in pixels. _height_ of -1 turns
+	off binding.
+
 *for_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -578,16 +578,22 @@ void container_update_title_textures(struct sway_container *container) {
 }
 
 void container_calculate_title_height(struct sway_container *container) {
+        int height;
+        int baseline;
+
 	if (!container->formatted_title) {
 		container->title_height = 0;
 		return;
 	}
-	cairo_t *cairo = cairo_create(NULL);
-	int height;
-	int baseline;
-	get_text_size(cairo, config->font, NULL, &height, &baseline, 1,
-			config->pango_markup, "%s", container->formatted_title);
-	cairo_destroy(cairo);
+	if (config->titlebar_height >= 0) {
+		height   = config->titlebar_height;
+		baseline = 0;
+	} else {
+		cairo_t *cairo = cairo_create(NULL);
+		get_text_size(cairo, config->font, NULL, &height, &baseline, 1,
+				config->pango_markup, "%s", container->formatted_title);
+		cairo_destroy(cairo);
+	}
 	container->title_height = height;
 	container->title_baseline = baseline;
 }


### PR DESCRIPTION
This pr is in wip state, as there is need to fix some things:

- [x] 1) We need new name for `fixed titlebar height`, since in code there already is a `titlebar_height` variable 
- [ ] 2) I need to remind myself what for `baseline` stands and find out how it can be calculated more correctly
- [x] 3) Remove or rewrite logging messages

Base logic is:
- If there is no configured `fixed titlebar height` - then variable assigns value `-1` and actual title height goes to be calculated with cairo.
- Same if there is explicit `-1` in config.
- If `fixed titlebar height` is set to 0 and above - title height is then picked from config.

----

For 1) my variants are:
- titlebar_height_fixed  <-- and my vote for this 
- titlebar_height_bind
- titlebar_height_exact
