### PR TITLE
swaybar: properly draw blocks with transparent black border

### DIFF
--- a/include/swaybar/i3bar.h
+++ b/include/swaybar/i3bar.h
@@ -19,6 +19,7 @@ struct i3bar_block {
 	// Airblader features
 	uint32_t background;
 	uint32_t border;
+	bool border_set;
 	int border_top;
 	int border_bottom;
 	int border_left;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -14,6 +14,7 @@
 #include "swaybar/ipc.h"
 #include "swaybar/render.h"
 #include "swaybar/status_line.h"
+#include "log.h"
 #if HAVE_TRAY
 #include "swaybar/tray/tray.h"
 #endif
@@ -215,11 +216,11 @@ static uint32_t render_status_block(struct render_context *ctx,
 	}
 
 	*x -= width;
-	if ((block->border || block->urgent) && block->border_left > 0) {
+	if ((block->border_set || block->urgent) && block->border_left > 0) {
 		*x -= (block->border_left + margin);
 		block_width += block->border_left + margin;
 	}
-	if ((block->border || block->urgent) && block->border_right > 0) {
+	if ((block->border_set || block->urgent) && block->border_right > 0) {
 		*x -= (block->border_right + margin);
 		block_width += block->border_right + margin;
 	}
@@ -273,18 +274,20 @@ static uint32_t render_status_block(struct render_context *ctx,
 
 	uint32_t border_color = block->urgent
 		? config->colors.urgent_workspace.border : block->border;
-	if (border_color && block->border_top > 0) {
-		render_sharp_line(cairo, border_color, x_pos, y_pos,
-				block_width, block->border_top);
-	}
-	if (border_color && block->border_bottom > 0) {
-		render_sharp_line(cairo, border_color, x_pos,
-				y_pos + render_height - block->border_bottom,
-				block_width, block->border_bottom);
-	}
-	if (border_color && block->border_left > 0) {
-		render_sharp_line(cairo, border_color, x_pos, y_pos,
-				block->border_left, render_height);
+	if (block->border_set || block->urgent) {
+		if (block->border_top > 0) {
+			render_sharp_line(cairo, border_color, x_pos, y_pos,
+					block_width, block->border_top);
+		}
+		if (block->border_bottom > 0) {
+			render_sharp_line(cairo, border_color, x_pos,
+					y_pos + render_height - block->border_bottom,
+					block_width, block->border_bottom);
+		}
+		if (block->border_left > 0) {
+			render_sharp_line(cairo, border_color, x_pos, y_pos,
+					block->border_left, render_height);
+		}
 		x_pos += block->border_left + margin;
 	}
 
@@ -307,10 +310,12 @@ static uint32_t render_status_block(struct render_context *ctx,
 	render_text(cairo, config->font, 1, block->markup, "%s", text);
 	x_pos += width;
 
-	if (border_color && block->border_right > 0) {
+	if (block->border_set || block->urgent) {
 		x_pos += margin;
-		render_sharp_line(cairo, border_color, x_pos, y_pos,
-				block->border_right, render_height);
+		if (block->border_right > 0) {
+			render_sharp_line(cairo, border_color, x_pos, y_pos,
+					block->border_right, render_height);
+		}
 		x_pos += block->border_right;
 	}
 
@@ -375,10 +380,10 @@ static void predict_status_block_pos(cairo_t *cairo,
 	}
 
 	*x -= width;
-	if ((block->border || block->urgent) && block->border_left > 0) {
+	if ((block->border_set || block->urgent) && block->border_left > 0) {
 		*x -= (block->border_left + margin);
 	}
-	if ((block->border || block->urgent) && block->border_right > 0) {
+	if ((block->border_set || block->urgent) && block->border_right > 0) {
 		*x -= (block->border_right + margin);
 	}
 


### PR DESCRIPTION
while the draw itself is a no-op, alignment must still be accounted

![image](https://user-images.githubusercontent.com/8540239/133412692-bf4295af-0f97-4416-b708-4fc14bc5e730.png)

the blue bordered blocks demonstrate the transparent black (`0x0`) border support working (the background is blue)

```
bar {
    status_command ./top.sh
    position bottom
    separator_symbol '¦'
    icon_theme Adwaita
    colors {
        urgent_workspace #FF7F00 #1F1F1F #FFFFFF
    }
}
bar {
    status_command ./bottom.sh
    position bottom
    icon_theme Adwaita
    separator_symbol '¦'
}
```
```bash
#!/usr/bin/env bash
echo '{ "version": 1, "click_events": true, "cont_signal": 18, "stop_signal": 19 }'
echo '[[]'
while sleep 1; do
    echo ',[
    {"full_text": "UDD", "urgent": true,  "border": "#1F7F1FFF"},
    {"full_text": "UTB", "urgent": true,  "border": "#00000000"},
    {"full_text": "U--", "urgent": true},
    {"full_text": "N--", "urgent": false},
    {"full_text": "NTB", "urgent": false, "border": "#00000000"},
    {"full_text": "NDD", "urgent": false, "border": "#1F7F1FFF"}
    ]'
done
```

```bash
#!/usr/bin/env bash
echo '{ "version": 1, "click_events": true, "cont_signal": 18, "stop_signal": 19 }'
echo '[[]'
while sleep 1; do
    echo ',[
    {"full_text": "U--", "urgent": true},
    {"full_text": "N--", "urgent": false},
    {"full_text": "UTB", "urgent": true,  "border": "#00000000"},
    {"full_text": "NTB", "urgent": false, "border": "#00000000"},
    {"full_text": "UDD", "urgent": true,  "border": "#1F7F1FFF"},
    {"full_text": "NDD", "urgent": false, "border": "#1F7F1FFF"}
    ]'
done
```

this does not alter margin application in general: non-bordered blocks still receive no margin