### PR TITLE
github: don't truncate debug logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,6 +18,7 @@ labels: 'bug'
 - **Debug Log:**
   - Run `sway -d 2> ~/sway.log` from a TTY and upload it to a pastebin, such as gist.github.com.
   - This will record information about sway's activity. Please try to keep the reproduction as brief as possible and exit sway.
+  - Attach the **full** file, do not truncate it.
 
 - **Configuration File:**
   - Please try to produce with the default configuration.


### PR DESCRIPTION
This happens a lot, the latest one is [1].

[1]: https://github.com/swaywm/sway/issues/6570