### PR TITLE
Session lock focus fixes

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -201,10 +201,6 @@ struct sway_workspace *seat_get_last_known_workspace(struct sway_seat *seat);
 
 struct sway_container *seat_get_focused_container(struct sway_seat *seat);
 
-// Force focus to a particular surface that is not part of the workspace
-// hierarchy (used for lockscreen)
-void sway_force_focus(struct wlr_surface *surface);
-
 /**
  * Return the last container to be focused for the seat (or the most recently
  * opened if no container has received focused) that is a child of the given

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -96,6 +96,7 @@ struct sway_server {
 		struct wlr_session_lock_manager_v1 *manager;
 
 		struct wlr_session_lock_v1 *lock;
+		struct wlr_surface *focused;
 		struct wl_listener lock_new_surface;
 		struct wl_listener lock_unlock;
 		struct wl_listener lock_destroy;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -214,15 +214,6 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 	}
 }
 
-void sway_force_focus(struct wlr_surface *surface) {
-	struct sway_seat *seat;
-	wl_list_for_each(seat, &server.input->seats, link) {
-		seat_keyboard_notify_enter(seat, surface);
-		seat_tablet_pads_notify_enter(seat, surface);
-		sway_input_method_relay_set_focus(&seat->im_relay, surface);
-	}
-}
-
 void seat_for_each_node(struct sway_seat *seat,
 		void (*f)(struct sway_node *node, void *data), void *data) {
 	struct sway_seat_node *current = NULL;


### PR DESCRIPTION
Keyboard focus tracking with session lock has some incorrect edge cases around output destroy/create; this changes them to more closely mirror those used by layer_shell.