### PR TITLE
commands: add mouse sensitivity

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -257,6 +257,7 @@ sway_cmd input_cmd_map_to_region;
 sway_cmd input_cmd_middle_emulation;
 sway_cmd input_cmd_natural_scroll;
 sway_cmd input_cmd_pointer_accel;
+sway_cmd input_cmd_sensitivity;
 sway_cmd input_cmd_scroll_factor;
 sway_cmd input_cmd_repeat_delay;
 sway_cmd input_cmd_repeat_rate;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -140,6 +140,7 @@ struct input_config {
 	int middle_emulation;
 	int natural_scroll;
 	float pointer_accel;
+	float sensitivity;
 	float scroll_factor;
 	int repeat_delay;
 	int repeat_rate;

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -73,4 +73,6 @@ char *input_device_get_identifier(struct wlr_input_device *device);
 
 const char *input_device_get_type(struct sway_input_device *device);
 
+struct sway_input_device *input_sway_device_from_wlr(struct wlr_input_device *device);
+
 #endif

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -27,6 +27,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "scroll_button", input_cmd_scroll_button },
 	{ "scroll_factor", input_cmd_scroll_factor },
 	{ "scroll_method", input_cmd_scroll_method },
+	{ "sensitivity", input_cmd_sensitivity },
 	{ "tap", input_cmd_tap },
 	{ "tap_button_map", input_cmd_tap_button_map },
 	{ "tool_mode", input_cmd_tool_mode },

--- a/sway/commands/input/sensitivity.c
+++ b/sway/commands/input/sensitivity.c
@@ -1,0 +1,30 @@
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_sensitivity(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "sensitivity", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	float sensitivity = parse_float(argv[0]);
+	if (isnan(sensitivity)) {
+		return cmd_results_new(CMD_INVALID,
+			"Invalid sensitivity; expected float.");
+	} else if (sensitivity < 0) {
+		return cmd_results_new(CMD_INVALID,
+			"Sensitivity cannot be negative.");
+	}
+	ic->sensitivity = sensitivity;
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -31,6 +31,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->natural_scroll = INT_MIN;
 	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
+	input->sensitivity = FLT_MIN;
 	input->scroll_factor = FLT_MIN;
 	input->scroll_button = INT_MIN;
 	input->scroll_method = INT_MIN;
@@ -72,6 +73,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->pointer_accel != FLT_MIN) {
 		dst->pointer_accel = src->pointer_accel;
+	}
+	if (src->sensitivity != FLT_MIN) {
+		dst->sensitivity = src->sensitivity;
 	}
 	if (src->scroll_factor != FLT_MIN) {
 		dst->scroll_factor = src->scroll_factor;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1,6 +1,8 @@
+#include "sway/config.h"
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <math.h>
+#include <float.h>
 #include <libevdev/libevdev.h>
 #include <linux/input-event-codes.h>
 #include <errno.h>
@@ -21,6 +23,7 @@
 #include "sway/commands.h"
 #include "sway/desktop.h"
 #include "sway/input/cursor.h"
+#include "sway/input/input-manager.h"
 #include "sway/input/keyboard.h"
 #include "sway/input/tablet.h"
 #include "sway/layers.h"
@@ -29,7 +32,7 @@
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
-#include "wlr-layer-shell-unstable-v1-protocol.h"
+#include "sway/commands.h"
 
 static struct wlr_surface *layer_surface_at(struct sway_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {
@@ -365,7 +368,7 @@ static void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 			return;
 		}
 
-		dx = sx_confined - sx;
+		dx = sx_confined - sx; 
 		dy = sy_confined - sy;
 	}
 
@@ -378,9 +381,14 @@ static void handle_pointer_motion_relative(
 		struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, motion);
 	struct wlr_event_pointer_motion *e = data;
+
+	struct sway_input_device *sid = input_sway_device_from_wlr(e->device);
+	struct input_config *ic = sid ? input_device_get_config(sid) : NULL;
+	float sensitivity = (ic && ic->sensitivity != FLT_MIN) ? ic->sensitivity : 1.0f;
+
 	cursor_handle_activity_from_device(cursor, e->device);
 
-	pointer_motion(cursor, e->time_msec, e->device, e->delta_x, e->delta_y,
+	pointer_motion(cursor, e->time_msec, e->device, e->delta_x * sensitivity, e->delta_y * sensitivity,
 			e->unaccel_dx, e->unaccel_dy);
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1,4 +1,3 @@
-#include "sway/config.h"
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <math.h>
@@ -33,6 +32,7 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "sway/commands.h"
+#include "sway/config.h"
 
 static struct wlr_surface *layer_surface_at(struct sway_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -154,7 +154,7 @@ static void apply_input_type_config(struct sway_input_device *input_device) {
 	}
 }
 
-static struct sway_input_device *input_sway_device_from_wlr(
+struct sway_input_device *input_sway_device_from_wlr(
 		struct wlr_input_device *device) {
 	struct sway_input_device *input_device = NULL;
 	wl_list_for_each(input_device, &server.input->devices, link) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1006,12 +1006,21 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 	if (device->wlr_device->type == WLR_INPUT_DEVICE_POINTER) {
 		struct input_config *ic = input_device_get_config(device);
 		float scroll_factor = 1.0f;
-		if (ic != NULL && !isnan(ic->scroll_factor) && 
-				ic->scroll_factor != FLT_MIN) {
-			scroll_factor = ic->scroll_factor;
+		float sensitivity = 1.0f;
+		if (ic != NULL) {
+			if (!isnan(ic->scroll_factor) && ic->scroll_factor != FLT_MIN) {
+				scroll_factor = ic->scroll_factor;
+			}
+			
+			if (!isnan(ic->sensitivity) && ic->sensitivity != FLT_MIN) {
+				sensitivity = ic->sensitivity;
+			}
 		}
+
 		json_object_object_add(object, "scroll_factor", 
 				json_object_new_double(scroll_factor));
+		json_object_object_add(object, "sensitivity", 
+				json_object_new_double(sensitivity));
 	}
 
 	if (wlr_input_device_is_libinput(device->wlr_device)) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -161,6 +161,7 @@ sway_sources = files(
 	'commands/input/middle_emulation.c',
 	'commands/input/natural_scroll.c',
 	'commands/input/pointer_accel.c',
+	'commands/input/sensitivity.c',
 	'commands/input/repeat_delay.c',
 	'commands/input/repeat_rate.c',
 	'commands/input/scroll_button.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -171,6 +171,10 @@ The following commands may only be used in the configuration file.
 *input* <identifier> pointer_accel [<-1|1>]
 	Changes the pointer acceleration for the specified input device.
 
+*input* <identifier> sensitivity <floating point value>
+	Multiplies the sensitivity of a relative pointing input device. Has no
+	effect on absolute pointing devices.
+
 *input* <identifier> scroll_button disable|button[1-3,8,9]|<event-code-or-name>
 	Sets the button used for scroll_method on_button_down. The button can
 	be given as an event name or code, which can be obtained from *libinput

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1134,6 +1134,9 @@ following properties:
 |- scroll_factor
 :  floating
 :  (Only pointers) Multiplier applied on scroll event values.
+|- sensitivity
+:  floating
+:  (Only pointers) Multiplier applied on relative pointer movements.
 |- libinput
 :  object
 :  (Only libinput devices) An object describing the current device settings.


### PR DESCRIPTION
This commit adds an input command for a mouse sensitivity float. Relative mouse movements are multiplied by the sensitivity.

Fixes #3174