### PR TITLE
commands: Remove unused code after 1d3681f52135

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -418,14 +418,6 @@ enum sway_popup_during_fullscreen {
 	POPUP_LEAVE,
 };
 
-enum command_context {
-	CONTEXT_CONFIG = 1 << 0,
-	CONTEXT_BINDING = 1 << 1,
-	CONTEXT_IPC = 1 << 2,
-	CONTEXT_CRITERIA = 1 << 3,
-	CONTEXT_ALL = 0xFFFFFFFF,
-};
-
 enum focus_follows_mouse_mode {
 	FOLLOWS_NO,
 	FOLLOWS_YES,

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -465,34 +465,6 @@ struct cmd_results *config_commands_command(char *exec) {
 		goto cleanup;
 	}
 
-	enum command_context context = 0;
-
-	struct {
-		char *name;
-		enum command_context context;
-	} context_names[] = {
-		{ "config", CONTEXT_CONFIG },
-		{ "binding", CONTEXT_BINDING },
-		{ "ipc", CONTEXT_IPC },
-		{ "criteria", CONTEXT_CRITERIA },
-		{ "all", CONTEXT_ALL },
-	};
-
-	for (int i = 1; i < argc; ++i) {
-		size_t j;
-		for (j = 0; j < sizeof(context_names) / sizeof(context_names[0]); ++j) {
-			if (strcmp(context_names[j].name, argv[i]) == 0) {
-				break;
-			}
-		}
-		if (j == sizeof(context_names) / sizeof(context_names[0])) {
-			results = cmd_results_new(CMD_INVALID,
-					"Invalid command context %s", argv[i]);
-			goto cleanup;
-		}
-		context |= context_names[j].context;
-	}
-
 	results = cmd_results_new(CMD_SUCCESS, NULL);
 
 cleanup:


### PR DESCRIPTION
Clang 13 reports:

../sway/commands.c:470:23: error: variable 'context' set but not used
[-Werror,-Wunused-but-set-variable]
        enum command_context context = 0;
                             ^
Last use of was removed in commit 1d3681f52135.

Downstream PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258813

--
I removed lines 470-495 and related because I couldn't find code that would pass "ipc"
and "binding" so they end up in argv[i]. This might be wrong.