### PR TITLE
readme: drop recommendation about packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Releases are signed with [E88F5E48] and published [on GitHub][GitHub releases].
 Sway is available in many distributions. Try installing the "sway" package for
 yours.
 
-If you're interested in packaging sway for your distribution, stop by the IRC
-channel or shoot an email to sir@cmpwn.com for advice.
-
 ### Compiling from Source
 
 Check out [this wiki page][Development setup] if you want to build the HEAD of


### PR DESCRIPTION
- The contact info is out-of-date
- Sway is packaged in many distributions now
- I don't think we necessarily need to mention this in the README