### PR TITLE
Backport "desktop/render: remove unused wlr_gles2_texture_attribs" to v1.6

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -105,9 +105,6 @@ static void render_texture(struct wlr_output *wlr_output,
 		wlr_backend_get_renderer(wlr_output->backend);
 	struct sway_output *output = wlr_output->data;
 
-	struct wlr_gles2_texture_attribs attribs;
-	wlr_gles2_texture_get_attribs(texture, &attribs);
-
 	pixman_region32_t damage;
 	pixman_region32_init(&damage);
 	pixman_region32_union_rect(&damage, &damage, dst_box->x, dst_box->y,


### PR DESCRIPTION
We were calling wlr_gles2_texture_get_attribs, but we were never
using the result.

(cherry picked from commit 86b08e3257a4e3e204740f6252c5b1180ead8467)

* * *

This fixes the Pixman renderer.