### PR TITLE
swaynag: move close_button up to fix SIGSEGV

### DIFF
--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -29,6 +29,11 @@ int main(int argc, char **argv) {
 	wl_list_init(&swaynag.outputs);
 	wl_list_init(&swaynag.seats);
 
+	struct swaynag_button button_close = { 0 };
+	button_close.text = strdup("X");
+	button_close.type = SWAYNAG_ACTION_DISMISS;
+	list_add(swaynag.buttons, &button_close);
+
 	char *config_path = NULL;
 	bool debug = false;
 	status = swaynag_parse_options(argc, argv, NULL, NULL, NULL,
@@ -84,11 +89,6 @@ int main(int argc, char **argv) {
 	swaynag.type = type;
 
 	swaynag_types_free(types);
-
-	struct swaynag_button button_close = { 0 };
-	button_close.text = strdup("X");
-	button_close.type = SWAYNAG_ACTION_DISMISS;
-	list_add(swaynag.buttons, &button_close);
 
 	if (swaynag.details.message) {
 		list_add(swaynag.buttons, &swaynag.details.button_details);


### PR DESCRIPTION
When swaynag_parse_options encounters '--dismiss-button' (or its
shorthand '-s'), it sets the text of the first button in the
swaynag.buttons list, which is expected to exist and to be the dismiss
button, to the one passed by the user.

Commit 4780afb68b4ee2cdf0e4925f40cf885819f8a74a ("swaynag: statically
allocate button_close, and move declaration") moved the list
initialization to after swaynag_parse_options is called which made that
code fail.

For example, the command 'swaynag --dismiss-button Dismiss' crashes and
'swaynag --message Message --button Yes "" --dismiss-button Dismiss'
shows the wrong buttons.

Move it back to before swaynag_parse_options is called.