### PR TITLE
don't add ": " to new_name, if icon_count is 0.

### DIFF
--- a/contrib/autoname-workspaces.py
+++ b/contrib/autoname-workspaces.py
@@ -64,16 +64,18 @@ def parse_workspace_name(name):
         "(?P<num>[0-9]+):?(?P<shortname>\w+)? ?(?P<icons>.+)?", name
     ).groupdict()
 
-
 def construct_workspace_name(parts):
     new_name = str(parts["num"])
     if parts["shortname"] or parts["icons"]:
-        new_name += ":"
+        icon_count=len(parts["icons"].split())
+        
+        if icon_count != 0:
+            new_name += ":"
 
         if parts["shortname"]:
             new_name += parts["shortname"]
 
-        if parts["icons"]:
+        if parts["icons"] and icon_count != 0:
             new_name += " " + parts["icons"]
 
     return new_name


### PR DESCRIPTION
Don't add ": " to new_name, if icon_count is 0. Otherwise exiting all windows in a workspace does not remove ": " from new_name.