### PR TITLE
Use shell for spawning swaybar

### DIFF
--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -236,10 +236,14 @@ static void invoke_swaybar(struct bar_config *bar) {
 			setenv("WAYLAND_SOCKET", wayland_socket_str, true);
 
 			// run custom swaybar
-			char *const cmd[] = {
-					bar->swaybar_command ? bar->swaybar_command : "swaybar",
-					"-b", bar->id, NULL};
+			const char *swaybarcmd =
+				bar->swaybar_command ? bar->swaybar_command : "exec swaybar";
+			int cmdlen = snprintf(NULL, 0, "%s -b %s", swaybarcmd, bar->id) + 1;
+			char *full_cmd = malloc(cmdlen);
+			sprintf(full_cmd, "%s -b %s", swaybarcmd, bar->id);
+			char *const cmd[] = {"sh", "-c", full_cmd};
 			execvp(cmd[0], cmd);
+			free(full_cmd);
 			_exit(EXIT_FAILURE);
 		}
 		_exit(EXIT_SUCCESS);


### PR DESCRIPTION
This adds ability to set any command in `swaybar_command`, not just path to binary, which is [default behavior](https://github.com/i3/i3/blob/next/src/main.c#L1186-L1191) in `i3`.