### PR TITLE
Backport subsurface parent fixes to v1.5

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -16,7 +16,7 @@ packages:
   - wayland-dev
   - wayland-protocols
   - xcb-util-image-dev
-  - xorg-server-xwayland
+  - xwayland
 sources:
   - https://github.com/swaywm/sway
   - https://github.com/swaywm/wlroots

--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -19,7 +19,7 @@ packages:
   - xwayland
 sources:
   - https://github.com/swaywm/sway
-  - https://github.com/swaywm/wlroots
+  - https://github.com/swaywm/wlroots#0.12.0
 tasks:
   - wlroots: |
       cd wlroots

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -3,6 +3,7 @@ packages:
   - cairo
   - gdk-pixbuf2
   - json-c
+  - libegl
   - libinput
   - libxcb
   - libxkbcommon
@@ -12,7 +13,7 @@ packages:
   - wayland
   - wayland-protocols
   - xcb-util-image
-  - xorg-server-xwayland
+  - xorg-xwayland
 sources:
   - https://github.com/swaywm/sway
   - https://github.com/swaywm/wlroots

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -16,7 +16,7 @@ packages:
   - xorg-xwayland
 sources:
   - https://github.com/swaywm/sway
-  - https://github.com/swaywm/wlroots
+  - https://github.com/swaywm/wlroots#0.12.0
 tasks:
   - wlroots: |
       cd wlroots

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -24,7 +24,7 @@ packages:
 - x11/xcb-util-wm
 sources:
 - https://github.com/swaywm/sway
-- https://github.com/swaywm/wlroots
+- https://github.com/swaywm/wlroots#0.12.0
 tasks:
 - setup: |
     cd sway

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1029,6 +1029,9 @@ void view_child_destroy(struct sway_view_child *child) {
 	wl_list_for_each_safe(subchild, tmpchild, &child->children, link) {
 		wl_list_remove(&subchild->link);
 		subchild->parent = NULL;
+		// The subchild lost its parent link, so it cannot see that the parent
+		// is unmapped. Unmap it directly.
+		subchild->mapped = false;
 	}
 
 	wl_list_remove(&child->surface_commit.link);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -464,6 +464,9 @@ static void view_subsurface_create(struct sway_view *view,
 static void view_init_subsurfaces(struct sway_view *view,
 	struct wlr_surface *surface);
 
+static void view_child_init_subsurfaces(struct sway_view_child *view_child,
+	struct wlr_surface *surface);
+
 static void view_handle_surface_new_subsurface(struct wl_listener *listener,
 		void *data) {
 	struct sway_view *view =
@@ -957,6 +960,14 @@ static void view_init_subsurfaces(struct sway_view *view,
 	}
 }
 
+static void view_child_init_subsurfaces(struct sway_view_child *view_child,
+		struct wlr_surface *surface) {
+	struct wlr_subsurface *subsurface;
+	wl_list_for_each(subsurface, &surface->subsurfaces, parent_link) {
+		view_child_subsurface_create(view_child, subsurface);
+	}
+}
+
 static void view_child_handle_surface_map(struct wl_listener *listener,
 		void *data) {
 	struct sway_view_child *child =
@@ -1012,7 +1023,7 @@ void view_child_init(struct sway_view_child *child,
 		wlr_surface_send_enter(child->surface, workspace->output->wlr_output);
 	}
 
-	view_init_subsurfaces(child->view, surface);
+	view_child_init_subsurfaces(child, surface);
 }
 
 void view_child_destroy(struct sway_view_child *child) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -906,8 +906,18 @@ static void view_child_subsurface_create(struct sway_view_child *child,
 	view_child_damage(&subsurface->child, true);
 }
 
+static bool view_child_is_mapped(struct sway_view_child *child) {
+	while (child) {
+		if (!child->mapped) {
+			return false;
+		}
+		child = child->parent;
+	}
+	return true;
+}
+
 static void view_child_damage(struct sway_view_child *child, bool whole) {
-	if (!child || !child->mapped || !child->view || !child->view->container) {
+	if (!child || !view_child_is_mapped(child) || !child->view || !child->view->container) {
 		return;
 	}
 	int sx, sy;
@@ -1006,7 +1016,7 @@ void view_child_init(struct sway_view_child *child,
 }
 
 void view_child_destroy(struct sway_view_child *child) {
-	if (child->mapped && child->view->container != NULL) {
+	if (view_child_is_mapped(child) && child->view->container != NULL) {
 		view_child_damage(child, true);
 	}
 


### PR DESCRIPTION
Cherry pick #6046 into the v1.5 branch in case it's useful for others not yet on 1.6.