### PR TITLE
config: allow whitespaces in config path

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -338,34 +338,58 @@ static bool file_exists(const char *path) {
 	return path && access(path, R_OK) != -1;
 }
 
+static char *config_path(const char *prefix, const char *config_folder) {
+	if (!prefix || !prefix[0] || !config_folder || !config_folder[0]) {
+		return NULL;
+	}
+
+	const char *filename = "config";
+
+	size_t size = 3 + strlen(prefix) + strlen(config_folder) + strlen(filename);
+	char *path = calloc(size, sizeof(char));
+	snprintf(path, size, "%s/%s/%s", prefix, config_folder, filename);
+	return path;
+}
+
 static char *get_config_path(void) {
-	static const char *config_paths[] = {
-		"$HOME/.sway/config",
-		"$XDG_CONFIG_HOME/sway/config",
-		"$HOME/.i3/config",
-		"$XDG_CONFIG_HOME/i3/config",
-		SYSCONFDIR "/sway/config",
-		SYSCONFDIR "/i3/config",
+	const char *home = getenv("HOME");
+	size_t size_fallback = 1 + strlen(home) + strlen("/.config");
+	char *config_home_fallback = calloc(size_fallback, sizeof(char));
+	snprintf(config_home_fallback, size_fallback, "%s/.config", home);
+
+	const char *config_home = getenv("XDG_CONFIG_HOME");
+	if (config_home == NULL || config_home[0] == '\0') {
+		config_home = config_home_fallback;
+	}
+
+	struct config_path {
+		const char *prefix;
+		const char *config_folder;
 	};
 
-	char *config_home = getenv("XDG_CONFIG_HOME");
-	if (!config_home || !*config_home) {
-		config_paths[1] = "$HOME/.config/sway/config";
-		config_paths[3] = "$HOME/.config/i3/config";
-	}
+	struct config_path config_paths[] = {
+		{ .prefix = home, .config_folder = ".sway"},
+		{ .prefix = config_home, .config_folder = "sway"},
+		{ .prefix = home, .config_folder = ".i3"},
+		{ .prefix = config_home, .config_folder = "i3"},
+		{ .prefix = SYSCONFDIR, .config_folder = "sway"},
+		{ .prefix = SYSCONFDIR, .config_folder = "i3"}
+	};
 
-	for (size_t i = 0; i < sizeof(config_paths) / sizeof(char *); ++i) {
-		wordexp_t p;
-		if (wordexp(config_paths[i], &p, WRDE_UNDEF) == 0) {
-			char *path = strdup(p.we_wordv[0]);
-			wordfree(&p);
-			if (file_exists(path)) {
-				return path;
-			}
-			free(path);
+	size_t num_config_paths = sizeof(config_paths)/sizeof(config_paths[0]);
+	for (size_t i = 0; i < num_config_paths; i++) {
+		char *path = config_path(config_paths[i].prefix, config_paths[i].config_folder);
+		if (!path) {
+			continue;
 		}
+		if (file_exists(path)) {
+			free(config_home_fallback);
+			return path;
+		}
+		free(path);
 	}
 
+	free(config_home_fallback);
 	return NULL;
 }
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -352,6 +352,7 @@ static char *config_path(const char *prefix, const char *config_folder) {
 }
 
 static char *get_config_path(void) {
+	char *path = NULL;
 	const char *home = getenv("HOME");
 	size_t size_fallback = 1 + strlen(home) + strlen("/.config");
 	char *config_home_fallback = calloc(size_fallback, sizeof(char));
@@ -378,19 +379,19 @@ static char *get_config_path(void) {
 
 	size_t num_config_paths = sizeof(config_paths)/sizeof(config_paths[0]);
 	for (size_t i = 0; i < num_config_paths; i++) {
-		char *path = config_path(config_paths[i].prefix, config_paths[i].config_folder);
+		path = config_path(config_paths[i].prefix, config_paths[i].config_folder);
 		if (!path) {
 			continue;
 		}
 		if (file_exists(path)) {
-			free(config_home_fallback);
-			return path;
+			break;
 		}
 		free(path);
+		path = NULL;
 	}
 
 	free(config_home_fallback);
-	return NULL;
+	return path;
 }
 
 static bool load_config(const char *path, struct sway_config *config,


### PR DESCRIPTION
Backport configpath building from xdg-desktop-portal-wlr.