### PR TITLE
output: damage whole output when exiting scanout

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -553,6 +553,7 @@ static int output_repaint_timer_handler(void *data) {
 		if (last_scanned_out && !scanned_out) {
 			sway_log(SWAY_DEBUG, "Stopping fullscreen view scan out on %s",
 				output->wlr_output->name);
+			output_damage_whole(output);
 		}
 		last_scanned_out = scanned_out;
 


### PR DESCRIPTION
Fixes #6149. See issue.