### PR TITLE
view: wait until surface is mapped to send enter

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1063,6 +1063,11 @@ static void view_child_handle_surface_map(struct wl_listener *listener,
 		wl_container_of(listener, child, surface_map);
 	child->mapped = true;
 	view_child_damage(child, true);
+
+	struct sway_workspace *workspace = child->view->container->pending.workspace;
+	if (workspace) {
+			wlr_surface_send_enter(child->surface, workspace->output->wlr_output);
+	}
 }
 
 static void view_child_handle_surface_unmap(struct wl_listener *listener,
@@ -1106,11 +1111,6 @@ void view_child_init(struct sway_view_child *child,
 
 	wl_signal_add(&view->events.unmap, &child->view_unmap);
 	child->view_unmap.notify = view_child_handle_view_unmap;
-
-	struct sway_workspace *workspace = child->view->container->pending.workspace;
-	if (workspace) {
-		wlr_surface_send_enter(child->surface, workspace->output->wlr_output);
-	}
 
 	view_child_init_subsurfaces(child, surface);
 }


### PR DESCRIPTION
Based on observation, this is what weston does. https://github.com/swaywm/sway/issues/6147#issuecomment-912857546

I'm not sure if it's useful to send enter on surface creation before the surface is mapped, however the wayland protocol seems to encourage it, saying explicitly enter should be send on "creation".

On the one hand, it seems like common sense the application should know the required scale before it attaches a buffer, so the old way makes sense. But on the other hand the surface hasn't actually been shown so hasn't entered any outputs.