### PR TITLE
sway/lock: set session lock hints if systemd is available

### DIFF
--- a/sway/meson.build
+++ b/sway/meson.build
@@ -229,6 +229,10 @@ if have_xwayland
 	sway_deps += xcb
 endif
 
+if sdbus.found()
+	sway_deps += sdbus
+endif
+
 executable(
 	'sway',
 	sway_sources,


### PR DESCRIPTION
## Motivation for this MR: 

User automation can benefit from knowing whether a session is locked. For example, automation can stop a time-tracking software when the screen is locked and prompt the user whether they'd like to continue the tracker when the session is unlocked.

systemd-logind provides support for this, but it needs to be notified about this hint.

## Why implement this in sway?

From the [The D-Bus interface of systemd-logind documentation](https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html):

> SetLockedHint() may be used to set the "locked hint" to locked, i.e. information whether the session is locked. This is intended to be used by the desktop environment to tell systemd-logind when the session is locked and unlocked.

## Alternatives

- User automation could listen whether the screenlocker programs is started, the problem is that if the user has many sessions in different ttys, distinguishing which session is locked becomes hairy.
- User automation could listen whether the screenlocker program is started, but then it would need to know a fixed list of screenlocking programs to detect, this seems rather unefficient.
- The screen locker software could set the hint on behalf of the desktop environment, but if the screen locker is killed, the hint would stay, leading to potentially unintended behaviour.
- The screen locker software could set the hint on behalf of the desktop environment, but then this would need to be implemented in all screenlockers.

## Downsides

- This feature is only available with systemd (to my knowledge).

## Future work

- Check whether a similar interface is implemented in environments with `libelogind` or `basu`. I don't know these environments and I can't test, therefore this is only enabled on systemd.
