### PR TITLE
swaybar: tidy swaybar_output struct

### DIFF
--- a/include/swaybar/bar.h
+++ b/include/swaybar/bar.h
@@ -69,14 +69,13 @@ struct swaybar_output {
 	bool focused;
 
 	uint32_t width, height;
-	int32_t scale;
-	enum wl_output_subpixel subpixel;
 	struct pool_buffer buffers[2];
 	struct pool_buffer *current_buffer;
 	bool dirty;
 	bool frame_scheduled;
 
-	uint32_t output_height, output_width, output_x, output_y;
+	uint32_t output_height, output_width, output_x, output_y, output_scale;
+	enum wl_output_subpixel output_subpixel;
 };
 
 struct swaybar_workspace {

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -199,12 +199,17 @@ static void output_geometry(void *data, struct wl_output *wl_output, int32_t x,
 		int32_t y, int32_t width_mm, int32_t height_mm, int32_t subpixel,
 		const char *make, const char *model, int32_t transform) {
 	struct swaybar_output *output = data;
-	output->subpixel = subpixel;
+	output->output_x = x;
+	output->output_y = y;
+	output->output_subpixel = subpixel;
 }
 
 static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags,
 		int32_t width, int32_t height, int32_t refresh) {
-	// Who cares
+	// Still unsure who cares
+	struct swaybar_output *output = data;
+	output->output_width = width;
+	output->output_height = height;
 }
 
 static void output_done(void *data, struct wl_output *wl_output) {
@@ -215,7 +220,7 @@ static void output_done(void *data, struct wl_output *wl_output) {
 static void output_scale(void *data, struct wl_output *wl_output,
 		int32_t factor) {
 	struct swaybar_output *output = data;
-	output->scale = factor;
+	output->output_scale = factor;
 
 	bool render = false;
 	struct swaybar_seat *seat;
@@ -246,6 +251,7 @@ static void xdg_output_handle_logical_position(void *data,
 
 static void xdg_output_handle_logical_size(void *data,
 		struct zxdg_output_v1 *xdg_output, int32_t width, int32_t height) {
+	// Who cares
 	struct swaybar_output *output = data;
 	output->output_height = height;
 	output->output_width = width;
@@ -353,7 +359,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 		output->output = wl_registry_bind(registry, name,
 				&wl_output_interface, 3);
 		wl_output_add_listener(output->output, &output_listener, output);
-		output->scale = 1;
+		output->output_scale = 1;
 		output->wl_name = name;
 		wl_list_init(&output->workspaces);
 		wl_list_init(&output->hotspots);

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -78,7 +78,7 @@ void update_cursor(struct swaybar_seat *seat) {
 			cursor_size = size;
 		}
 	}
-	int scale = pointer->current ? pointer->current->scale : 1;
+	int scale = pointer->current ? pointer->current->output_scale : 1;
 	pointer->cursor_theme = wl_cursor_theme_load(
 		cursor_theme, cursor_size * scale, seat->bar->shm);
 	struct wl_cursor *cursor;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -764,7 +764,7 @@ void render_frame(struct swaybar_output *output) {
 	cairo_surface_t *recorder = cairo_recording_surface_create(
 			CAIRO_CONTENT_COLOR_ALPHA, NULL);
 	cairo_t *cairo = cairo_create(recorder);
-	cairo_scale(cairo, output->scale, output->scale);
+	cairo_scale(cairo, output->output_scale, output->output_scale);
 	cairo_set_antialias(cairo, CAIRO_ANTIALIAS_BEST);
 	ctx.cairo = cairo;
 
@@ -772,14 +772,14 @@ void render_frame(struct swaybar_output *output) {
 	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
 	ctx.textaa_safe = fo;
-	if (output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
+	if (output->output_subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
 		ctx.textaa_sharp = ctx.textaa_safe;
 	} else {
 		fo = cairo_font_options_create();
 		cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
 		cairo_font_options_set_subpixel_order(fo,
-			to_cairo_subpixel_order(output->subpixel));
+			to_cairo_subpixel_order(output->output_subpixel));
 		ctx.textaa_sharp = fo;
 	}
 
@@ -810,8 +810,8 @@ void render_frame(struct swaybar_output *output) {
 		// Replay recording into shm and send it off
 		output->current_buffer = get_next_buffer(output->bar->shm,
 				output->buffers,
-				output->width * output->scale,
-				output->height * output->scale);
+				output->width * output->output_scale,
+				output->height * output->output_scale);
 		if (!output->current_buffer) {
 			cairo_surface_destroy(recorder);
 			cairo_destroy(cairo);
@@ -827,7 +827,7 @@ void render_frame(struct swaybar_output *output) {
 		cairo_set_source_surface(shm, recorder, 0.0, 0.0);
 		cairo_paint(shm);
 
-		wl_surface_set_buffer_scale(output->surface, output->scale);
+		wl_surface_set_buffer_scale(output->surface, output->output_scale);
 		wl_surface_attach(output->surface,
 				output->current_buffer->buffer, 0, 0);
 		wl_surface_damage(output->surface, 0, 0,

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -454,7 +454,7 @@ static void reload_sni(struct swaybar_sni *sni, char *icon_theme,
 
 uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 		struct swaybar_sni *sni) {
-	uint32_t height = output->height * output->scale;
+	uint32_t height = output->height * output->output_scale;
 	int padding = output->bar->config->tray_padding;
 	int target_size = height - 2*padding;
 	if (target_size != sni->target_size && sni_ready(sni)) {


### PR DESCRIPTION
split from #6518; tidies `swaybar_output` to make the code a bit clearer