### PR TITLE
swaynag: remove buffer destruction condition

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -511,13 +511,8 @@ void swaynag_destroy(struct swaynag *swaynag) {
 		swaynag_seat_destroy(seat);
 	}
 
-	if (&swaynag->buffers[0]) {
-		destroy_buffer(&swaynag->buffers[0]);
-	}
-
-	if (&swaynag->buffers[1]) {
-		destroy_buffer(&swaynag->buffers[1]);
-	}
+	destroy_buffer(&swaynag->buffers[0]);
+	destroy_buffer(&swaynag->buffers[1]);
 
 	if (swaynag->outputs.prev || swaynag->outputs.next) {
 		struct swaynag_output *output, *temp;


### PR DESCRIPTION
An address of a variable can never be NULL, so checking it doesn't make
sense; and `destroy_buffer()` can operate on already destroyed buffers
anyway.

Fixes #6780