### PR TITLE
Flatten redundant splits after deleting nodes

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1505,6 +1505,10 @@ void container_detach(struct sway_container *child) {
 		if (index != -1) {
 			list_del(siblings, index);
 		}
+    // if con has one sibling which is split, deleting con leaves redundant splits. squash them
+    if (siblings->length == 1 && old_parent) {
+        container_flatten(old_parent);
+      }
 	}
 	child->pending.parent = NULL;
 	child->pending.workspace = NULL;


### PR DESCRIPTION
**The bug:** 
When you have a layout like H[app1 V[app2]], killing app1 results in H[V[app2]] which is 
functionally equivalent to just V[app2]. The horizontally split container should be squashed. 

This bug can lead to deeply nested layers of containers over time. For example, if you open a sequence of containers with alternating splits:

    H[app1 V[app2 H[app3 V[app4 ... H[appN]...]]]]

then close them in the same order you opened them, you'll end up with

    H[V[H[V[...H[appN]...]]]]

These redundant splits can get deeply nested over time and incur a heavy performance cost (especially if using something like `autotiling`).

**How to replicate:** 
Start with a blank workspace
Spawn a single container by launching an app
`splith` it and spawn a new container
`splitv` the child
`kill` the parent
The workspace is now in the layout `H[V[app]]` instead of the expected `V[app]`

**The fix:**

When detaching a container, check if it has exactly one sibling. If the sibling is split and parent are both split, then flatten the parent and sibling.

**Comments:**
This patch prevents containers from accumulating and causing lag, but will not flatten a duplicate split on the very outer layer, e.g. H[H[app]]. (It will flatten H[H[H[app]]] --> H[H[app]] and so on.) If anyone sees a better way to do it, I'd be grateful.

container_squash (introduced in 8eb0c54693e44e7c6126ce35045e34ad0f4d4607) fails to detect the squashable containers because it only squashes containers with no grandchildren (i.e., it looks at the bottom of the chain of containers). it seems like workspace_squash was originally intended to squash from the top down:

    /**
     * workspace_squash is container_flatten in the reverse
     * direction. Instead of eliminating redundant splits that are
     * parents of the target container, it eliminates pairs of
     * redundant H/V splits that are children of the workspace.
     */

however, workspace_squash simply calls container_squash on all the children of a workspace, so it still only sees the bottom of the chain(s).





