### PR TITLE
swaybar/swaynag: Add meson options to enable/disable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,9 +140,15 @@ if scdoc.found()
 		'sway/sway-output.5.scd',
 		'swaybar/swaybar-protocol.7.scd',
 		'swaymsg/swaymsg.1.scd',
-		'swaynag/swaynag.1.scd',
-		'swaynag/swaynag.5.scd',
 	]
+
+	if get_option('swaynag')
+		man_files += [
+			'swaynag/swaynag.1.scd',
+			'swaynag/swaynag.5.scd',
+		]
+	endif
+
 	foreach filename : man_files
 		topic = filename.split('.')[-3].split('/')[-1]
 		section = filename.split('.')[-2]
@@ -224,9 +230,15 @@ subdir('common')
 subdir('sway')
 subdir('swaymsg')
 
-subdir('client')
-subdir('swaybar')
-subdir('swaynag')
+if get_option('swaybar') or get_option('swaynag')
+	subdir('client')
+endif
+if get_option('swaybar')
+	subdir('swaybar')
+endif
+if get_option('swaynag')
+	subdir('swaynag')
+endif
 
 config = configuration_data()
 config.set('datadir', join_paths(prefix, datadir))
@@ -274,9 +286,13 @@ endif
 if get_option('bash-completions')
 	bash_files = files(
 		'completions/bash/sway',
-		'completions/bash/swaybar',
 		'completions/bash/swaymsg',
 	)
+
+	if get_option('swaybar')
+		bash_files += files('completions/bash/swaybar')
+	endif
+
 	if bash_comp.found()
 		bash_install_dir = bash_comp.get_variable(
 			pkgconfig: 'completionsdir',
@@ -293,8 +309,12 @@ if get_option('fish-completions')
 	fish_files = files(
 		'completions/fish/sway.fish',
 		'completions/fish/swaymsg.fish',
-		'completions/fish/swaynag.fish',
 	)
+
+	if get_option('swaynag')
+		fish_files += files('completions/fish/swaynag.fish')
+	endif
+
 	if fish_comp.found()
 		fish_install_dir = fish_comp.get_variable(
 			pkgconfig: 'completionsdir',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,8 @@ option('default-wallpaper', type: 'boolean', value: true, description: 'Install 
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions.')
+option('swaybar', type: 'boolean', value: true, description: 'Enable support for swaybar')
+option('swaynag', type: 'boolean', value: true, description: 'Enable support for swaynag')
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('tray', type: 'feature', value: 'auto', description: 'Enable support for swaybar tray')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybg')


### PR DESCRIPTION
- Both options default to on (no change in behavior).
- Users can toggle them off.
- Not sure if an option should also be added for `swaymsg`, let me know.
- Files related to swaybar/swaynag are still compiled (`sway/commands/bar/` for example). Shall I also make these conditional?