### PR TITLE
Fix behaviour of container_move_to_container, add move to con_id

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -373,4 +373,9 @@ bool container_is_sticky_or_child(struct sway_container *con);
  */
 int container_squash(struct sway_container *con);
 
+bool container_has_con_id(struct sway_container *con, size_t *con_id);
+
+/** Returns a container with the given con_id */
+struct sway_container *container_find_con_id(size_t *con_id);
+
 #endif

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -25,7 +25,8 @@ static const char expected_syntax[] =
 	"Expected 'move <left|right|up|down> <[px] px>' or "
 	"'move [--no-auto-back-and-forth] <container|window> [to] workspace <name>' or "
 	"'move <container|window|workspace> [to] output <name|direction>' or "
-	"'move <container|window> [to] mark <mark>'";
+	"'move <container|window> [to] mark <mark>' or "
+	"'move <container|window> [to] con_id <con_id>'";
 
 static struct sway_output *output_in_direction(const char *direction_string,
 		struct sway_output *reference, int ref_lx, int ref_ly) {
@@ -520,6 +521,14 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 					"Mark '%s' not found", argv[1]);
 		}
 		destination = &dest_con->node;
+	} else if (strcasecmp(argv[0], "con_id") == 0) {
+		size_t con_id = atoi(argv[1]);
+		struct sway_container *dest_con = container_find_con_id(&con_id);
+		if (dest_con == NULL) {
+			return cmd_results_new(CMD_FAILURE,
+					"No container with con_id '%s' found", argv[1]);
+		}
+		destination = &dest_con->node;
 	} else {
 		return cmd_results_new(CMD_INVALID, expected_syntax);
 	}
@@ -982,6 +991,7 @@ static const char expected_full_syntax[] = "Expected "
 	"  <name>|next|prev|next_on_output|prev_on_output|current|(number <num>)'"
 	" or 'move [window|container] [to] output <name/id>|left|right|up|down'"
 	" or 'move [window|container] [to] mark <mark>'"
+	" or 'move [window|container] [to] con_id <con_id>'"
 	" or 'move [window|container] [to] scratchpad'"
 	" or 'move workspace to [output] <name/id>|left|right|up|down'"
 	" or 'move [window|container] [to] [absolute] position <x> [px] <y> [px]'"
@@ -1040,7 +1050,8 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 
 	if (strcasecmp(argv[0], "workspace") == 0 ||
 			strcasecmp(argv[0], "output") == 0 ||
-			strcasecmp(argv[0], "mark") == 0) {
+			strcasecmp(argv[0], "mark") == 0 ||
+			strcasecmp(argv[0], "con_id") == 0) {
 		return cmd_move_container(no_auto_back_and_forth, argc, argv);
 	} else if (strcasecmp(argv[0], "scratchpad") == 0) {
 		return cmd_move_to_scratchpad();

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -232,7 +232,6 @@ static void container_move_to_workspace(struct sway_container *container,
 static void container_move_to_container(struct sway_container *container,
 		struct sway_container *destination) {
 	if (container == destination
-			|| container_has_ancestor(container, destination)
 			|| container_has_ancestor(destination, container)) {
 		return;
 	}

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -231,6 +231,10 @@ set|plus|minus|toggle <amount>
 *move* [container|window] [to] mark <mark>
 	Moves the focused container to the specified mark.
 
+*move* [container|window] [to] con_id <con_id>
+	Moves the focused container to become a direct descendant of the specified
+	con_id. If the destination can't have descendants, the command does nothing.
+
 *move* [--no-auto-back-and-forth] [container|window] [to] workspace [number] <name>
 	Moves the focused container to the specified workspace. The string _number_
 	is optional and is used to match a workspace with the same number, even if

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1821,3 +1821,16 @@ int container_squash(struct sway_container *con) {
 	}
 	return change;
 }
+
+bool container_has_con_id(struct sway_container *con, size_t *con_id) {
+	return con->node.id == *con_id;
+}
+
+static bool find_by_con_id(struct sway_container *con, void *data) {
+	size_t *con_id = data;
+	return con->node.id == *con_id;
+}
+
+struct sway_container *container_find_con_id(size_t *con_id) {
+	return root_find_container(find_by_con_id, con_id);
+}


### PR DESCRIPTION
Closes #6818 
Okay so this PR does two things:

One, it removes this line
https://github.com/swaywm/sway/blob/f707f583e17cb5e8323ceb4bfd951ad0465b7d10/sway/commands/move.c#L235
In order to match the behaviour of i3's move functionality, which can be found [here](https://github.com/i3/i3/blob/c822eff1bfdeac30baf92b14a09d1c81a0193997/src/move.c#L72-L79), posted below:
```c
    /* We compare the focus order of the children of the lowest common ancestor. If con or
     * its ancestor is before target's ancestor then con should be placed before the target
     * in the focus stack. */
    Con *lca = lowest_common_ancestor(con, parent);
    if (lca == con) {
        ELOG("Container is being inserted into one of its descendants.\n");
        return;
    }
```
Basically, sway is checking on move that a destination is neither a descendant of the container to be moved, *and* that the container to be moved is not a descendant of the destination, whereas i3 only (rightly, I think) checks that the destination is not a descendant, as such a lot of valid moves in i3 simply don't work in sway and this fixes that.

The second, sort of incidental thing this PR adds is the command `move [container|window] [to] con_id <con_id>`. I use a script with a lot of "macros" to make navigating formerly-i3-and-now-sway easier, and I noticed that in decently upwards of half of them they all have the same repeated behaviour:
```
[con_id=$someDestination] mark _destination; move container to mark _destination; unmark _destination;
```
or something similar, so it seemed like there was a very obvious use case to just have that be
```
move container to con_id $someDestination
```
All of the rules surrounding whether a move is valid and how the move functions are identical to move-to-mark, this just saves some steps if you happen to have a con_id handy.

So yeah! Let me know what you think.