### PR TITLE
ipc: make `bar <bar_id> mode|hidden_state` behave as documented

### DIFF
--- a/sway/commands/bar/hidden_state.c
+++ b/sway/commands/bar/hidden_state.c
@@ -54,7 +54,7 @@ struct cmd_results *bar_cmd_hidden_state(int argc, char **argv) {
 	}
 
 	const char *state = argv[0];
-	if (config->reading) {
+	if (config->current_bar) {
 		error = bar_set_hidden_state(config->current_bar, state);
 	} else {
 		const char *id = argc == 2 ? argv[1] : NULL;

--- a/sway/commands/bar/mode.c
+++ b/sway/commands/bar/mode.c
@@ -58,7 +58,7 @@ struct cmd_results *bar_cmd_mode(int argc, char **argv) {
 	}
 
 	const char *mode = argv[0];
-	if (config->reading) {
+	if (config->current_bar) {
 		error = bar_set_mode(config->current_bar, mode);
 	} else {
 		const char *id = argc == 2 ? argv[1] : NULL;


### PR DESCRIPTION
sway-bar(5) says:

> For compatibility with i3, `bar mode <mode> [<bar-id>]` syntax is supported along with the sway only `bar <bar-id> mode <mode>` syntax.

while the actual behavior is that `bar_cmd_mode` ignores already selected `config->current_bar` and applies the change to all the configured bars.

Before:
```
00:00:15.799 [INFO] [sway/commands.c:257] Handling command 'bar bar-0 mode dock'
00:00:15.799 [DEBUG] [sway/commands/bar.c:66] Selecting bar: bar-0
00:00:15.799 [DEBUG] [sway/commands.c:428] Subcommand: mode dock
00:00:15.799 [DEBUG] [sway/commands/bar/mode.c:33] Setting mode: 'dock' for bar: bar-0
00:00:15.799 [DEBUG] [sway/commands/bar/mode.c:33] Setting mode: 'dock' for bar: bar-1
00:00:15.799 [DEBUG] [sway/ipc-server.c:347] Sending barconfig_update event
```
Note that the `barconfig_update` event is only sent to the `config->current_bar` (bar-0), even if we just updated mode for all the bars.

After:
```
00:00:22.724 [INFO] [sway/commands.c:257] Handling command 'bar bar-0 mode dock'
00:00:22.724 [DEBUG] [sway/commands/bar.c:66] Selecting bar: bar-0
00:00:22.724 [DEBUG] [sway/commands.c:428] Subcommand: mode dock
00:00:22.724 [DEBUG] [sway/commands/bar/mode.c:33] Setting mode: 'dock' for bar: bar-0
00:00:22.724 [DEBUG] [sway/ipc-server.c:347] Sending barconfig_update event
```


