### PR TITLE
Improve built-in touchscreen detection

### DIFF
--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -332,6 +332,13 @@ bool sway_libinput_device_is_builtin(struct sway_input_device *sway_device) {
 		return false;
 	}
 
-	const char prefix[] = "platform-";
-	return strncmp(id_path, prefix, strlen(prefix)) == 0;
+	const char prefix_platform[] = "platform-";
+	if (strncmp(id_path, prefix_platform, strlen(prefix_platform)) != 0) {
+		return false;
+	}
+
+	const char prefix_pci[] = "pci-";
+	const char infix_platform[] = "-platform-";
+	return (strncmp(id_path, prefix_pci, strlen(prefix_pci)) == 0) &&
+		strstr(id_path, infix_platform);
 }


### PR DESCRIPTION
Adds detection code to handle pci-*-platform-* strings in ID_PATH

References: https://github.com/swaywm/sway/issues/6590

Signed-off-by: Jari Ronkainen <ronchaine@gmail.com>