### PR TITLE
add DesktopNames to sway.desktop

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
This allows xdg-desktop-portal-wlr to work and exports XDG_CURRENT_DESKTOP upon starting sway from a display manager