### PR TITLE
Treat misbehaving IPC communications

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -153,9 +153,15 @@ char *ipc_single_command(int socketfd, uint32_t type, const char *payload, size_
 	}
 
 	struct ipc_response *resp = ipc_recv_response(socketfd);
-	char *response = resp->payload;
-	*len = resp->size;
-	free(resp);
+	char *response;
+	if (resp == NULL) {
+		response = NULL;
+		*len = 0;
+	} else {
+		response = resp->payload;
+		*len = resp->size;
+		free(resp);
+	}
 
 	return response;
 }

--- a/include/ipc-client.h
+++ b/include/ipc-client.h
@@ -12,7 +12,7 @@
  * encoded payload string.
  */
 struct ipc_response {
-	uint32_t size;
+	size_t size;
 	uint32_t type;
 	char *payload;
 };
@@ -29,7 +29,7 @@ int ipc_open_socket(const char *socket_path);
  * Issues a single IPC command and returns the buffer. len will be updated with
  * the length of the buffer returned from sway.
  */
-char *ipc_single_command(int socketfd, uint32_t type, const char *payload, uint32_t *len);
+char *ipc_single_command(int socketfd, uint32_t type, const char *payload, size_t *len);
 /**
  * Receives a single IPC response and returns an ipc_response.
  */

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -3,6 +3,9 @@
 
 #define event_mask(ev) (1 << (ev & 0x7F))
 
+// maximum size of payload is 4 MB
+#define IPC_MAX_SIZE 4e6
+
 enum ipc_command_type {
 	// i3 command types - see i3's I3_REPLY_TYPE constants
 	IPC_COMMAND = 0,

--- a/sway/main.c
+++ b/sway/main.c
@@ -89,7 +89,7 @@ void run_as_ipc_client(char *command, char *socket_path) {
 	int socketfd = ipc_open_socket(socket_path);
 	size_t len = strlen(command);
 	char *resp = ipc_single_command(socketfd, IPC_COMMAND, command, &len);
-	printf("%s\n", resp);
+	printf("%s\n", resp == NULL ? "(null)" : resp);
 	free(resp);
 	close(socketfd);
 }

--- a/sway/main.c
+++ b/sway/main.c
@@ -87,7 +87,7 @@ void detect_proprietary(int allow_unsupported_gpu) {
 
 void run_as_ipc_client(char *command, char *socket_path) {
 	int socketfd = ipc_open_socket(socket_path);
-	uint32_t len = strlen(command);
+	size_t len = strlen(command);
 	char *resp = ipc_single_command(socketfd, IPC_COMMAND, command, &len);
 	printf("%s\n", resp);
 	free(resp);

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -344,6 +344,9 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 	size_t len = 0;
 	char *res = ipc_single_command(bar->ipc_socketfd,
 			IPC_GET_WORKSPACES, NULL, &len);
+	if (res == NULL) {
+		return false;
+	}
 	json_object *results = json_tokener_parse(res);
 	if (!results) {
 		free(res);
@@ -418,7 +421,7 @@ bool ipc_initialize(struct swaybar *bar) {
 	size_t len = strlen(bar->id);
 	char *res = ipc_single_command(bar->ipc_socketfd,
 			IPC_GET_BAR_CONFIG, bar->id, &len);
-	if (!ipc_parse_config(bar->config, res)) {
+	if (res == NULL || !ipc_parse_config(bar->config, res)) {
 		free(res);
 		return false;
 	}

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -19,7 +19,7 @@
 #include "util.h"
 
 void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
-	uint32_t size = strlen("workspace \"\"") + strlen(ws);
+	size_t size = strlen("workspace \"\"") + strlen(ws);
 	for (size_t i = 0; i < strlen(ws); ++i) {
 		if (ws[i] == '"' || ws[i] == '\\') {
 			++size;
@@ -341,7 +341,7 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 		free_workspaces(&output->workspaces);
 		output->focused = false;
 	}
-	uint32_t len = 0;
+	size_t len = 0;
 	char *res = ipc_single_command(bar->ipc_socketfd,
 			IPC_GET_WORKSPACES, NULL, &len);
 	json_object *results = json_tokener_parse(res);
@@ -409,13 +409,13 @@ bool ipc_get_workspaces(struct swaybar *bar) {
 void ipc_execute_binding(struct swaybar *bar, struct swaybar_binding *bind) {
 	sway_log(SWAY_DEBUG, "Executing binding for button %u (release=%d): `%s`",
 			bind->button, bind->release, bind->command);
-	uint32_t len = strlen(bind->command);
+	size_t len = strlen(bind->command);
 	free(ipc_single_command(bar->ipc_socketfd,
 			IPC_COMMAND, bind->command, &len));
 }
 
 bool ipc_initialize(struct swaybar *bar) {
-	uint32_t len = strlen(bar->id);
+	size_t len = strlen(bar->id);
 	char *res = ipc_single_command(bar->ipc_socketfd,
 			IPC_GET_BAR_CONFIG, bar->id, &len);
 	if (!ipc_parse_config(bar->config, res)) {

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -476,7 +476,7 @@ int main(int argc, char **argv) {
 	int socketfd = ipc_open_socket(socket_path);
 	struct timeval timeout = {.tv_sec = 3, .tv_usec = 0};
 	ipc_set_recv_timeout(socketfd, timeout);
-	uint32_t len = strlen(command);
+	size_t len = strlen(command);
 	char *resp = ipc_single_command(socketfd, type, command, &len);
 
 	// pretty print the json

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -478,6 +478,14 @@ int main(int argc, char **argv) {
 	ipc_set_recv_timeout(socketfd, timeout);
 	size_t len = strlen(command);
 	char *resp = ipc_single_command(socketfd, type, command, &len);
+	if (resp == NULL) {
+		if (!quiet) {
+			sway_log(SWAY_ERROR, "Failed to receive reply");
+		}
+		close(socketfd);
+		free(socket_path);
+		return 1;
+	}
 
 	// pretty print the json
 	json_object *obj = json_tokener_parse(resp);


### PR DESCRIPTION
Sway and its clients do not properly validate transmitted payload lengths. Hostile values can lead to out of boundary writes.
The server side should not rely on operating system socket buffers. Although they should be large enough in usual cases, a hostile client can lead to high CPU loads in server because buffers are only cleared when all bytes are available.

See Python example code to trigger these effects attached to commit messages.