### PR TITLE
sway: create wlr_renderer and wlr_allocator

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -4,6 +4,7 @@
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
+#include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_data_device.h>
@@ -35,6 +36,8 @@ struct sway_server {
 	struct wlr_backend *noop_backend;
 	// secondary headless backend used for creating virtual outputs on-the-fly
 	struct wlr_backend *headless_backend;
+	struct wlr_renderer *renderer;
+	struct wlr_allocator *allocator;
 
 	struct wlr_compositor *compositor;
 	struct wl_listener compositor_new_surface;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -850,6 +850,12 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		return;
 	}
 
+	if (!wlr_output_init_render(wlr_output, server->allocator,
+			server->renderer)) {
+		sway_log(SWAY_ERROR, "Failed to init output render");
+		return;
+	}
+
 	struct sway_output *output = output_create(wlr_output);
 	if (!output) {
 		return;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -52,7 +52,7 @@ static int scale_length(int length, int offset, float scale) {
 
 static void scissor_output(struct wlr_output *wlr_output,
 		pixman_box32_t *rect) {
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = wlr_output->renderer;
 	assert(renderer);
 
 	struct wlr_box box = {
@@ -100,8 +100,7 @@ static void render_texture(struct wlr_output *wlr_output,
 		pixman_region32_t *output_damage, struct wlr_texture *texture,
 		const struct wlr_fbox *src_box, const struct wlr_box *dst_box,
 		const float matrix[static 9], float alpha) {
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = wlr_output->renderer;
 	struct sway_output *output = wlr_output->data;
 
 	pixman_region32_t damage;
@@ -218,8 +217,7 @@ void render_rect(struct sway_output *output,
 		pixman_region32_t *output_damage, const struct wlr_box *_box,
 		float color[static 4]) {
 	struct wlr_output *wlr_output = output->wlr_output;
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
+	struct wlr_renderer *renderer = wlr_output->renderer;
 
 	struct wlr_box box;
 	memcpy(&box, _box, sizeof(struct wlr_box));
@@ -1013,13 +1011,7 @@ static void render_seatops(struct sway_output *output,
 void output_render(struct sway_output *output, struct timespec *when,
 		pixman_region32_t *damage) {
 	struct wlr_output *wlr_output = output->wlr_output;
-
-	struct wlr_renderer *renderer =
-		wlr_backend_get_renderer(wlr_output->backend);
-	if (!sway_assert(renderer != NULL,
-			"expected the output backend to have a renderer")) {
-		return;
-	}
+	struct wlr_renderer *renderer = output->server->renderer;
 
 	struct sway_workspace *workspace = output->current.active_workspace;
 	if (workspace == NULL) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -547,8 +547,7 @@ static void render_titlebar_text_texture(struct sway_output *output,
 	cairo_surface_flush(surface);
 	unsigned char *data = cairo_image_surface_get_data(surface);
 	int stride = cairo_image_surface_get_stride(surface);
-	struct wlr_renderer *renderer = wlr_backend_get_renderer(
-			output->wlr_output->backend);
+	struct wlr_renderer *renderer = output->wlr_output->renderer;
 	*texture = wlr_texture_from_pixels(
 			renderer, DRM_FORMAT_ARGB8888, stride, width, height, data);
 	cairo_surface_destroy(surface);


### PR DESCRIPTION
wlroots now required the compositor to create its own wlr_renderer and wlr_allocator to initialize the wlr_output

Matching wlroots PR: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3349