### PR TITLE
Fix wlroots symbol collision

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -38,3 +38,10 @@ tasks:
       cd sway
       meson configure build -Dxwayland=disabled
       ninja -C build
+  - build-static: |
+      cd sway
+      mkdir subprojects
+      ln -s ../../wlroots subprojects/wlroots
+      rm -rf build
+      meson build --default-library=static --force-fallback-for=wlroots
+      ninja -C build

--- a/common/util.c
+++ b/common/util.c
@@ -10,12 +10,6 @@
 #include "log.h"
 #include "util.h"
 
-uint32_t get_current_time_msec(void) {
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-	return now.tv_sec * 1000 + now.tv_nsec / 1000000;
-}
-
 int wrap(int i, int max) {
 	return ((i % max) + max) % max;
 }

--- a/include/util.h
+++ b/include/util.h
@@ -30,12 +30,6 @@ int parse_movement_amount(int argc, char **argv,
 		struct movement_amount *amount);
 
 /**
- * Get the current time, in milliseconds.
- */
-
-uint32_t get_current_time_msec(void);
-
-/**
  * Wrap i into the range [0, max]
  */
 int wrap(int i, int max);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -4,6 +4,7 @@
 #include <libevdev/libevdev.h>
 #include <linux/input-event-codes.h>
 #include <errno.h>
+#include <time.h>
 #include <strings.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_cursor.h>
@@ -30,6 +31,12 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "wlr-layer-shell-unstable-v1-protocol.h"
+
+static uint32_t get_current_time_msec(void) {
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return now.tv_sec * 1000 + now.tv_nsec / 1000000;
+}
 
 static struct wlr_surface *layer_surface_at(struct sway_output *output,
 		struct wl_list *layer, double ox, double oy, double *sx, double *sy) {


### PR DESCRIPTION
As plans are to temporarily revert our solution to symbol collisions (https://github.com/swaywm/wlroots/pull/2980), we'll have to instead work around the problem locally.

If we make a 1.6.1 for wlroots 0.14 support, we should cherry-pick this PR as well.