### PR TITLE
Disable auto_back_and_forth for next_on_output

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -215,8 +215,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			ws = workspace_by_name(argv[0]);
 		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
 			ws = workspace_output_next(current, create);
+			no_auto_back_and_forth = true;
 		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
 			ws = workspace_output_prev(current, create);
+			no_auto_back_and_forth = true;
 		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
 			if (!seat->prev_workspace_name) {
 				return cmd_results_new(CMD_INVALID,


### PR DESCRIPTION
Fix #6299 

This forces `no_auto_back_and_forth` to true for `workspace next_on_output` and `workspace prev_on_output` to keep parity with i3.
In i3, running `next_on_output` never changes focus to another output.
In Sway currently, with `workspace_auto_back_and_forth` set to `yes`, running `next_on_output` on an output with only a single active workspace will typically end up focussing the other output:
1. `next_on_output` focusses the current workspace, because it's the only
one
2. `auto_back_and_forth` focusses the last focussed workspace, because the
workspace to focus is the current one. This will usually be on the other monitor if the workspace there was last focused one


Looking at the code, I actually think it may be cleaner to not make `no_auto_back_and_forth` an argument of `workspace_switch` (which is only called from 1 place anyway). Instead the back-and-forth could be resolved in a separate function call from the workspace switching, since it's really only needed for switching to a named/numbered workspace, and for explicit calls to `workspace back_and_forth`. (But this would be a larger code change, so didn't do that for now.)