### PR TITLE
xdg-decoration: let floating clients set borders

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -443,12 +443,15 @@ static void handle_map(struct wl_listener *listener, void *data) {
 
 	bool csd = false;
 
-	if (!view->xdg_decoration) {
+	if (view->xdg_decoration) {
+		enum wlr_xdg_toplevel_decoration_v1_mode mode =
+			view->xdg_decoration->wlr_xdg_decoration->client_pending_mode;
+		csd = mode == WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
+	} else {
 		struct sway_server_decoration *deco =
 				decoration_from_surface(xdg_surface->surface);
 		csd = !deco || deco->wlr_server_decoration->mode ==
 			WLR_SERVER_DECORATION_MANAGER_MODE_CLIENT;
-
 	}
 
 	view_map(view, view->wlr_xdg_surface->surface,

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -20,6 +20,7 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
+#include "sway/xdg_decoration.h"
 #include "list.h"
 #include "log.h"
 #include "stringop.h"
@@ -835,7 +836,13 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		if (container->view) {
 			view_set_tiled(container->view, false);
 			if (container->view->using_csd) {
+				container->saved_border = container->pending.border;
 				container->pending.border = B_CSD;
+				if (container->view->xdg_decoration) {
+					struct sway_xdg_decoration *deco = container->view->xdg_decoration;
+					wlr_xdg_toplevel_decoration_v1_set_mode(deco->wlr_xdg_decoration,
+							WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE);
+				}
 			}
 		}
 		container_floating_set_default_size(container);
@@ -873,6 +880,11 @@ void container_set_floating(struct sway_container *container, bool enable) {
 			view_set_tiled(container->view, true);
 			if (container->view->using_csd) {
 				container->pending.border = container->saved_border;
+				if (container->view->xdg_decoration) {
+					struct sway_xdg_decoration *deco = container->view->xdg_decoration;
+					wlr_xdg_toplevel_decoration_v1_set_mode(deco->wlr_xdg_decoration,
+							WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+				}
 			}
 		}
 		container->width_fraction = 0;


### PR DESCRIPTION
The xdg-decoration protocol allows clients to request whether they want
to use server side decorations or client side decorations. Currently,
sway ignores this and always enforces whatever the server is currently
set to. Although tiled clients cannot be allowed to set borders, there
is no harm in listening requests from floating clients. First,
handle_map needs to check if the client has requested client side
decorations and flip the csd bool to true if it has. Secondly,
xdg_decoration_handle_request_mode needs to also check if a client
requests a different mode and update the container if applicable.
Sidenote: also fixed an unrelated style error.

I didn't check, but I think this would fix #6414 assuming this is how SDL requests a borderless window.