### PR TITLE
Revert workspace {prev,next}_on_output --create

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -69,13 +69,11 @@ struct sway_workspace *workspace_by_number(const char* name);
 
 struct sway_workspace *workspace_by_name(const char*);
 
-struct sway_workspace *workspace_output_next(
-		struct sway_workspace *current, bool create);
+struct sway_workspace *workspace_output_next(struct sway_workspace *current);
 
 struct sway_workspace *workspace_next(struct sway_workspace *current);
 
-struct sway_workspace *workspace_output_prev(
-		struct sway_workspace *current, bool create);
+struct sway_workspace *workspace_output_prev(struct sway_workspace *current);
 
 struct sway_workspace *workspace_prev(struct sway_workspace *current);
 

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -187,12 +187,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			++argv;
 		}
 
-		bool create = argc > 1 && strcasecmp(argv[1], "--create") == 0;
 		struct sway_seat *seat = config->handler_context.seat;
-		struct sway_workspace *current = seat_get_focused_workspace(seat);
-		if (!current) {
-			return cmd_results_new(CMD_FAILURE, "No workspace to switch from");
-		}
 
 		struct sway_workspace *ws = NULL;
 		if (strcasecmp(argv[0], "number") == 0) {
@@ -214,12 +209,10 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			}
 		} else if (strcasecmp(argv[0], "next") == 0 ||
 				strcasecmp(argv[0], "prev") == 0 ||
+				strcasecmp(argv[0], "next_on_output") == 0 ||
+				strcasecmp(argv[0], "prev_on_output") == 0 ||
 				strcasecmp(argv[0], "current") == 0) {
 			ws = workspace_by_name(argv[0]);
-		} else if (strcasecmp(argv[0], "next_on_output") == 0) {
-			ws = workspace_output_next(current, create);
-		} else if (strcasecmp(argv[0], "prev_on_output") == 0) {
-			ws = workspace_output_prev(current, create);
 		} else if (strcasecmp(argv[0], "back_and_forth") == 0) {
 			if (!seat->prev_workspace_name) {
 				return cmd_results_new(CMD_INVALID,

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -222,10 +222,8 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 		// not a command about workspaces
 		if (strcmp(_target, "next") == 0 ||
 				strcmp(_target, "prev") == 0 ||
-				strncmp(_target, "next_on_output",
-					strlen("next_on_output")) == 0 ||
-				strncmp(_target, "prev_on_output",
-					strlen("next_on_output")) == 0 ||
+				strcmp(_target, "next_on_output") == 0 ||
+				strcmp(_target, "prev_on_output") == 0 ||
 				strcmp(_target, "number") == 0 ||
 				strcmp(_target, "back_and_forth") == 0 ||
 				strcmp(_target, "current") == 0) {
@@ -363,11 +361,11 @@ struct sway_workspace *workspace_by_name(const char *name) {
 	if (current && strcmp(name, "prev") == 0) {
 		return workspace_prev(current);
 	} else if (current && strcmp(name, "prev_on_output") == 0) {
-		return workspace_output_prev(current, false);
+		return workspace_output_prev(current);
 	} else if (current && strcmp(name, "next") == 0) {
 		return workspace_next(current);
 	} else if (current && strcmp(name, "next_on_output") == 0) {
-		return workspace_output_next(current, false);
+		return workspace_output_next(current);
 	} else if (strcmp(name, "current") == 0) {
 		return current;
 	} else if (strcasecmp(name, "back_and_forth") == 0) {
@@ -530,7 +528,7 @@ struct sway_workspace *workspace_next(struct sway_workspace *workspace) {
  * otherwise the next one is returned.
  */
 static struct sway_workspace *workspace_output_prev_next_impl(
-		struct sway_output *output, int dir, bool create) {
+		struct sway_output *output, int dir) {
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *workspace = seat_get_focused_workspace(seat);
 	if (!workspace) {
@@ -540,25 +538,17 @@ static struct sway_workspace *workspace_output_prev_next_impl(
 	}
 
 	int index = list_find(output->workspaces, workspace);
-	if (!workspace_is_empty(workspace) && create &&
-			(index + dir < 0 || index + dir == output->workspaces->length)) {
-		struct sway_output *output = workspace->output;
-		char *next = workspace_next_name(output->wlr_output->name);
-		workspace_create(output, next);
-		free(next);
-	}
 	size_t new_index = wrap(index + dir, output->workspaces->length);
 	return output->workspaces->items[new_index];
 }
 
-struct sway_workspace *workspace_output_next(
-		struct sway_workspace *current, bool create) {
-	return workspace_output_prev_next_impl(current->output, 1, create);
+
+struct sway_workspace *workspace_output_next(struct sway_workspace *current) {
+	return workspace_output_prev_next_impl(current->output, 1);
 }
 
-struct sway_workspace *workspace_output_prev(
-		struct sway_workspace *current, bool create) {
-	return workspace_output_prev_next_impl(current->output, -1, create);
+struct sway_workspace *workspace_output_prev(struct sway_workspace *current) {
+	return workspace_output_prev_next_impl(current->output, -1);
 }
 
 struct sway_workspace *workspace_auto_back_and_forth(


### PR DESCRIPTION
This reverts commit 487c83f0de9ca2a7650ad636eed6fd694ddcb82e.

The `--create` flag is undocumented, not in i3, and at least partially broken (#5913), so this removes the feature.

@ddevault should probably review this, since he added it.

Fix #5913