### PR TITLE
Add `anything` option to grimshot

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -137,7 +137,7 @@ elif [ "$SUBJECT" = "window" ] ; then
   fi
   WHAT="Window"
 elif [ "$SUBJECT" = "selection" ] ; then
-  GEOM=$(swaymsg -t get_tree | jq -r '.. | select((.pid? and .visible?) or (.type == "output" and .active)) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp)
+  GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp -o)
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
    exit

--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -32,7 +32,7 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window|selection] [FILE|-]"
+  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window|anything] [FILE|-]"
   echo "  grimshot check"
   echo "  grimshot usage"
   echo ""
@@ -47,8 +47,8 @@ if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" 
   echo "  screen: All visible outputs."
   echo "  output: Currently active output."
   echo "  area: Manually select a region."
-  echo "  window: Manually select a window."
-  echo "  selection: Manually select an area, window, or output."
+  echo "  window: Manually select an area or window."
+  echo "  anything: Manually select an area, window, or output."
   exit
 fi
 
@@ -136,13 +136,13 @@ elif [ "$SUBJECT" = "window" ] ; then
    exit 1
   fi
   WHAT="Window"
-elif [ "$SUBJECT" = "selection" ] ; then
+elif [ "$SUBJECT" = "anything" ] ; then
   GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp -o)
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
    exit
   fi
-  WHAT="Selection"
+  WHAT="Anything"
 else
   die "Unknown subject to take a screen shot from" "$SUBJECT"
 fi

--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -32,7 +32,7 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window] [FILE|-]"
+  echo "  grimshot [--notify] (copy|save) [active|screen|output|area|window|selection] [FILE|-]"
   echo "  grimshot check"
   echo "  grimshot usage"
   echo ""
@@ -48,6 +48,7 @@ if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" 
   echo "  output: Currently active output."
   echo "  area: Manually select a region."
   echo "  window: Manually select a window."
+  echo "  selection: Manually select an area, window, or output."
   exit
 fi
 
@@ -135,6 +136,13 @@ elif [ "$SUBJECT" = "window" ] ; then
    exit 1
   fi
   WHAT="Window"
+elif [ "$SUBJECT" = "selection" ] ; then
+  GEOM=$(swaymsg -t get_tree | jq -r '.. | select((.pid? and .visible?) or (.type == "output" and .active)) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+   exit
+  fi
+  WHAT="Selection"
 else
   die "Unknown subject to take a screen shot from" "$SUBJECT"
 fi

--- a/contrib/grimshot.1
+++ b/contrib/grimshot.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "grimshot" "1" "2021-02-23"
+.TH "grimshot" "1" "2021-05-20"
 .P
 .SH NAME
 .P
@@ -92,6 +92,13 @@ captures it.\&
 \fIoutput\fR
 .RS 4
 Captures the currently active output.\&
+.P
+.RE
+\fIselection\fR
+.RS 4
+Allows manually selection a single window (by clicking on it), an output (by
+clicking outside of all windows, e.\&g.\& on the status bar), or an area (by
+using click and drag).\&
 .P
 .RE
 .SH OUTPUT

--- a/contrib/grimshot.1
+++ b/contrib/grimshot.1
@@ -94,7 +94,7 @@ captures it.\&
 Captures the currently active output.\&
 .P
 .RE
-\fIselection\fR
+\fIanything\fR
 .RS 4
 Allows manually selection a single window (by clicking on it), an output (by
 clicking outside of all windows, e.\&g.\& on the status bar), or an area (by

--- a/contrib/grimshot.1.scd
+++ b/contrib/grimshot.1.scd
@@ -67,7 +67,7 @@ _window_
 _output_
 	Captures the currently active output.
 
-_selection_
+_anything_
 	Allows manually selection a single window (by clicking on it), an output (by
 	clicking outside of all windows, e.g. on the status bar), or an area (by
 	using click and drag).

--- a/contrib/grimshot.1.scd
+++ b/contrib/grimshot.1.scd
@@ -67,6 +67,11 @@ _window_
 _output_
 	Captures the currently active output.
 
+_selection_
+	Allows manually selection a single window (by clicking on it), an output (by
+	clicking outside of all windows, e.g. on the status bar), or an area (by
+	using click and drag).
+
 # OUTPUT
 
 Grimshot will print the filename of the captured screenshot to stdout if called


### PR DESCRIPTION
This enables selecting a window, output, or area within one invocation, removing the need for multiple keybindings.
- Drag for an area (note that this already works in the `window` case)
- Click on a window to select it
- Click outside of all windows (e.g. in gaps or on the statusbar) to
select the output

Ideally this needs some testing with multiple monitors, which I don't have.

~The name `selection` may need to change.~ It's `anything` now.