### PR TITLE
swaybar: fail gracefully on tokener creation fail

### DIFF
--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -547,7 +547,16 @@ bool handle_ipc_readable(struct swaybar *bar) {
 		return false;
 	}
 
-	json_tokener *tok = json_tokener_new_ex(INT_MAX);
+	// The default depth of 32 is too small to represent some nested layouts, but
+	// we can't pass INT_MAX here because json-c (as of this writing) prefaults
+	// all the memory for its stack.
+	json_tokener *tok = json_tokener_new_ex(256);
+	if (!tok) {
+		sway_log_errno(SWAY_ERROR, "failed to create tokener");
+		free_ipc_response(resp);
+		return false;
+	}
+
 	json_object *result = json_tokener_parse_ex(tok, resp->payload, -1);
 	enum json_tokener_error err = json_tokener_get_error(tok);
 	json_tokener_free(tok);


### PR DESCRIPTION
This commit adds missing error-handling to the creation of the tokener
instance. The stack depth parameter is used to initialize an array that
json-c prefaults ahead of time, causing INT_MAX to result in out of
memory errors.

Also drop the depth to 256 to prevent this OOM.

Though this fix is not very satisfactory -- json-c could be made to
not prefault -- it should do for now. At the very least, swaybar will
not crash.

Fixes #6126.