### PR TITLE
Don't enter seatop_move_floating when fullscreen

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -360,7 +360,8 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, request_move);
 	struct sway_view *view = &xdg_shell_view->view;
-	if (!container_is_floating(view->container)) {
+	if (!container_is_floating(view->container) ||
+			view->container->pending.fullscreen_mode) {
 		return;
 	}
 	struct wlr_xdg_toplevel_move_event *e = data;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -594,7 +594,8 @@ static void handle_request_move(struct wl_listener *listener, void *data) {
 	if (!xsurface->mapped) {
 		return;
 	}
-	if (!container_is_floating(view->container)) {
+	if (!container_is_floating(view->container) ||
+			view->container->pending.fullscreen_mode) {
 		return;
 	}
 	struct sway_seat *seat = input_manager_current_seat();


### PR DESCRIPTION
Currently, a floating window that's been fullscreened can send us `xdg_toplevel::move`, and we'll enter seatop_move_floating, which lets us drag the surface around while it's fullscreen. We don't want this—fullscreen surfaces should always be aligned to the screen—so add the same check that seatop_default already does when entering this mode.

Tested with Weston's weston-fullscreen demo, which sends a move request if you click anywhere on its surface.

Note that this fix is pretty fragile. There's nothing stopping some other code path from altering `pending.x` and `pending.y` of a fullscreen container. If there's a place where we can consolidate this logic to be more bulletproof, let me know.