### PR TITLE
output: remove surface buffer damage check

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -633,21 +633,19 @@ static void damage_surface_iterator(struct sway_output *output,
 	struct wlr_box box = *_box;
 	scale_box(&box, output->wlr_output->scale);
 
-	if (pixman_region32_not_empty(&surface->buffer_damage)) {
-		pixman_region32_t damage;
-		pixman_region32_init(&damage);
-		wlr_surface_get_effective_damage(surface, &damage);
-		wlr_region_scale(&damage, &damage, output->wlr_output->scale);
-		if (ceil(output->wlr_output->scale) > surface->current.scale) {
-			// When scaling up a surface, it'll become blurry so we need to
-			// expand the damage region
-			wlr_region_expand(&damage, &damage,
-				ceil(output->wlr_output->scale) - surface->current.scale);
-		}
-		pixman_region32_translate(&damage, box.x, box.y);
-		wlr_output_damage_add(output->damage, &damage);
-		pixman_region32_fini(&damage);
+	pixman_region32_t damage;
+	pixman_region32_init(&damage);
+	wlr_surface_get_effective_damage(surface, &damage);
+	wlr_region_scale(&damage, &damage, output->wlr_output->scale);
+	if (ceil(output->wlr_output->scale) > surface->current.scale) {
+		// When scaling up a surface, it'll become blurry so we need to
+		// expand the damage region
+		wlr_region_expand(&damage, &damage,
+			ceil(output->wlr_output->scale) - surface->current.scale);
 	}
+	pixman_region32_translate(&damage, box.x, box.y);
+	wlr_output_damage_add(output->damage, &damage);
+	pixman_region32_fini(&damage);
 
 	if (whole) {
 		wlr_output_damage_add_box(output->damage, &box);


### PR DESCRIPTION
A surface can have effective damage even without any buffer damage
committed.

---

https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3389