### PR TITLE
Improve tablet tool button handling.

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -64,6 +64,7 @@ struct sway_cursor {
 	struct wl_listener tool_proximity;
 	struct wl_listener tool_button;
 	bool simulating_pointer_from_tool_tip;
+	bool simulating_pointer_from_tool_button;
 	uint32_t tool_buttons;
 
 	struct wl_listener request_set_cursor;


### PR DESCRIPTION
This change allows the tablet tool button to be used for floating mod resize. In addition, it attempts to ensure that tablet tool events are consistent such that tablet v2 events and pointer events will never be interleaved, and such that the tool buttons count will never fall out of sync and cause tool button emulation to break.

Some of this logic is similar to what is done for tablet tool tip, but not quite identical, because of the complication that we have to deal with multiple inputs that can overlap each-other.

The logic described to fix this in #7036 is not sufficient as it does not account for the inverse case (going from tablet events to pointer events.) Implementing the fix this way leads to much better behavior if you, for example, use a tool button to open a menu, then before releasing the tool button, hold the modifier key down.

(Note: I'm currently unable to compile SwayWM from `master` as I do not have the ability to run `meson>=0.60` right now, among other deps. So although I made a best effort to ensure this patch is right for SwayWM `master`, I could not actually test this yet on my own setup. Sorry.)

Fixes #7036.