### PR TITLE
Gcc 12 fixes

### DIFF
--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -102,19 +102,19 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 			}
 
 			char *conf_path = dirname(conf);
-			char *rel_path = src;
-			src = malloc(strlen(conf_path) + strlen(src) + 2);
-			if (!src) {
-				free(rel_path);
+			char *real_src = malloc(strlen(conf_path) + strlen(src) + 2);
+			if (!real_src) {
+				free(src);
 				free(conf);
 				sway_log(SWAY_ERROR, "Unable to allocate memory");
 				return cmd_results_new(CMD_FAILURE,
 						"Unable to allocate resources");
 			}
 
-			snprintf(src, strlen(conf_path) + strlen(src) + 2, "%s/%s", conf_path, rel_path);
-			free(rel_path);
+			snprintf(real_src, strlen(conf_path) + strlen(src) + 2, "%s/%s", conf_path, src);
+			free(src);
 			free(conf);
+			src = real_src;
 		}
 
 		bool can_access = access(src, F_OK) != -1;

--- a/sway/server.c
+++ b/sway/server.c
@@ -213,8 +213,8 @@ bool server_init(struct sway_server *server) {
 
 	// Avoid using "wayland-0" as display socket
 	char name_candidate[16];
-	for (int i = 1; i <= 32; ++i) {
-		snprintf(name_candidate, sizeof(name_candidate), "wayland-%d", i);
+	for (unsigned int i = 1; i <= 32; ++i) {
+		snprintf(name_candidate, sizeof(name_candidate), "wayland-%u", i);
 		if (wl_display_add_socket(server->wl_display, name_candidate) >= 0) {
 			server->socket = strdup(name_candidate);
 			break;


### PR DESCRIPTION
Sway master has two compile errors when using GCC 12; one false positive and one due to an actual bug.  This adjusts the code slightly to fix the warnings.