### PR TITLE
input/seat: emit focus events when focusing parent

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1198,8 +1198,10 @@ void seat_set_focus(struct sway_seat *seat, struct sway_node *node) {
 
 	// emit ipc events
 	set_workspace(seat, new_workspace);
-	if (container && container->view) {
+	if (container) {
 		ipc_event_window(container, "focus");
+	} else if(last_workspace == new_workspace) {
+		ipc_event_workspace(NULL, new_workspace, "focus");
 	}
 
 	// Move sticky containers to new workspace


### PR DESCRIPTION
Emit a focus event when a container or the entire workspace gets focused
(for example, when focus_parent is called).

Previously, focus events were only emitted when another view or
workspace was focused. This made it impossible to accurately follow the
focus by monitoring focus events.

This is a deviation from i3s behaviour but I'd consider that a bug as well.

I'm not sure if this change doesn't have some side effects or introduces bugs that I haven't noticed yet.