### PR TITLE
swaynag: add `--no-dock` option

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -96,6 +96,7 @@ struct swaynag {
 	char *message;
 	list_t *buttons;
 	struct swaynag_details details;
+	bool no_dock;
 };
 
 void swaynag_setup(struct swaynag *swaynag);

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -69,6 +69,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		{"detailed-message", no_argument, NULL, 'l'},
 		{"detailed-button", required_argument, NULL, 'L'},
 		{"message", required_argument, NULL, 'm'},
+		{"no-dock", no_argument, NULL, 'n'},
 		{"output", required_argument, NULL, 'o'},
 		{"dismiss-button", required_argument, NULL, 's'},
 		{"type", required_argument, NULL, 't'},
@@ -116,6 +117,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 		"  -l, --detailed-message          Read a detailed message from stdin.\n"
 		"  -L, --detailed-button <text>    Set the text of the detail button.\n"
 		"  -m, --message <msg>             Set the message text.\n"
+		"  -n, --no-dock                   Do not set the exclusive zone.\n"
 		"  -o, --output <output>           Set the output to use.\n"
 		"  -s, --dismiss-button <text>     Set the dismiss button text.\n"
 		"  -t, --type <type>               Set the message type.\n"
@@ -140,7 +142,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 
 	optind = 1;
 	while (1) {
-		int c = getopt_long(argc, argv, "b:B:z:Z:c:de:y:f:hlL:m:o:s:t:v", opts, NULL);
+		int c = getopt_long(argc, argv, "b:B:z:Z:c:de:y:f:hlL:m:o:s:t:nv", opts, NULL);
 		if (c == -1) {
 			break;
 		}
@@ -240,6 +242,11 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			if (swaynag) {
 				free(swaynag->message);
 				swaynag->message = strdup(optarg);
+			}
+			break;
+		case 'n':
+			if (swaynag) {
+				swaynag->no_dock = true;
 			}
 			break;
 		case 'o': // Output

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -264,8 +264,10 @@ void render_frame(struct swaynag *swaynag) {
 	uint32_t height = render_to_cairo(cairo, swaynag);
 	if (height != swaynag->height) {
 		zwlr_layer_surface_v1_set_size(swaynag->layer_surface, 0, height);
-		zwlr_layer_surface_v1_set_exclusive_zone(swaynag->layer_surface,
-				height);
+		if (!swaynag->no_dock) {
+			zwlr_layer_surface_v1_set_exclusive_zone(swaynag->layer_surface,
+					height);
+		}
 		wl_surface_commit(swaynag->surface);
 		wl_display_roundtrip(swaynag->display);
 	} else {


### PR DESCRIPTION
I think is is useful to be able to render swaynag on top of everything, without pushing surfaces.