### PR TITLE
input: Use seatop_down on layer surface click

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -241,7 +241,7 @@ void seatop_begin_default(struct sway_seat *seat);
 void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
 		uint32_t time_msec, double sx, double sy);
 
-void seatop_begin_down_on_layer_surface(struct sway_seat *seat,
+void seatop_begin_down_on_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, uint32_t time_msec, double sx, double sy);
 
 void seatop_begin_move_floating(struct sway_seat *seat,

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -241,6 +241,9 @@ void seatop_begin_default(struct sway_seat *seat);
 void seatop_begin_down(struct sway_seat *seat, struct sway_container *con,
 		uint32_t time_msec, double sx, double sy);
 
+void seatop_begin_down_on_layer_surface(struct sway_seat *seat,
+		struct wlr_surface *surface, uint32_t time_msec, double sx, double sy);
+
 void seatop_begin_move_floating(struct sway_seat *seat,
 		struct sway_container *con);
 

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -373,6 +373,9 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 			seat_set_focus_layer(seat, layer);
 			transaction_commit_dirty();
 		}
+		if (state == WLR_BUTTON_PRESSED) {
+			seatop_begin_down_on_layer_surface(seat, surface, time_msec, sx, sy);
+		}
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;
 	}

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -374,7 +374,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 			transaction_commit_dirty();
 		}
 		if (state == WLR_BUTTON_PRESSED) {
-			seatop_begin_down_on_layer_surface(seat, surface, time_msec, sx, sy);
+			seatop_begin_down_on_surface(seat, surface, time_msec, sx, sy);
 		}
 		seat_pointer_notify_button(seat, time_msec, button, state);
 		return;


### PR DESCRIPTION
This PR changes the seatop implementation to ```seatop_down``` after a layer-surface has been clicked.

## Issue

This solves an issue with layer-shell surfaces not receiving button release events. Especially when "mouse_warping container" is set.
On Waybar the issue leads to secondary interactions being necessary to "re-activate" the bar after changing workspaces with a mouse click.

However, the issue can also be triggered when moving the cursor away from the surface while being held pressed.

See https://github.com/Alexays/Waybar/issues/1047 for complaints and https://github.com/wmww/gtk-layer-shell/issues/109 for videos and a log. Maybe [this warning](https://codeberg.org/dnkl/foot/src/branch/master/input.c#L1773) from foot is also related.

## Proposed solution

The problem seems to be that on click the pointer is relocated and a different surface is focused immediately. Using ```seatop_down``` this re-focus is delayed until the button is released.
This is also why the problem does not occur if we do not use a layer-surface. Hence, the solution would be to make use of ```seatop_down```. The only additional changes necessary are null-pointer checks for the ```con``` field.

Thanks,
Simon