### PR TITLE
container: restore next to sibling after floating

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -821,8 +821,6 @@ void container_set_floating(struct sway_container *container, bool enable) {
 
 	struct sway_seat *seat = input_manager_current_seat();
 	struct sway_workspace *workspace = container->pending.workspace;
-	struct sway_container *focus = seat_get_focused_container(seat);
-	bool set_focus = focus == container;
 
 	if (enable) {
 		struct sway_container *old_parent = container->pending.parent;
@@ -843,10 +841,6 @@ void container_set_floating(struct sway_container *container, bool enable) {
 		container_floating_set_default_size(container);
 		container_floating_resize_and_center(container);
 		if (old_parent) {
-			if (set_focus) {
-				seat_set_raw_focus(seat, &old_parent->node);
-				seat_set_raw_focus(seat, &container->node);
-			}
 			container_reap_empty(old_parent);
 		}
 	} else {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -861,7 +861,13 @@ void container_set_floating(struct sway_container *container, bool enable) {
 			if (reference->view) {
 				container_add_sibling(reference, container, 1);
 			} else {
-				container_add_child(reference, container);
+				struct sway_container *sibling =
+					seat_get_focus_inactive_view(seat, &reference->node);
+				if (sibling) {
+					container_add_sibling(sibling, container, 1);
+				} else {
+					container_add_child(reference, container);
+				}
 			}
 			container->pending.width = reference->pending.width;
 			container->pending.height = reference->pending.height;


### PR DESCRIPTION
I was testing the issue I reported in https://github.com/swaywm/sway/issues/6573 a bit further, and noticed a small difference in the behavior compared to i3. This PR attempts to fix it.