### PR TITLE
swaybar: Prioritize hotspot events to bar bindings

### DIFF
--- a/include/swaybar/i3bar.h
+++ b/include/swaybar/i3bar.h
@@ -30,6 +30,6 @@ void i3bar_block_unref(struct i3bar_block *block);
 bool i3bar_handle_readable(struct status_line *status);
 enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, double x, double y, double rx, double ry,
-		double w, double h, int scale, uint32_t button);
+		double w, double h, int scale, uint32_t button, bool released);
 
 #endif

--- a/include/swaybar/input.h
+++ b/include/swaybar/input.h
@@ -49,7 +49,7 @@ struct swaybar_hotspot {
 	int x, y, width, height;
 	enum hotspot_event_handling (*callback)(struct swaybar_output *output,
 		struct swaybar_hotspot *hotspot, double x, double y, uint32_t button,
-		void *data);
+		bool released, void *data);
 	void (*destroy)(void *data);
 	void *data;
 };

--- a/swaybar/i3bar.c
+++ b/swaybar/i3bar.c
@@ -269,10 +269,15 @@ bool i3bar_handle_readable(struct status_line *status) {
 
 enum hotspot_event_handling i3bar_block_send_click(struct status_line *status,
 		struct i3bar_block *block, double x, double y, double rx, double ry,
-		double w, double h, int scale, uint32_t button) {
+		double w, double h, int scale, uint32_t button, bool released) {
 	sway_log(SWAY_DEBUG, "block %s clicked", block->name);
 	if (!block->name || !status->click_events) {
 		return HOTSPOT_PROCESS;
+	}
+	if (released) {
+		// Since we handle the pressed event, also handle the released event
+		// to block it from falling through to a binding in the bar
+		return HOTSPOT_IGNORE;
 	}
 
 	struct json_object *event_json = json_object_new_object();

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -166,14 +166,13 @@ static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 		return;
 	}
 
-	if (check_bindings(seat->bar, button, state)) {
-		return;
+	if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
+		if (process_hotspots(output, pointer->x, pointer->y, button)) {
+			return;
+		}
 	}
 
-	if (state != WL_POINTER_BUTTON_STATE_PRESSED) {
-		return;
-	}
-	process_hotspots(output, pointer->x, pointer->y, button);
+	check_bindings(seat->bar, button, state);
 }
 
 static void workspace_next(struct swaybar *bar, struct swaybar_output *output,
@@ -222,15 +221,14 @@ static void workspace_next(struct swaybar *bar, struct swaybar_output *output,
 static void process_discrete_scroll(struct swaybar_seat *seat,
 		struct swaybar_output *output, struct swaybar_pointer *pointer,
 		uint32_t axis, wl_fixed_t value) {
-	// If there is a button press binding, execute it, skip default behavior,
-	// and check button release bindings
 	uint32_t button = wl_axis_to_button(axis, value);
-	if (check_bindings(seat->bar, button, WL_POINTER_BUTTON_STATE_PRESSED)) {
-		check_bindings(seat->bar, button, WL_POINTER_BUTTON_STATE_RELEASED);
+	if (process_hotspots(output, pointer->x, pointer->y, button)) {
 		return;
 	}
 
-	if (process_hotspots(output, pointer->x, pointer->y, button)) {
+	// If there is a button press binding, execute it, and check button release bindings
+	if (check_bindings(seat->bar, button, WL_POINTER_BUTTON_STATE_PRESSED)) {
+		check_bindings(seat->bar, button, WL_POINTER_BUTTON_STATE_RELEASED);
 		return;
 	}
 

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -160,7 +160,7 @@ static void render_sharp_line(cairo_t *cairo, uint32_t color,
 
 static enum hotspot_event_handling block_hotspot_callback(
 		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
-		double x, double y, uint32_t button, void *data) {
+		double x, double y, uint32_t button, bool released, void *data) {
 	struct i3bar_block *block = data;
 	struct status_line *status = output->bar->status;
 	return i3bar_block_send_click(status, block, x, y,
@@ -168,7 +168,7 @@ static enum hotspot_event_handling block_hotspot_callback(
 			y - (double)hotspot->y,
 			(double)hotspot->width,
 			(double)hotspot->height,
-			output->scale, button);
+			output->scale, button, released);
 }
 
 static void i3bar_block_unref_callback(void *data) {
@@ -599,9 +599,14 @@ static uint32_t render_binding_mode_indicator(struct render_context *ctx,
 
 static enum hotspot_event_handling workspace_hotspot_callback(
 		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
-		double x, double y, uint32_t button, void *data) {
+		double x, double y, uint32_t button, bool released, void *data) {
 	if (button != BTN_LEFT) {
 		return HOTSPOT_PROCESS;
+	}
+	if (released) {
+		// Since we handle the pressed event, also handle the released event
+		// to block it from falling through to a binding in the bar
+		return HOTSPOT_IGNORE;
 	}
 	ipc_send_workspace_command(output->bar, (const char *)data);
 	return HOTSPOT_IGNORE;

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -385,13 +385,18 @@ static int cmp_sni_id(const void *item, const void *cmp_to) {
 
 static enum hotspot_event_handling icon_hotspot_callback(
 		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
-		double x, double y, uint32_t button, void *data) {
+		double x, double y, uint32_t button, bool released, void *data) {
 	sway_log(SWAY_DEBUG, "Clicked on %s", (char *)data);
 
 	struct swaybar_tray *tray = output->bar->tray;
 	int idx = list_seq_find(tray->items, cmp_sni_id, data);
 
 	if (idx != -1) {
+		if (released) {
+			// Since we handle the pressed event, also handle the released event
+			// to block it from falling through to a binding in the bar
+			return HOTSPOT_IGNORE;
+		}
 		struct swaybar_sni *sni = tray->items->items[idx];
 		// guess global position since wayland doesn't expose it
 		struct swaybar_config *config = tray->bar->config;


### PR DESCRIPTION
This is consistent with i3bar's behaviour, and for example, allows binding a command to button1, while still being able to click on tray icons or other zones on the bar's status line which may have their own bindings.

E.g., in Sway, without this commit, this config. makes tray icons unclickable:

```
    bar {
        # ...
        bindsym button1 exec swaynag -m You_clicked_the_tray._Want_some_help?
    }
```

But the same configuration in i3 (with i3-nagbar) keeps tray items clickable.