### PR TITLE
input/cursor: don't allow resizing tiling fullscreen views

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -399,7 +399,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 
 	// Handle tiling resize via mod
 	bool mod_pressed = modifiers & config->floating_mod;
-	if (cont && !is_floating_or_child && mod_pressed &&
+	if (cont && !is_floating_or_child && !is_fullscreen_or_child && mod_pressed &&
 			state == WLR_BUTTON_PRESSED) {
 		uint32_t btn_resize = config->floating_mod_inverse ?
 			BTN_LEFT : BTN_RIGHT;


### PR DESCRIPTION
This check already exists for floating fullscreen views, just copying it
over. The views never truly got resized, but the cursor image would
erroneously change to the resize cursor.