### PR TITLE
C: Handle _POSIX_C_SOURCE macro properly

### DIFF
--- a/client/pool-buffer.c
+++ b/client/pool-buffer.c
@@ -1,4 +1,8 @@
-#define _POSIX_C_SOURCE 200809
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <cairo.h>
 #include <fcntl.h>

--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/common/log.c
+++ b/common/log.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200112L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/common/loop.c
+++ b/common/loop.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200112L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/common/util.c
+++ b/common/util.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <math.h>

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1,4 +1,8 @@
-#define _POSIX_C_SOURCE 200809
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdlib.h>

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include "sway/commands.h"

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -1,4 +1,8 @@
-#define _POSIX_C_SOURCE 200809
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>

--- a/sway/commands/bar/font.c
+++ b/sway/commands/bar/font.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/bar/hidden_state.c
+++ b/sway/commands/bar/hidden_state.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"

--- a/sway/commands/bar/icon_theme.c
+++ b/sway/commands/bar/icon_theme.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "config.h"
 #include "sway/commands.h"

--- a/sway/commands/bar/id.c
+++ b/sway/commands/bar/id.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"

--- a/sway/commands/bar/output.c
+++ b/sway/commands/bar/output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <string.h>
 #include "sway/commands.h"

--- a/sway/commands/bar/position.c
+++ b/sway/commands/bar/position.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <strings.h>
 #include "sway/commands.h"

--- a/sway/commands/bar/separator_symbol.c
+++ b/sway/commands/bar/separator_symbol.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/bar/tray_output.c
+++ b/sway/commands/bar/tray_output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "config.h"
 #include "sway/commands.h"

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <libevdev/libevdev.h>
 #include <linux/input-event-codes.h>
 #include <string.h>

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/sway/commands/font.c
+++ b/sway/commands/font.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/input/calibration_matrix.c
+++ b/sway/commands/input/calibration_matrix.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <strings.h>
 #include "sway/config.h"

--- a/sway/commands/input/map_from_region.c
+++ b/sway/commands/input/map_from_region.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <string.h>
 #include <strings.h>

--- a/sway/commands/input/map_to_output.c
+++ b/sway/commands/input/map_to_output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include <strings.h>
 #include "sway/config.h"

--- a/sway/commands/input/map_to_region.c
+++ b/sway/commands/input/map_to_region.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <wlr/types/wlr_box.h>

--- a/sway/commands/input/xkb_file.c
+++ b/sway/commands/input/xkb_file.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <unistd.h>
 #include <errno.h>
 #include "sway/config.h"

--- a/sway/commands/input/xkb_layout.c
+++ b/sway/commands/input/xkb_layout.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/input/xkb_model.c
+++ b/sway/commands/input/xkb_model.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/input/xkb_numlock.c
+++ b/sway/commands/input/xkb_numlock.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "util.h"

--- a/sway/commands/input/xkb_options.c
+++ b/sway/commands/input/xkb_options.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/input/xkb_rules.c
+++ b/sway/commands/input/xkb_rules.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/input/xkb_switch_layout.c
+++ b/sway/commands/input/xkb_switch_layout.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include "sway/config.h"
 #include "sway/commands.h"

--- a/sway/commands/input/xkb_variant.c
+++ b/sway/commands/input/xkb_variant.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "log.h"

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/mode.c
+++ b/sway/commands/mode.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <string.h>
 #include "sway/commands.h"

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <math.h>
 #include <stdbool.h>

--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <libgen.h>
 #include <stdio.h>
 #include <string.h>

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <linux/input-event-codes.h>
 
 #include <strings.h>

--- a/sway/commands/seat/hide_cursor.c
+++ b/sway/commands/seat/hide_cursor.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/seat/idle.c
+++ b/sway/commands/seat/idle.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h>
 #include <string.h>
 #include <strings.h>

--- a/sway/commands/seat/xcursor_theme.c
+++ b/sway/commands/seat/xcursor_theme.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>

--- a/sway/commands/show_marks.c
+++ b/sway/commands/show_marks.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <strings.h>
 #include "config.h"
 #include "log.h"

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 #include "sway/commands.h"
 #include "sway/config.h"

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <limits.h>
 #include <string.h>

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <limits.h>
 #include <float.h>

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <stdbool.h>
 #include <string.h>

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <stdlib.h>
 #include <strings.h>

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <GLES2/gl2.h>
 #include <stdlib.h>

--- a/sway/desktop/surface.c
+++ b/sway/desktop/surface.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200112L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <stdlib.h>
 #include <time.h>
 #include <wlr/types/wlr_surface.h>

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 199309L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309L
+#endif
+
 #include <float.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 199309L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309L
+#endif
+
 #include <float.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <math.h>
 #include <libevdev/libevdev.h>

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <string.h>

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <float.h>
 #include <libevdev/libevdev.h>
 #include <wlr/types/wlr_cursor.h>

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <float.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_tablet_v2.h>

--- a/sway/input/seatop_move_floating.c
+++ b/sway/input/seatop_move_floating.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <wlr/types/wlr_cursor.h>
 #include "sway/desktop.h"
 #include "sway/desktop/transaction.h"

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/edges.h>

--- a/sway/input/seatop_resize_floating.c
+++ b/sway/input/seatop_resize_floating.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>

--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/util/edges.h>
 #include "sway/commands.h"

--- a/sway/input/tablet.c
+++ b/sway/input/tablet.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/types/wlr_tablet_v2.h>

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -1,5 +1,9 @@
 // See https://i3wm.org/docs/ipc.html for protocol information
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200112L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <linux/input-event-codes.h>
 #include <assert.h>
 #include <errno.h>

--- a/sway/main.c
+++ b/sway/main.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <getopt.h>
 #include <pango/pangocairo.h>
 #include <signal.h>

--- a/sway/server.c
+++ b/sway/server.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <signal.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <drm_fourcc.h>
 #include <stdint.h>

--- a/sway/tree/node.c
+++ b/sway/tree/node.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "sway/output.h"
 #include "sway/server.h"
 #include "sway/tree/container.h"

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <string.h>

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <strings.h>
 #include <wayland-server-core.h>

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -1,4 +1,8 @@
-#define _POSIX_C_SOURCE 200809
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <limits.h>
 #include <stdbool.h>

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include "swaybar/config.h"

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <json.h>
 #include <linux/input-event-codes.h>
 #include <ctype.h>

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -1,4 +1,8 @@
-#define _POSIX_C_SOURCE 200809
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits.h>
 #include <poll.h>
 #include <stdio.h>

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <limits.h>

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/swaybar/tray/host.c
+++ b/swaybar/tray/host.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <ctype.h>
 #include <dirent.h>
 #include <stdbool.h>

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <arpa/inet.h>
 #include <cairo.h>
 #include <limits.h>

--- a/swaybar/tray/watcher.c
+++ b/swaybar/tray/watcher.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <signal.h>
 #include "log.h"

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdlib.h>
 #include <assert.h>
 #include <sys/stat.h>

--- a/swaynag/types.c
+++ b/swaynag/types.c
@@ -1,4 +1,8 @@
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE+0 < 200809L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
`_POSIX_C_SOURCE` macro should be handled properly. I had a case where `_POSIX_C_SOURCE=200809L` was in my cflags, and the build was failing with (due to `werror=true` in Meson):
```
error: '_POSIX_C_SOURCE' macro redefined [-Werror,-Wmacro-redefined]
```
We should define `_POSIX_C_SOURCE` only when required, so I wrapped each define with a condition.

Thank you.