### PR TITLE
Ignore modifiers on bindsym release, to match i3 behaviour

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -159,7 +159,7 @@ static void get_active_binding(const struct sway_shortcut_state *state,
 		bool binding_inhibited = (binding->flags & BINDING_INHIBITED) != 0;
 		bool binding_release = binding->flags & BINDING_RELEASE;
 
-		if (modifiers ^ binding->modifiers ||
+		if ((modifiers ^ binding->modifiers && !release) ||
 				release != binding_release ||
 				locked > binding_locked ||
 				inhibited > binding_inhibited ||

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -124,7 +124,7 @@ static struct sway_binding* get_active_mouse_binding(
 	struct sway_binding *current = NULL;
 	for (int i = 0; i < bindings->length; ++i) {
 		struct sway_binding *binding = bindings->items[i];
-		if (modifiers ^ binding->modifiers ||
+		if ((modifiers ^ binding->modifiers && !release) ||
 				e->pressed_button_count != (size_t)binding->keys->length ||
 				release != (binding->flags & BINDING_RELEASE) ||
 				!(click_region & binding->flags) ||


### PR DESCRIPTION
Fixes #6456.

The i3 window manager ignores modifiers when a button is being released. Mimic this behaviour in Sway.

---

As this is my first commit to Sway, let me know if there's anything else you need!

Thanks