### PR TITLE
view: commit transactions for foreign toplevel requests

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -644,6 +644,7 @@ static void handle_foreign_activate_request(
 			break;
 		}
 	}
+	transaction_commit_dirty();
 }
 
 static void handle_foreign_fullscreen_request(
@@ -683,6 +684,7 @@ static void handle_foreign_fullscreen_request(
 			arrange_workspace(container->pending.workspace);
 		}
 	}
+	transaction_commit_dirty();
 }
 
 static void handle_foreign_close_request(


### PR DESCRIPTION
These foreign toplevel actions require a transaction, but currently none are triggered. The ipc/binding fullscreen/focus commands already have their transactions triggered later.

To see the issue, send a foreign fullscreen request for your terminal and observe it won't fullscreen until you disturb something to commit a transaction.