### PR TITLE
realtime: request SCHED_RR using CAP_SYS_NICE

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -173,4 +173,6 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data);
 void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 	void *data);
 
+void set_rr_scheduling(void);
+
 #endif

--- a/sway/main.c
+++ b/sway/main.c
@@ -413,6 +413,8 @@ int main(int argc, char **argv) {
 		goto shutdown;
 	}
 
+	set_rr_scheduling();
+
 	if (!server_start(&server)) {
 		sway_terminate(EXIT_FAILURE);
 		goto shutdown;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -7,6 +7,7 @@ sway_sources = files(
 	'ipc-server.c',
 	'lock.c',
 	'main.c',
+	'realtime.c',
 	'server.c',
 	'swaynag.c',
 	'xdg_activation_v1.c',

--- a/sway/realtime.c
+++ b/sway/realtime.c
@@ -1,0 +1,40 @@
+#include <sys/resource.h>
+#include <sched.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "sway/server.h"
+#include "log.h"
+
+static void child_fork_callback(void) {
+	struct sched_param param;
+
+	param.sched_priority = 0;
+
+	int ret = pthread_setschedparam(pthread_self(), SCHED_OTHER, &param);
+	if (ret != 0) {
+		sway_log(SWAY_ERROR, "Failed to reset scheduler policy on fork");
+	}
+}
+
+void set_rr_scheduling(void) {
+	int prio = sched_get_priority_min(SCHED_RR);
+	int old_policy;
+	int ret;
+	struct sched_param param;
+
+	ret = pthread_getschedparam(pthread_self(), &old_policy, &param);
+	if (ret != 0) {
+		sway_log(SWAY_DEBUG, "Failed to get old scheduling priority");
+		return;
+	}
+
+	param.sched_priority = prio;
+
+	ret = pthread_setschedparam(pthread_self(), SCHED_RR, &param);
+	if (ret != 0) {
+		sway_log(SWAY_INFO, "Failed to set scheduling priority to %d", prio);
+		return;
+	}
+
+	pthread_atfork(NULL, NULL, child_fork_callback);
+}


### PR DESCRIPTION
Try to gain SCHED_RR (round-robin) realtime scheduling privileges before
starting the server. This requires CAP_SYS_NICE on Linux systems.
We additionally register a pthread_atfork callback which resets the
scheduling class back to SCHED_OTHER (the Linux system default).

Due to CAP_SYS_NICE, setting RLIMIT_RTPRIO has no effect on the process
as documented within man 7 sched (from Linux):
```
  Privileged (CAP_SYS_NICE) threads ignore the RLIMIT_RTPRIO limit;
  as with older kernels, they can make arbitrary changes to
  scheduling policy and priority. See getrlimit(2) for further
  information on RLIMIT_RTPRIO
```
Note that this requires the sway distribution packagers to set the
CAP_SYS_NICE capability on the sway binary.

Supersedes #6992