### PR TITLE
build: Add dependency on libdrm

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,8 @@ glesv2         = dependency('glesv2')
 libevdev       = dependency('libevdev')
 libinput       = dependency('libinput', version: '>=1.6.0')
 xcb            = dependency('xcb', required: get_option('xwayland'))
+drm_full       = dependency('libdrm') # only needed for drm_fourcc.h
+drm            = drm_full.partial_dependency(compile_args: true, includes: true)
 bash_comp      = dependency('bash-completion', required: false)
 fish_comp      = dependency('fish', required: false)
 math           = cc.find_library('m')

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -204,6 +204,7 @@ sway_sources = files(
 
 sway_deps = [
 	cairo,
+	drm,
 	jsonc,
 	libevdev,
 	libinput,


### PR DESCRIPTION
As of 66343839b146a54505b746784cd42a8efb844963, sway now uses a
libdrm header. Add this dependency to the build system so headers from
it can be used on systems where pkg-config is required to find them.

(Encountered on NixOS.)