### PR TITLE
config.in: use portable hour specifier

### DIFF
--- a/config.in
+++ b/config.in
@@ -205,7 +205,7 @@ bar {
 
     # When the status_command prints a new line to stdout, swaybar updates.
     # The default just shows the current date and time.
-    status_command while date +'%Y-%m-%d %l:%M:%S %p'; do sleep 1; done
+    status_command while date +'%Y-%m-%d %I:%M:%S %p'; do sleep 1; done
 
     colors {
         statusline #ffffff


### PR DESCRIPTION
"%l" is (afaik) specific to GNU date, and isn't supported on busybox
or sbase. "%_I" is equivalent, and is supported by strptime, and is
therefore portable to other date implementations (such as busybox or
sbase).