### PR TITLE
grimshot: Handle slurp cancellations

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -113,7 +113,7 @@ elif [ "$SUBJECT" = "area" ] ; then
   GEOM=$(slurp -d)
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
-    exit
+    exit 1
   fi
   WHAT="Area"
 elif [ "$SUBJECT" = "active" ] ; then
@@ -132,7 +132,7 @@ elif [ "$SUBJECT" = "window" ] ; then
   GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp)
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
-   exit
+   exit 1
   fi
   WHAT="Window"
 else


### PR DESCRIPTION
Whenever the selection is cancelled by the user, exit 1, since not
screenshot has been taken.