### PR TITLE
Add toggle logic inside DPMS handler

### DIFF
--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -1,6 +1,8 @@
 #include "sway/commands.h"
 #include "sway/config.h"
+#include "sway/output.h"
 #include "util.h"
+#include <strings.h>
 
 struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 	if (!config->handler_context.output_config) {
@@ -10,7 +12,28 @@ struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Missing dpms argument.");
 	}
 
-	if (parse_boolean(argv[0], true)) {
+	enum config_dpms current_dpms = DPMS_ON;
+
+	if (strcasecmp(argv[0], "toggle") == 0) {
+
+		const char *oc_name = config->handler_context.output_config->name;
+		if (strcmp(oc_name, "*") == 0) {
+			return cmd_results_new(CMD_INVALID,
+					"Cannot apply toggle to all outputs.");
+		}
+
+		struct sway_output *sway_output = all_output_by_name_or_id(oc_name);
+		if (!sway_output || !sway_output->wlr_output) {
+			return cmd_results_new(CMD_FAILURE,
+					"Cannot apply toggle to unknown output %s", oc_name);
+		}
+
+		if (sway_output->enabled && !sway_output->wlr_output->enabled) {
+			current_dpms = DPMS_OFF;
+		}
+	}
+
+	if (parse_boolean(argv[0], current_dpms == DPMS_ON)) {
 		config->handler_context.output_config->dpms_state = DPMS_ON;
 	} else {
 		config->handler_context.output_config->dpms_state = DPMS_OFF;

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -112,7 +112,7 @@ must be separated by one space. For example:
 *output* <name> toggle
 	Toggle the specified output.
 
-*output* <name> dpms on|off
+*output* <name> dpms on|off|toggle
 	Enables or disables the specified output via DPMS. To turn an output off
 	(ie. blank the screen but keep workspaces as-is), one can set DPMS to off.
 


### PR DESCRIPTION
Logic that obtains current DPMS state is put inside the handler.

sway_output from which the current DPMS state will be obtained is selected by the following logic:
* For `-` and `--` the focused output is used;
* For `*` error "Cannot apply toggle to all outputs" is reported;
* For everything else all_output_by_name_or_id() is used.

Fixes #5929.