### PR TITLE
sway/main: move constants off the stack

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -240,34 +240,34 @@ static void handle_wlr_log(enum wlr_log_importance importance,
 	_sway_vlog(convert_wlr_log_importance(importance), sway_fmt, args);
 }
 
+static const struct option long_options[] = {
+	{"help", no_argument, NULL, 'h'},
+	{"config", required_argument, NULL, 'c'},
+	{"validate", no_argument, NULL, 'C'},
+	{"debug", no_argument, NULL, 'd'},
+	{"version", no_argument, NULL, 'v'},
+	{"verbose", no_argument, NULL, 'V'},
+	{"get-socketpath", no_argument, NULL, 'p'},
+	{"unsupported-gpu", no_argument, NULL, 'u'},
+	{0, 0, 0, 0}
+};
+
+static const char usage[] =
+	"Usage: sway [options] [command]\n"
+	"\n"
+	"  -h, --help             Show help message and quit.\n"
+	"  -c, --config <config>  Specify a config file.\n"
+	"  -C, --validate         Check the validity of the config file, then exit.\n"
+	"  -d, --debug            Enables full logging, including debug information.\n"
+	"  -v, --version          Show the version number and quit.\n"
+	"  -V, --verbose          Enables more verbose logging.\n"
+	"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
+	"\n";
+
 int main(int argc, char **argv) {
 	static bool verbose = false, debug = false, validate = false, allow_unsupported_gpu = false;
 
-	static const struct option long_options[] = {
-		{"help", no_argument, NULL, 'h'},
-		{"config", required_argument, NULL, 'c'},
-		{"validate", no_argument, NULL, 'C'},
-		{"debug", no_argument, NULL, 'd'},
-		{"version", no_argument, NULL, 'v'},
-		{"verbose", no_argument, NULL, 'V'},
-		{"get-socketpath", no_argument, NULL, 'p'},
-		{"unsupported-gpu", no_argument, NULL, 'u'},
-		{0, 0, 0, 0}
-	};
-
 	char *config_path = NULL;
-
-	const char* usage =
-		"Usage: sway [options] [command]\n"
-		"\n"
-		"  -h, --help             Show help message and quit.\n"
-		"  -c, --config <config>  Specify a config file.\n"
-		"  -C, --validate         Check the validity of the config file, then exit.\n"
-		"  -d, --debug            Enables full logging, including debug information.\n"
-		"  -v, --version          Show the version number and quit.\n"
-		"  -V, --verbose          Enables more verbose logging.\n"
-		"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
-		"\n";
 
 	int c;
 	while (1) {


### PR DESCRIPTION
This is a mostly aesthetic change; it keeps the constants `long_options` and `usage` out of stack traces, making it slightly easier to see the important parts.

```diff
#14 0x00007f51a64302e5 in wl_display_run (display=0x5563ffc0c720)
    at ../wayland/src/wayland-server.c:1408
#15 0x00005563ff0bd620 in server_run (server=server@entry=0x5563ff1264c0 <server>)
    at ../sway/sway/server.c:307
#16 0x00005563ff0b1d82 in main (argc=3, argv=0x7fff18269888) at ../sway/sway/main.c:431
        verbose = false
        debug = false
        validate = false
        allow_unsupported_gpu = false
-        long_options = 
-            {{name = 0x5563ff105459 "help", has_arg = 0, flag = 0x0, val = 104}, {name = 0x5563ff109365 "config", has_arg = 1, flag = 0x0, val = 99}, {name = 0x5563ff10545e "validate", has_arg = 0, flag = 0x0, val = 67}, {name = 0x5563ff105467 "debug", has_arg = 0, flag = 0x0, val = 100}, {name = 0x5563ff1053bd "version", has_arg = 0, flag = 0x0, val = 118}, {name = 0x5563ff10451e "verbose", has_arg = 0, flag = 0x0, val = 86}, {name = 0x5563ff10546d "get-socketpath", has_arg = 0, flag = 0x0, val = 112}, {name = 0x5563ff10547c "unsupported-gpu", has_arg = 0, flag = 0x0, val = 117}, {name = 0x0, has_arg = 0, flag = 0x0, val = 0}}
        config_path = 0x5563ffc0c010 "empty"
-        usage = 0x5563ff105a18 "Usage: sway [options] [command]\n\n  -h, --help", ' ' <repeats 13 times>, "Show help message and quit.\n  -c, --config <config>  Specify a config file.\n  -C, --validate         Check the validity of the config file, th"...
        c = <optimized out>
```