### PR TITLE
swaynag: remove xdg-output logic

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -5,7 +5,6 @@
 #include "list.h"
 #include "pool-buffer.h"
 #include "swaynag/types.h"
-#include "xdg-output-unstable-v1-client-protocol.h"
 
 #define SWAYNAG_MAX_HEIGHT 500
 
@@ -75,13 +74,11 @@ struct swaynag_details {
 
 struct swaynag {
 	bool run_display;
-	int querying_outputs;
 
 	struct wl_display *display;
 	struct wl_compositor *compositor;
 	struct wl_seat *seat;
 	struct wl_shm *shm;
-	struct zxdg_output_manager_v1 *xdg_output_manager;
 	struct wl_list outputs;  // swaynag_output::link
 	struct wl_list seats;  // swaynag_seat::link
 	struct swaynag_output *output;

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ endif
 
 jsonc = dependency('json-c', version: '>=0.13')
 pcre = dependency('libpcre')
-wayland_server = dependency('wayland-server')
+wayland_server = dependency('wayland-server', version: '>=1.20.0')
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_egl = dependency('wayland-egl')

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -54,7 +54,6 @@ static void swaybar_output_free(struct swaybar_output *output) {
 	if (output->input_region != NULL) {
 		wl_region_destroy(output->input_region);
 	}
-	zxdg_output_v1_destroy(output->xdg_output);
 	wl_output_destroy(output->output);
 	destroy_buffer(&output->buffers[0]);
 	destroy_buffer(&output->buffers[1]);


### PR DESCRIPTION
We can just get the output name from wl_output directly, now that
wl_output version 4 exists.