### PR TITLE
layer_shell: damage previous area when a surface shrinks

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -22,6 +22,7 @@ struct sway_layer_surface {
 	struct wl_listener new_subsurface;
 
 	struct wlr_box geo;
+	struct wlr_box extent;
 	enum zwlr_layer_shell_v1_layer layer;
 };
 


### PR DESCRIPTION
Feels a bit lame, but it does fix #6415. Previously only the size of the new surface (+subsurfaces) was damaged, now the whole previous extent is damaged.