### PR TITLE
Change link for IRC support chat

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -26,7 +26,7 @@
               <a class="nav-link" href="https://github.com/swaywm/sway/wiki">Wiki ≫</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="https://webchat.freenode.net/?channels=sway&uio=d4">Support Chat ≫</a>
+              <a class="nav-link" href="https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway">Support Chat ≫</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Changed the link address to point to libera.chat instead of freenode.net
Added a note to the landing page.