### PR TITLE
render: handle containers without output when rendering titles

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -285,6 +285,7 @@ bool container_is_fullscreen_or_child(struct sway_container *container);
 /**
  * Return the output which will be used for scale purposes.
  * This is the most recently entered output.
+ * If the container is not on any output, return NULL.
  */
 struct sway_output *container_get_effective_output(struct sway_container *con);
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -519,7 +519,11 @@ static void render_titlebar(struct sway_output *output,
 		wlr_texture_get_size(title_texture,
 			&texture_box.width, &texture_box.height);
 
-		float title_scale = container_get_effective_output(con)->wlr_output->scale;
+		// The effective output may be NULL when con is not on any output.
+		// This can happen because we render all children of containers,
+		// even those that are out of the bounds of any output.
+		struct sway_output *effective = container_get_effective_output(con);
+		float title_scale = effective ? effective->wlr_output->scale : output_scale;
 		texture_box.width = texture_box.width * output_scale / title_scale;
 		texture_box.height = texture_box.height * output_scale / title_scale;
 		ob_title_width = texture_box.width;


### PR DESCRIPTION
In e0a94bee8da3271f942c0881ee18a7e2d4138063, it was believed that if the
container is being rendered, it must have an output.

This turned out not to be the case. When rendering a container, all its
children are rendered, even if the children is positioned off screen and
thus not having any output. This is the cause of the crash in #6061.

This commit introduces a null-check, which fixes #6061.