### PR TITLE
Add -Dnoscanout debug option

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -119,6 +119,7 @@ struct sway_debug {
 	bool noatomic;         // Ignore atomic layout updates
 	bool txn_timings;      // Log verbose messages about transactions
 	bool txn_wait;         // Always wait for the timeout before applying
+	bool noscanout;        // Disable direct scan-out
 
 	enum {
 		DAMAGE_DEFAULT,    // Default behaviour

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -507,7 +507,7 @@ static int output_repaint_timer_handler(void *data) {
 		fullscreen_con = workspace->current.fullscreen;
 	}
 
-	if (fullscreen_con && fullscreen_con->view) {
+	if (fullscreen_con && fullscreen_con->view && !debug.noscanout) {
 		// Try to scan-out the fullscreen view
 		static bool last_scanned_out = false;
 		bool scanned_out =

--- a/sway/main.c
+++ b/sway/main.c
@@ -182,6 +182,8 @@ void enable_debug_flag(const char *flag) {
 		debug.txn_timings = true;
 	} else if (strncmp(flag, "txn-timeout=", 12) == 0) {
 		server.txn_timeout_ms = atoi(&flag[12]);
+	} else if (strcmp(flag, "noscanout") == 0) {
+		debug.noscanout = true;
 	} else {
 		sway_log(SWAY_ERROR, "Unknown debug flag: %s", flag);
 	}


### PR DESCRIPTION
This can help debugging direct scan-out issues, such as [1].

[1]: https://github.com/swaywm/wlroots/issues/3185