### PR TITLE
Prevent use-after-free on first bar subcommand error

### DIFF
--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -116,6 +116,7 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 	if (res && res->status != CMD_SUCCESS) {
 		if (id) {
 			free_bar_config(config->current_bar);
+			config->current_bar = NULL;
 			id = NULL;
 		}
 		return res;


### PR DESCRIPTION
If any error is encountered during execution of the first subcommand of
a freshly created bar configuration, parsing apparently is to be aborted
and the current bar config is freed. The pointer to that memory is left
dangling though, leading to a use-after-free on successive bar
subcommands. This quite reliably ends in a crash like so:
```
sway -c reproducer.config
00:00:00.083 [sway/config.c:865] Error on line 2 'foo bar': Unknown/invalid command 'foo' (s)
free(): double free detected in tcache 2
00:00:00.608 [swaynag/swaynag.c:451] failed to register with the wayland display
Aborted (core dumped)
```
Minimal reproducer config:
```
bar {
        foo bar
        position top
}
```
Other messages:
```
malloc(): unaligned fastbin chunk detected
double free or corruption (fasttop)
```
The invalid command has to be the first for a newly created bar config.
Removing the command or switching order so it's not the first one masks
the problem.

Prevent this from occuring by resetting the pointer to NULL after
freeing the memory.