### PR TITLE
cmd_fullscreen: allow fullscreen on fullscreen split containers

### DIFF
--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -33,15 +33,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 		}
 	}
 
-	bool is_fullscreen = false;
-	for (struct sway_container *curr = container; curr; curr = curr->pending.parent) {
-		if (curr->pending.fullscreen_mode != FULLSCREEN_NONE) {
-			container = curr;
-			is_fullscreen = true;
-			break;
-		}
-	}
-
+	bool is_fullscreen = container->pending.fullscreen_mode != FULLSCREEN_NONE;
 	bool global = false;
 	bool enable = !is_fullscreen;
 


### PR DESCRIPTION
#6152 fixes fullscreen split containers to better match i3 visually.

For commands, using the fullscreen command on a child of a fullscreen split container should fullscreen that child, rather than just unfullscreen the parent.

I've also noticed that i3 seems to refuse move commands that add a child to a fullscreened container, but I've left that alone for now.