### PR TITLE
check if icon_count is not 0

### DIFF
--- a/contrib/autoname-workspaces.py
+++ b/contrib/autoname-workspaces.py
@@ -68,15 +68,18 @@ def parse_workspace_name(name):
 def construct_workspace_name(parts):
     new_name = str(parts["num"])
     if parts["shortname"] or parts["icons"]:
-        new_name += ":"
+        icon_count = len(parts["icons"].split())
+        
+        if icon_count != 0 or parts["shortname"]:
+            new_name += ":"
 
         if parts["shortname"]:
             new_name += parts["shortname"]
 
-        if parts["icons"]:
+        if parts["icons"] and icon_count != 0:
             new_name += " " + parts["icons"]
 
-    return new_name
+    return new_name 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the number of icons is 0 i. e. there are no windows in a workspace, then, assuming parts["shortname"] is None, ": " is appended to new_name. 

The following edit fixes that small issue, but also adds ":" to new_name, if parts["shortname"] is not None.