### PR TITLE
add drag_mode command to move/resize window without floating_modifier

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -121,6 +121,7 @@ sway_cmd cmd_create_output;
 sway_cmd cmd_default_border;
 sway_cmd cmd_default_floating_border;
 sway_cmd cmd_default_orientation;
+sway_cmd cmd_drag_mode;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -518,6 +518,8 @@ struct sway_config {
 	bool tiling_drag;
 	int tiling_drag_threshold;
 
+    bool drag_mode;
+
 	bool smart_gaps;
 	int gaps_inner;
 	struct side_gaps gaps_outer;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -56,6 +56,7 @@ static const struct cmd_handler handlers[] = {
 	{ "client.urgent", cmd_client_urgent },
 	{ "default_border", cmd_default_border },
 	{ "default_floating_border", cmd_default_floating_border },
+	{ "drag_mode", cmd_drag_mode },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands/drag_mode.c
+++ b/sway/commands/drag_mode.c
@@ -1,0 +1,13 @@
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_drag_mode(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "drag_mode", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	config->drag_mode = parse_boolean(argv[0], config->drag_mode);
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -266,6 +266,7 @@ static void config_defaults(struct sway_config *config) {
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
+    config->drag_mode = false;
 
 	config->smart_gaps = false;
 	config->gaps_inner = 0;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -49,6 +49,7 @@ sway_sources = files(
 	'commands/default_border.c',
 	'commands/default_floating_border.c',
 	'commands/default_orientation.c',
+    'commands/drag_mode.c',
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',


### PR DESCRIPTION
I added a drag_mode command which causes any BTN_LEFT or BTN_RIGHT to resize/move regardless of the floating modifier. This makes it possible to e.g. toggle a resize mode which supports touch resizing on a tablet when no keyboard is connected (my usecase).

Documentation is still missing. But I want to get Feedback on whether this is a wanted addition.