### PR TITLE
Print deprecation notice when running SUID

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -153,6 +153,9 @@ static void log_kernel(void) {
 
 static bool drop_permissions(void) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
+		sway_log(SWAY_ERROR, "!!! DEPRECATION WARNING: "
+			"SUID privilege drop will be removed in a future release, please migrate to seatd-launch");
+
 		// Set the gid and uid in the correct order.
 		if (setgid(getgid()) != 0) {
 			sway_log(SWAY_ERROR, "Unable to drop root group, refusing to start");


### PR DESCRIPTION
SUID privilege drop is needed for the "builtin"-backend of libseat,
which copied our old "direct" backend behavior for the sake of
compatibility and ease of transition.

libseat now has a better alternative in the form of seatd-launch. It
uses the normal seatd daemon and libseat backend and takes care of SUID
for us.

Add a soft deprecation warning to highlight our future intent of
removing this code. The deprecation cycle is needed to avoid surprises
when sway no longer drops privileges.

We should put this in the release notes as well.