### PR TITLE
Avoid unecessary font metric calculations

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -113,10 +113,8 @@ void get_text_metrics(const char *font, int *height, int *baseline) {
 	cairo_t *cairo = cairo_create(NULL);
 	PangoContext *pango = pango_cairo_create_context(cairo);
 	PangoFontDescription *description = pango_font_description_from_string(font);
-	PangoFontMetrics *metrics;
-
 	// When passing NULL as a language, pango uses the current locale.
-	metrics = pango_context_get_metrics(pango, description, NULL);
+	PangoFontMetrics *metrics = pango_context_get_metrics(pango, description, NULL);
 
 	*baseline = pango_font_metrics_get_ascent(metrics) / PANGO_SCALE;
 	*height = *baseline + pango_font_metrics_get_descent(metrics) / PANGO_SCALE;

--- a/sway/commands/reload.c
+++ b/sway/commands/reload.c
@@ -48,7 +48,6 @@ static void do_reload(void *data) {
 	}
 	list_free_items_and_destroy(bar_ids);
 
-	config_update_font_height();
 	root_for_each_container(rebuild_textures_iterator, NULL);
 
 	arrange_root();

--- a/sway/commands/title_format.c
+++ b/sway/commands/title_format.c
@@ -23,6 +23,5 @@ struct cmd_results *cmd_title_format(int argc, char **argv) {
 	}
 	view->title_format = format;
 	view_update_title(view, true);
-	config_update_font_height();
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -236,8 +236,6 @@ static void config_defaults(struct sway_config *config) {
 	config->default_layout = L_NONE;
 	config->default_orientation = L_NONE;
 	if (!(config->font = strdup("monospace 10"))) goto cleanup;
-	config->font_height = 17; // height of monospace 10
-	config->font_baseline = 11; // baselint of monospace 10
 	config->urgent_timeout = 500;
 	config->focus_on_window_activation = FOWA_URGENT;
 	config->popup_during_fullscreen = POPUP_SMART;
@@ -541,6 +539,9 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		config = old_config;
 		return success;
 	}
+
+	// Only really necessary if not explicitly `font` is set in the config.
+	config_update_font_height();
 
 	if (is_active && !validating) {
 		input_manager_verify_fallback_seat();

--- a/sway/config.c
+++ b/sway/config.c
@@ -237,6 +237,7 @@ static void config_defaults(struct sway_config *config) {
 	config->default_orientation = L_NONE;
 	if (!(config->font = strdup("monospace 10"))) goto cleanup;
 	config->font_height = 17; // height of monospace 10
+	config->font_baseline = 11; // baselint of monospace 10
 	config->urgent_timeout = 500;
 	config->focus_on_window_activation = FOWA_URGENT;
 	config->popup_during_fullscreen = POPUP_SMART;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1280,7 +1280,6 @@ void view_update_title(struct sway_view *view, bool force) {
 		view->container->title = NULL;
 		view->container->formatted_title = NULL;
 	}
-	config_update_font_height();
 
 	// Update title after the global font height is updated
 	container_update_title_textures(view->container);


### PR DESCRIPTION
Prior to 62d90a8e, titlebar's font height (and other related values)
would change any time any titlebar's content changed, so these values
were recalculated each time any titlebar's content changed (or a new
titlebar was created).

However, since the above was merge, these values no longer change so
often and we only need to recalculate them when the configured font
changes (and stop calling `config_update_font_height` each time
titlebars are rendered).

This commit removes all the unecessary calls to this function and avoids
all those unecessary calculations. Whenever the font strays from the
default value, the `font` command is called, and it calls
`config_update_font_height`, which is enough to keep the value always up
to date.

I've also added a default value to the `font_baseline` config, since
otherwise that's zero for setups that don't explicitly specify a font.