### PR TITLE
view_destroy: fix use-after-free with subsurface_destroy

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -56,6 +56,7 @@ void view_destroy(struct sway_view *view) {
 				"(might have a pending transaction?)")) {
 		return;
 	}
+	wl_list_remove(&view->events.unmap.listener_list);
 	if (!wl_list_empty(&view->saved_buffers)) {
 		view_remove_saved_buffer(view);
 	}


### PR DESCRIPTION
remove view from its own unmap event listener so when subsurfaces
link try to remove themselves they won't run into it.

This fixes the following ASAN use-after-free error on a build slightly
modified to instrument wl_list operations:
```
==71705==ERROR: AddressSanitizer: heap-use-after-free on address 0x6160000829a0 at pc 0x000000508eb7 bp 0x7ffec8fd8030 sp 0x7ffec8fd8028
WRITE of size 8 at 0x6160000829a0 thread T0
    #0 0x508eb6 in wl_list_remove ../common/list.c:181
    #1 0x4f4998 in view_child_destroy ../sway/tree/view.c:1131
    #2 0x4f38fa in subsurface_handle_destroy ../sway/tree/view.c:946
    #3 0x7fda50744892 in wlr_signal_emit_safe ../util/signal.c:29
    #4 0x7fda5072f0dd in subsurface_destroy ../types/wlr_surface.c:649
    #5 0x7fda507312c4 in subsurface_handle_surface_destroy ../types/wlr_surface.c:1094
    #6 0x7fda50744892 in wlr_signal_emit_safe ../util/signal.c:29
    #7 0x7fda5072f305 in surface_handle_resource_destroy ../types/wlr_surface.c:677
    #8 0x7fda508180ce in destroy_resource (/lib64/libwayland-server.so.0+0xc0ce)
    #9 0x7fda508187f2 in wl_client_destroy (/lib64/libwayland-server.so.0+0xc7f2)
    #10 0x7fda50818e5f in wl_client_connection_data (/lib64/libwayland-server.so.0+0xce5f)
    #11 0x7fda50818219 in wl_event_loop_dispatch (/lib64/libwayland-server.so.0+0xc219)
    #12 0x7fda50818984 in wl_display_run (/lib64/libwayland-server.so.0+0xc984)
    #13 0x43122c in server_run ../sway/server.c:254
    #14 0x42f47c in main ../sway/main.c:433
    #15 0x7fda503cab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
    #16 0x40f6fd in _start (/opt/wayland/bin/sway+0x40f6fd)

0x6160000829a0 is located 288 bytes inside of 592-byte region [0x616000082880,0x616000082ad0)
freed by thread T0 here:
    #0 0x7fda50f01a27 in free (/lib64/libasan.so.6+0xaea27)
    #1 0x4532d8 in destroy ../sway/desktop/xdg_shell.c:262
    #2 0x4ed17b in view_destroy ../sway/tree/view.c:67
    #3 0x4ed300 in view_begin_destroy ../sway/tree/view.c:83
    #4 0x454a3f in handle_destroy ../sway/desktop/xdg_shell.c:507
    #5 0x7fda50744892 in wlr_signal_emit_safe ../util/signal.c:29
    #6 0x7fda506e2c87 in reset_xdg_surface ../types/xdg_shell/wlr_xdg_surface.c:481
    #7 0x7fda506e3018 in destroy_xdg_surface ../types/xdg_shell/wlr_xdg_surface.c:516
    #8 0x7fda506dfbe5 in xdg_client_handle_resource_destroy ../types/xdg_shell/wlr_xdg_shell.c:71
    #9 0x7fda508180ce in destroy_resource (/lib64/libwayland-server.so.0+0xc0ce)

previously allocated by thread T0 here:
    #0 0x7fda50f01ed7 in calloc (/lib64/libasan.so.6+0xaeed7)
    #1 0x454bc8 in handle_xdg_shell_surface ../sway/desktop/xdg_shell.c:528
    #2 0x7fda50744892 in wlr_signal_emit_safe ../util/signal.c:29
    #3 0x7fda506e2363 in handle_xdg_surface_commit ../types/xdg_shell/wlr_xdg_surface.c:378
    #4 0x7fda5072e368 in surface_commit_state ../types/wlr_surface.c:455
    #5 0x7fda5072e51d in surface_commit_pending ../types/wlr_surface.c:474
    #6 0x7fda5072ea58 in surface_commit ../types/wlr_surface.c:542
    #7 0x7fda4fb3ac03 in ffi_call_unix64 (/lib64/libffi.so.6+0x6c03)
```

Fixes #5168


-----

I agree with @emersion's comment way back then that it would be better to free all children at that point, but while subsurfaces have a link to the view I don't see a handy list to children in the view to use for that?
wlroots has similar wl_list_remove on listener_list link so I guess this is fair enough of an usage...