### PR TITLE
Fix #6297

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -236,7 +236,6 @@ void cursor_update_image(struct sway_cursor *cursor,
 static void cursor_hide(struct sway_cursor *cursor) {
 	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	cursor->hidden = true;
-	wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
 }
 
 static int hide_notify(void *data) {


### PR DESCRIPTION
This makes it so that `seat hide_cursor` no longer clears cursor focus when hidding.

Clearing focus casuses problems whenever keyboard and mouse are to be used in conjunction, like Games, video editors, 3D/CAD software.

A better alternative to removing the call to `wlr_seat_pointer_notify_clear_focus` would be to only run it when dwt is active, however that means mixing code related to `seat` and `input`.