### PR TITLE
Swaybar scaling fixes

### DIFF
--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -493,24 +493,36 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 		cairo_destroy(cairo_icon);
 	}
 
-	int padded_size = icon_size + 2*padding;
-	*x -= padded_size;
-	int y = floor((height - padded_size) / 2.0);
+	double descaled_padding = (double)padding / output->scale;
+	double descaled_icon_size = (double)icon_size / output->scale;
+
+	int size = descaled_icon_size + 2 * descaled_padding;
+	*x -= size;
+	int icon_y = floor((output->height - size) / 2.0);
 
 	cairo_operator_t op = cairo_get_operator(cairo);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_OVER);
-	cairo_set_source_surface(cairo, icon, *x + padding, y + padding);
-	cairo_rectangle(cairo, *x, y, padded_size, padded_size);
+
+	cairo_matrix_t scale_matrix;
+	cairo_pattern_t *icon_pattern = cairo_pattern_create_for_surface(icon);
+	// TODO: check cairo_pattern_status for "ENOMEM"
+	cairo_matrix_init_scale(&scale_matrix, output->scale, output->scale);
+	cairo_matrix_translate(&scale_matrix, -(*x + descaled_padding), -(icon_y + descaled_padding));
+	cairo_pattern_set_matrix(icon_pattern, &scale_matrix);
+	cairo_set_source(cairo, icon_pattern);
+	cairo_rectangle(cairo, *x, icon_y, size, size);
 	cairo_fill(cairo);
+
 	cairo_set_operator(cairo, op);
 
+	cairo_pattern_destroy(icon_pattern);
 	cairo_surface_destroy(icon);
 
 	struct swaybar_hotspot *hotspot = calloc(1, sizeof(struct swaybar_hotspot));
 	hotspot->x = *x;
 	hotspot->y = 0;
-	hotspot->width = height;
-	hotspot->height = height;
+	hotspot->width = size;
+	hotspot->height = output->height;
 	hotspot->callback = icon_hotspot_callback;
 	hotspot->destroy = free;
 	hotspot->data = strdup(sni->watcher_id);

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -116,8 +116,8 @@ uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 		}
 	} // else display on all
 
-	if ((int) output->height*output->scale <= 2*config->tray_padding) {
-		return 2*config->tray_padding + 1;
+	if ((int)(output->height * output->scale) <= 2 * config->tray_padding) {
+		return (2 * config->tray_padding + 1) / output->scale;
 	}
 
 	uint32_t max_height = 0;


### PR DESCRIPTION
Fixes some fallout from #6504:
- tray item rendering, due to scale changes, and creeping bad logic
- tray_padding vs min-height computation

---
This branch/solution; notice the icons are all crisp, they are all vertically centered and evenly spaced (but not evenly sized width-wise!):
(https://github.com/nmschulte/sway/commit/fa75a39295326aa54a32666b01c6d088ba8920a9)
![swaybar-scaling-fixes-with-debug](https://user-images.githubusercontent.com/8540239/133322022-93242b78-4584-4fdf-a12b-262c743bc4d2.png)

One of my prior/first attempts, not really knowing how the scaling is applied or the intricacies of libcairo and wayland-protocols/sway; notice the aliasing/blur due to the reversal/removal of scale:
![old-swaybar-scaling-fixes-with-debug](https://user-images.githubusercontent.com/8540239/133322024-6d42e0bd-6ddd-481d-be80-a4702481894d.png)

`master` with the same/similar diagnostic as my dev; note the large icons:
(https://github.com/nmschulte/sway/commit/8425299c80dac8e80d7f06739f4d9342c406bbe6)
![master-with-debug](https://user-images.githubusercontent.com/8540239/133322025-eae6f15d-cb7c-47cd-af97-6dbbd73475ee.png)