### PR TITLE
refactor: use same JSON_MAX_DEPTH everywhere

### DIFF
--- a/include/ipc-client.h
+++ b/include/ipc-client.h
@@ -1,6 +1,9 @@
 #ifndef _SWAY_IPC_CLIENT_H
 #define _SWAY_IPC_CLIENT_H
 
+// arbitrary number, it's probably sufficient, higher number = more memory usage
+#define JSON_MAX_DEPTH 512
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/time.h>

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -550,7 +550,7 @@ bool handle_ipc_readable(struct swaybar *bar) {
 	// The default depth of 32 is too small to represent some nested layouts, but
 	// we can't pass INT_MAX here because json-c (as of this writing) prefaults
 	// all the memory for its stack.
-	json_tokener *tok = json_tokener_new_ex(256);
+	json_tokener *tok = json_tokener_new_ex(JSON_MAX_DEPTH);
 	if (!tok) {
 		sway_log_errno(SWAY_ERROR, "failed to create tokener");
 		free_ipc_response(resp);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -1,8 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
 
-// arbitrary number, it's probably sufficient, higher number = more memory usage
-#define JSON_MAX_DEPTH 512
-
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Unifies the values introduced by these PRs:

https://github.com/swaywm/sway/pull/6127
https://github.com/swaywm/sway/pull/6628