### PR TITLE
Remove all sprintf calls

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1706,7 +1706,7 @@ static void update_marks_texture(struct sway_container *con,
 	for (int i = 0; i < con->marks->length; ++i) {
 		char *mark = con->marks->items[i];
 		if (mark[0] != '_') {
-			sprintf(part, "[%s]", mark);
+			snprintf(part, len + 1, "[%s]", mark);
 			strcat(buffer, part);
 		}
 	}

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -209,7 +209,7 @@ static pid_t get_parent_pid(pid_t child) {
 	FILE *stat = NULL;
 	size_t buf_size = 0;
 
-	sprintf(file_name, "/proc/%d/stat", child);
+	snprintf(file_name, sizeof(file_name), "/proc/%d/stat", child);
 
 	if ((stat = fopen(file_name, "r"))) {
 		if (getline(&buffer, &buf_size, stat) != -1) {

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -414,8 +414,8 @@ int swaynag_load_config(char *path, struct swaynag *swaynag, list_t *types) {
 			}
 			free(name);
 		} else {
-			char *flag = malloc(sizeof(char) * (nread + 3));
-			sprintf(flag, "--%s", line);
+			char *flag = malloc(nread + 3);
+			snprintf(flag, nread + 3, "--%s", line);
 			char *argv[] = {"swaynag", flag};
 			result = swaynag_parse_options(2, argv, swaynag, types, type,
 					NULL, NULL);

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -28,8 +28,9 @@ static bool terminal_execute(char *terminal, char *command) {
 	fprintf(tmp, "#!/bin/sh\nrm %s\n%s", fname, command);
 	fclose(tmp);
 	chmod(fname, S_IRUSR | S_IWUSR | S_IXUSR);
-	char *cmd = malloc(sizeof(char) * (strlen(terminal) + strlen(" -e ") + strlen(fname) + 1));
-	sprintf(cmd, "%s -e %s", terminal, fname);
+	size_t cmd_size = strlen(terminal) + strlen(" -e ") + strlen(fname) + 1;
+	char *cmd = malloc(cmd_size);
+	snprintf(cmd, cmd_size, "%s -e %s", terminal, fname);
 	execlp("sh", "sh", "-c", cmd, NULL);
 	sway_log_errno(SWAY_ERROR, "Failed to run command, execlp() returned.");
 	free(cmd);


### PR DESCRIPTION
Replace them with snprintf, which ensures buffer overflows won't
happen.