### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,9 +8,11 @@ IndentCaseLabels: false
 SortIncludes: false
 ColumnLimit: 80
 AlignAfterOpenBracket: DontAlign
-BinPackParameters: false
-BinPackArguments: false
+BinPackParameters: true
+BinPackArguments: true
 ContinuationIndentWidth: 8
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortLoopsOnASingleLine: true
 ReflowComments: false
+AllowAllArgumentsOnNextLine: false
+AlignOperands: DontAlign


### PR DESCRIPTION
I had a look at the `.clang-format` file. It seems that the current code isn't formatted very consistently. In particular, the `ContinuationIndentWidth` is usually 8 when continuing if statements (so that there is an indent relative to the following block), but 4 in other places. I don't think clang-format supports it that way though, so I chose to put it to 8 here.

Also, `BinPack{Arguments,Parameters}` were both `false`, but in practice arguments are packed almost everywhere, so I've changed those to `true`.

`AllowAllArgumentsOnNextLine: false` makes sure to prefer the current practice of
```
f(a,b,
 c);
```
over
```
f(
 a,b,c);
```
See [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for the documentation and examples of all options.

To see some diffs, I have added formatted `tree/{container,workspace}.c` with these settings in this PR.
The biggest changes are wrapping of lines over 80 chars, and better packing of function arguments on the first line when some are wrapped to a second line.

Anyway, I don't want to force anything on you, so feel free to ignore this.