### PR TITLE
readme: mention seatd

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Run these commands:
     ninja -C build/
     sudo ninja -C build/ install
 
-On systems without logind, you need to suid the sway binary:
+On systems without logind nor seatd, you need to suid the sway binary:
 
     sudo chmod a+s /usr/local/bin/sway
 


### PR DESCRIPTION
When seatd is used, it isn't necessary to suid the sway binary.