### PR TITLE
sway: allow IPCs on proprietary drivers

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -342,7 +342,6 @@ int main(int argc, char **argv) {
 	log_kernel();
 	log_distro();
 	log_env();
-	detect_proprietary(allow_unsupported_gpu);
 
 	if (optind < argc) { // Behave as IPC client
 		if (optind != 1) {
@@ -368,6 +367,8 @@ int main(int argc, char **argv) {
 		free(command);
 		return 0;
 	}
+
+	detect_proprietary(allow_unsupported_gpu);
 
 	if (!server_privileged_prepare(&server)) {
 		return 1;


### PR DESCRIPTION
Proprietary drivers require `--unsupported-gpu` to be allowed, and IPCs
require no option to be passed.

The only way to satisfy both is to run IPCs before checking for
proprietary drivers.

---
I have an nvidia card (I didn't know better 8 years ago, unfortunately), but since they've finally added support for Wayland I've installed the `nvidia` driver on my machine, but to my surprise `sway reload` stopped working as a result.

I understand having to pass `--unsupported-gpu` to run sway itself, but I think having to pass that to execute IPC commands is a bit much, so instead of the complex solution of allowing this flag but not others in the IPC path, I opted to simply move the check after it.