### PR TITLE
tree/view: don't give focus to views mapped under fullscreen views

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -599,6 +599,11 @@ static bool should_focus(struct sway_view *view) {
 		return true;
 	}
 
+	// View opened "under" fullscreen view should not be given focus.
+	if (root->fullscreen_global || map_ws->fullscreen) {
+		return false;
+	}
+
 	// Views can only take focus if they are mapped into the active workspace
 	if (prev_ws != map_ws) {
 		return false;
@@ -757,7 +762,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	view_init_subsurfaces(view, wlr_surface);
 	wl_signal_add(&wlr_surface->events.new_subsurface,
-		&view->surface_new_subsurface);
+			&view->surface_new_subsurface);
 	view->surface_new_subsurface.notify = view_handle_surface_new_subsurface;
 
 	if (decoration) {
@@ -805,9 +810,9 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 #if HAVE_XWAYLAND
 	if (wlr_surface_is_xwayland_surface(wlr_surface)) {
 		struct wlr_xwayland_surface *xsurface =
-			wlr_xwayland_surface_from_wlr_surface(wlr_surface);
-    	set_focus = (wlr_xwayland_icccm_input_model(xsurface) !=
-			WLR_ICCCM_INPUT_MODEL_NONE) && set_focus;
+				wlr_xwayland_surface_from_wlr_surface(wlr_surface);
+		set_focus &= wlr_xwayland_icccm_input_model(xsurface) !=
+				WLR_ICCCM_INPUT_MODEL_NONE;
 	}
 #endif
 
@@ -818,11 +823,9 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	const char *app_id;
 	const char *class;
 	if ((app_id = view_get_app_id(view)) != NULL) {
-		wlr_foreign_toplevel_handle_v1_set_app_id(
-				view->foreign_toplevel, app_id);
+		wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel, app_id);
 	} else if ((class = view_get_class(view)) != NULL) {
-		wlr_foreign_toplevel_handle_v1_set_app_id(
-				view->foreign_toplevel, class);
+		wlr_foreign_toplevel_handle_v1_set_app_id(view->foreign_toplevel, class);
 	}
 }
 


### PR DESCRIPTION
Fixes #6211.

Since I'm touching the focus function anyway, took the opportunity
to fix some formatting issues (mixed tabs and spaces, etc.)