### PR TITLE
cairo: Replace <cairo/cairo.h> by <cairo.h>

### DIFF
--- a/client/pool-buffer.c
+++ b/client/pool-buffer.c
@@ -1,6 +1,6 @@
 #define _POSIX_C_SOURCE 200809
 #include <assert.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <fcntl.h>
 #include <pango/pangocairo.h>
 #include <stdio.h>

--- a/common/background-image.c
+++ b/common/background-image.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 #include "background-image.h"
-#include "cairo.h"
+#include "cairo_util.h"
 #include "log.h"
 #if HAVE_GDK_PIXBUF
 #include <gdk-pixbuf/gdk-pixbuf.h>

--- a/common/cairo.c
+++ b/common/cairo.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
-#include <cairo/cairo.h>
-#include "cairo.h"
+#include <cairo.h>
+#include "cairo_util.h"
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color) {
 	cairo_set_source_rgba(cairo,

--- a/common/pango.c
+++ b/common/pango.c
@@ -1,4 +1,4 @@
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "cairo.h"
+#include "cairo_util.h"
 #include "log.h"
 #include "stringop.h"
 

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -1,6 +1,6 @@
 #ifndef _SWAY_BACKGROUND_IMAGE_H
 #define _SWAY_BACKGROUND_IMAGE_H
-#include "cairo.h"
+#include "cairo_util.h"
 
 enum background_mode {
 	BACKGROUND_MODE_STRETCH,

--- a/include/cairo_util.h
+++ b/include/cairo_util.h
@@ -1,8 +1,8 @@
-#ifndef _SWAY_CAIRO_H
-#define _SWAY_CAIRO_H
+#ifndef _SWAY_CAIRO_UTIL_H
+#define _SWAY_CAIRO_UTIL_H
 #include "config.h"
 #include <stdint.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <wayland-client-protocol.h>
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color);

--- a/include/pango.h
+++ b/include/pango.h
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 
 /**

--- a/include/pool-buffer.h
+++ b/include/pool-buffer.h
@@ -1,6 +1,6 @@
 #ifndef _SWAY_BUFFERS_H
 #define _SWAY_BUFFERS_H
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/sway/config.c
+++ b/sway/config.c
@@ -26,7 +26,7 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/root.h"
 #include "sway/tree/workspace.h"
-#include "cairo.h"
+#include "cairo_util.h"
 #include "pango.h"
 #include "stringop.h"
 #include "list.h"

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -7,7 +7,7 @@
 #include <strings.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_output_layout.h>
-#include "cairo.h"
+#include "cairo_util.h"
 #include "pango.h"
 #include "sway/config.h"
 #include "sway/desktop.h"

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include "cairo.h"
+#include "cairo_util.h"
 #include "pango.h"
 #include "pool-buffer.h"
 #include "swaybar/bar.h"

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -13,7 +13,7 @@
 #include "swaybar/tray/item.h"
 #include "swaybar/tray/tray.h"
 #include "background-image.h"
-#include "cairo.h"
+#include "cairo_util.h"
 #include "list.h"
 #include "log.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -1,5 +1,5 @@
 #include <stdint.h>
-#include "cairo.h"
+#include "cairo_util.h"
 #include "log.h"
 #include "pango.h"
 #include "pool-buffer.h"


### PR DESCRIPTION
For full context, read https://github.com/Cloudef/bemenu/issues/170 and https://gitlab.freedesktop.org/cairo/cairo/-/issues/479.
TL;DR, cairo’s pc file adds `/cairo` to CFLAGS.
So namespace cairo shouldn’t be used.
It was working simply because `/usr/include` is always used, not because of Meson + pkg-config.
A similar patch will land in swaybg too.
Thank you.