### PR TITLE
output: Reconfigure xcursor when applying output config

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -483,6 +483,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 	// this output came online, and some config items (like map_to_output) are
 	// dependent on an output being present.
 	input_manager_configure_all_inputs();
+	// Reconfigure the cursor images, since the scale may have changed.
+	input_manager_configure_xcursor();
 	return true;
 }
 


### PR DESCRIPTION
Before this commit, when an output had its scale dynamically changed,
Sway would not load a cursor theme with the new scale. This results
in stale cursor images when moving the cursor into an area controlled
by the compositor, like the background or resize areas.

To reproduce:
- Using IPC, set an output scale to a value that isn't currently used
- Move the cursor into a compositor-controlled area
- The cursor will not change