### PR TITLE
xwayland: Clear wlr_xwayland_surface in handle_destroy

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -436,6 +436,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 		wl_list_remove(&xwayland_view->commit.link);
 	}
 
+	xwayland_view->view.wlr_xwayland_surface = NULL;
+
 	wl_list_remove(&xwayland_view->destroy.link);
 	wl_list_remove(&xwayland_view->request_configure.link);
 	wl_list_remove(&xwayland_view->request_fullscreen.link);


### PR DESCRIPTION
If the destroyed xwayland view is in transaction, it won't
be destroyed immediately. wlr_xwayland_surface then becomes
dangling pointer.

Closes #6605
Closes #5884