### PR TITLE
Allow running as root when not using setuid bit

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -150,7 +150,12 @@ static void log_kernel(void) {
 
 
 static bool drop_permissions(void) {
+	if (getuid() == 0 || getgid() == 0) {
+		sway_log(SWAY_INFO, "Running as root user, this is dangerous");
+		return true;
+	}
 	if (getuid() != geteuid() || getgid() != getegid()) {
+		sway_log(SWAY_INFO, "setuid/setgid bit detected, dropping permissions");
 		// Set the gid and uid in the correct order.
 		if (setgid(getgid()) != 0) {
 			sway_log(SWAY_ERROR, "Unable to drop root group, refusing to start");


### PR DESCRIPTION
For debugging (bypass DRM_AUTH), recovery (single user mode) and in some embedded scenarios (root shell instead of sudo/doas) it maybe desirable to run the compositor (and everything else within) as root. Currently, this is not supported to prevent foot-shooting when using `builtin` server in libseat.

```
$ sudo sway -c /dev/null
00:00:00.090 [sway/main.c:166] Unable to drop root (we shouldn't be able to restore it after setuid), refusing to start
```

Similar to #5669 but setuid vs. root is detected automatically. This makes Sway behave like wlroots compositors that don't drop priveleges (e.g., river, phoc, gamescope). Alternatively, `drop_permissions()` can be removed in favor of seatd-launch(1).
