### PR TITLE
Fix wl_pointer.frame not sent on touch emulation

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -54,6 +54,7 @@ struct sway_cursor {
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 	bool simulating_pointer_from_touch;
+	bool pointer_touch_up;
 	int32_t pointer_touch_id;
 
 	struct wl_listener tool_axis;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -507,7 +507,7 @@ static void handle_touch_up(struct wl_listener *listener, void *data) {
 
 	if (cursor->simulating_pointer_from_touch) {
 		if (cursor->pointer_touch_id == cursor->seat->touch_id) {
-			cursor->simulating_pointer_from_touch = false;
+			cursor->pointer_touch_up = true;
 			dispatch_cursor_button(cursor, event->device, event->time_msec,
 					BTN_LEFT, WLR_BUTTON_RELEASED);
 		}
@@ -565,6 +565,11 @@ static void handle_touch_frame(struct wl_listener *listener, void *data) {
 
 	if (cursor->simulating_pointer_from_touch) {
 		wlr_seat_pointer_notify_frame(wlr_seat);
+
+		if (cursor->pointer_touch_up) {
+			cursor->pointer_touch_up = false;
+			cursor->simulating_pointer_from_touch = false;
+		}
 	} else {
 		wlr_seat_touch_notify_frame(wlr_seat);
 	}


### PR DESCRIPTION
When emulating touch, the simulating_pointer_from_touch field is
set to true. It's switched back to false when a touch_up event is
received. However we need to ensure we always send a wl_pointer.frame
event following a group of other wl_pointer events.

Since a touch_frame event is always guaranteed to come after a group
of touch events, unset simulating_pointer_from_touch in the touch_frame
handler instead of the touch_up handler. Add a new field to know whether
the touch_frame handler should stop emulation.