### PR TITLE
build: bump version to 1.8-dev

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'sway',
 	'c',
-	version: '1.6',
+	version: '1.8-dev',
 	license: 'MIT',
 	meson_version: '>=0.60.0',
 	default_options: [


### PR DESCRIPTION
Historically we've been sticking with the last release number in
the master branch. However that's a bit confusing, people can't
easily figure out whether they're using a release or a work-in-progress
snapshot. Only the commit hash appended to the version number may
help, but that's not very explicit and disappears when using a
tarball.

We could bump the version in master to the next release number.
However during the RC cycle there would be a downgrade from 1.8 to
1.8-rc1. Also it would be hard to tell the difference between a
stable release and an old snapshot.

This patch introduces a new pre-release identifier, "dev". It's
alphabetically before "rc" so it should be correctly sorted by
semver comparisons. "dev" is upgraded to "rc" (and then to stable)
when doing a release. The master branch always uses a "dev"
version, only release branches use "rc" or stable versions.

cc @RPigott @kennylevinsen 