### PR TITLE
view: remove reference to wlr_wl_shell_surface

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -112,7 +112,6 @@ struct sway_view {
 #if HAVE_XWAYLAND
 		struct wlr_xwayland_surface *wlr_xwayland_surface;
 #endif
-		struct wlr_wl_shell_surface *wlr_wl_shell_surface;
 	};
 
 	struct {


### PR DESCRIPTION
Remove reference to deprecated `wlr_wl_shell_surface` found by @ifreund 