### PR TITLE
Rename pango_printf to render_text

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -127,7 +127,7 @@ void get_text_metrics(const char *font, int *height, int *baseline) {
 	cairo_destroy(cairo);
 }
 
-void pango_printf(cairo_t *cairo, const char *font,
+void render_text(cairo_t *cairo, const char *font,
 		double scale, bool markup, const char *fmt, ...) {
 	va_list args;
 	va_start(args, fmt);

--- a/include/pango.h
+++ b/include/pango.h
@@ -18,7 +18,7 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font,
 void get_text_size(cairo_t *cairo, const char *font, int *width, int *height,
 		int *baseline, double scale, bool markup, const char *fmt, ...);
 void get_text_metrics(const char *font, int *height, int *baseline);
-void pango_printf(cairo_t *cairo, const char *font,
+void render_text(cairo_t *cairo, const char *font,
 		double scale, bool markup, const char *fmt, ...);
 
 #endif

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -544,7 +544,7 @@ static void render_titlebar_text_texture(struct sway_output *output,
 			class->text[2], class->text[3]);
 	cairo_move_to(cairo, 0, config->font_baseline * scale - baseline);
 
-	pango_printf(cairo, config->font, scale, pango_markup, "%s", text);
+	render_text(cairo, config->font, scale, pango_markup, "%s", text);
 
 	cairo_surface_flush(surface);
 	unsigned char *data = cairo_image_surface_get_data(surface);

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -77,7 +77,7 @@ static uint32_t render_status_line_error(struct render_context *ctx, double *x) 
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_move_to(cairo, *x, (int)floor(text_y));
 	choose_text_aa_mode(ctx, 0xFF0000FF);
-	pango_printf(cairo, font, 1, false, "%s", error);
+	render_text(cairo, font, 1, false, "%s", error);
 	*x -= margin;
 	return output->height;
 }
@@ -114,7 +114,7 @@ static uint32_t render_status_line_text(struct render_context *ctx, double *x) {
 	double text_y = height / 2.0 - text_height / 2.0;
 	cairo_move_to(cairo, *x, (int)floor(text_y));
 	choose_text_aa_mode(ctx, fontcolor);
-	pango_printf(cairo, config->font, 1, config->pango_markup, "%s", text);
+	render_text(cairo, config->font, 1, config->pango_markup, "%s", text);
 	*x -= margin;
 	return output->height;
 }
@@ -304,7 +304,7 @@ static uint32_t render_status_block(struct render_context *ctx,
 	color = block->urgent ? config->colors.urgent_workspace.text : color;
 	cairo_set_source_u32(cairo, color);
 	choose_text_aa_mode(ctx, color);
-	pango_printf(cairo, config->font, 1, block->markup, "%s", text);
+	render_text(cairo, config->font, 1, block->markup, "%s", text);
 	x_pos += width;
 
 	if (block->border && block->border_right > 0) {
@@ -326,7 +326,7 @@ static uint32_t render_status_block(struct render_context *ctx,
 			double sep_y = height / 2.0 - sep_height / 2.0;
 			cairo_move_to(cairo, offset, (int)floor(sep_y));
 			choose_text_aa_mode(ctx, color);
-			pango_printf(cairo, config->font, 1, false,
+			render_text(cairo, config->font, 1, false,
 					"%s", config->sep_symbol);
 		} else {
 			cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
@@ -587,7 +587,7 @@ static uint32_t render_binding_mode_indicator(struct render_context *ctx,
 	cairo_set_source_u32(cairo, config->colors.binding_mode.text);
 	cairo_move_to(cairo, x + width / 2 - text_width / 2, (int)floor(text_y));
 	choose_text_aa_mode(ctx, config->colors.binding_mode.text);
-	pango_printf(cairo, config->font, 1, output->bar->mode_pango_markup,
+	render_text(cairo, config->font, 1, output->bar->mode_pango_markup,
 			"%s", mode);
 	return output->height;
 }
@@ -661,7 +661,7 @@ static uint32_t render_workspace_button(struct render_context *ctx,
 	cairo_set_source_u32(cairo, box_colors.text);
 	cairo_move_to(cairo, *x + width / 2 - text_width / 2, (int)floor(text_y));
 	choose_text_aa_mode(ctx, box_colors.text);
-	pango_printf(cairo, config->font, 1, config->pango_markup,
+	render_text(cairo, config->font, 1, config->pango_markup,
 			"%s", ws->label);
 
 	struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -22,7 +22,7 @@ static uint32_t render_message(cairo_t *cairo, struct swaynag *swaynag) {
 
 	cairo_set_source_u32(cairo, swaynag->type->text);
 	cairo_move_to(cairo, padding, (int)(ideal_height - text_height) / 2);
-	pango_printf(cairo, swaynag->type->font, 1, false,
+	render_text(cairo, swaynag->type->font, 1, false,
 			"%s", swaynag->message);
 
 	return ideal_surface_height;
@@ -50,7 +50,7 @@ static void render_details_scroll_button(cairo_t *cairo,
 	cairo_set_source_u32(cairo, swaynag->type->button_text);
 	cairo_move_to(cairo, button->x + border + padding,
 			button->y + border + (button->height - text_height) / 2);
-	pango_printf(cairo, swaynag->type->font, 1, true,
+	render_text(cairo, swaynag->type->font, 1, true,
 			"%s", button->text);
 }
 
@@ -201,7 +201,7 @@ static uint32_t render_button(cairo_t *cairo, struct swaynag *swaynag,
 
 	cairo_set_source_u32(cairo, swaynag->type->button_text);
 	cairo_move_to(cairo, button->x + padding, button->y + padding);
-	pango_printf(cairo, swaynag->type->font, 1, true,
+	render_text(cairo, swaynag->type->font, 1, true,
 			"%s", button->text);
 
 	*x = button->x - border;


### PR DESCRIPTION
This avoids using the pango_ prefix, reserved for functions coming
from the Pango library.