### PR TITLE
xwayland: listen to `request_activate` event 

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -169,6 +169,7 @@ struct sway_xwayland_unmanaged {
 
 	int lx, ly;
 
+	struct wl_listener request_activate;
 	struct wl_listener request_configure;
 	struct wl_listener request_fullscreen;
 	struct wl_listener commit;


### PR DESCRIPTION
When REAPER submenu is closed `XCB_CLIENT_MESSAGE` with type
`NET_ACTIVE_WINDOW` is sent to set focus to parent menu.

Closes: #6324