### PR TITLE
Remove --my-next-gpu-wont-be-nvidia

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -63,7 +63,7 @@ void detect_proprietary(int allow_unsupported_gpu) {
 				sway_log(SWAY_ERROR,
 					"Proprietary Nvidia drivers are NOT supported. "
 					"Use Nouveau. To launch sway anyway, launch with "
-					"--my-next-gpu-wont-be-nvidia and DO NOT report issues.");
+					"--unsupported-gpu and DO NOT report issues.");
 				exit(EXIT_FAILURE);
 			}
 			break;
@@ -220,7 +220,6 @@ int main(int argc, char **argv) {
 		{"verbose", no_argument, NULL, 'V'},
 		{"get-socketpath", no_argument, NULL, 'p'},
 		{"unsupported-gpu", no_argument, NULL, 'u'},
-		{"my-next-gpu-wont-be-nvidia", no_argument, NULL, 'u'},
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
Nvidia has historically been a bad actor in the open-source graphics
ecosystem because they required a special EGLStreams code-path
instead of exposing the de-facto standard GBM API. However, with
their upcoming release they now support GBM as well.

This is a push in the right direction for Nvidia, so there's no
reason we should be more hostile to them than to any other proprietary
driver. Let's remove the --my-next-gpu-wont-be-nvidia flag, and advise
users to use --unsupported-gpu now.

Note, proprietary Nvidia drivers are still unsupported by the Sway
project (just like all other proprietary drivers).