### PR TITLE
container: Fix crash when view unmaps + maps quickly

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -74,10 +74,8 @@ void container_destroy(struct sway_container *con) {
 	wlr_texture_destroy(con->marks_unfocused);
 	wlr_texture_destroy(con->marks_urgent);
 
-	if (con->view) {
-		if (con->view->container == con) {
-			con->view->container = NULL;
-		}
+	if (con->view && con->view->container == con) {
+		con->view->container = NULL;
 		if (con->view->destroying) {
 			view_destroy(con->view);
 		}


### PR DESCRIPTION
Followup on 4e4898e90f.

If a view quickly maps and unmaps repeatedly, there will be multiple
destroyed containers with same view in a single transaction. Each of
these containers will then try to destroy this view, resulting in use
after free.
The container should only destroy the view if the view still belongs
to the container.

Simple reproducer: couple XMapWindow + XUnmapWindow in a loop followed
by XDestroyWindow.

See #6605