### PR TITLE
Avoid and handle NULL pointer json_tokener_new_ex 

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -487,32 +487,33 @@ int main(int argc, char **argv) {
 	// pretty print the json
 	json_tokener *tok = json_tokener_new_ex(JSON_MAX_DEPTH);
 	if (tok == NULL) {
-		sway_log(SWAY_ERROR, "failed allocating json_tokener");
+		if (quiet) {
+			exit(EXIT_FAILURE);
+		}
+		sway_abort("failed allocating json_tokener");
+	}
+	json_object *obj = json_tokener_parse_ex(tok, resp, -1);
+	enum json_tokener_error err = json_tokener_get_error(tok);
+	json_tokener_free(tok);
+	if (obj == NULL || err != json_tokener_success) {
+		if (!quiet) {
+			sway_log(SWAY_ERROR, "failed to parse payload as json: %s",
+				json_tokener_error_desc(err));
+		}
 		ret = 1;
 	} else {
-		json_object *obj = json_tokener_parse_ex(tok, resp, -1);
-		enum json_tokener_error err = json_tokener_get_error(tok);
-		json_tokener_free(tok);
-		if (obj == NULL || err != json_tokener_success) {
-			if (!quiet) {
-				sway_log(SWAY_ERROR, "failed to parse payload as json: %s",
-					json_tokener_error_desc(err));
-			}
-			ret = 1;
-		} else {
-			if (!success(obj, true)) {
-				ret = 2;
-			}
-			if (!quiet && (type != IPC_SUBSCRIBE  || ret != 0)) {
-				if (raw) {
-					printf("%s\n", json_object_to_json_string_ext(obj,
-						JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
-				} else {
-					pretty_print(type, obj);
-				}
-			}
-			json_object_put(obj);
+		if (!success(obj, true)) {
+			ret = 2;
 		}
+		if (!quiet && (type != IPC_SUBSCRIBE  || ret != 0)) {
+			if (raw) {
+				printf("%s\n", json_object_to_json_string_ext(obj,
+					JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
+			} else {
+				pretty_print(type, obj);
+			}
+		}
+		json_object_put(obj);
 	}
 	free(command);
 	free(resp);
@@ -531,9 +532,10 @@ int main(int argc, char **argv) {
 
 			json_tokener *tok = json_tokener_new_ex(JSON_MAX_DEPTH);
 			if (tok == NULL) {
-				sway_log(SWAY_ERROR, "failed allocating json_tokener");
-				ret = 1;
-				break;
+				if (quiet) {
+					exit(EXIT_FAILURE);
+				}
+				sway_abort("failed allocating json_tokener");
 			}
 			json_object *obj = json_tokener_parse_ex(tok, reply->payload, -1);
 			enum json_tokener_error err = json_tokener_get_error(tok);


### PR DESCRIPTION
Fixes #6618
Introduced by #6611

When passing `INT_MAX` to `json_tokener_new_ex`, it tries to allocate `INT_MAX * sizeof(struct json_tokener_srec)`. That's a bit excessive if you ask me. I pulled that value down to 512. But maybe @ammgws can chime in and say if it needs to be higher.

Other than that I also added basic handling of the potential NULL pointer from the allocs that `json_tokener_new_ex` is doing.
