### PR TITLE
swaybar: Use position from wl_pointer.enter

### DIFF
--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -101,6 +101,8 @@ static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	struct swaybar_seat *seat = data;
 	struct swaybar_pointer *pointer = &seat->pointer;
+	seat->pointer.x = wl_fixed_to_double(surface_x);
+	seat->pointer.y = wl_fixed_to_double(surface_y);
 	pointer->serial = serial;
 	struct swaybar_output *output;
 	wl_list_for_each(output, &seat->bar->outputs, link) {


### PR DESCRIPTION
Only wl_pointer.motion was used to update pointer position, which would
cause issues if the pointer was not moved prior to wl_pointer.button.

This also fixes touch input through wl_pointer emulation, which fires
wl_pointer.button immediately after wl_pointer.enter.

Copied from a similar fix made to swaynag.

Closes: https://github.com/swaywm/sway/issues/6109