### PR TITLE
Fix offset toplevel geometry issue

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -99,8 +99,8 @@ static bool get_surface_box(struct surface_iterator_data *data,
 	int sw = surface->current.width;
 	int sh = surface->current.height;
 
-	double _sx = sx + surface->sx;
-	double _sy = sy + surface->sy;
+	double _sx = sx;
+	double _sy = sy;
 	rotate_child_position(&_sx, &_sy, sw, sh, data->width, data->height,
 		data->rotation);
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -159,8 +159,8 @@ static void render_surface_iterator(struct sway_output *output, struct sway_view
 	struct wlr_box dst_box = *_box;
 	struct sway_container *container = data->container;
 	if (container != NULL) {
-		dst_box.width = fmin(dst_box.width, container->current.content_width - surface->sx);
-		dst_box.height = fmin(dst_box.height, container->current.content_height - surface->sy);
+		dst_box.width = fmin(dst_box.width, container->current.content_width);
+		dst_box.height = fmin(dst_box.height, container->current.content_height);
 	}
 	scale_box(&dst_box, wlr_output->scale);
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -32,7 +32,7 @@
 struct render_data {
 	pixman_region32_t *damage;
 	float alpha;
-	struct sway_container *container;
+	struct wlr_box *clip_box;
 };
 
 /**
@@ -157,10 +157,10 @@ static void render_surface_iterator(struct sway_output *output, struct sway_view
 		wlr_output->transform_matrix);
 
 	struct wlr_box dst_box = *_box;
-	struct sway_container *container = data->container;
-	if (container != NULL) {
-		dst_box.width = fmin(dst_box.width, container->current.content_width);
-		dst_box.height = fmin(dst_box.height, container->current.content_height);
+	struct wlr_box *clip_box = data->clip_box;
+	if (clip_box != NULL) {
+		dst_box.width = fmin(dst_box.width, clip_box->width);
+		dst_box.height = fmin(dst_box.height, clip_box->height);
 	}
 	scale_box(&dst_box, wlr_output->scale);
 
@@ -262,8 +262,13 @@ static void render_view_toplevels(struct sway_view *view,
 		.damage = damage,
 		.alpha = alpha,
 	};
+	struct wlr_box clip_box;
 	if (!container_is_current_floating(view->container)) {
-		data.container = view->container;
+		// As we pass the geometry offsets to the surface iterator, we will
+		// need to account for the offsets in the clip dimensions.
+		clip_box.width = view->container->current.content_width + view->geometry.x;
+		clip_box.height = view->container->current.content_height + view->geometry.y;
+		data.clip_box = &clip_box;
 	}
 	// Render all toplevels without descending into popups
 	double ox = view->container->surface_x -
@@ -329,10 +334,10 @@ static void render_saved_view(struct sway_view *view,
 		if (!floating) {
 			dst_box.width = fmin(dst_box.width,
 					view->container->current.content_width -
-					(saved_buf->x - view->container->current.content_x));
+					(saved_buf->x - view->container->current.content_x) + view->saved_geometry.x);
 			dst_box.height = fmin(dst_box.height,
 					view->container->current.content_height -
-					(saved_buf->y - view->container->current.content_y));
+					(saved_buf->y - view->container->current.content_y) + view->saved_geometry.y);
 		}
 		scale_box(&dst_box, wlr_output->scale);
 


### PR DESCRIPTION
The first commit removes `surface->sx`/`surface->sy` from these calculations. It doesn't work, break things if non-zero, and causes confusion.

The second commit shuffles the clip box handling around a bit, in order to compensate for the offset in the clip dimensions, which could otherwise lead to insufficient or excessive clipping.

Closes: https://github.com/swaywm/sway/issues/6223