### PR TITLE
idle_inhibit: Store wlr inhibitor instead of view

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -22,6 +22,7 @@ struct sway_idle_inhibit_manager_v1 {
 
 struct sway_idle_inhibitor_v1 {
 	struct sway_idle_inhibit_manager_v1 *manager;
+	struct wlr_idle_inhibitor_v1 *wlr_inhibitor;
 	struct sway_view *view;
 	enum sway_idle_inhibit_mode mode;
 

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -36,7 +36,7 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 
 	inhibitor->manager = manager;
 	inhibitor->mode = INHIBIT_IDLE_APPLICATION;
-	inhibitor->view = view_from_wlr_surface(wlr_inhibitor->surface);
+	inhibitor->wlr_inhibitor = wlr_inhibitor;
 	wl_list_insert(&manager->inhibitors, &inhibitor->link);
 
 	inhibitor->destroy.notify = handle_destroy;
@@ -104,10 +104,10 @@ void sway_idle_inhibit_v1_user_inhibitor_destroy(
 
 bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 	switch (inhibitor->mode) {
-	case INHIBIT_IDLE_APPLICATION:
+	case INHIBIT_IDLE_APPLICATION:;
 		// If there is no view associated with the inhibitor, assume visible
-		return !inhibitor->view || !inhibitor->view->container ||
-			view_is_visible(inhibitor->view);
+		struct sway_view *view = view_from_wlr_surface(inhibitor->wlr_inhibitor->surface);
+		return !view || !view->container || view_is_visible(view);
 	case INHIBIT_IDLE_FOCUS:;
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1139,12 +1139,18 @@ struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
 	if (wlr_surface_is_xdg_surface(wlr_surface)) {
 		struct wlr_xdg_surface *xdg_surface =
 			wlr_xdg_surface_from_wlr_surface(wlr_surface);
+		if (xdg_surface == NULL) {
+			return NULL;
+		}
 		return view_from_wlr_xdg_surface(xdg_surface);
 	}
 #if HAVE_XWAYLAND
 	if (wlr_surface_is_xwayland_surface(wlr_surface)) {
 		struct wlr_xwayland_surface *xsurface =
 			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
+		if (xsurface == NULL) {
+			return NULL;
+		}
 		return view_from_wlr_xwayland_surface(xsurface);
 	}
 #endif


### PR DESCRIPTION
Should fix a dangling sway_view pointer in between view unmap and inhibitor destroy, which could cause issues if inhibition is checked in between.

As a bonus, we should now support idle inhibitors persisting across surface remap.

I still haven't managed to reproduce the original issue, so it would be nice if we could have someone experiencing problems test it.

Closes: https://github.com/swaywm/sway/issues/5325
Closes: https://github.com/swaywm/sway/issues/5680
Closes: https://github.com/swaywm/sway/issues/6091
Closes: https://github.com/swaywm/sway/issues/6103
Supersedes https://github.com/swaywm/sway/pull/6104