### PR TITLE
Add DesktopNames key to sway.desktop

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
As [documented][1] in the Desktop Entry Specification, this key causes the login manager to set `XDG_CURRENT_DESKTOP` to its value. Projects like [xdg-desktop-portal-wlr][2] require `XDG_CURRENT_DESKTOP=sway` to work properly, so let's add this key to our desktop file to make those projects work more seamlessly for people who use login managers.

[1]: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
[2]: https://github.com/emersion/xdg-desktop-portal-wlr