### PR TITLE
Allow not having SWAYSOCK set if there is a single socket in XDG_RUNTIME_DIR

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -87,6 +87,24 @@ void detect_proprietary(int allow_unsupported_gpu) {
 	fclose(f);
 }
 
+int query_for_swaypid(char *xdg_runtime_dir) {
+	if (xdg_runtime_dir != NULL) {
+		char pidline[1024];
+		char *pid;
+		FILE *fp = popen("pidof sway", "r");
+		fgets(pidline, 1024, fp);
+		pid = strtok(pidline, " ");
+		int sway_pid = atoi(pid);
+		if (strtok(NULL, " ") != NULL) {
+			return -1;
+		} else {
+			return sway_pid;
+		}
+	} else {
+		exit(EXIT_FAILURE);
+	};
+}
+
 void run_as_ipc_client(char *command, char *socket_path) {
 	int socketfd = ipc_open_socket(socket_path);
 	uint32_t len = strlen(command);
@@ -102,6 +120,7 @@ static void log_env(void) {
 		"LD_PRELOAD",
 		"PATH",
 		"SWAYSOCK",
+		"XDG_RUNTIME_DIR",
 	};
 	for (size_t i = 0; i < sizeof(log_vars) / sizeof(char *); ++i) {
 		char *value = getenv(log_vars[i]);
@@ -307,7 +326,20 @@ int main(int argc, char **argv) {
 		case 'p': ; // --get-socketpath
 			if (getenv("SWAYSOCK")) {
 				printf("%s\n", getenv("SWAYSOCK"));
-				exit(EXIT_SUCCESS);
+			} else if (getenv("XDG_RUNTIME_DIR") && getuid()) {
+				int swaypid = query_for_swaypid(getenv("XDG_RUNTIME_DIR"));
+				char *swaysock = {0};
+				if (swaypid > 0) {
+					sprintf(swaysock, "%s/sway-ipc.%u.%i.sock", getenv("XDG_RUNTIME_DIR"), getuid(), swaypid);
+					if (access(swaysock, F_OK) != -1) {
+						printf("%s\n", swaysock);
+					} else {
+						fprintf(stderr, "sway socket not detected.\n"); // found a pid, but no socket file
+					}
+				} else {
+					fprintf(stderr, "Found more than one sway instance running.\n");
+					exit(EXIT_FAILURE);
+				}
 			} else {
 				fprintf(stderr, "sway socket not detected.\n");
 				exit(EXIT_FAILURE);


### PR DESCRIPTION
Quite often, I run into a scenario where I've set XDG_RUNTIME_DIR as a hardcoded path, but I haven't exported SWAYSOCK since it depends on the PID of sway.

If there is a single `sway-ipc.USER_ID.%d.sock` in the current `${XDG_RUNTIME_DIR}` there is a good chance this is the current sway session. Since some people may be running multiple instances of Sway, it should fail if more than one sway pid is found.

