### PR TITLE
container: ignore borders in fullscreen windows

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -894,7 +894,7 @@ void container_set_geometry_from_content(struct sway_container *con) {
 	size_t border_width = 0;
 	size_t top = 0;
 
-	if (con->pending.border != B_CSD) {
+	if (con->pending.border != B_CSD && !con->pending.fullscreen_mode) {
 		border_width = con->pending.border_thickness * (con->pending.border != B_NONE);
 		top = con->pending.border == B_NORMAL ?
 			container_titlebar_height() : border_width;


### PR DESCRIPTION
~In the special case of fullscreening a floating window,
container_discover_outputs would detect that the container box
intersected with a sway_output that the window wasn't actually over.
This would then send bogus surface entrance events to clients which
would confuse them. The cause of this appears to be con_box using
x/y/width/height instead of content_x/content_y (and so on). Just the
"plain" x/y could return negative values at times which is clearly
incorrect. Since output_get_box uses layout coordinates, it makes more
sense to properly use the layout coordinates for the container as well
when we are comparing the geometry between the two. Fixes #6080.~

~I'm unsure if using the `content`coordinates here has any deeper implications, but just running through the logic for this, I saw `content` being used basically in every step of the process except for this part. From my testing, it seemed to return the correct and expected coordinates at least.~