### PR TITLE
Clean up output destroy sequence

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -48,7 +48,7 @@ struct sway_output {
 	struct wl_listener damage_frame;
 
 	struct {
-		struct wl_signal destroy;
+		struct wl_signal disable;
 	} events;
 
 	struct timespec last_presentation;

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -664,7 +664,7 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 
 	struct sway_output *output = layer_surface->output->data;
 	sway_layer->output_destroy.notify = handle_output_destroy;
-	wl_signal_add(&output->events.destroy, &sway_layer->output_destroy);
+	wl_signal_add(&output->events.disable, &sway_layer->output_destroy);
 
 	wl_list_insert(&output->layers[layer_surface->pending.layer],
 			&sway_layer->link);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -755,17 +755,21 @@ static void update_output_manager_config(struct sway_server *server) {
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, destroy);
 	struct sway_server *server = output->server;
-	wl_signal_emit(&output->events.destroy, output);
+	output_begin_destroy(output);
 
 	if (output->enabled) {
 		output_disable(output);
 	}
-	output_begin_destroy(output);
+
+	wl_list_remove(&output->link);
 
 	wl_list_remove(&output->destroy.link);
 	wl_list_remove(&output->commit.link);
 	wl_list_remove(&output->mode.link);
 	wl_list_remove(&output->present.link);
+
+	output->wlr_output->data = NULL;
+	output->wlr_output = NULL;
 
 	transaction_commit_dirty();
 

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -286,6 +286,7 @@ void output_begin_destroy(struct sway_output *output) {
 		return;
 	}
 	sway_log(SWAY_DEBUG, "Destroying output '%s'", output->wlr_output->name);
+	wl_signal_emit(&output->node.events.destroy, &output->node);
 
 	output->node.destroying = true;
 	node_set_dirty(&output->node);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -95,7 +95,7 @@ struct sway_output *output_create(struct wlr_output *wlr_output) {
 	output->detected_subpixel = wlr_output->subpixel;
 	output->scale_filter = SCALE_FILTER_NEAREST;
 
-	wl_signal_init(&output->events.destroy);
+	wl_signal_init(&output->events.disable);
 
 	wl_list_insert(&root->all_outputs, &output->link);
 
@@ -262,7 +262,7 @@ void output_disable(struct sway_output *output) {
 	}
 
 	sway_log(SWAY_DEBUG, "Disabling output '%s'", output->wlr_output->name);
-	wl_signal_emit(&output->events.destroy, output);
+	wl_signal_emit(&output->events.disable, output);
 
 	output_evacuate(output);
 
@@ -289,10 +289,6 @@ void output_begin_destroy(struct sway_output *output) {
 
 	output->node.destroying = true;
 	node_set_dirty(&output->node);
-
-	wl_list_remove(&output->link);
-	output->wlr_output->data = NULL;
-	output->wlr_output = NULL;
 }
 
 struct sway_output *output_from_wlr_output(struct wlr_output *output) {


### PR DESCRIPTION
This is just the first 2 commits from #6639.

Previously an output had a destroy event that was emitted twice in a row (once in `output_begin_destroy` and again in the handler that is its only caller) and the output node destroy event was never signaled.

This renames the output destroy event to "disable" to better reflect it's usage and updates it to only emit once, and now the output node destroy event is emitted in `output_begin_destroy`.

There's no functional change to sway here, .