### PR TITLE
build: bump wlroots dependency to 0.16.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ math = cc.find_library('m')
 rt = cc.find_library('rt')
 
 # Try first to find wlroots as a subproject, then as a system dependency
-wlroots_version = ['>=0.15.0', '<0.16.0']
+wlroots_version = ['>=0.16.0', '<0.17.0']
 wlroots_proj = subproject(
 	'wlroots',
 	default_options: ['examples=false'],


### PR DESCRIPTION
I think this is relatively self explanatory :D

[Version bump in wlroots](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/7360810f2e5c71fe143b25b63517ab1a6475ce0a)