### PR TITLE
swaybar: signal status command's process group

### DIFF
--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -172,7 +172,7 @@ bool determine_bar_visibility(struct swaybar *bar, bool moving_layer) {
 		if (bar->status) {
 			sway_log(SWAY_DEBUG, "Sending %s signal to status command",
 					visible ? "cont" : "stop");
-			kill(bar->status->pid, visible ?
+			kill(-bar->status->pid, visible ?
 					bar->status->cont_signal : bar->status->stop_signal);
 		}
 	}

--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -157,7 +157,12 @@ struct status_line *status_line_init(char *cmd) {
 	assert(!getenv("WAYLAND_SOCKET") && "display must be initialized before "
 		" starting `status-command`; WAYLAND_SOCKET should not be set");
 	status->pid = fork();
-	if (status->pid == 0) {
+	if (status->pid < 0) {
+		sway_log_errno(SWAY_ERROR, "fork failed");
+		exit(1);
+	} else if (status->pid == 0) {
+		setpgid(0, 0);
+
 		dup2(pipe_read_fd[1], STDOUT_FILENO);
 		close(pipe_read_fd[0]);
 		close(pipe_read_fd[1]);
@@ -185,8 +190,8 @@ struct status_line *status_line_init(char *cmd) {
 
 void status_line_free(struct status_line *status) {
 	status_line_close_fds(status);
-	kill(status->pid, status->cont_signal);
-	kill(status->pid, SIGTERM);
+	kill(-status->pid, status->cont_signal);
+	kill(-status->pid, SIGTERM);
 	waitpid(status->pid, NULL, 0);
 	if (status->protocol == PROTOCOL_I3BAR) {
 		struct i3bar_block *block, *tmp;


### PR DESCRIPTION
Make the status command a process group leader and change the kill(2)
calls to target the new process group. Signals sent by swaybar will then
be received by both the status command and its children, if any. While
here, check the result of fork(2).

Without this, children spawned by the status command may not receive the
signals sent by swaybar. As a result, these children may be orphaned on
reload.

The issue could be shown by setting the bar to

    bar {
        status_command i3status | tee /tmp/i3status.out
    }

which would leave orphaned processes for each reload of sway

    $ ps o pid,ppid,cmd | grep i3status | grep -v grep
    43633   43624 sh -c i3status | tee /tmp/i3status.out
    43634   43633 i3status
    43635   43633 tee /tmp/i3status.out

    $ swaymsg reload

    $ ps o pid,ppid,cmd | grep i3status | grep -v grep
    43634       1 i3status
    43635       1 tee /tmp/i3status.out
    43801   43788 sh -c i3status | tee /tmp/i3status.out
    43802   43801 i3status
    43803   43801 tee /tmp/i3status.out

This fixes #5584.