### PR TITLE
view: fix child position calc

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -183,7 +183,7 @@ struct sway_xwayland_unmanaged {
 struct sway_view_child;
 
 struct sway_view_child_impl {
-	void (*get_root_coords)(struct sway_view_child *child, int *sx, int *sy);
+	void (*get_view_coords)(struct sway_view_child *child, int *sx, int *sy);
 	void (*destroy)(struct sway_view_child *child);
 };
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -21,18 +21,15 @@
 
 static const struct sway_view_child_impl popup_impl;
 
-static void popup_get_root_coords(struct sway_view_child *child,
-		int *root_sx, int *root_sy) {
+static void popup_get_view_coords(struct sway_view_child *child,
+		int *sx, int *sy) {
 	struct sway_xdg_popup *popup = (struct sway_xdg_popup *)child;
 	struct wlr_xdg_surface *surface = popup->wlr_xdg_surface;
 
-	int x_offset = -child->view->geometry.x - surface->geometry.x;
-	int y_offset = -child->view->geometry.y - surface->geometry.y;
-
 	wlr_xdg_popup_get_toplevel_coords(surface->popup,
-		x_offset + surface->popup->geometry.x,
-		y_offset + surface->popup->geometry.y,
-		root_sx, root_sy);
+		surface->popup->geometry.x - surface->geometry.x,
+		surface->popup->geometry.y - surface->geometry.y,
+		sx, sy);
 }
 
 static void popup_destroy(struct sway_view_child *child) {
@@ -47,7 +44,7 @@ static void popup_destroy(struct sway_view_child *child) {
 }
 
 static const struct sway_view_child_impl popup_impl = {
-	.get_root_coords = popup_get_root_coords,
+	.get_view_coords = popup_get_view_coords,
 	.destroy = popup_destroy,
 };
 


### PR DESCRIPTION
Previously, the position was calculated incorrectly for nested
subsurfaces.

---

Test client: [subsurface-client/grandchild-damage](https://codeberg.org/vyivel/subsurface-client)