### PR TITLE
Fix IRC links in READMEs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: 'bug'
 ---
 
 ### Please read the following before submitting:
-- Please do NOT submit bug reports for questions. Ask questions on IRC at #sway on irc.freenode.net.
+- Please do NOT submit bug reports for questions. Ask questions on IRC at #sway on irc.libera.chat.
 - Proprietary graphics drivers, including nvidia, are not supported. Please use the open source equivalents, such as nouveau, if you would like to use Sway.
 - Please do NOT submit issues for information from the github wiki. The github wiki is community maintained and therefore may contain outdated information, scripts that don't work or obsolete workarounds.
   If you fix a script or find outdated information, don't hesitate to adjust the wiki page.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions
-    url: "http://webchat.freenode.net/?channels=sway&uio=d4"
-    about: "Please ask questions on IRC in #sway on irc.freenode.net"
+    url: "https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway"
+    about: "Please ask questions on IRC in #sway on irc.libera.chat"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Contributing just involves sending a pull request. You will probably be more
 successful with your contribution if you visit
-[#sway-devel](https://webchat.freenode.net/?channels=sway-devel) on
-irc.freenode.net upfront and discuss your plans.
+[#sway-devel](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway-devel) on
+irc.libera.chat upfront and discuss your plans.
 
 Note: rules are made to be broken. Adjust or ignore any/all of these as you see
 fit, but be prepared to justify it to your peers.

--- a/README.de.md
+++ b/README.de.md
@@ -1,5 +1,5 @@
 # Sway
-Sway ist ein [i3](https://i3wm.org/)-kompatibler [Wayland](http://wayland.freedesktop.org/)-Compositor. Lies die [FAQ](https://github.com/swaywm/sway/wiki). Tritt dem [IRC Channel](http://webchat.freenode.net/?channels=sway&uio=d4) bei (#sway on irc.freenode.net; Englisch).
+Sway ist ein [i3](https://i3wm.org/)-kompatibler [Wayland](http://wayland.freedesktop.org/)-Compositor. Lies die [FAQ](https://github.com/swaywm/sway/wiki). Tritt dem [IRC Channel](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) bei (#sway on irc.libera.chat; Englisch).
 
 ## Signaturen
 Jedes Release wird mit dem PGP-Schlüssel [B22DA89A](http://pgp.mit.edu/pks/lookup?op=vindex&search=0x52CB6609B22DA89A) signiert und auf GitHub veröffentlicht.

--- a/README.dk.md
+++ b/README.dk.md
@@ -2,7 +2,7 @@
 
 Sway er en [i3](https://i3wm.org/)-kompatibel [Wayland](http://wayland.freedesktop.org/) compositor.
 Læs [Ofte stillede spørgsmål](https://github.com/swaywm/sway/wiki).
-Deltag på [IRC kanalen](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway på irc.freenode.net).
+Deltag på [IRC kanalen](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway på irc.libera.chat).
 
 ## Udgivelses Signaturer
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,8 @@
 # sway
 
 sway es un compositor de [Wayland](http://wayland.freedesktop.org/) compatible con [i3](https://i3wm.org/).
-Lea el [FAQ](https://github.com/swaywm/sway/wiki). Únase al [canal de IRC](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway on
-irc.freenode.net).
+Lea el [FAQ](https://github.com/swaywm/sway/wiki). Únase al [canal de IRC](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway on
+irc.libera.chat).
 
 ## Firmas de las versiones
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,7 +1,7 @@
 # sway
 
 Sway est un compositeur [Wayland] compatible avec [i3]. Lisez la
-[FAQ]. Rejoignez le [canal IRC] (#sway sur irc.freenode.net).
+[FAQ]. Rejoignez le [canal IRC] (#sway sur irc.libera.chat).
 
 ## Aide en français
 
@@ -74,7 +74,7 @@ bien fonctionner).
 [Wayland]: http://wayland.freedesktop.org/
 [i3]: https://i3wm.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[canal IRC]: http://webchat.freenode.net/?channels=sway&uio=d4
+[canal IRC]: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway
 [abdelq]: https://github.com/abdelq
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [versions GitHub]: https://github.com/swaywm/sway/releases

--- a/README.hu.md
+++ b/README.hu.md
@@ -1,6 +1,6 @@
 # sway
 
-A Sway egy [i3]-kompatibilis [Wayland] kompozitor. Olvasd el a [Gyarkan Ismételt Kérdéseket][FAQ]. Csatlakozz az [IRC csatornához][IRC channel] \(`#sway` az `irc.freenode.net`-en).
+A Sway egy [i3]-kompatibilis [Wayland] kompozitor. Olvasd el a [Gyarkan Ismételt Kérdéseket][FAQ]. Csatlakozz az [IRC csatornához][IRC channel] \(`#sway` az `irc.libera.chat`-en).
 
 ## Csomag aláírások
 
@@ -69,7 +69,7 @@ gdm-ről ismeretes, hogy egész jól működik.)
 [i3]: https://i3wm.org/
 [Wayland]: http://wayland.freedesktop.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[IRC channel]: http://webchat.freenode.net/?channels=sway&uio=d4
+[IRC channel]: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [GitHub releases]: https://github.com/swaywm/sway/releases
 [Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 Swayは[i3](https://i3wm.org/)互換な[Wayland](http://wayland.freedesktop.org/)コンポジタです。
 [FAQ](https://github.com/swaywm/sway/wiki)も合わせてご覧ください。
-[IRC チャンネル](http://webchat.freenode.net/?channels=sway&uio=d4) (irc.freenode.netの#sway)もあります。
+[IRC チャンネル](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (irc.libera.chatの#sway)もあります。
 
 [![](https://sr.ht/ICd5.png)](https://sr.ht/ICd5.png)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 # sway
 
 sway는 [i3](https://i3wm.org/)-호환 [Wayland](http://wayland.freedesktop.org/) 컴포지터입니다.
-[FAQ](https://github.com/swaywm/sway/wiki)를 읽어보세요. [IRC 채널](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway on irc.freenode.net)도 있습니다.
+[FAQ](https://github.com/swaywm/sway/wiki)를 읽어보세요. [IRC 채널](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway on irc.libera.chat)도 있습니다.
 
 ## 릴리즈 서명
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **[English][en]** - [日本語][ja] - [Français][fr] - [Українська][uk] - [Español][es] - [Polski][pl] - [中文-简体][zh-CN] - [Deutsch][de] - [Nederlands][nl] - [Русский][ru] - [中文-繁體][zh-TW] - [Português][pt] - [Danish][dk] - [한국어][ko] - [Română][ro] - [Magyar][hu] - [Türkçe][tr]
 
 sway is an [i3]-compatible [Wayland] compositor. Read the [FAQ]. Join the
-[IRC channel] \(#sway on irc.freenode.net).
+[IRC channel] \(#sway on irc.libera.chat).
 
 ## Release Signatures
 
@@ -84,7 +84,7 @@ sway (gdm is known to work fairly well).
 [i3]: https://i3wm.org/
 [Wayland]: http://wayland.freedesktop.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[IRC channel]: http://webchat.freenode.net/?channels=sway&uio=d4
+[IRC channel]: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [GitHub releases]: https://github.com/swaywm/sway/releases
 [Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup

--- a/README.nl.md
+++ b/README.nl.md
@@ -2,8 +2,8 @@
 
 Sway is een [i3](https://i3wm.org/)-compatibele [Wayland](http://wayland.freedesktop.org/) compositor.
 Lees de [FAQ](https://github.com/swaywm/sway/wiki). Word lid van het [IRC
-kanaal](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway op
-irc.freenode.net).
+kanaal](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway op
+irc.libera.chat).
 
 ## Releasehandtekeningen
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,8 +1,8 @@
 # sway
 
 sway jest kompozytorem [Wayland](http://wayland.freedesktop.org/) kompatybilnym z [i3](https://i3wm.org/).
-Przeczytaj [FAQ](https://github.com/swaywm/sway/wiki). Dołącz do [kanału IRC](http://webchat.freenode.net/?channels=sway&uio=d4)
-(#sway na irc.freenode.net).
+Przeczytaj [FAQ](https://github.com/swaywm/sway/wiki). Dołącz do [kanału IRC](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway)
+(#sway na irc.libera.chat).
 
 ## Podpisy cyfrowe wydań
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -2,8 +2,8 @@
 
 O sway é um compositor do [Wayland](http://wayland.freedesktop.org/) compatível com o [i3](https://i3wm.org/).
 Leia o [FAQ](https://github.com/swaywm/sway/wiki). Junte-se ao [canal do    
-IRC](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway em
-irc.freenode.net).
+IRC](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway em
+irc.libera.chat).
 
 ## Assinatura das versões
 

--- a/README.ro.md
+++ b/README.ro.md
@@ -1,7 +1,7 @@
 # sway
 
 sway este un compositor pentru [Wayland](http://wayland.freedesktop.org/) compatibil cu [i3](https://i3wm.org/).
-Citiți [FAQ](https://github.com/swaywm/sway/wiki)-ul. Connectați-vă la canalul nostru [IRC](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway pe irc.freenode.net).
+Citiți [FAQ](https://github.com/swaywm/sway/wiki)-ul. Connectați-vă la canalul nostru [IRC](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway pe irc.libera.chat).
 
 ## Semnarea digitală
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,7 @@
 sway - это [i3]-совместимый композитор [Wayland].
 Больше информации в [FAQ]. Присоединяйтесь к
 [IRC-каналу][IRC channel] (#sway на
-irc.freenode.net).
+irc.libera.chat).
 
 ## Подписи релизов
 
@@ -66,7 +66,7 @@ sway (gdm работает довольно неплохо).
 [i3]: https://i3wm.org/
 [Wayland]: http://wayland.freedesktop.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[IRC channel]: http://webchat.freenode.net/?channels=sway&uio=d4
+[IRC channel]: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [GitHub releases]: https://github.com/swaywm/sway/releases
 [Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup

--- a/README.tr.md
+++ b/README.tr.md
@@ -2,7 +2,7 @@
 
 
 Sway, [i3]-uyumlu bir [Wayland] dizgicisidir. [SSS][FAQ]'yi okuyun. 
-[IRC kanalı][IRC channel]na katılın \(irc.freenode.net'te #sway (İngilizce)).
+[IRC kanalı][IRC channel]na katılın \(irc.libera.chat'te #sway (İngilizce)).
 
 ## Sürüm imzaları
 
@@ -60,7 +60,7 @@ TTY'den `sway` çalıştırın. Bazı  görüntü yöneticileriyle(display manag
 [i3]: https://i3wm.org/
 [Wayland]: http://wayland.freedesktop.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[IRC channel]: http://webchat.freenode.net/?channels=sway&uio=d4
+[IRC channel]: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [GitHub releases]: https://github.com/swaywm/sway/releases
 [Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup

--- a/README.uk.md
+++ b/README.uk.md
@@ -2,8 +2,8 @@
 
 Sway це сумісний з [i3](https://i3wm.org/) композитор [Wayland](http://wayland.freedesktop.org/).
 Ознайомтесь з [ЧаПами](https://github.com/swaywm/sway/wiki). Приєднуйтесь до [спільноти в
-IRC](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway на
-irc.freenode.net).
+IRC](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway на
+irc.libera.chat).
 
 ## Підтримка українською мовою
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,8 +2,8 @@
 
 sway 是和 [i3](https://i3wm.org/) 兼容的 [Wayland](http://wayland.freedesktop.org/) compositor.
 阅读 [FAQ](https://github.com/swaywm/sway/wiki). 加入 [IRC
-频道](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway on
-irc.freenode.net).
+频道](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway on
+irc.libera.chat).
 
 ## 发布签名
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,8 +2,8 @@
 
 sway 是一個與 [i3](https://i3wm.org/) 相容的 [Wayland](http://wayland.freedesktop.org/) compositor。
 閱讀 [FAQ](https://github.com/swaywm/sway/wiki)。 加入 [IRC
-頻道](http://webchat.freenode.net/?channels=sway&uio=d4) (#sway on
-irc.freenode.net)
+頻道](https://kiwiirc.com/nextclient/irc.libera.chat:+6697/#sway) (#sway on
+irc.libera.chat)
 
 ## 發行簽章
 


### PR DESCRIPTION
Change the webchat links from freenode.net to point to the new
destination libera.chat.