### PR TITLE
Prevent a layer shell infinite looping case

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -308,8 +308,8 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 			wl_list_insert(&output->layers[layer_surface->current.layer],
 				&layer->link);
 			layer->layer = layer_surface->current.layer;
+			arrange_layers(output);
 		}
-		arrange_layers(output);
 	}
 
 	wlr_surface_get_extends(layer_surface->surface, &layer->extent);


### PR DESCRIPTION
This commit try to fix a case we encounter when running wayout, a layer
shell to display text above the background.

When running wayout, other layer shell start to consume 100% of the CPU.
This seems related to a previous fix 744e85b. Then later, another commit
reworks this handle_surface_commit method 5fd5d643.

https://todo.sr.ht/~mil/sxmo-tickets/413

This is a tentative to fix the issue without missing the points of those
patches.

We basically try to not re-arrange layers if no layer changed.

Related to : https://github.com/swaywm/sway/issues/6546

This patch seems to solve our issue,  but am I missing something ?