### PR TITLE
Improve man 5 sway

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -653,7 +653,8 @@ The default colors are:
 
 *for_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
-	See *CRITERIA* for more details.
+	See *CRITERIA* for more details. Please note this configuration is not
+	reloaded on _reload_ action.
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left <amount>
 	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the inner

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -855,7 +855,8 @@ The string contains one or more (space separated) attribute/value pairs. They
 are used by some commands to choose which views to execute actions on. All
 attributes must match for the criteria to match. Criteria is retained across
 commands separated by a *,*, but will be reset (and allow for new criteria, if
-desired) for commands separated by a *;*.
+desired) for commands separated by a *;*. The strings has to be quoted by *"*
+the simple quotes *'* are not supported.
 
 Criteria may be used with either the *for_window* or *assign* commands to
 specify operations to perform on new views. A criteria may also be used to


### PR DESCRIPTION
Recently I spent a few hours on making the `for_window` configuration option to work. The whole problem is that there are missing information in the man page. Let's add the missing info there.

However, question to someone knowing the code:
- should I add this also to `assign`?
- aren't these bugs?