### PR TITLE
swaymsg: show non-desktop outputs

### DIFF
--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_IPC_JSON_H
 #define _SWAY_IPC_JSON_H
 #include <json.h>
+#include "sway/output.h"
 #include "sway/tree/container.h"
 #include "sway/input/input-manager.h"
 
@@ -9,6 +10,7 @@ json_object *ipc_json_get_version(void);
 json_object *ipc_json_get_binding_mode(void);
 
 json_object *ipc_json_describe_disabled_output(struct sway_output *o);
+json_object *ipc_json_describe_non_desktop_output(struct sway_output_non_desktop *o);
 json_object *ipc_json_describe_node(struct sway_node *node);
 json_object *ipc_json_describe_node_recursive(struct sway_node *node);
 json_object *ipc_json_describe_input(struct sway_input_device *device);

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -57,6 +57,12 @@ struct sway_output {
 	struct wl_event_source *repaint_timer;
 };
 
+struct sway_output_non_desktop {
+	struct wlr_output *wlr_output;
+
+	struct wl_listener destroy;
+};
+
 struct sway_output *output_create(struct wlr_output *wlr_output);
 
 void output_destroy(struct sway_output *output);
@@ -176,5 +182,7 @@ void handle_output_manager_test(struct wl_listener *listener, void *data);
 
 void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
+
+struct sway_output_non_desktop *output_non_desktop_create(struct wlr_output *wlr_output);
 
 #endif

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -28,6 +28,7 @@ struct sway_root {
 	double width, height;
 
 	list_t *outputs; // struct sway_output
+	list_t *non_desktop_outputs; // struct sway_output_non_desktop
 	list_t *scratchpad; // struct sway_container
 
 	// For when there's no connected outputs

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -883,10 +883,12 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	if (wlr_output->non_desktop) {
 		sway_log(SWAY_DEBUG, "Not configuring non-desktop output");
+		struct sway_output_non_desktop *non_desktop = output_non_desktop_create(wlr_output);
 		if (server->drm_lease_manager) {
 			wlr_drm_lease_v1_manager_offer_output(server->drm_lease_manager,
 					wlr_output);
 		}
+		list_add(root->non_desktop_outputs, non_desktop);
 		return;
 	}
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -240,10 +240,7 @@ static json_object *ipc_json_create_node(int id, const char* type, char *name,
 	return object;
 }
 
-static void ipc_json_describe_output(struct sway_output *output,
-		json_object *object) {
-	struct wlr_output *wlr_output = output->wlr_output;
-
+static void ipc_json_describe_wlr_output(struct wlr_output *wlr_output, json_object *object) {
 	json_object_object_add(object, "primary", json_object_new_boolean(false));
 	json_object_object_add(object, "make",
 			json_object_new_string(wlr_output->make ? wlr_output->make : "Unknown"));
@@ -267,11 +264,17 @@ static void ipc_json_describe_output(struct sway_output *output,
 	json_object_object_add(object, "modes", modes_array);
 }
 
+static void ipc_json_describe_output(struct sway_output *output,
+		json_object *object) {
+	ipc_json_describe_wlr_output(output->wlr_output, object);
+}
+
 static void ipc_json_describe_enabled_output(struct sway_output *output,
 		json_object *object) {
 	ipc_json_describe_output(output, object);
 
 	struct wlr_output *wlr_output = output->wlr_output;
+	json_object_object_add(object, "non_desktop", json_object_new_boolean(false));
 	json_object_object_add(object, "active", json_object_new_boolean(true));
 	json_object_object_add(object, "dpms",
 			json_object_new_boolean(wlr_output->enabled));
@@ -349,6 +352,7 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 
 	ipc_json_describe_output(output, object);
 
+	json_object_object_add(object, "non_desktop", json_object_new_boolean(false));
 	json_object_object_add(object, "type", json_object_new_string("output"));
 	json_object_object_add(object, "name",
 			json_object_new_string(wlr_output->name));
@@ -366,6 +370,21 @@ json_object *ipc_json_describe_disabled_output(struct sway_output *output) {
 	json_object_object_add(object, "rect", rect_object);
 
 	json_object_object_add(object, "percent", NULL);
+
+	return object;
+}
+
+json_object *ipc_json_describe_non_desktop_output(struct sway_output_non_desktop *output) {
+	struct wlr_output *wlr_output = output->wlr_output;
+
+	json_object *object = json_object_new_object();
+
+	ipc_json_describe_wlr_output(wlr_output, object);
+
+	json_object_object_add(object, "non_desktop", json_object_new_boolean(true));
+	json_object_object_add(object, "type", json_object_new_string("output"));
+	json_object_object_add(object, "name",
+				json_object_new_string(wlr_output->name));
 
 	return object;
 }

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -685,6 +685,12 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 						ipc_json_describe_disabled_output(output));
 			}
 		}
+
+		for (int i = 0; i < root->non_desktop_outputs->length; i++) {
+			struct sway_output_non_desktop *non_desktop_output = root->non_desktop_outputs->items[i];
+			json_object_array_add(outputs, ipc_json_describe_non_desktop_output(non_desktop_output));
+		}
+
 		const char *json_string = json_object_to_json_string(outputs);
 		ipc_send_reply(client, payload_type, json_string,
 			(uint32_t)strlen(json_string));

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -38,6 +38,7 @@ struct sway_root *root_create(void) {
 	wl_list_init(&root->drag_icons);
 	wl_signal_init(&root->events.new_node);
 	root->outputs = create_list();
+	root->non_desktop_outputs = create_list();
 	root->scratchpad = create_list();
 
 	root->output_layout_change.notify = output_layout_handle_change;

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -185,12 +185,13 @@ static void pretty_print_seat(json_object *i) {
 }
 
 static void pretty_print_output(json_object *o) {
-	json_object *name, *rect, *focused, *active, *ws, *current_mode;
+	json_object *name, *rect, *focused, *active, *ws, *current_mode, *non_desktop;
 	json_object_object_get_ex(o, "name", &name);
 	json_object_object_get_ex(o, "rect", &rect);
 	json_object_object_get_ex(o, "focused", &focused);
 	json_object_object_get_ex(o, "active", &active);
 	json_object_object_get_ex(o, "current_workspace", &ws);
+	json_object_object_get_ex(o, "non_desktop", &non_desktop);
 	json_object *make, *model, *serial, *scale, *scale_filter, *subpixel,
 		*transform, *max_render_time, *adaptive_sync_status;
 	json_object_object_get_ex(o, "make", &make);
@@ -213,7 +214,15 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(current_mode, "height", &height);
 	json_object_object_get_ex(current_mode, "refresh", &refresh);
 
-	if (json_object_get_boolean(active)) {
+	if (json_object_get_boolean(non_desktop)) {
+		printf(
+			"Output %s '%s %s %s' (non-desktop)\n",
+			json_object_get_string(name),
+			json_object_get_string(make),
+			json_object_get_string(model),
+			json_object_get_string(serial)
+		);
+	} else if (json_object_get_boolean(active)) {
 		printf(
 			"Output %s '%s %s %s'%s\n"
 			"  Current mode: %dx%d @ %.3f Hz\n"


### PR DESCRIPTION
Currently, `swaymsg -t get_outputs` doesn't report VR headsets.  This ultimately adds that support by adding non-desktop outputs to a list of the new type `sway_output_non_desktop` to `sway_root` since sway doesn't hold on to those outputs. I could simply create `sway_outputs` for non-desktop outputs, but I wasn't sure of the implications.  Let me know your thoughts