### PR TITLE
Log exec failures

### DIFF
--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -238,6 +238,8 @@ static void invoke_swaybar(struct bar_config *bar) {
 					bar->swaybar_command ? bar->swaybar_command : "swaybar",
 					"-b", bar->id, NULL};
 			execvp(cmd[0], cmd);
+
+			sway_log_errno(SWAY_ERROR, "Failed to start swaybar");
 			_exit(EXIT_FAILURE);
 		}
 		_exit(EXIT_SUCCESS);

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -168,6 +168,8 @@ struct status_line *status_line_init(char *cmd) {
 
 		char *const _cmd[] = { "sh", "-c", cmd, NULL, };
 		execvp(_cmd[0], _cmd);
+
+		sway_log(SWAY_ERROR, "Failed to start status command");
 		exit(1);
 	}
 


### PR DESCRIPTION
This can happen when the swaybar or its status command isn't found.
Instead of silently doing nothing, log the error.