### PR TITLE
Fix snprintf compiler warnings (errors)

### DIFF
--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -112,7 +112,7 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 						"Unable to allocate resources");
 			}
 
-			sprintf(src, "%s/%s", conf_path, rel_path);
+			snprintf(src, strlen(conf_path) + strlen(src) + 2, "%s/%s", conf_path, rel_path);
 			free(rel_path);
 			free(conf);
 		}

--- a/sway/server.c
+++ b/sway/server.c
@@ -214,7 +214,7 @@ bool server_init(struct sway_server *server) {
 	// Avoid using "wayland-0" as display socket
 	char name_candidate[16];
 	for (int i = 1; i <= 32; ++i) {
-		sprintf(name_candidate, "wayland-%d", i);
+		snprintf(name_candidate, sizeof(name_candidate), "wayland-%d", i);
 		if (wl_display_add_socket(server->wl_display, name_candidate) >= 0) {
 			server->socket = strdup(name_candidate);
 			break;


### PR DESCRIPTION
https://github.com/swaywm/sway/issues/6784
Hello this replaces sprintf with snprintf to avoid
`../sway/server.c:217:50: warning: ‘%d’ directive writing between 1 and 11 bytes into a region of size 8 [-Wformat-overflow=]
`
and
`../sway/commands/output/background.c:115:25: warning: ‘sprintf’ argument 4 overlaps destination object ‘src’ [-Wrestrict]
`