### PR TITLE
ext-session-lock: disable direct scan-out when locked

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -453,6 +453,10 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
+	if (server.session_lock.locked) {
+		return false;
+	}
+
 	if (!wl_list_empty(&view->saved_buffers)) {
 		return false;
 	}


### PR DESCRIPTION
Fixes https://github.com/swaywm/swaylock/issues/236.

@alextsits - please confirm this fixes it for you.