### PR TITLE
transaction: lock/unlock views

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -35,20 +35,26 @@ void transaction_commit_dirty(void);
 void transaction_commit_dirty_client(void);
 
 /**
- * Notify the transaction system that a view is ready for the new layout.
- *
- * When all views in the transaction are ready, the layout will be applied.
+ * Notify the transaction system that a view has acknowledged a configure.
  */
-void transaction_notify_view_ready_by_serial(struct sway_view *view,
+void transaction_notify_view_acked_by_serial(struct sway_view *view,
 		uint32_t serial);
 
 /**
- * Notify the transaction system that a view is ready for the new layout, but
+ * Notify the transaction system that a view has acknowledged a configure, but
  * identifying the instruction by geometry rather than by serial.
  *
- * This is used by xwayland views, as they don't have serials.
+ * This is used by Xwayland views, as they don't have serials.
  */
-void transaction_notify_view_ready_by_geometry(struct sway_view *view,
+void transaction_notify_view_acked_by_geometry(struct sway_view *view,
 		double x, double y, int width, int height);
+
+/**
+ * Notify the transaction system that a view is ready for the new layout. This
+ * call has no effect if the view hasn't acknowledged a configure yet.
+ *
+ * When all views in the transaction are ready, the layout will be applied.
+ */
+void transaction_notify_view_ready(struct sway_view *view);
 
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -56,15 +56,6 @@ struct sway_view_impl {
 	void (*destroy)(struct sway_view *view);
 };
 
-struct sway_saved_buffer {
-	struct wlr_client_buffer *buffer;
-	int x, y;
-	int width, height;
-	enum wl_output_transform transform;
-	struct wlr_fbox source_box;
-	struct wl_list link; // sway_view::saved_buffers
-};
-
 struct sway_view {
 	enum sway_view_type type;
 	const struct sway_view_impl *impl;
@@ -87,15 +78,9 @@ struct sway_view {
 	bool allow_request_urgent;
 	struct wl_event_source *urgent_timer;
 
-	struct wl_list saved_buffers; // sway_saved_buffer::link
-
 	// The geometry for whatever the client is committing, regardless of
 	// transaction state. Updated on every commit.
 	struct wlr_box geometry;
-
-	// The "old" geometry during a transaction. Used to damage the old location
-	// when a transaction is applied.
-	struct wlr_box saved_geometry;
 
 	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel;
 	struct wl_listener foreign_activate_request;
@@ -355,10 +340,6 @@ bool view_is_visible(struct sway_view *view);
 void view_set_urgent(struct sway_view *view, bool enable);
 
 bool view_is_urgent(struct sway_view *view);
-
-void view_remove_saved_buffer(struct sway_view *view);
-
-void view_save_buffer(struct sway_view *view);
 
 bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -70,6 +70,9 @@ struct sway_view {
 	// Used when changing a view from tiled to floating.
 	int natural_width, natural_height;
 
+	bool surface_locked;
+	uint32_t lock_seq;
+
 	char *title_format;
 
 	bool using_csd;
@@ -340,6 +343,10 @@ bool view_is_visible(struct sway_view *view);
 void view_set_urgent(struct sway_view *view, bool enable);
 
 bool view_is_urgent(struct sway_view *view);
+
+void view_lock_pending(struct sway_view *view);
+
+void view_unlock_cached(struct sway_view *view);
 
 bool view_is_transient_for(struct sway_view *child, struct sway_view *ancestor);
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -116,6 +116,7 @@ struct sway_view {
 struct sway_xdg_shell_view {
 	struct sway_view view;
 
+	struct wl_listener ack_configure;
 	struct wl_listener commit;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -117,6 +117,7 @@ struct sway_xdg_shell_view {
 	struct sway_view view;
 
 	struct wl_listener ack_configure;
+	struct wl_listener cache;
 	struct wl_listener commit;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -134,6 +134,7 @@ struct sway_xdg_shell_view {
 struct sway_xwayland_view {
 	struct sway_view view;
 
+	struct wl_listener cache;
 	struct wl_listener commit;
 	struct wl_listener request_move;
 	struct wl_listener request_resize;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -431,10 +431,6 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
-	if (!wl_list_empty(&view->saved_buffers)) {
-		return false;
-	}
-
 	for (int i = 0; i < workspace->current.floating->length; ++i) {
 		struct sway_container *floater =
 			workspace->current.floating->items[i];

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -290,6 +290,13 @@ static void handle_ack_configure(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void handle_cache(struct wl_listener *listener, void *data) {
+	struct sway_xdg_shell_view *xdg_shell_view =
+		wl_container_of(listener, xdg_shell_view, cache);
+	struct sway_view *view = &xdg_shell_view->view;
+	transaction_notify_view_ready(view);
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
@@ -316,10 +323,6 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			view_center_surface(view);
 		}
 		desktop_damage_view(view);
-	}
-
-	if (view->container->node.instruction) {
-		transaction_notify_view_ready(view);
 	}
 
 	view_damage_from(view);
@@ -429,6 +432,7 @@ static void handle_unmap(struct wl_listener *listener, void *data) {
 	view_unmap(view);
 
 	wl_list_remove(&xdg_shell_view->ack_configure.link);
+	wl_list_remove(&xdg_shell_view->cache.link);
 	wl_list_remove(&xdg_shell_view->commit.link);
 	wl_list_remove(&xdg_shell_view->new_popup.link);
 	wl_list_remove(&xdg_shell_view->request_fullscreen.link);
@@ -472,6 +476,10 @@ static void handle_map(struct wl_listener *listener, void *data) {
 	xdg_shell_view->ack_configure.notify = handle_ack_configure;
 	wl_signal_add(&xdg_surface->events.ack_configure,
 		&xdg_shell_view->ack_configure);
+
+	xdg_shell_view->cache.notify = handle_cache;
+	wl_signal_add(&xdg_surface->surface->events.cache,
+		&xdg_shell_view->cache);
 
 	xdg_shell_view->commit.notify = handle_commit;
 	wl_signal_add(&xdg_surface->surface->events.commit,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -418,8 +418,9 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	}
 
 	if (view->container->node.instruction) {
-		transaction_notify_view_ready_by_geometry(view,
-				xsurface->x, xsurface->y, state->width, state->height);
+		transaction_notify_view_acked_by_geometry(view,
+			xsurface->x, xsurface->y, state->width, state->height);
+		transaction_notify_view_ready(view);
 	}
 
 	view_damage_from(view);


### PR DESCRIPTION
Supersedes https://github.com/swaywm/sway/pull/6362
Depends on ~https://github.com/swaywm/wlroots/pull/3081~, https://github.com/swaywm/wlroots/pull/3068 and on a to-be-written wlroots PR for Xwayland surface state caching support.

Notes:
- `wleird/slow-ack-configure` doesn't work anymore (it acks instantly), as the transaction system calls `wlr_surface_send_frame_done()` repeatedly to acquire the requested commit faster.
- There are still some rendering issues (just like in `master`) when a view's surface gets destroyed during a transaction. This will supposedly get fixed by https://github.com/swaywm/wlroots/pull/3024.