### PR TITLE
grimshot: Check if an instance is already running

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -109,6 +109,9 @@ if [ "$ACTION" = "check" ] ; then
   check jq
   check notify-send
   exit
+elif [ "$(pgrep -u $USER grimshot)" != $$ ]; then
+  echo "An instance is already running"
+  exit 1
 elif [ "$SUBJECT" = "area" ] ; then
   GEOM=$(slurp -d)
   # Check if user exited slurp without selecting the area


### PR DESCRIPTION
Right now, it is possible to execute multiple instances of Grimshot, meaning you can have multiple overlays of Slurp or make a screenshot of its overlay. This is probably not a user's desired behavior.
Slurp itself doesn't intend to have this feature https://github.com/emersion/slurp/issues/96, but since this is a helper script I guess it's appropriate here.
Not sure if `pgrep` is a command that can be taken for granted like `echo` is. (I mean, I don't know if it should be added to the dependencies)