### PR TITLE
Use wlroots surface locking for transactions

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -43,6 +43,11 @@ void transaction_notify_view_ready_by_serial(struct sway_view *view,
 		uint32_t serial);
 
 /**
+ * Unlock the cached surface state held by the transaction system.
+ */
+void transaction_unlock_view_by_serial(struct sway_view *view, uint32_t serial);
+
+/**
  * Notify the transaction system that a view is ready for the new layout, but
  * identifying the instruction by geometry rather than by serial.
  *

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -56,15 +56,6 @@ struct sway_view_impl {
 	void (*destroy)(struct sway_view *view);
 };
 
-struct sway_saved_buffer {
-	struct wlr_client_buffer *buffer;
-	int x, y;
-	int width, height;
-	enum wl_output_transform transform;
-	struct wlr_fbox source_box;
-	struct wl_list link; // sway_view::saved_buffers
-};
-
 struct sway_view {
 	enum sway_view_type type;
 	const struct sway_view_impl *impl;
@@ -87,7 +78,8 @@ struct sway_view {
 	bool allow_request_urgent;
 	struct wl_event_source *urgent_timer;
 
-	struct wl_list saved_buffers; // sway_saved_buffer::link
+	bool surface_locked;
+	uint32_t surface_locked_seq;
 
 	// The geometry for whatever the client is committing, regardless of
 	// transaction state. Updated on every commit.
@@ -129,6 +121,7 @@ struct sway_view {
 struct sway_xdg_shell_view {
 	struct sway_view view;
 
+	struct wl_listener cache;
 	struct wl_listener commit;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;
@@ -357,9 +350,9 @@ void view_set_urgent(struct sway_view *view, bool enable);
 
 bool view_is_urgent(struct sway_view *view);
 
-void view_remove_saved_buffer(struct sway_view *view);
+void view_lock_pending(struct sway_view *view);
 
-void view_save_buffer(struct sway_view *view);
+void view_unlock_pending(struct sway_view *view);
 
 bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -432,10 +432,6 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
-	if (!wl_list_empty(&view->saved_buffers)) {
-		return false;
-	}
-
 	for (int i = 0; i < workspace->current.floating->length; ++i) {
 		struct sway_container *floater =
 			workspace->current.floating->items[i];

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -289,76 +289,13 @@ static void render_view_popups(struct sway_view *view,
 		render_surface_iterator, &data);
 }
 
-static void render_saved_view(struct sway_view *view,
-		struct sway_output *output, pixman_region32_t *damage, float alpha) {
-	struct wlr_output *wlr_output = output->wlr_output;
-
-	if (wl_list_empty(&view->saved_buffers)) {
-		return;
-	}
-
-	bool floating = container_is_current_floating(view->container);
-
-	struct sway_saved_buffer *saved_buf;
-	wl_list_for_each(saved_buf, &view->saved_buffers, link) {
-		if (!saved_buf->buffer->texture) {
-			continue;
-		}
-
-		struct wlr_box proj_box = {
-			.x = saved_buf->x - view->saved_geometry.x - output->lx,
-			.y = saved_buf->y - view->saved_geometry.y - output->ly,
-			.width = saved_buf->width,
-			.height = saved_buf->height,
-		};
-
-		struct wlr_box output_box = {
-			.width = output->width,
-			.height = output->height,
-		};
-
-		struct wlr_box intersection;
-		bool intersects = wlr_box_intersection(&intersection, &output_box, &proj_box);
-		if (!intersects) {
-			continue;
-		}
-
-		struct wlr_box dst_box = proj_box;
-		scale_box(&proj_box, wlr_output->scale);
-
-		float matrix[9];
-		enum wl_output_transform transform = wlr_output_transform_invert(saved_buf->transform);
-		wlr_matrix_project_box(matrix, &proj_box, transform, 0,
-			wlr_output->transform_matrix);
-
-		if (!floating) {
-			dst_box.width = fmin(dst_box.width,
-					view->container->current.content_width -
-					(saved_buf->x - view->container->current.content_x) + view->saved_geometry.x);
-			dst_box.height = fmin(dst_box.height,
-					view->container->current.content_height -
-					(saved_buf->y - view->container->current.content_y) + view->saved_geometry.y);
-		}
-		scale_box(&dst_box, wlr_output->scale);
-
-		render_texture(wlr_output, damage, saved_buf->buffer->texture,
-			&saved_buf->source_box, &dst_box, matrix, alpha);
-	}
-
-	// FIXME: we should set the surface that this saved buffer originates from
-	// as sampled here.
-	// https://github.com/swaywm/sway/pull/4465#discussion_r321082059
-}
-
 /**
  * Render a view's surface and left/bottom/right borders.
  */
 static void render_view(struct sway_output *output, pixman_region32_t *damage,
 		struct sway_container *con, struct border_colors *colors) {
 	struct sway_view *view = con->view;
-	if (!wl_list_empty(&view->saved_buffers)) {
-		render_saved_view(view, output, damage, view->container->alpha);
-	} else if (view->surface) {
+	if (view->surface) {
 		render_view_toplevels(view, output, damage, view->container->alpha);
 	}
 
@@ -1063,9 +1000,7 @@ void output_render(struct sway_output *output, struct timespec *when,
 		}
 
 		if (fullscreen_con->view) {
-			if (!wl_list_empty(&fullscreen_con->view->saved_buffers)) {
-				render_saved_view(fullscreen_con->view, output, damage, 1.0f);
-			} else if (fullscreen_con->view->surface) {
+			if (fullscreen_con->view->surface) {
 				render_view_toplevels(fullscreen_con->view,
 						output, damage, 1.0f);
 			}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -37,7 +37,6 @@ void view_init(struct sway_view *view, enum sway_view_type type,
 	view->type = type;
 	view->impl = impl;
 	view->executed_criteria = create_list();
-	wl_list_init(&view->saved_buffers);
 	view->allow_request_urgent = true;
 	view->shortcuts_inhibit = SHORTCUTS_INHIBIT_DEFAULT;
 	wl_signal_init(&view->events.unmap);
@@ -57,10 +56,11 @@ void view_destroy(struct sway_view *view) {
 		return;
 	}
 	wl_list_remove(&view->events.unmap.listener_list);
-	if (!wl_list_empty(&view->saved_buffers)) {
-		view_remove_saved_buffer(view);
+	if (view->surface_locked) {
+		view_unlock_pending(view);
 	}
 	list_free(view->executed_criteria);
+
 
 	free(view->title_format);
 
@@ -1376,41 +1376,28 @@ bool view_is_urgent(struct sway_view *view) {
 	return view->urgent.tv_sec || view->urgent.tv_nsec;
 }
 
-void view_remove_saved_buffer(struct sway_view *view) {
-	if (!sway_assert(!wl_list_empty(&view->saved_buffers), "Expected a saved buffer")) {
+void view_lock_pending(struct sway_view *view) {
+	if (!sway_assert(!view->surface_locked,
+			"Didn't expect surface to be already locked")) {
+		view_unlock_pending(view);
+	}
+
+	if (view->surface == NULL) {
 		return;
 	}
-	struct sway_saved_buffer *saved_buf, *tmp;
-	wl_list_for_each_safe(saved_buf, tmp, &view->saved_buffers, link) {
-		wlr_buffer_unlock(&saved_buf->buffer->base);
-		wl_list_remove(&saved_buf->link);
-		free(saved_buf);
-	}
+
+	// TODO: maybe lock the whole surface tree?
+	view->surface_locked = true;
+	view->surface_locked_seq = wlr_surface_lock_pending(view->surface);
 }
 
-static void view_save_buffer_iterator(struct wlr_surface *surface,
-		int sx, int sy, void *data) {
-	struct sway_view *view = data;
-
-	if (surface && wlr_surface_has_buffer(surface)) {
-		wlr_buffer_lock(&surface->buffer->base);
-		struct sway_saved_buffer *saved_buffer = calloc(1, sizeof(struct sway_saved_buffer));
-		saved_buffer->buffer = surface->buffer;
-		saved_buffer->width = surface->current.width;
-		saved_buffer->height = surface->current.height;
-		saved_buffer->x = view->container->surface_x + sx;
-		saved_buffer->y = view->container->surface_y + sy;
-		saved_buffer->transform = surface->current.transform;
-		wlr_surface_get_buffer_source_box(surface, &saved_buffer->source_box);
-		wl_list_insert(&view->saved_buffers, &saved_buffer->link);
+void view_unlock_pending(struct sway_view *view) {
+	if (!sway_assert(view->surface_locked, "Expected surface to be locked")) {
+		return;
 	}
-}
 
-void view_save_buffer(struct sway_view *view) {
-	if (!sway_assert(wl_list_empty(&view->saved_buffers), "Didn't expect saved buffer")) {
-		view_remove_saved_buffer(view);
-	}
-	view_for_each_surface(view, view_save_buffer_iterator, view);
+	view->surface_locked = false;
+	wlr_surface_unlock_cached(view->surface, view->surface_locked_seq);
 }
 
 bool view_is_transient_for(struct sway_view *child,


### PR DESCRIPTION
References: https://github.com/swaywm/wlroots/issues/2957
Depends on: https://github.com/swaywm/wlroots/pull/2977

* * *

- [ ] Xwayland
- [ ] Consider locking the whole surface tree? Technically clients who care should synchronize their surface tree (`wl_subsurface.set_sync`), but without the surface-transactions protocol might not have the tools to do so (e.g. xdg-popup cannot be synchronized).
- [ ] On `wl_surface.events.cache` we release the surface cache lock. However that doesn't mean that the transaction is ready to be applied: someone else might still have a lock. We need to wait for `wl_surface.events.commit` to apply the transaction. 
- [ ] Consider dropping `saved_geometry` as well.