### PR TITLE
ipc: Add idle and keyboard shortcuts inhibitor events

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -36,6 +36,7 @@ enum ipc_command_type {
 	// sway-specific event types
 	IPC_EVENT_BAR_STATE_UPDATE = ((1<<31) | 20),
 	IPC_EVENT_INPUT = ((1<<31) | 21),
+	IPC_EVENT_IDLE_INHIBITOR = ((1<<31) | 22),
 };
 
 #endif

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -37,6 +37,7 @@ enum ipc_command_type {
 	IPC_EVENT_BAR_STATE_UPDATE = ((1<<31) | 20),
 	IPC_EVENT_INPUT = ((1<<31) | 21),
 	IPC_EVENT_IDLE_INHIBITOR = ((1<<31) | 22),
+	IPC_EVENT_KEYBOARD_SHORTCUTS_INHIBITOR = ((1<<31) | 23),
 };
 
 #endif

--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -39,6 +39,10 @@ struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
 struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_application_inhibitor_for_view(
 		struct sway_view *view);
 
+void sway_idle_inhibit_v1_user_inhibitor_update_mode(
+		struct sway_idle_inhibitor_v1 *inhibitor,
+		enum sway_idle_inhibit_mode mode);
+
 void sway_idle_inhibit_v1_user_inhibitor_destroy(
 		struct sway_idle_inhibitor_v1 *inhibitor);
 

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -368,4 +368,12 @@ keyboard_shortcuts_inhibitor_get_for_surface(const struct sway_seat *seat,
 struct sway_keyboard_shortcuts_inhibitor *
 keyboard_shortcuts_inhibitor_get_for_focused_surface(const struct sway_seat *seat);
 
+/**
+ * Returns the keyboard shortcuts inhibitor that applies to the given surface
+ * or NULL if none exists. It looks at inhibitors attached to all seats.
+ */
+struct sway_keyboard_shortcuts_inhibitor *
+keyboard_shortcuts_inhibitor_get_for_surface_on_any_seat(
+		const struct wlr_surface *surface);
+
 #endif

--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -3,7 +3,9 @@
 #include <json.h>
 #include "sway/output.h"
 #include "sway/tree/container.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
+#include "sway/tree/container.h"
 
 json_object *ipc_json_get_version(void);
 
@@ -16,5 +18,7 @@ json_object *ipc_json_describe_node_recursive(struct sway_node *node);
 json_object *ipc_json_describe_input(struct sway_input_device *device);
 json_object *ipc_json_describe_seat(struct sway_seat *seat);
 json_object *ipc_json_describe_bar_config(struct bar_config *bar);
+json_object *ipc_json_describe_idle_inhibitor(
+		struct sway_idle_inhibitor_v1 *sway_inhibitor);
 
 #endif

--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -5,6 +5,7 @@
 #include "sway/tree/container.h"
 #include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/seat.h"
 #include "sway/tree/container.h"
 
 json_object *ipc_json_get_version(void);
@@ -20,5 +21,7 @@ json_object *ipc_json_describe_seat(struct sway_seat *seat);
 json_object *ipc_json_describe_bar_config(struct bar_config *bar);
 json_object *ipc_json_describe_idle_inhibitor(
 		struct sway_idle_inhibitor_v1 *sway_inhibitor);
+json_object *ipc_json_describe_keyboard_shortcuts_inhibitor(
+		struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor);
 
 #endif

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -4,6 +4,7 @@
 #include "sway/config.h"
 #include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/seat.h"
 #include "sway/tree/container.h"
 #include "ipc.h"
 
@@ -24,5 +25,8 @@ void ipc_event_binding(struct sway_binding *binding);
 void ipc_event_input(const char *change, struct sway_input_device *device);
 void ipc_event_output(void);
 void ipc_event_idle_inhibitor(struct sway_idle_inhibitor_v1 *inhibitor, const char *change);
+void ipc_event_keyboard_shortcuts_inhibitor(
+		struct sway_keyboard_shortcuts_inhibitor *inhibitor,
+		const char *change);
 
 #endif

--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -2,6 +2,7 @@
 #define _SWAY_IPC_SERVER_H
 #include <sys/socket.h>
 #include "sway/config.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #include "sway/input/input-manager.h"
 #include "sway/tree/container.h"
 #include "ipc.h"
@@ -22,5 +23,6 @@ void ipc_event_shutdown(const char *reason);
 void ipc_event_binding(struct sway_binding *binding);
 void ipc_event_input(const char *change, struct sway_input_device *device);
 void ipc_event_output(void);
+void ipc_event_idle_inhibitor(struct sway_idle_inhibitor_v1 *inhibitor, const char *change);
 
 #endif

--- a/sway/commands/inhibit_idle.c
+++ b/sway/commands/inhibit_idle.c
@@ -40,7 +40,7 @@ struct cmd_results *cmd_inhibit_idle(int argc, char **argv) {
 		if (clear) {
 			sway_idle_inhibit_v1_user_inhibitor_destroy(inhibitor);
 		} else {
-			inhibitor->mode = mode;
+			sway_idle_inhibit_v1_user_inhibitor_update_mode(inhibitor, mode);
 			sway_idle_inhibit_v1_check_active();
 		}
 	} else if (!clear) {

--- a/sway/commands/seat/shortcuts_inhibitor.c
+++ b/sway/commands/seat/shortcuts_inhibitor.c
@@ -2,6 +2,7 @@
 #include "sway/commands.h"
 #include "sway/input/seat.h"
 #include "sway/input/input-manager.h"
+#include "sway/ipc-server.h"
 #include "util.h"
 
 static struct cmd_results *handle_action(struct seat_config *sc,
@@ -12,6 +13,8 @@ static struct cmd_results *handle_action(struct seat_config *sc,
 
 		wl_list_for_each(sway_inhibitor,
 				&seat->keyboard_shortcuts_inhibitors, link) {
+			ipc_event_keyboard_shortcuts_inhibitor(
+					sway_inhibitor, "deactivate");
 			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
 					sway_inhibitor->inhibitor);
 		}
@@ -39,8 +42,12 @@ static struct cmd_results *handle_action(struct seat_config *sc,
 		}
 
 		if (inhibit) {
+			ipc_event_keyboard_shortcuts_inhibitor(
+					sway_inhibitor, "activate");
 			wlr_keyboard_shortcuts_inhibitor_v1_activate(inhibitor);
 		} else {
+			ipc_event_keyboard_shortcuts_inhibitor(
+					sway_inhibitor, "deactivate");
 			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(inhibitor);
 		}
 

--- a/sway/commands/shortcuts_inhibitor.c
+++ b/sway/commands/shortcuts_inhibitor.c
@@ -3,6 +3,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/input/seat.h"
+#include "sway/ipc-server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 
@@ -33,12 +34,13 @@ struct cmd_results *cmd_shortcuts_inhibitor(int argc, char **argv) {
 				continue;
 			}
 
+			ipc_event_keyboard_shortcuts_inhibitor(
+					sway_inhibitor, "deactivate");
 			wlr_keyboard_shortcuts_inhibitor_v1_deactivate(
 					sway_inhibitor->inhibitor);
 			sway_log(SWAY_DEBUG, "Deactivated keyboard shortcuts "
 					"inhibitor for seat %s on view",
 					seat->wlr_seat->name);
-
 		}
 	} else {
 		return cmd_results_new(CMD_INVALID,

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -290,6 +290,8 @@ static void handle_keyboard_shortcuts_inhibitor_destroy(
 
 	sway_log(SWAY_DEBUG, "Removing keyboard shortcuts inhibitor");
 
+	ipc_event_keyboard_shortcuts_inhibitor(sway_inhibitor, "destroy");
+
 	// sway_seat::keyboard_shortcuts_inhibitors
 	wl_list_remove(&sway_inhibitor->link);
 	wl_list_remove(&sway_inhibitor->destroy.link);
@@ -312,6 +314,8 @@ static void handle_keyboard_shortcuts_inhibit_new_inhibitor(
 		return;
 	}
 	sway_inhibitor->inhibitor = inhibitor;
+
+	ipc_event_keyboard_shortcuts_inhibitor(sway_inhibitor, "create");
 
 	sway_inhibitor->destroy.notify = handle_keyboard_shortcuts_inhibitor_destroy;
 	wl_signal_add(&inhibitor->events.destroy, &sway_inhibitor->destroy);
@@ -353,6 +357,7 @@ static void handle_keyboard_shortcuts_inhibit_new_inhibitor(
 		return;
 	}
 
+	ipc_event_keyboard_shortcuts_inhibitor(sway_inhibitor, "activate");
 	wlr_keyboard_shortcuts_inhibitor_v1_activate(inhibitor);
 }
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1715,3 +1715,18 @@ keyboard_shortcuts_inhibitor_get_for_focused_surface(
 	return keyboard_shortcuts_inhibitor_get_for_surface(seat,
 		seat->wlr_seat->keyboard_state.focused_surface);
 }
+
+struct sway_keyboard_shortcuts_inhibitor *
+keyboard_shortcuts_inhibitor_get_for_surface_on_any_seat(
+		const struct wlr_surface *surface) {
+	struct sway_seat *seat = NULL;
+	wl_list_for_each(seat, &server.input->seats, link) {
+		struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor =
+			keyboard_shortcuts_inhibitor_get_for_surface(seat, surface);
+		if (sway_inhibitor) {
+			return sway_inhibitor;
+		}
+	}
+
+	return NULL;
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1468,3 +1468,17 @@ json_object *ipc_json_describe_idle_inhibitor(
 
 	return object;
 }
+
+json_object *ipc_json_describe_keyboard_shortcuts_inhibitor(
+		struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor) {
+	json_object *object = json_object_new_object();
+
+	struct sway_view *view = view_from_wlr_surface(
+			sway_inhibitor->inhibitor->surface);
+	if (view && view->container) {
+		json_object_object_add(object, "container",
+			ipc_json_describe_node(&view->container->node));
+	}
+
+	return object;
+}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -220,6 +220,19 @@ static const char *ipc_json_content_type_description(enum wp_content_type_v1_typ
 	return NULL;
 }
 
+static const char *ipc_json_keyboard_shortcuts_inhibitor_description(
+		struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor) {
+	if (!sway_inhibitor) {
+		return "none";
+	}
+
+	if (!sway_inhibitor->inhibitor->active) {
+		return "inactive";
+	}
+
+	return "active";
+}
+
 json_object *ipc_json_get_version(void) {
 	int major = 0, minor = 0, patch = 0;
 	json_object *version = json_object_new_object();
@@ -630,6 +643,12 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 		json_object_object_add(object, "content_type",
 			json_object_new_string(ipc_json_content_type_description(content_type)));
 	}
+
+	json_object_object_add(object, "keyboard_shortcuts_inhibitor",
+		json_object_new_string(
+			ipc_json_keyboard_shortcuts_inhibitor_description(
+				keyboard_shortcuts_inhibitor_get_for_surface_on_any_seat(
+					c->view->surface))));
 
 #if HAVE_XWAYLAND
 	if (c->view->type == SWAY_VIEW_XWAYLAND) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1434,3 +1434,37 @@ json_object *ipc_json_get_binding_mode(void) {
 			json_object_new_string(config->current_mode->name));
 	return current_mode;
 }
+
+json_object *ipc_json_describe_idle_inhibitor(
+		struct sway_idle_inhibitor_v1 *sway_inhibitor) {
+	json_object *object = json_object_new_object();
+
+	json_object_object_add(object, "active",
+		json_object_new_boolean(
+			sway_idle_inhibit_v1_is_active(sway_inhibitor)));
+
+	const char *type = NULL;
+	struct sway_view *view = NULL;
+	if (sway_inhibitor->mode == INHIBIT_IDLE_APPLICATION) {
+		type = "application";
+		view = view_from_wlr_surface(sway_inhibitor->wlr_inhibitor->surface);
+	} else {
+		type = "user";
+		view = sway_inhibitor->view;
+		json_object_object_add(object, "mode",
+			json_object_new_string(
+				ipc_json_user_idle_inhibitor_description(
+					sway_inhibitor->mode)));
+	}
+
+	if (type) {
+		json_object_object_add(object, "type", json_object_new_string(type));
+	}
+
+	if (view && view->container) {
+		json_object_object_add(object, "container",
+			ipc_json_describe_node(&view->container->node));
+	}
+
+	return object;
+}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -537,6 +537,24 @@ void ipc_event_idle_inhibitor(struct sway_idle_inhibitor_v1 *inhibitor, const ch
 	json_object_put(obj);
 }
 
+void ipc_event_keyboard_shortcuts_inhibitor(
+		struct sway_keyboard_shortcuts_inhibitor *inhibitor,
+		const char *change) {
+	if (!ipc_has_event_listeners(IPC_EVENT_KEYBOARD_SHORTCUTS_INHIBITOR)) {
+		return;
+	}
+	sway_log(SWAY_DEBUG, "Sending keyboard shortcuts "
+			"inhibitor::%s event", change);
+	json_object *obj = json_object_new_object();
+	json_object_object_add(obj, "change", json_object_new_string(change));
+	json_object_object_add(obj, "keyboard_shortcuts_inhibitor",
+			ipc_json_describe_keyboard_shortcuts_inhibitor(inhibitor));
+
+	const char *json_string = json_object_to_json_string(obj);
+	ipc_send_event(json_string, IPC_EVENT_KEYBOARD_SHORTCUTS_INHIBITOR);
+	json_object_put(obj);
+}
+
 int ipc_client_handle_writable(int client_fd, uint32_t mask, void *data) {
 	struct ipc_client *client = data;
 
@@ -775,6 +793,9 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 				client->subscribed_events |= event_mask(IPC_EVENT_INPUT);
 			} else if (strcmp(event_type, "idle_inhibitor") == 0) {
 				client->subscribed_events |= event_mask(IPC_EVENT_IDLE_INHIBITOR);
+			} else if (strcmp(event_type, "keyboard_shortcuts_inhibitor") == 0) {
+				client->subscribed_events |= event_mask(
+						IPC_EVENT_KEYBOARD_SHORTCUTS_INHIBITOR);
 			} else {
 				const char msg[] = "{\"success\": false}";
 				ipc_send_reply(client, payload_type, msg, strlen(msg));


### PR DESCRIPTION
As discussed in #5124 and #5324 I would like to react to status changes of both idle and keyboard shortcuts inhibitors by giving some (visual) feedback to the user. An external script monitoring window property changes via ipc was identified as preferred solution in #5323. Idle inhibitor status was added to `get_tree` output in #5307.

This PR attempts to add the following additional functionality:
* add keyboard shortcuts inhibitor status to `get_tree` output per container as `"keyboard_shortcuts_inhibitor": "none|inactive|active"`, reflecting presence and current state of any applicable inhibitor. Shortened example `get_tree` output:
```
                {
                  "id": 12,
                  "type": "con",
[...]
                  "inhibit_idle": false,
                  "idle_inhibitors": {
                    "user": "none",
                    "application": "none"
                  },
                  "keyboard_shortcuts_inhibitor": "none"
                },
```
* add and emit new events on status changes of idle and keyboard shortcuts inhibitors. Structure:
   * idle inhibitor:
```
{
  "change": "create|mode|destroy",
  "idle_inhibitor": {
    "active": true|false,
    "type": "application|user",
    "mode": "<standard user inhibitor mode description>",
    "container": {
      "id": 34,
      "type": "con",
[standard container description]
      "inhibit_idle": true,
      "idle_inhibitors": {
        "user": "<previous state[1]>",
        "application": "<previous state>"
      },
[...]
    }
  }
}
```
   * keyboard shortcuts inhibitor:
```
{
  "change": "create|activate|deactivate|destroy",
  "keyboard_shortcuts_inhibitor": {
    "container": {
      "id": 34,
      "type": "con",
[standard container description]
      "keyboard_shortcuts_inhibitor": "<previous state>"
    }
  }
}
```
Example `subscribe` command: `swaymsg -t subscribe -m "['idle_inhibitor','keyboard_shortcuts_inhibitor']"`.

[1] showing previous state in the container description is a side-effect of event send and object update ordering which seemed nice to have if available for no cost. It does not work for attribute changes (such as the user inhibitor mode) though because those are updated in-place. Guidance if this is desirable at all would be helpful. My use-case actually only needs the container id.

Rationale for adding new events instead of adding more events for affected objects:
* efficiency: clients would need to subscribe to e.g. all window change events even if only interested in inhibitors
* interface overload: inhibitors would require sub-event types for window changes, e.g. `idle_inhibitor::create`, suggesting a conceptual mismatch
* extensiblity: if the next user wants to (additionally) refer to the seat or output affected by an inhibitor this information could potentially be added to the per-inhibitor events instead of adding more events for the other object classes