### PR TITLE
Allocate enough space for `cmd_results->error`

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -485,13 +485,19 @@ struct cmd_results *cmd_results_new(enum cmd_status status,
 	}
 	results->status = status;
 	if (format) {
-		char *error = malloc(256);
+		char *error = NULL;
 		va_list args;
 		va_start(args, format);
-		if (error) {
-			vsnprintf(error, 256, format, args);
-		}
+		int slen = vsnprintf(NULL, 0, format, args);
 		va_end(args);
+		if (slen > 0) {
+			error = malloc(slen + 1);
+			if (error != NULL) {
+				va_start(args, format);
+				vsnprintf(error, slen + 1, format, args);
+				va_end(args);
+			}
+		}
 		results->error = error;
 	} else {
 		results->error = NULL;


### PR DESCRIPTION
Sometimes (i.e. https://github.com/swaywm/sway/blob/master/sway/commands/move.c#L980-L990), 256 bytes is not enough to hold an error message.