### PR TITLE
swaynag: die on all allocation failures

### DIFF
--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -19,6 +19,10 @@ static char *read_from_stdin(void) {
 	ssize_t nread;
 	while ((nread = getline(&line, &line_size, stdin)) != -1) {
 		buffer = realloc(buffer, buffer_len + nread + 1);
+		if (!buffer) {
+			perror("realloc");
+			return NULL;
+		}
 		snprintf(&buffer[buffer_len], nread + 1, "%s", line);
 		buffer_len += nread;
 	}
@@ -152,6 +156,10 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 				}
 				struct swaynag_button *button;
 				button = calloc(sizeof(struct swaynag_button), 1);
+				if (!button) {
+					perror("calloc");
+					return EXIT_FAILURE;
+				}
 				button->text = strdup(optarg);
 				button->type = SWAYNAG_ACTION_COMMAND;
 				button->action = strdup(argv[optind]);
@@ -215,6 +223,9 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			if (swaynag) {
 				free(swaynag->details.message);
 				swaynag->details.message = read_from_stdin();
+				if (!swaynag->details.message) {
+					return EXIT_FAILURE;
+				}
 				swaynag->details.button_up.text = strdup("▲");
 				swaynag->details.button_down.text = strdup("▼");
 			}
@@ -406,6 +417,10 @@ int swaynag_load_config(char *path, struct swaynag *swaynag, list_t *types) {
 				break;
 			}
 			char *name = calloc(1, close - line);
+			if (!name) {
+				perror("calloc");
+				return EXIT_FAILURE;
+			}
 			strncat(name, line + 1, close - line - 1);
 			type = swaynag_type_get(types, name);
 			if (!type) {
@@ -415,6 +430,10 @@ int swaynag_load_config(char *path, struct swaynag *swaynag, list_t *types) {
 			free(name);
 		} else {
 			char *flag = malloc(nread + 3);
+			if (!flag) {
+				perror("calloc");
+				return EXIT_FAILURE;
+			}
 			snprintf(flag, nread + 3, "--%s", line);
 			char *argv[] = {"swaynag", flag};
 			result = swaynag_parse_options(2, argv, swaynag, types, type,

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -32,12 +32,20 @@ int main(int argc, char **argv) {
 
 	struct swaynag_button *button_close =
 		calloc(sizeof(struct swaynag_button), 1);
+	if (!button_close) {
+		perror("calloc");
+		return EXIT_FAILURE;
+	}
 	button_close->text = strdup("X");
 	button_close->type = SWAYNAG_ACTION_DISMISS;
 	list_add(swaynag.buttons, button_close);
 
 	swaynag.details.button_details =
 		calloc(sizeof(struct swaynag_button), 1);
+	if (!swaynag.details.button_details) {
+		perror("calloc");
+		return EXIT_FAILURE;
+	}
 	swaynag.details.button_details->text = strdup("Toggle details");
 	swaynag.details.button_details->type = SWAYNAG_ACTION_EXPAND;
 

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -30,6 +30,10 @@ static bool terminal_execute(char *terminal, char *command) {
 	chmod(fname, S_IRUSR | S_IWUSR | S_IXUSR);
 	size_t cmd_size = strlen(terminal) + strlen(" -e ") + strlen(fname) + 1;
 	char *cmd = malloc(cmd_size);
+	if (!cmd) {
+		perror("malloc");
+		return false;
+	}
 	snprintf(cmd, cmd_size, "%s -e %s", terminal, fname);
 	execlp("sh", "sh", "-c", cmd, NULL);
 	sway_log_errno(SWAY_ERROR, "Failed to run command, execlp() returned.");
@@ -340,6 +344,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 		struct swaynag_seat *seat =
 			calloc(1, sizeof(struct swaynag_seat));
 		if (!seat) {
+			perror("calloc");
 			return;
 		}
 
@@ -357,6 +362,10 @@ static void handle_global(void *data, struct wl_registry *registry,
 		if (!swaynag->output) {
 			struct swaynag_output *output =
 				calloc(1, sizeof(struct swaynag_output));
+			if (!output) {
+				perror("calloc");
+				return;
+			}
 			output->wl_output = wl_registry_bind(registry, name,
 					&wl_output_interface, 4);
 			output->wl_name = name;


### PR DESCRIPTION
Ideally the number of allocations should be reduced, but until then, detecting failure is better than not.