### PR TITLE
config: Fix swaybar pango_markup inconsistency

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -292,6 +292,12 @@ struct workspace_config {
 	struct side_gaps gaps_outer;
 };
 
+enum pango_markup_config {
+	PANGO_MARKUP_DISABLED = false,
+	PANGO_MARKUP_ENABLED = true,
+	PANGO_MARKUP_DEFAULT // The default is font dependent ("pango:" prefix)
+};
+
 struct bar_config {
 	char *swaybar_command;
 	struct wl_client *client;
@@ -323,7 +329,7 @@ struct bar_config {
 	char *position;
 	list_t *bindings;
 	char *status_command;
-	bool pango_markup;
+	enum pango_markup_config pango_markup;
 	char *font;
 	int height; // -1 not defined
 	bool workspace_buttons;

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -11,7 +11,20 @@ struct cmd_results *bar_cmd_font(int argc, char **argv) {
 	}
 	char *font = join_args(argv, argc);
 	free(config->current_bar->font);
-	config->current_bar->font = font;
+
+	if (strncmp(font, "pango:", 6) == 0) {
+		if (config->current_bar->pango_markup == PANGO_MARKUP_DEFAULT) {
+			config->current_bar->pango_markup = true;
+		}
+		config->current_bar->font = strdup(font + 6);
+	} else {
+		if (config->current_bar->pango_markup == PANGO_MARKUP_DEFAULT) {
+			config->current_bar->pango_markup = false;
+		}
+		config->current_bar->font = strdup(font);
+	}
+
+	free(font);
 	sway_log(SWAY_DEBUG, "Settings font '%s' for bar: %s",
 			config->current_bar->font, config->current_bar->id);
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -91,7 +91,7 @@ struct bar_config *default_bar_config(void) {
 	}
 	bar->outputs = NULL;
 	bar->position = strdup("bottom");
-	bar->pango_markup = false;
+	bar->pango_markup = PANGO_MARKUP_DEFAULT;
 	bar->swaybar_command = NULL;
 	bar->font = NULL;
 	bar->height = 0;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1127,7 +1127,9 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	json_object_object_add(json, "verbose",
 			json_object_new_boolean(bar->verbose));
 	json_object_object_add(json, "pango_markup",
-			json_object_new_boolean(bar->pango_markup));
+			json_object_new_boolean(bar->pango_markup == PANGO_MARKUP_DEFAULT
+											? config->pango_markup
+											: bar->pango_markup));
 
 	json_object *colors = json_object_new_object();
 	json_object_object_add(colors, "background",


### PR DESCRIPTION
Until now, swaybar did not have pango markup enabled by default, even if
the sway config had it on. This patch aims to mimic the i3 behavior, but
maintaining the functionality of the "pango_markup" sway config command.

Fixes swaywm/sway#6118

More details can be found in the referenced issue.