### PR TITLE
Remove advice about Firefox from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ labels: 'bug'
 ### Please read the following before submitting:
 - Please do NOT submit bug reports for questions. Ask questions on IRC at #sway on irc.freenode.net.
 - Proprietary graphics drivers, including nvidia, are not supported. Please use the open source equivalents, such as nouveau, if you would like to use Sway.
-- Problems with the Wayland version of Firefox are likely to be Firefox bugs. Start by submitting your issue to the Firefox Bugzilla and come back here only after they confirm otherwise.
 - Please do NOT submit issues for information from the github wiki. The github wiki is community maintained and therefore may contain outdated information, scripts that don't work or obsolete workarounds.
   If you fix a script or find outdated information, don't hesitate to adjust the wiki page.
 


### PR DESCRIPTION
Firefox got a lot better. I think now would be a good time to remove
the advice from the issue template. We can always add it back if we
start getting invalid bug reports again.