### PR TITLE
xdg-shell: use toplevel geometry to adjust the popup box

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -72,8 +72,8 @@ static void popup_unconstrain(struct sway_xdg_popup *popup) {
 	// the output box expressed in the coordinate system of the toplevel parent
 	// of the popup
 	struct wlr_box output_toplevel_sx_box = {
-		.x = output->lx - view->container->pending.content_x,
-		.y = output->ly - view->container->pending.content_y,
+		.x = output->lx - view->container->pending.content_x + view->geometry.x,
+		.y = output->ly - view->container->pending.content_y + view->geometry.y,
 		.width = output->width,
 		.height = output->height,
 	};


### PR DESCRIPTION
`popup_unconstrain` uses view coordinates to init the output box for
popups. However wlroots expects the box to be set in a toplevel surface
coordinate system, which is not always equal to view. The difference
between those is a window geometry set via xdg-shell.

GTK4 reserves some space for client-side decoration and thus has a
window with top left corner not matching to (0, 0) of a surface. The box
calculated without taking that into account was slightly shifted
compared to the actual output and allowed to position part of the popup
off screen.

***
I'm not entirely sure that this is the right change. xdg-shell alternates between using window geometry coordinates and surface coordinates, but then  `wlr_xdg_popup_unconstrain_from_box` clearly wants a surface-local coordinates (as implied by `wlr_xdg_popup_get_toplevel_coords` code). And the configure event we get from xdg_popup seems correct after the change:
`[2715352.407] xdg_popup@51.configure(0, 40, 282, 303)` (the configure is using window geometry coordinates).
 
The issue seems common for other compositors (just confirmed on river) and maybe API change or clarification is a better way to deal with that.

**Edit:**
It got worse with libadwaita update - `xdg_surface@37.set_window_geometry(61, 55, 1920, 1176)`
Screenshots:
![image](https://user-images.githubusercontent.com/2681151/149074859-e2fa9044-0a74-48e4-a6b6-3da5b1631288.png)
![image](https://user-images.githubusercontent.com/2681151/149074890-2e9e38f9-1bac-4f93-807e-bb7c55fe8470.png)

