### PR TITLE
config.in: change terminal emulator to foot

### DIFF
--- a/config.in
+++ b/config.in
@@ -14,7 +14,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term alacritty
+set $term foot
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.


### PR DESCRIPTION
This is my preferred terminal emulator now. Seeing as the default config
file is basically "Drew's preferences watered down a bit for a general
audience", I reckon it should be updated accordingly :)