### PR TITLE
build: execute wlroots subproject before finding deps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,15 @@ if is_freebsd
 	add_project_arguments('-D_C11_SOURCE', language: 'c')
 endif
 
+# Execute the wlroots subproject, if any
+wlroots_version = ['>=0.16.0', '<0.17.0']
+subproject(
+	'wlroots',
+	default_options: ['examples=false'],
+	required: false,
+	version: wlroots_version,
+)
+
 jsonc = dependency('json-c', version: '>=0.13')
 pcre = dependency('libpcre')
 wayland_server = dependency('wayland-server', version: '>=1.20.0')
@@ -42,6 +51,7 @@ wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_egl = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols', version: '>=1.24')
+wlroots = dependency('wlroots', version: wlroots_version)
 xkbcommon = dependency('xkbcommon')
 cairo = dependency('cairo')
 pango = dependency('pango')
@@ -59,20 +69,6 @@ bash_comp = dependency('bash-completion', required: false)
 fish_comp = dependency('fish', required: false)
 math = cc.find_library('m')
 rt = cc.find_library('rt')
-
-# Try first to find wlroots as a subproject, then as a system dependency
-wlroots_version = ['>=0.16.0', '<0.17.0']
-wlroots_proj = subproject(
-	'wlroots',
-	default_options: ['examples=false'],
-	required: false,
-	version: wlroots_version,
-)
-if wlroots_proj.found()
-	wlroots = wlroots_proj.get_variable('wlroots')
-else
-	wlroots = dependency('wlroots', version: wlroots_version)
-endif
 
 wlroots_features = {
 	'xwayland': false,


### PR DESCRIPTION
wlroots often requires dependencies more recent than Sway's.
Executing the wlroots subproject first will give Meson a chance to
find these newer dependencies, possibly via subprojects.

The subproject will override the "wlroots" dependency when executed,
so we don't need to use get_variable anymore.

References: https://github.com/swaywm/sway/pull/6498#issuecomment-1001746017