### PR TITLE
swaybar: tray_padding is scaled

### DIFF
--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -162,9 +162,10 @@ ContextMenu|Activate|SecondaryActivate|ScrollDown|ScrollLeft|ScrollRight|ScrollU
 	action (Activate for button1, ContextMenu for button2 and SecondaryActivate
 	for button3).
 
-*tray_padding* <px> [px]
-	Sets the pixel padding of the system tray. This padding will surround the
-	tray on all sides and between each item. The default value for _px_ is 2.
+*tray_padding* <padding>
+	Sets the padding of the system tray. This padding will surround the tray on
+	all sides and between each item. This value will be multiplied by the output
+	scale. The default is _2_.
 
 *tray_output* none|<output>|\*
 	Restrict the tray to a certain output, can be specified multiple times. If

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -116,8 +116,8 @@ uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 		}
 	} // else display on all
 
-	if ((int)(output->height * output->scale) <= 2 * config->tray_padding) {
-		return (2 * config->tray_padding + 1) / output->scale;
+	if (output->height <= 2 * (uint32_t)config->tray_padding) {
+		return 2 * config->tray_padding + 1;
 	}
 
 	uint32_t max_height = 0;


### PR DESCRIPTION
As @xdavidwu noted, and @emersion directed, re: fixes for #6504: -- https://github.com/swaywm/sway/pull/6517#issuecomment-922702239

> > tray_padding config is currently defined in device pixels
> 
> That seems like an oversight. I wouldn't mind a follow-up PR to change it to surface-local coords. But yeah better to keep it as-is for this bugfix PR, so that we can more easily revert that change if needed.

----

Unfortunately, no, it seems we cannot ignore scaling concerns when drawing the tray item icons.  This is because the displayed icon-size (e.g. 24px vs 48px size) is determined at the chosen scale, and so further this size must be scaled back, and also the scale imparted as part of the libcairo drawing operation.