### PR TITLE
output: update xcursor configuration on scale change

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -824,6 +824,13 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		transaction_commit_dirty();
 
 		update_output_manager_config(output->server);
+
+		if (event->committed & WLR_OUTPUT_STATE_SCALE) {
+			struct sway_seat *seat;
+			wl_list_for_each(seat, &server.input->seats, link) {
+				seat_configure_xcursor(seat);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Sway will not correctly update the cursor glyph cache on an output
scale change. This results in sway falling back to a lower resolution
cursor glyph or just not rendering the correct cursor at all.

This is reproducible simply by using `swaymsg` to change
the scale sometimes, but I found 100% reproducibility when using
these patches[1].

[1] https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3418