### PR TITLE
Only defer seat attachment during initial startup

### DIFF
--- a/sway/commands/seat/attach.c
+++ b/sway/commands/seat/attach.c
@@ -12,7 +12,7 @@ struct cmd_results *seat_cmd_attach(int argc, char **argv) {
 	if (!config->handler_context.seat_config) {
 		return cmd_results_new(CMD_FAILURE, "No seat defined");
 	}
-	if (config->reading) {
+	if (!config->active) {
 		return cmd_results_new(CMD_DEFER, NULL);
 	}
 


### PR DESCRIPTION
Deferred commands are only run once, during sway startup. This means that deferring seat attachment based on whether we are reading the config prevents devices from being reattached to the correct seat during a config reload. Instead, only defer if the config is not yet active.

Fixes #6048.

It sort of feels like there's still something more fundamental going on here, but this at least fixes the crash and gets devices where they're supposed to be. I think there might be some race with the device getting added to its intended seat before being removed from seat0 (or whatever fallback) based on how they happen to be iterated. It also seems like we tend to apply the config more times to a single device than is necessary based on the debug logs from the original issue. Finally, I'm also not sure why we can't set up seat configs during initial start given that they should all be referencing only the identifier strings. I'm not familiar enough with the seat code to make much more headway on any of these at the moment though.

I tested:
* Device is attached to the correct seat if present at sway startup.
* Device remains attached to the correct seat after reload, and nothing crashes.