### PR TITLE
container: fix surface_is_popup()

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -382,19 +382,17 @@ struct sway_container *tiling_container_at(struct sway_node *parent,
 }
 
 static bool surface_is_popup(struct wlr_surface *surface) {
-	if (wlr_surface_is_xdg_surface(surface)) {
-		struct wlr_xdg_surface *xdg_surface =
-			wlr_xdg_surface_from_wlr_surface(surface);
-		while (xdg_surface && xdg_surface->role != WLR_XDG_SURFACE_ROLE_NONE) {
-			if (xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP) {
-				return true;
-			}
-			xdg_surface = xdg_surface->toplevel->parent;
+	while (!wlr_surface_is_xdg_surface(surface)) {
+		if (!wlr_surface_is_subsurface(surface)) {
+			return false;
 		}
-		return false;
+		struct wlr_subsurface *subsurface =
+			wlr_subsurface_from_wlr_surface(surface);
+		surface = subsurface->parent;
 	}
-
-	return false;
+	struct wlr_xdg_surface *xdg_surface =
+		wlr_xdg_surface_from_wlr_surface(surface);
+	return xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP;
 }
 
 struct sway_container *container_at(struct sway_workspace *workspace,


### PR DESCRIPTION
```
18:04:58 <vyivel> maybe i'm a bit too tired for this, but can someone explain the logic behind https://github.com/swaywm/sway/blob/master/sway/tree/container.c#L384?
18:05:14 <vyivel> it seems like it assumes that a popup can be toplevel's parent
18:05:30 <vyivel> or that anything but toplevel can be toplevel's parent
18:09:14 <vyivel> hm, a simple check like "is this xdg surface and popup" wouldn't be enough, if it's a popup with subsurfaces
18:09:58 <emersion> hm yeah not sure what this code is doing
18:11:22 <vyivel> the intention probably was to check parent-child relationship in terms of subsurfaces
18:12:04 <vyivel> eacalate until current surface is xdg-surface, if it's also a popup then return true
18:12:31 <emersion> hm maybe
18:12:42 <emersion> it's clearly not doing this though
18:13:03 <vyivel> yeah
18:13:14 <vyivel> works somehow though /shrug
```

Test client: `popup` from https://codeberg.org/vyivel/subsurface-client
This PR allows to move/resize the client by dragging a popup's subsurface.