### PR TITLE
Add `gaps <type> <scope> toggle <px>` command

### DIFF
--- a/sway/commands/gaps.c
+++ b/sway/commands/gaps.c
@@ -11,7 +11,8 @@
 enum gaps_op {
 	GAPS_OP_SET,
 	GAPS_OP_ADD,
-	GAPS_OP_SUBTRACT
+	GAPS_OP_SUBTRACT,
+	GAPS_OP_TOGGLE
 };
 
 struct gaps_data {
@@ -102,6 +103,9 @@ static void apply_gaps_op(int *prop, enum gaps_op op, int amount) {
 	case GAPS_OP_SUBTRACT:
 		*prop -= amount;
 		break;
+	case GAPS_OP_TOGGLE:
+		*prop = *prop ? 0 : amount;
+		break;
 	}
 }
 
@@ -133,9 +137,9 @@ static void configure_gaps(struct sway_workspace *ws, void *_data) {
 }
 
 // gaps inner|outer|horizontal|vertical|top|right|bottom|left current|all
-// set|plus|minus <px>
+// set|plus|minus|toggle <px>
 static const char expected_runtime[] = "'gaps inner|outer|horizontal|vertical|"
-	"top|right|bottom|left current|all set|plus|minus <px>'";
+	"top|right|bottom|left current|all set|plus|minus|toggle <px>'";
 static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 	struct cmd_results *error = checkarg(argc, "gaps", EXPECTED_EQUAL_TO, 4);
 	if (error) {
@@ -180,6 +184,8 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 		data.operation = GAPS_OP_ADD;
 	} else if (strcasecmp(argv[2], "minus") == 0) {
 		data.operation = GAPS_OP_SUBTRACT;
+	} else if (strcasecmp(argv[2], "toggle") == 0) {
+		data.operation = GAPS_OP_TOGGLE;
 	} else {
 		return cmd_results_new(CMD_INVALID, "Expected %s", expected_runtime);
 	}
@@ -200,7 +206,7 @@ static struct cmd_results *gaps_set_runtime(int argc, char **argv) {
 }
 
 // gaps inner|outer|<dir>|<side> <px> - sets defaults for workspaces
-// gaps inner|outer|<dir>|<side> current|all set|plus|minus <px> - runtime only
+// gaps inner|outer|<dir>|<side> current|all set|plus|minus|toggle <px> - runtime only
 // <dir> = horizontal|vertical
 // <side> = top|right|bottom|left
 struct cmd_results *cmd_gaps(int argc, char **argv) {

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -155,7 +155,7 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 	is specified, the view will be fullscreen across all outputs.
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left all|current
-set|plus|minus <amount>
+set|plus|minus|toggle <amount>
 	Changes the _inner_ or _outer_ gaps for either _all_ workspaces or the
 	_current_ workspace. _outer_ gaps can be altered per side with _top_,
 	_right_, _bottom_, and _left_ or per direction with _horizontal_ and


### PR DESCRIPTION
This command is part of i3-gaps since Airblader/i3#264 but is currently missing in sway.
It can be used to toggle gaps at runtime either via a keybinding or via `swaymsg`, e.g.:
```
bindsym $mod+g gaps inner current toggle 30
swaymsg gaps outer all toggle 15
```