### PR TITLE
view: fix saved buffer order

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1401,7 +1401,7 @@ static void view_save_buffer_iterator(struct wlr_surface *surface,
 		saved_buffer->y = view->container->surface_y + sy;
 		saved_buffer->transform = surface->current.transform;
 		wlr_surface_get_buffer_source_box(surface, &saved_buffer->source_box);
-		wl_list_insert(&view->saved_buffers, &saved_buffer->link);
+		wl_list_insert(view->saved_buffers.prev, &saved_buffer->link);
 	}
 }
 


### PR DESCRIPTION
Fixes the issue when saved buffers were rendered in a reversed order.