### PR TITLE
swaybar: fix tray icons rendering on scaled outputs

### DIFF
--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -520,7 +520,7 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 	struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
 	hotspot->x = *x;
 	hotspot->y = 0;
-	hotspot->width = output->height;
+	hotspot->width = padded_surface_size;
 	hotspot->height = output->height;
 	hotspot->callback = icon_hotspot_callback;
 	hotspot->destroy = free;

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -117,7 +117,7 @@ uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 	} // else display on all
 
 	if ((int) output->height*output->scale <= 2*config->tray_padding) {
-		return 2*config->tray_padding + 1;
+		return (2*config->tray_padding + 1) / output->scale;
 	}
 
 	uint32_t max_height = 0;


### PR DESCRIPTION
#6504 simplified rendering code by setting scale at cairo, but not the code
for rendering tray icons, making it draws at scale of expected size.
This fixes by resetting scale before drawing icons, and restoring it
afterward.