### PR TITLE
Restore SIGPIPE before exec:ing

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -57,6 +57,7 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 		sigset_t set;
 		sigemptyset(&set);
 		sigprocmask(SIG_SETMASK, &set, NULL);
+		signal(SIGPIPE, SIG_DFL);
 		close(fd[0]);
 		if ((child = fork()) == 0) {
 			close(fd[1]);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -217,6 +217,7 @@ static void invoke_swaybar(struct bar_config *bar) {
 		sigset_t set;
 		sigemptyset(&set);
 		sigprocmask(SIG_SETMASK, &set, NULL);
+		signal(SIGPIPE, SIG_DFL);
 
 		pid = fork();
 		if (pid < 0) {


### PR DESCRIPTION
Sway ignores `SIGPIPE` (by installing a `SIG_IGN` handler), in order to [prevent IPC from crashing Sway](https://github.com/swaywm/sway/blob/9755684fb0fd665a65be2a3cbabc5d502244c459/sway/main.c#L356).

`SIG_IGN` handlers are the *only* signal handlers inherited by sub-processes. As such, we should be a good citizen and restore the `SIGPIPE` handler to its default handler.

One way to reproduce is to bind `foot bash` in Sway's config:
```
bindsym $mod+t exec foot bash
```
Activate the key combo, and then run e.g. this program:
```c
#include <stdio.h>
#include <signal.h>

int
main(int argc, const char *const *argv)
{
    for (int i = 1; i < 32; i++) {
        struct sigaction sig;
        if (sigaction(i, NULL, &sig) < 0)
            return 1;
        if (sig.sa_handler != SIG_DFL)
            printf("signal #%d is NOT the default handler\n", i);
    }

    printf("done\n");
    return 0;
}
```
The foot+bash combo is important, because neither foot, nor bash restores signal handlers they themselves haven't touched. Zsh and fish seem to reset all signals, thus hiding the issue.

Original bug report: https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1806907.html

Alternatively, we can loop **all** signals and reset their handlers to `SIG_DFL`. I thought it slightly cleaner to only reset the signals actually touched by Sway. But doing so opens up for the same thing happening again in the future, if Sway starts ignoring more signals. I'm fine with both solutions.

Finally, the same issue exists in swaynag. However, that fork+exec doesn't even bother to restore the signal mask. I can open up a separate PR to fix swaynag, it that's something that's wanted?