### PR TITLE
input/cursor: pass through pointer hold gestures

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -42,6 +42,8 @@ struct sway_cursor {
 	struct wl_listener swipe_begin;
 	struct wl_listener swipe_update;
 	struct wl_listener swipe_end;
+	struct wl_listener hold_begin;
+	struct wl_listener hold_end;
 
 	struct wl_listener motion;
 	struct wl_listener motion_absolute;


### PR DESCRIPTION
This just follows swaywm/wlroots#3047, so `wl_pointer_gestures_v1`
clients can be notified of these events.