### PR TITLE
sway/input: don't pass possibly invalid modifiers pointer

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -77,8 +77,6 @@ static void handle_im_grab_keyboard(struct wl_listener *listener, void *data) {
 	struct wlr_keyboard *active_keyboard = wlr_seat_get_keyboard(relay->seat->wlr_seat);
 	wlr_input_method_keyboard_grab_v2_set_keyboard(keyboard_grab,
 		active_keyboard);
-	wlr_input_method_keyboard_grab_v2_send_modifiers(keyboard_grab,
-		&active_keyboard->modifiers);
 
 	wl_signal_add(&keyboard_grab->events.destroy,
 		&relay->input_method_keyboard_grab_destroy);


### PR DESCRIPTION
active_keyboard may be NULL, in which case an invalid pointer could be
passed to wlr_input_method_keyboard_grab_v2_send_modifiers. This
procedure call is unnecessary since wlroots commit [372a52ec](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/372a52ec) "input
method: send modifiers in set_keyboard", so the call can simply be
removed.

Fixes #6836.