### PR TITLE
Add primary_selection config option

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -164,6 +164,7 @@ sway_cmd cmd_no_focus;
 sway_cmd cmd_output;
 sway_cmd cmd_permit;
 sway_cmd cmd_popup_during_fullscreen;
+sway_cmd cmd_primary_selection;
 sway_cmd cmd_reject;
 sway_cmd cmd_reload;
 sway_cmd cmd_rename;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -130,6 +130,7 @@ struct input_config_tool {
 	enum sway_tablet_tool_mode mode;
 };
 
+
 /**
  * options for input devices
  */
@@ -468,6 +469,12 @@ enum xwayland_mode {
 	XWAYLAND_MODE_IMMEDIATE,
 };
 
+enum config_primary_selection {
+	PRIMARY_SELECTION_DEFAULT,
+	PRIMARY_SELECTION_DISABLED,
+	PRIMARY_SELECTION_ENABLED,
+};
+
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -527,6 +534,7 @@ struct sway_config {
 	bool auto_back_and_forth;
 	bool show_marks;
 	enum alignment title_align;
+	enum config_primary_selection primary_selection;
 
 	bool tiling_drag;
 	int tiling_drag_threshold;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -81,6 +81,7 @@ static const struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "primary_selection", cmd_primary_selection },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/primary_selection.c
+++ b/sway/commands/primary_selection.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_primary_selection(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "primary_selection", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (parse_boolean(argv[0], true)) {
+		config->primary_selection = PRIMARY_SELECTION_ENABLED;
+	} else {
+		config->primary_selection = PRIMARY_SELECTION_DISABLED;
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -265,6 +265,7 @@ static void config_defaults(struct sway_config *config) {
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
+	config->primary_selection = PRIMARY_SELECTION_DEFAULT;
 
 	config->smart_gaps = SMART_GAPS_OFF;
 	config->gaps_inner = 0;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -531,7 +531,14 @@ static void handle_request_set_primary_selection(struct wl_listener *listener,
 	struct sway_seat *seat =
 		wl_container_of(listener, seat, request_set_primary_selection);
 	struct wlr_seat_request_set_primary_selection_event *event = data;
-	wlr_seat_set_primary_selection(seat->wlr_seat, event->source, event->serial);
+	struct wlr_primary_selection_source *source;
+
+	if (config->primary_selection == PRIMARY_SELECTION_DISABLED) {
+		source = NULL;
+	} else {
+		source = event->source;
+	}
+	wlr_seat_set_primary_selection(seat->wlr_seat, source, event->serial);
 }
 
 static void collect_focus_iter(struct sway_node *node, void *data) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -83,6 +83,7 @@ sway_sources = files(
 	'commands/nop.c',
 	'commands/output.c',
 	'commands/popup_during_fullscreen.c',
+  'commands/primary_selection.c',
 	'commands/reload.c',
 	'commands/rename.c',
 	'commands/resize.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -746,6 +746,9 @@ The default colors are:
 	dialog will not be rendered. If _leave_fullscreen_, the view will exit
 	fullscreen mode and the dialog will be rendered.
 
+*primary_selection* enabled|disabled
+	Enable or disable the primary selection clipboard.
+
 *set* $<name> <value>
 	Sets variable $_name_ to _value_. You can use the new variable in the
 	arguments of future commands. When the variable is used, it can be escaped


### PR DESCRIPTION
See: https://github.com/swaywm/sway/issues/4511.

Adds a config option 'primary_selection', which explicitly
enables/disables the primary selection clipboard.

This is implemented as a config-option check in 'handle_request_set_primary_selection', which clears
the primary selection if the option is set to 'disabled'.

## Effect of Changes

With 'primary_config = enabled' in the config, the primary selection clipboard will not be filled.

## A Consideration

After setting the option with the cli: `sway primary_selection disabled`, there may still be a selection in the clipboard until the selection is cleared later. This could be addressed by clearing the clipboard after the option is set, but I'm not sure if that kind of effect would be desirable in the command function.

## Alternatives

- Existing workarounds suggested in the linked issue
- A better & more flexible config option that can instead disable the middle-mouse paste action, while retaining the other functionality of middle_emulation. It seems like this would require some deeper changes to wlr, or lipinput, so I didn't pursue this yet (but would be willing to, perhaps with some guidance)