### PR TITLE
Prevent segfault on keyboard connection

### DIFF
--- a/include/sway/input/libinput.h
+++ b/include/sway/input/libinput.h
@@ -2,7 +2,7 @@
 #define _SWAY_INPUT_LIBINPUT_H
 #include "sway/input/input-manager.h"
 
-void sway_input_configure_libinput_device(struct sway_input_device *device);
+bool sway_input_configure_libinput_device(struct sway_input_device *device);
 
 void sway_input_reset_libinput_device(struct sway_input_device *device);
 

--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -187,10 +187,10 @@ static bool set_calibration_matrix(struct libinput_device *dev, float mat[6]) {
 	return changed;
 }
 
-void sway_input_configure_libinput_device(struct sway_input_device *input_device) {
+bool sway_input_configure_libinput_device(struct sway_input_device *input_device) {
 	struct input_config *ic = input_device_get_config(input_device);
 	if (!ic || !wlr_input_device_is_libinput(input_device->wlr_device)) {
-		return;
+		return false;
 	}
 
 	struct libinput_device *device =
@@ -259,9 +259,7 @@ void sway_input_configure_libinput_device(struct sway_input_device *input_device
 		changed |= set_calibration_matrix(device, ic->calibration_matrix.matrix);
 	}
 
-	if (changed) {
-		ipc_event_input("libinput_config", input_device);
-	}
+	return changed;
 }
 
 void sway_input_reset_libinput_device(struct sway_input_device *input_device) {


### PR DESCRIPTION
Sway was crashing on me everytime I connected or reconnected my Thinkpad usb keyboard. It turns out that for some reason, upon connection, the pointer to the keymap was NULL, therefore crashing Sway as it attempted to access the pointer in ipc_json_describe_input. I've added a check for that.

So far I've tested it and it doesn't crash on me anymore when connecting my keyboard. `swaymsg -t get_inputs` still shows the correct layouts for the keyboard, so I guess it sets the keymap pointer in a later event.