### PR TITLE
resolve #6092: silence IconThemePath message

### DIFF
--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -115,10 +115,11 @@ static int get_property_callback(sd_bus_message *msg, void *data,
 	const char *prop = d->prop;
 	const char *type = d->type;
 	void *dest = d->dest;
+	sway_log_importance_t log_lv = strcmp(prop, "IconThemePath") ? SWAY_ERROR : SWAY_DEBUG;
 
 	int ret;
 	if (sd_bus_message_is_method_error(msg, NULL)) {
-		sway_log(SWAY_ERROR, "%s %s: %s", sni->watcher_id, prop,
+		sway_log(log_lv, "%s %s: %s", sni->watcher_id, prop,
 				sd_bus_message_get_error(msg)->message);
 		ret = sd_bus_message_get_errno(msg);
 		goto cleanup;

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -115,12 +115,16 @@ static int get_property_callback(sd_bus_message *msg, void *data,
 	const char *prop = d->prop;
 	const char *type = d->type;
 	void *dest = d->dest;
-	sway_log_importance_t log_lv = strcmp(prop, "IconThemePath") ? SWAY_ERROR : SWAY_DEBUG;
 
 	int ret;
 	if (sd_bus_message_is_method_error(msg, NULL)) {
-		sway_log(log_lv, "%s %s: %s", sni->watcher_id, prop,
-				sd_bus_message_get_error(msg)->message);
+		const sd_bus_error *err = sd_bus_message_get_error(msg);
+		sway_log_importance_t log_lv = SWAY_ERROR;
+		if ((!strcmp(prop, "IconThemePath")) &&
+				(!strcmp(err->name, SD_BUS_ERROR_UNKNOWN_PROPERTY))) {
+			log_lv = SWAY_DEBUG;
+		}
+		sway_log(log_lv, "%s %s: %s", sni->watcher_id, prop, err->message);
 		ret = sd_bus_message_get_errno(msg);
 		goto cleanup;
 	}


### PR DESCRIPTION
`IconThemePath` is not a standard property in XDG's StatusNotifierItem specification, so missing this property should not be logged as an error.

This patch changes the log level to `SWAY_DEBUG` when `swaybar` queries the value of `IconThemePath` so that `swaybar` won't log the returned message as an error if `IconThemePath` does not exist. It's a quick fix and may not look nice though...

Now, if users want to see the return message regarding `IconThemePath`, they'll have to enable the debug flag, like `swaybar -b bar-0 --debug`.