### PR TITLE
Ignore superfluous fullscreen output hints

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -358,7 +358,8 @@ static void handle_request_fullscreen(struct wl_listener *listener, void *data) 
 	if (e->fullscreen && e->output && e->output->data) {
 		struct sway_output *output = e->output->data;
 		struct sway_workspace *ws = output_get_active_workspace(output);
-		if (ws && !container_is_scratchpad_hidden(container)) {
+		if (ws && !container_is_scratchpad_hidden(container) &&
+				container->pending.workspace != ws) {
 			if (container_is_floating(container)) {
 				workspace_add_floating(ws, container);
 			} else {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -794,7 +794,11 @@ void workspace_detach(struct sway_workspace *workspace) {
 struct sway_container *workspace_add_tiling(struct sway_workspace *workspace,
 		struct sway_container *con) {
 	if (con->pending.workspace) {
+		struct sway_container *old_parent = con->pending.parent;
 		container_detach(con);
+		if (old_parent) {
+			container_reap_empty(old_parent);
+		}
 	}
 	if (config->default_layout != L_NONE) {
 		con = container_split(con, config->default_layout);


### PR DESCRIPTION
So for whatever reason qutebrowser likes to give us an output hint for fullscreen requests, which is fine. But in response sway tries to add qutebrowser to the tiling workspace it's already in and bungles things.

There's really two bugs here I think,

1. There's no reason to remove and re-add a window to the workspace it's already in if it requests the output it's already on. This would mess up the tiling order even without the ghost containers because it get's re-added at workspace level even if it was nested.
2. Doing that shouldn't make ghost containers anyway, so let's reap them in workspace_tiling add.

Fixes #6202.