### PR TITLE
Fix inconsistent floating window z order across outputs

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -113,6 +113,12 @@ struct sway_seat {
 				// sway_keyboard_shortcuts_inhibitor::link
 
 	struct wl_list link; // input_manager::seats
+
+	// Used by sway_container.floating_order. This value will increment as
+	// floating windows request to be shown on top, this makes sure that a
+	// value can be assigned to a floating window that is guaranteed
+	// to be highter (ignoring overflow) than other floating windows.
+	uint32_t floating_counter;
 };
 
 struct sway_pointer_constraint {

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -113,6 +113,12 @@ struct sway_container {
 	// Hidden scratchpad containers have a NULL parent.
 	bool scratchpad;
 
+	// Value specifing in which order floating windows should be shown
+	// higher values means that the floating window should appear
+	// ontop of others. This variable is undefined if this container is not
+	// floating.
+	uint32_t floating_order;
+
 	float alpha;
 
 	struct wlr_texture *title_focused;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -565,6 +565,8 @@ struct sway_seat *seat_create(const char *seat_name) {
 	}
 	seat->wlr_seat->data = seat;
 
+	seat->floating_counter = 0;
+
 	seat->cursor = sway_cursor_create(seat);
 	if (!seat->cursor) {
 		wlr_seat_destroy(seat->wlr_seat);

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -813,6 +813,8 @@ void workspace_add_floating(struct sway_workspace *workspace,
 	if (con->pending.workspace) {
 		container_detach(con);
 	}
+	struct sway_seat *seat = input_manager_current_seat();
+	con->floating_order = ++seat->floating_counter;
 	list_add(workspace->floating, con);
 	con->pending.workspace = workspace;
 	container_for_each_child(con, set_workspace, NULL);


### PR DESCRIPTION
Currently floating windows when appearing across outputs (in a multi-monitor setup) will cover other floating windows unconditionally sometimes even if I try to focus the covered floating window. This happens when a window belongs to say workspace 1. If that window is strung across multiple monitors such that it also covers contents of workspace 2, floating windows in 2 will always be either behind or above floating windows in workspace 1. This makes working impossible sometimes unless you move the windows out of the way.

My fix is to maintain a counter that increments everytime a floating window wants to be shown on top. This counter is shared across the entire seat so that even across workspaces, floating windows maintain the expected z order.