### PR TITLE
Remove support for arbitrary rotations

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -72,8 +72,8 @@ struct sway_output *output_get_in_direction(struct sway_output *reference,
 void output_add_workspace(struct sway_output *output,
 		struct sway_workspace *workspace);
 
-typedef void (*sway_surface_iterator_func_t)(struct sway_output *output, struct sway_view *view,
-	struct wlr_surface *surface, struct wlr_box *box, float rotation,
+typedef void (*sway_surface_iterator_func_t)(struct sway_output *output,
+	struct sway_view *view, struct wlr_surface *surface, struct wlr_box *box,
 	void *user_data);
 
 void output_damage_whole(struct sway_output *output);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -131,9 +131,9 @@ damage_finish:
 	pixman_region32_fini(&damage);
 }
 
-static void render_surface_iterator(struct sway_output *output, struct sway_view *view,
-		struct wlr_surface *surface, struct wlr_box *_box, float rotation,
-		void *_data) {
+static void render_surface_iterator(struct sway_output *output,
+		struct sway_view *view, struct wlr_surface *surface,
+		struct wlr_box *_box, void *_data) {
 	struct render_data *data = _data;
 	struct wlr_output *wlr_output = output->wlr_output;
 	pixman_region32_t *output_damage = data->damage;
@@ -153,7 +153,7 @@ static void render_surface_iterator(struct sway_output *output, struct sway_view
 	float matrix[9];
 	enum wl_output_transform transform =
 		wlr_output_transform_invert(surface->current.transform);
-	wlr_matrix_project_box(matrix, &proj_box, transform, rotation,
+	wlr_matrix_project_box(matrix, &proj_box, transform, 0.0,
 		wlr_output->transform_matrix);
 
 	struct wlr_box dst_box = *_box;


### PR DESCRIPTION
There was some unused code-paths for rendering surfaces with an
arbitrary rotation applied. This was imported from rootston.

Since we don't have plans to make use of this, remove it.