### PR TITLE
Add always_hide_tab command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -104,6 +104,7 @@ sway_cmd cmd_exec_validate;
 sway_cmd cmd_exec_process;
 
 sway_cmd cmd_assign;
+sway_cmd cmd_always_hide_tab;
 sway_cmd cmd_bar;
 sway_cmd cmd_bindcode;
 sway_cmd cmd_bindswitch;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -536,6 +536,7 @@ struct sway_config {
 	enum edge_border_types hide_edge_borders;
 	enum edge_border_smart_types hide_edge_borders_smart;
 	bool hide_lone_tab;
+	bool always_hide_tab;
 
 	// border colors
 	struct {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -43,6 +43,7 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 
 /* Keep alphabetized */
 static const struct cmd_handler handlers[] = {
+	{ "always_hide_tab", cmd_always_hide_tab },
 	{ "assign", cmd_assign },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },

--- a/sway/commands/always_hide_tab.c
+++ b/sway/commands/always_hide_tab.c
@@ -1,0 +1,29 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/tree/arrange.h"
+#include "sway/tree/view.h"
+
+struct cmd_results *cmd_always_hide_tab(int argc, char **argv) {
+	const char *expected_syntax = "Expected 'always_hide_tab "
+		"yes|no";
+
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "always_hide_tab", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (!argc) {
+		return cmd_results_new(CMD_INVALID, expected_syntax);
+	}
+
+	if (strcmp(argv[0], "yes") == 0) {
+		config->always_hide_tab = true;
+	} else if (strcmp(argv[0], "no") == 0) {
+		config->always_hide_tab = false;
+	} else {
+		return cmd_results_new(CMD_INVALID, expected_syntax);
+	}
+	arrange_root();
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -289,6 +289,7 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_edge_borders = E_NONE;
 	config->hide_edge_borders_smart = ESMART_OFF;
 	config->hide_lone_tab = false;
+	config->always_hide_tab = false;
 
 	// border colors
 	color_to_rgba(config->border_colors.focused.border, 0x4C7899FF);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -40,6 +40,7 @@ sway_sources = files(
 	'config/seat.c',
 	'config/input.c',
 
+	'commands/always_hide_tab.c',
 	'commands/assign.c',
 	'commands/bar.c',
 	'commands/bind.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -369,6 +369,10 @@ set|plus|minus|toggle <amount>
 The following commands may be used either in the configuration file or at
 runtime.
 
+*always_hide_tab* yes|no
+	If *always_hide_tab* is yes, titles on tabbed and stacked windows will
+	be hidden.
+
 *assign* <criteria> [→] [workspace] [number] <workspace>
 	Assigns views matching _criteria_ (see *CRITERIA* for details) to
 	_workspace_. The → (U+2192) is optional and cosmetic. This command is

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -294,8 +294,8 @@ void view_autoconfigure(struct sway_view *view) {
 		// title area. We have to offset the surface y by the height of the title,
 		// bar, and disable any top border because we'll always have the title bar.
 		list_t *siblings = container_get_siblings(con);
-		bool show_titlebar = (siblings && siblings->length > 1)
-			|| !config->hide_lone_tab;
+		bool show_titlebar = ((siblings && siblings->length > 1)
+			|| !config->hide_lone_tab) && !config->always_hide_tab;
 		if (show_titlebar) {
 			enum sway_container_layout layout = container_parent_layout(con);
 			if (layout == L_TABBED) {


### PR DESCRIPTION
Titles on tabbed and stacked windows can be disabled, I was trying to get similar behavior to dwm monocle mode.

Command name can be changed if there is better idea.
I was also thinking about setting the flag when **default_border** is **none**, but that would change current behavior so I used new command.