### PR TITLE
Move auto_back_and_forth logic out of workspace_switch

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -60,8 +60,10 @@ void workspace_consider_destroy(struct sway_workspace *ws);
 
 char *workspace_next_name(const char *output_name);
 
-bool workspace_switch(struct sway_workspace *workspace,
-		bool no_auto_back_and_forth);
+struct sway_workspace *workspace_auto_back_and_forth(
+		struct sway_workspace *workspace);
+
+bool workspace_switch(struct sway_workspace *workspace);
 
 struct sway_workspace *workspace_by_number(const char* name);
 

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -178,9 +178,9 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				"Can't switch workspaces while fullscreen global");
 		}
 
-		bool no_auto_back_and_forth = false;
+		bool auto_back_and_forth = true;
 		while (strcasecmp(argv[0], "--no-auto-back-and-forth") == 0) {
-			no_auto_back_and_forth = true;
+			auto_back_and_forth = false;
 			if ((error = checkarg(--argc, "workspace", EXPECTED_AT_LEAST, 1))) {
 				return error;
 			}
@@ -215,10 +215,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			ws = workspace_by_name(argv[0]);
 		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
 			ws = workspace_output_next(current, create);
-			no_auto_back_and_forth = true;
+			auto_back_and_forth = false;
 		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
 			ws = workspace_output_prev(current, create);
-			no_auto_back_and_forth = true;
+			auto_back_and_forth = false;
 		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
 			if (!seat->prev_workspace_name) {
 				return cmd_results_new(CMD_INVALID,
@@ -227,6 +227,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			if (!(ws = workspace_by_name(argv[0]))) {
 				ws = workspace_create(NULL, seat->prev_workspace_name);
 			}
+			auto_back_and_forth = false;
 		} else {
 			char *name = join_args(argv, argc);
 			if (!(ws = workspace_by_name(name))) {
@@ -237,7 +238,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		if (!ws) {
 			return cmd_results_new(CMD_FAILURE, "No workspace to switch to");
 		}
-		workspace_switch(ws, no_auto_back_and_forth);
+		if(auto_back_and_forth){
+			ws = workspace_auto_back_and_forth(ws);
+		}
+		workspace_switch(ws);
 		seat_consider_warp_to_focus(seat);
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -209,16 +209,17 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				ws = workspace_create(NULL, name);
 				free(name);
 			}
+			if (ws && auto_back_and_forth) {
+				ws = workspace_auto_back_and_forth(ws);
+			}
 		} else if (strcasecmp(argv[0], "next") == 0 ||
 				strcasecmp(argv[0], "prev") == 0 ||
 				strcasecmp(argv[0], "current") == 0) {
 			ws = workspace_by_name(argv[0]);
 		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
 			ws = workspace_output_next(current, create);
-			auto_back_and_forth = false;
 		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
 			ws = workspace_output_prev(current, create);
-			auto_back_and_forth = false;
 		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
 			if (!seat->prev_workspace_name) {
 				return cmd_results_new(CMD_INVALID,
@@ -227,19 +228,18 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			if (!(ws = workspace_by_name(argv[0]))) {
 				ws = workspace_create(NULL, seat->prev_workspace_name);
 			}
-			auto_back_and_forth = false;
 		} else {
 			char *name = join_args(argv, argc);
 			if (!(ws = workspace_by_name(name))) {
 				ws = workspace_create(NULL, name);
 			}
 			free(name);
+			if (ws && auto_back_and_forth) {
+				ws = workspace_auto_back_and_forth(ws);
+			}
 		}
 		if (!ws) {
 			return cmd_results_new(CMD_FAILURE, "No workspace to switch to");
-		}
-		if(auto_back_and_forth){
-			ws = workspace_auto_back_and_forth(ws);
 		}
 		workspace_switch(ws);
 		seat_consider_warp_to_focus(seat);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -561,8 +561,8 @@ struct sway_workspace *workspace_output_prev(
 	return workspace_output_prev_next_impl(current->output, -1, create);
 }
 
-bool workspace_switch(struct sway_workspace *workspace,
-		bool no_auto_back_and_forth) {
+struct sway_workspace *workspace_auto_back_and_forth(
+		struct sway_workspace *workspace) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *active_ws = NULL;
 	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
@@ -572,14 +572,18 @@ bool workspace_switch(struct sway_workspace *workspace,
 		active_ws = focus->sway_container->pending.workspace;
 	}
 
-	if (!no_auto_back_and_forth && config->auto_back_and_forth && active_ws
-			&& active_ws == workspace && seat->prev_workspace_name) {
+	if (config->auto_back_and_forth && active_ws &&
+			active_ws == workspace && seat->prev_workspace_name) {
 		struct sway_workspace *new_ws =
-			workspace_by_name(seat->prev_workspace_name);
-		workspace = new_ws ?
-			new_ws :
-			workspace_create(NULL, seat->prev_workspace_name);
+				workspace_by_name(seat->prev_workspace_name);
+		workspace = new_ws ? new_ws
+						   : workspace_create(NULL, seat->prev_workspace_name);
 	}
+	return workspace;
+}
+
+bool workspace_switch(struct sway_workspace *workspace) {
+	struct sway_seat *seat = input_manager_current_seat();
 
 	sway_log(SWAY_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -572,12 +572,13 @@ struct sway_workspace *workspace_auto_back_and_forth(
 		active_ws = focus->sway_container->pending.workspace;
 	}
 
-	if (config->auto_back_and_forth && active_ws &&
-			active_ws == workspace && seat->prev_workspace_name) {
+	if (config->auto_back_and_forth && active_ws && active_ws == workspace &&
+			seat->prev_workspace_name) {
 		struct sway_workspace *new_ws =
-				workspace_by_name(seat->prev_workspace_name);
-		workspace = new_ws ? new_ws
-						   : workspace_create(NULL, seat->prev_workspace_name);
+			workspace_by_name(seat->prev_workspace_name);
+		workspace = new_ws ?
+			new_ws :
+			workspace_create(NULL, seat->prev_workspace_name);
 	}
 	return workspace;
 }


### PR DESCRIPTION
Followup on #6331

- Extract the auto back and forth code to a separate `workspace_auto_back_and_forth` function.
- Rename/repurpose `no_auto_back_and_forth` to `auto_back_and_forth` for easier understanding
- Only call `workspace_auto_back_and_forth` in the 2 cases it's actually needed, instead of disabling it for all other cases.

I had a closer look at the [i3 implementation](https://github.com/Airblader/i3-original/blob/next/parser-specs/commands.spec#L122-L136) now, and they only use the flag for changing to a named/numbered workspace, so I've made it similar here. Actually, `man 5 sway` already documents it this way as well.

Note that in both sway and i3 providing the flag is allowed in all cases. It's just ignored in some of them.
