### PR TITLE
input: stash current node and surface in cursor

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -22,6 +22,15 @@ struct sway_cursor {
 		double x, y;
 		struct sway_node *node;
 	} previous;
+
+	// Not to be confused with `previous` above; they store entirely unrelated
+	// data.
+	struct {
+		double sx, sy;
+		struct sway_node *node;
+		struct wlr_surface *surface;
+	} current;
+
 	struct wlr_xcursor_manager *xcursor_manager;
 	struct wl_list tablets;
 	struct wl_list tablet_pads;
@@ -78,10 +87,6 @@ struct sway_cursor {
 };
 
 struct sway_node;
-
-struct sway_node *node_at_coords(
-		struct sway_seat *seat, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
 
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -618,11 +618,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 	struct sway_container *con = NULL;
 	if (binding->type == BINDING_MOUSESYM
 			|| binding->type == BINDING_MOUSECODE) {
-		struct wlr_surface *surface = NULL;
-		double sx, sy;
-		struct sway_node *node = node_at_coords(seat,
-				seat->cursor->cursor->x, seat->cursor->cursor->y,
-				&surface, &sx, &sy);
+		struct sway_node *node = seat->cursor->current.node;
 		if (node && node->type == N_CONTAINER) {
 			con = node->sway_container;
 		}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -213,10 +213,9 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 	}
 
 	struct sway_cursor *cursor = seat->cursor;
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct wlr_surface *surface = cursor->current.surface;
+	double sx = cursor->current.sx, sy = cursor->current.sy;
+	struct sway_node *node = cursor->current.node;
 
 	if (!sway_assert(surface,
 			"Expected null-surface tablet input to route through pointer emulation")) {
@@ -328,10 +327,9 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	struct sway_cursor *cursor = seat->cursor;
 
 	// Determine what's under the cursor
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct wlr_surface *surface = cursor->current.surface;
+	double sx = cursor->current.sx, sy = cursor->current.sy;
+	struct sway_node *node = cursor->current.node;
 
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
@@ -574,10 +572,9 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct wlr_surface *surface = cursor->current.surface;
+	double sx = cursor->current.sx, sy = cursor->current.sy;
+	struct sway_node *node = cursor->current.node;
 
 	if (config->focus_follows_mouse != FOLLOWS_NO) {
 		check_focus_follows_mouse(seat, e, node);
@@ -608,10 +605,9 @@ static void handle_tablet_tool_motion(struct sway_seat *seat,
 	struct seatop_default_event *e = seat->seatop_data;
 	struct sway_cursor *cursor = seat->cursor;
 
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct wlr_surface *surface = cursor->current.surface;
+	double sx = cursor->current.sx, sy = cursor->current.sy;
+	struct sway_node *node = cursor->current.node;
 
 	if (config->focus_follows_mouse != FOLLOWS_NO) {
 		check_focus_follows_mouse(seat, e, node);
@@ -664,10 +660,8 @@ static void handle_pointer_axis(struct sway_seat *seat,
 	struct seatop_default_event *e = seat->seatop_data;
 
 	// Determine what's under the cursor
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct wlr_surface *surface = cursor->current.surface;
+	struct sway_node *node = cursor->current.node;
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
 	enum wlr_edges edge = cont ? find_edge(cont, surface, cursor) : WLR_EDGE_NONE;
@@ -756,8 +750,7 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 	struct sway_cursor *cursor = seat->cursor;
 	struct wlr_surface *surface = NULL;
 	double sx = 0.0, sy = 0.0;
-	e->previous_node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	e->previous_node = cursor->current.node;
 
 	if (surface) {
 		if (seat_is_input_allowed(seat, surface)) {

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -94,11 +94,8 @@ static void resize_box(struct wlr_box *box, enum wlr_edges edge,
 
 static void handle_motion_postthreshold(struct sway_seat *seat) {
 	struct seatop_move_tiling_event *e = seat->seatop_data;
-	struct wlr_surface *surface = NULL;
-	double sx, sy;
 	struct sway_cursor *cursor = seat->cursor;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = cursor->current.node;
 	// Damage the old location
 	desktop_damage_box(&e->drop_box);
 


### PR DESCRIPTION
If an actively constrained surface is partially occluded by another node
(say, by a floating node), the cursor should remain constrained and pass
"under" the floating node.

Previously, this did not always happen, as `node_at_coords` is a simple
top-down hit test that doesn't cover constraints.

Furthermore, whether the cursor should remain constrained is a function
of the input device type: only pointer devices should be constrained.

This commit addresses this issue by stashing the surface and node that
currently have cursor input focus, and using the stashed values
everywhere.

When `wlr_cursor_move` and friends are called, one must now take care to
also call `cursor_update_current_node` with the `wlr_input_device` that
initiated the movement.

Fixes #6073.

---

The input logic is really finicky, so while this is ready for review I'd prefer
to not merge it until after 1.6. There are bound to be bugs.

Note that I have only tested this code with pointer input; I'll be able to
test with a tablet later, but I do not own a touchscreen device.