### PR TITLE
build: subproject support for wayland-protocols

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,4 +1,4 @@
-wl_protocol_dir = wayland_protos.get_variable(pkgconfig: 'pkgdatadir')
+wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
 
 wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
 if wayland_scanner_dep.found()


### PR DESCRIPTION
As in wlroots: https://github.com/swaywm/wlroots/pull/2953.

To build sway on my system with outdated wayland-protocols (1.20):

- add wlroots, wayland-protocols, seatd as subprojects
- run `meson setup --force-fallback-for wayland-protocols build`
- ...

Without the force-fallback, sway finds wayland-protocols from the system, which does not satisfy wlroots (>=1.21) and the setup fails without a good error message.

I'll add a note in the wiki if this is merged.