### PR TITLE
swaymsg: use INT_MAX max JSON depth when parsing IPC response

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -528,8 +528,8 @@ int main(int argc, char **argv) {
 				if (!quiet) {
 					sway_log(SWAY_ERROR, "failed to parse payload as json: %s",
 						json_tokener_error_desc(err));
-					ret = 1;
 				}
+				ret = 1;
 				break;
 			} else if (quiet) {
 				json_object_put(obj);


### PR DESCRIPTION
With the latest sway release (possibly also for sway-git and previous releases), `swaymsg -t get_tree` sometimes fails and returns "ERROR: Could not parse json response from ipc. This is a bug in sway."

In my case it turned out to be "failed to parse payload as json: nesting too deep", which is something that has come up before in other parts of the codebase (https://github.com/swaywm/sway/pull/6125)

This PR adopts the same solution as #6125, and also returns a better error message in case another issue comes up in the future.