### PR TITLE
Do not default to `off` for dpms command

### DIFF
--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -35,8 +35,11 @@ struct cmd_results *output_cmd_dpms(int argc, char **argv) {
 
 	if (parse_boolean(argv[0], current_dpms == DPMS_ON)) {
 		config->handler_context.output_config->dpms_state = DPMS_ON;
-	} else {
+	} else if (strcmp(argv[0], "off") == 0) {
 		config->handler_context.output_config->dpms_state = DPMS_OFF;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+				"Invalid dpms argument: %s", argv[0]);
 	}
 
 	config->handler_context.leftovers.argc = argc - 1;


### PR DESCRIPTION
Currently any argument passed to the dpms command that isn't in [`parse_boolean`](https://github.com/swaywm/sway/blob/cbecc5cbaed6b30c995d2c245def458e383b4e38/common/util.c#L41) will cause the command to default to `off`. While this behaviour/usage of parse_boolean might make sense for config options in order to [match i3](https://github.com/swaywm/sway/pull/2340/files#r204566486)'s lenient behaviour, it seems a bit out of place for this command in sway.