### PR TITLE
Fix menu dropdown focus logic in xwayland

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -111,10 +111,24 @@ static void unmanaged_handle_unmap(struct wl_listener *listener, void *data) {
 			return;
 		}
 
+        // Try to find another unmanaged surface from the same process to pass
+        // focus to. This is necessary because some applications (e.g. Jetbrains
+        // IDEs) represent their multi-level menus as unmanaged surfaces, and
+        // when closing a submenu, the main menu should get input focus.
+        struct sway_xwayland_unmanaged *current;
+        wl_list_for_each(current, &root->xwayland_unmanaged, link) {
+            struct wlr_xwayland_surface *prev_xsurface =
+                    current->wlr_xwayland_surface;
+            if (prev_xsurface->pid == xsurface->pid &&
+                    wlr_xwayland_or_surface_wants_focus(prev_xsurface)) {
+                seat_set_focus_surface(seat, prev_xsurface->surface, false);
+                return;
+            }
+        }
+
 		// Restore focus
 		struct sway_node *previous = seat_get_focus_inactive(seat, &root->node);
 		if (previous) {
-			// Hack to get seat to re-focus the return value of get_focus
 			seat_set_focus(seat, NULL);
 			seat_set_focus(seat, previous);
 		}


### PR DESCRIPTION
Not sure what unforeseen results this will have. But it seems to close #6324.
I tested with `code` (vscode) running under `xwayland` and the menu's seemed to work fine there without setting seat focus to NULL before setting to previous.

https://github.com/swaywm/sway/blob/bb3fd0abc56f39e35dc7f4e86f25da1b4a6efbd7/sway/desktop/xwayland.c#L118

At least removing that line makes the drop down menu's in **Reaper** usable again.