### PR TITLE
build: use list for sdbus dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '1.6',
 	license: 'MIT',
-	meson_version: '>=0.59.0',
+	meson_version: '>=0.60.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -92,30 +92,15 @@ if get_option('sd-bus-provider') == 'auto'
 	if not get_option('tray').disabled()
 		assert(get_option('auto_features').auto(), 'sd-bus-provider must not be set to auto since auto_features != auto')
 	endif
-	sdbus = dependency('libsystemd',
-		required: false,
+	sdbus = dependency(['libsystemd', 'libelogind', 'basu'],
+		required: get_option('tray'),
 		version: '>=239',
-		not_found_message: 'libsystemd not found, trying libelogind',
 	)
-	if not sdbus.found()
-		sdbus = dependency('libelogind',
-			required: false,
-			version: '>=239',
-			not_found_message: 'libelogind not found, trying basu',
-		)
-	endif
-	if not sdbus.found()
-		sdbus = dependency('basu', required: false)
-	endif
 else
 	sdbus = dependency(get_option('sd-bus-provider'), required: get_option('tray'))
 endif
 
-tray_deps_found = sdbus.found()
-if get_option('tray').enabled() and not tray_deps_found
-	error('Building with -Dtray=enabled, but sd-bus has not been not found')
-endif
-have_tray = (not get_option('tray').disabled()) and tray_deps_found
+have_tray = sdbus.found()
 
 conf_data = configuration_data()
 


### PR DESCRIPTION
This allows to simplify our logic. Meson will pick the first found
library.