### PR TITLE
Treat fullscreen windows as 'tiled' for commands/focus

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -451,7 +451,8 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "");
 	}
 	struct sway_node *next_focus = NULL;
-	if (container_is_floating(container)) {
+	if (container_is_floating(container) &&
+			container->pending.fullscreen_mode == FULLSCREEN_NONE) {
 		next_focus = node_get_in_direction_floating(container, seat, direction);
 	} else {
 		next_focus = node_get_in_direction_tiling(container, seat, direction, descend);


### PR DESCRIPTION
Currently, fullscreen containers are treated differently based on whether they were originally floating or tiled. This is strange from a user perspective, since there is no visual hint whether a container was originally floating or tiled. This change only affects multi-monitor setups.

To see the current effect, try the following:

1. Open a window in tiled mode
2. Fullscreen it
3. You can still move between monitors with `$mod-$left`/`$mod-$right`.
4. Open a window in floating mode
5. Fullscreen it
6. You can _not_ move between monitors with `$mod-$left`/`$mod-$right`
7. However, there is no visual difference between 3. and 6.

This PR makes the behaviour in 6. consistent with the behaviour in 3.