### PR TITLE
Don't try to resize a client smaller than its constraints

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -38,8 +38,8 @@ struct sway_view_impl {
 	const char *(*get_string_prop)(struct sway_view *view,
 			enum sway_view_prop prop);
 	uint32_t (*get_int_prop)(struct sway_view *view, enum sway_view_prop prop);
-	uint32_t (*configure)(struct sway_view *view, double lx, double ly,
-			int width, int height);
+	bool (*configure)(struct sway_view *view, uint32_t *serial,
+			double lx, double ly, int width, int height);
 	void (*set_activated)(struct sway_view *view, bool activated);
 	void (*set_tiled)(struct sway_view *view, bool tiled);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
@@ -244,8 +244,8 @@ const char *view_get_shell(struct sway_view *view);
 void view_get_constraints(struct sway_view *view, double *min_width,
 		double *max_width, double *min_height, double *max_height);
 
-uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
-	int height);
+bool view_configure(struct sway_view *view, uint32_t *serial,
+		double lx, double ly, int width, int height);
 
 bool view_inhibit_idle(struct sway_view *view);
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -149,6 +149,13 @@ static bool configure(struct sway_view *view, uint32_t *serial,
 		return false;
 	}
 
+	// avoid same size configures as clients may not ack & commit them
+	struct wlr_xdg_toplevel *top = view->wlr_xdg_toplevel;
+	if ((int) top->pending.width == width &&
+			(int) top->pending.height == height) {
+		return false;
+	}
+
 	*serial = wlr_xdg_toplevel_set_size(top, width, height);
 	return true;
 }

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -141,15 +141,16 @@ static const char *get_string_prop(struct sway_view *view,
 	}
 }
 
-static uint32_t configure(struct sway_view *view, double lx, double ly,
-		int width, int height) {
+static bool configure(struct sway_view *view, uint32_t *serial,
+		double lx, double ly, int width, int height) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		xdg_shell_view_from_view(view);
 	if (xdg_shell_view == NULL) {
-		return 0;
+		return false;
 	}
-	return wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel,
-		width, height);
+
+	*serial = wlr_xdg_toplevel_set_size(top, width, height);
+	return true;
 }
 
 static void set_activated(struct sway_view *view, bool activated) {

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -246,18 +246,18 @@ static uint32_t get_int_prop(struct sway_view *view, enum sway_view_prop prop) {
 	}
 }
 
-static uint32_t configure(struct sway_view *view, double lx, double ly, int width,
-		int height) {
+static bool configure(struct sway_view *view, uint32_t *serial,
+		double lx, double ly, int width, int height) {
 	struct sway_xwayland_view *xwayland_view = xwayland_view_from_view(view);
 	if (xwayland_view == NULL) {
-		return 0;
+		return false;
 	}
 	struct wlr_xwayland_surface *xsurface = view->wlr_xwayland_surface;
 
 	wlr_xwayland_surface_configure(xsurface, lx, ly, width, height);
 
 	// xwayland doesn't give us a serial for the configure
-	return 0;
+	return true;
 }
 
 static void set_activated(struct sway_view *view, bool activated) {
@@ -544,13 +544,17 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		view->natural_height = ev->height;
 		container_floating_resize_and_center(view->container);
 
-		configure(view, view->container->pending.content_x,
+		bool successful = configure(view, NULL,
+				view->container->pending.content_x,
 				view->container->pending.content_y,
 				view->container->pending.content_width,
 				view->container->pending.content_height);
-		node_set_dirty(&view->container->node);
+
+		if (successful) {
+			node_set_dirty(&view->container->node);
+		}
 	} else {
-		configure(view, view->container->current.content_x,
+		configure(view, NULL, view->container->current.content_x,
 				view->container->current.content_y,
 				view->container->current.content_width,
 				view->container->current.content_height);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include <stdlib.h>
 #include <strings.h>
+#include <math.h>
 #include <wayland-server-core.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_buffer.h>
@@ -166,6 +167,14 @@ void view_get_constraints(struct sway_view *view, double *min_width,
 
 bool view_configure(struct sway_view *view, uint32_t *serial,
 		double lx, double ly, int width, int height) {
+	// Many clients don't play nicely if you try to reconfigure them out of
+	// their specified constraints. Clamp the values.
+	double minw, maxw, minh, maxh;
+	view_get_constraints(view, &minw, &maxw, &minh, &maxh);
+
+	width = fmax(fmin(width, maxw), minw);
+	height = fmax(fmin(height, maxh), minh);
+
 	if (view->impl->configure) {
 		return view->impl->configure(view, serial, lx, ly, width, height);
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -164,12 +164,13 @@ void view_get_constraints(struct sway_view *view, double *min_width,
 	}
 }
 
-uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
-		int height) {
+bool view_configure(struct sway_view *view, uint32_t *serial,
+		double lx, double ly, int width, int height) {
 	if (view->impl->configure) {
-		return view->impl->configure(view, lx, ly, width, height);
+		return view->impl->configure(view, serial, lx, ly, width, height);
 	}
-	return 0;
+
+	return false;
 }
 
 bool view_inhibit_idle(struct sway_view *view) {


### PR DESCRIPTION
Many clients will not ack & commit configures that make them smaller
or larger than their specified constraints. This means that the
transaction will timeout and poor perceived performance will endure.

Before:
https://user-images.githubusercontent.com/3621017/154896925-868b8713-8d92-4ed8-9586-3c965bce01a5.mp4

After:
https://user-images.githubusercontent.com/3621017/154896935-205b800f-5e27-485a-8b45-5ff223d48fd1.mp4

Is this the right solution to the problem?
