### PR TITLE
build: link with -pthread

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,6 +70,7 @@ fish_comp = dependency('fish', required: false)
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 xcb_icccm = dependency('xcb-icccm', required: get_option('xwayland'))
+threads = dependency('threads') # for pthread_setschedparam
 
 wlroots_features = {
 	'xwayland': false,

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -220,6 +220,7 @@ sway_deps = [
 	glesv2,
 	pixman,
 	server_protos,
+	threads,
 	wayland_server,
 	wlroots,
 	xkbcommon,


### PR DESCRIPTION
Fixes the following FreeBSD error:

    ld: error: undefined symbol: pthread_getschedparam
    >>> referenced by realtime.c:25 (../sway/realtime.c:25)
    >>>               sway/sway.p/realtime.c.o:(set_rr_scheduling)

Fixes: a3a82efbf6b5 ("realtime: request SCHED_RR using CAP_SYS_NICE")