### PR TITLE
Fix overly-wide mark textures

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -518,7 +518,7 @@ static void render_titlebar_text_texture(struct sway_output *output,
 	}
 	cairo_set_font_options(c, fo);
 	get_text_size(c, config->font, &width, NULL, &baseline, scale,
-			config->pango_markup, "%s", con->formatted_title);
+			config->pango_markup, "%s", text);
 	cairo_surface_destroy(dummy_surface);
 	cairo_destroy(c);
 


### PR DESCRIPTION
The width of the texture needs to be calculated using the string that is
actually displayed in the texture.