### PR TITLE
idle_inhibit: Always listen for view_unmap

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -27,6 +27,7 @@ struct sway_idle_inhibitor_v1 {
 
 	struct wl_list link;
 	struct wl_listener destroy;
+	struct wl_listener view_unmap;
 };
 
 bool sway_idle_inhibit_v1_is_active(


### PR DESCRIPTION
For wlr_idle_inhibit, we'd listen to inhibitor destroy, whereas for
manual idle inhibition, we'd listen for view unmap. If a view associated
with a wlr_idle_inhibit inhibitor was destroyed, we could possibly end
up with a dangling view pointer.

Always listen to view unmap to ensure we clean up properly.