### PR TITLE
Ellipsize long window titles

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -152,3 +152,33 @@ void render_text(cairo_t *cairo, const char *font,
 	g_object_unref(layout);
 	free(buf);
 }
+
+void render_text_ellipsize(cairo_t *cairo, const char *font, double scale,
+		bool markup, double width, const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	// Add one since vsnprintf excludes null terminator.
+	int length = vsnprintf(NULL, 0, fmt, args) + 1;
+	va_end(args);
+
+	char *buf = malloc(length);
+	if (buf == NULL) {
+		sway_log(SWAY_ERROR, "Failed to allocate memory");
+		return;
+	}
+	va_start(args, fmt);
+	vsnprintf(buf, length, fmt, args);
+	va_end(args);
+
+	PangoLayout *layout = get_pango_layout(cairo, font, buf, scale, markup);
+	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+	pango_layout_set_width(layout, width * PANGO_SCALE);
+	cairo_font_options_t *fo = cairo_font_options_create();
+	cairo_get_font_options(cairo, fo);
+	pango_cairo_context_set_font_options(pango_layout_get_context(layout), fo);
+	cairo_font_options_destroy(fo);
+	pango_cairo_update_layout(cairo, layout);
+	pango_cairo_show_layout(cairo, layout);
+	g_object_unref(layout);
+	free(buf);
+}

--- a/include/pango.h
+++ b/include/pango.h
@@ -20,5 +20,7 @@ void get_text_size(cairo_t *cairo, const char *font, int *width, int *height,
 void get_text_metrics(const char *font, int *height, int *baseline);
 void render_text(cairo_t *cairo, const char *font,
 		double scale, bool markup, const char *fmt, ...);
+void render_text_ellipsize(cairo_t *cairo, const char *font, double scale,
+		bool markup, double width, const char *fmt, ...);
 
 #endif

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -517,6 +517,8 @@ static void render_titlebar_text_texture(struct sway_output *output,
 	cairo_set_font_options(c, fo);
 	get_text_size(c, config->font, &width, NULL, &baseline, scale,
 			config->pango_markup, "%s", text);
+	int max_width = con->current.width - 2 * config->titlebar_h_padding;
+	width = width > max_width ? max_width : width;
 	cairo_surface_destroy(dummy_surface);
 	cairo_destroy(c);
 
@@ -529,7 +531,7 @@ static void render_titlebar_text_texture(struct sway_output *output,
 	}
 
 	cairo_surface_t *surface = cairo_image_surface_create(
-			CAIRO_FORMAT_ARGB32, width, height);
+		CAIRO_FORMAT_ARGB32, width, height);
 	cairo_t *cairo = cairo_create(surface);
 	cairo_set_antialias(cairo, CAIRO_ANTIALIAS_BEST);
 	cairo_set_font_options(cairo, fo);
@@ -542,7 +544,8 @@ static void render_titlebar_text_texture(struct sway_output *output,
 			class->text[2], class->text[3]);
 	cairo_move_to(cairo, 0, config->font_baseline * scale - baseline);
 
-	render_text(cairo, config->font, scale, pango_markup, "%s", text);
+	render_text_ellipsize(cairo, config->font, scale, pango_markup, width, "%s",
+			text);
 
 	cairo_surface_flush(surface);
 	unsigned char *data = cairo_image_surface_get_data(surface);
@@ -799,6 +802,7 @@ void container_set_resizing(struct sway_container *con, bool resizing) {
 		return;
 	}
 
+	container_update_title_textures(con);
 	if (con->view) {
 		if (con->view->impl->set_resizing) {
 			con->view->impl->set_resizing(con->view, resizing);


### PR DESCRIPTION
cairo_image_surface_create() return CAIRO_STATUS_INVALID_SIZE on too
long window titles and creates then no surface. Therefore it makes
sense to limit the window title length to a reasonable length.

Fix: https://github.com/swaywm/sway/issues/6531

Signed-off-by: Felix Weilbach <felix.weilbach@t-online.de>