### PR TITLE
Rename dpms output command to power

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -287,6 +287,7 @@ sway_cmd output_cmd_max_render_time;
 sway_cmd output_cmd_mode;
 sway_cmd output_cmd_modeline;
 sway_cmd output_cmd_position;
+sway_cmd output_cmd_power;
 sway_cmd output_cmd_render_bit_depth;
 sway_cmd output_cmd_scale;
 sway_cmd output_cmd_scale_filter;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -18,6 +18,7 @@ static const struct cmd_handler output_handlers[] = {
 	{ "modeline", output_cmd_modeline },
 	{ "pos", output_cmd_position },
 	{ "position", output_cmd_position },
+	{ "power", output_cmd_power },
 	{ "render_bit_depth", output_cmd_render_bit_depth },
 	{ "res", output_cmd_mode },
 	{ "resolution", output_cmd_mode },

--- a/sway/commands/output/dpms.c
+++ b/sway/commands/output/dpms.c
@@ -1,45 +1,8 @@
+#include "log.h"
 #include "sway/commands.h"
-#include "sway/config.h"
-#include "sway/output.h"
-#include "util.h"
-#include <strings.h>
 
 struct cmd_results *output_cmd_dpms(int argc, char **argv) {
-	if (!config->handler_context.output_config) {
-		return cmd_results_new(CMD_FAILURE, "Missing output config");
-	}
-	if (!argc) {
-		return cmd_results_new(CMD_INVALID, "Missing dpms argument.");
-	}
-
-	enum config_dpms current_dpms = DPMS_ON;
-
-	if (strcasecmp(argv[0], "toggle") == 0) {
-
-		const char *oc_name = config->handler_context.output_config->name;
-		if (strcmp(oc_name, "*") == 0) {
-			return cmd_results_new(CMD_INVALID,
-					"Cannot apply toggle to all outputs.");
-		}
-
-		struct sway_output *sway_output = all_output_by_name_or_id(oc_name);
-		if (!sway_output || !sway_output->wlr_output) {
-			return cmd_results_new(CMD_FAILURE,
-					"Cannot apply toggle to unknown output %s", oc_name);
-		}
-
-		if (sway_output->enabled && !sway_output->wlr_output->enabled) {
-			current_dpms = DPMS_OFF;
-		}
-	}
-
-	if (parse_boolean(argv[0], current_dpms == DPMS_ON)) {
-		config->handler_context.output_config->dpms_state = DPMS_ON;
-	} else {
-		config->handler_context.output_config->dpms_state = DPMS_OFF;
-	}
-
-	config->handler_context.leftovers.argc = argc - 1;
-	config->handler_context.leftovers.argv = argv + 1;
-	return NULL;
+	sway_log(SWAY_INFO, "The \"output dpms\" command is deprecated, "
+		"use \"output power\" instead");
+	return output_cmd_power(argc, argv);
 }

--- a/sway/commands/output/power.c
+++ b/sway/commands/output/power.c
@@ -1,0 +1,43 @@
+#include <strings.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/output.h"
+#include "util.h"
+
+struct cmd_results *output_cmd_power(int argc, char **argv) {
+	if (!config->handler_context.output_config) {
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
+	}
+	if (argc == 0) {
+		return cmd_results_new(CMD_INVALID, "Missing power argument");
+	}
+
+	enum config_dpms current_dpms = DPMS_ON;
+	if (strcasecmp(argv[0], "toggle") == 0) {
+		const char *oc_name = config->handler_context.output_config->name;
+		if (strcmp(oc_name, "*") == 0) {
+			return cmd_results_new(CMD_INVALID,
+				"Cannot apply toggle to all outputs");
+		}
+
+		struct sway_output *sway_output = all_output_by_name_or_id(oc_name);
+		if (!sway_output || !sway_output->wlr_output) {
+			return cmd_results_new(CMD_FAILURE,
+				"Cannot apply toggle to unknown output %s", oc_name);
+		}
+
+		if (sway_output->enabled && !sway_output->wlr_output->enabled) {
+			current_dpms = DPMS_OFF;
+		}
+	}
+
+	if (parse_boolean(argv[0], current_dpms == DPMS_ON)) {
+		config->handler_context.output_config->dpms_state = DPMS_ON;
+	} else {
+		config->handler_context.output_config->dpms_state = DPMS_OFF;
+	}
+
+	config->handler_context.leftovers.argc = argc - 1;
+	config->handler_context.leftovers.argv = argv + 1;
+	return NULL;
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -191,6 +191,7 @@ sway_sources = files(
 	'commands/output/max_render_time.c',
 	'commands/output/mode.c',
 	'commands/output/position.c',
+	'commands/output/power.c',
 	'commands/output/render_bit_depth.c',
 	'commands/output/scale.c',
 	'commands/output/scale_filter.c',

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -119,12 +119,20 @@ must be separated by one space. For example:
 	Enables or disables the specified output (all outputs are enabled by
 	default).
 
+	As opposed to the _power_ command, the output will loose its current
+	workspace and windows.
+
 *output* <name> toggle
 	Toggle the specified output.
 
+*output* <name> power on|off|toggle
+	Turns on or off the specified output.
+
+	As opposed to the _enable_ and _disable_ commands, the output keeps its
+	current workspaces and windows.
+
 *output* <name> dpms on|off|toggle
-	Enables or disables the specified output via DPMS. To turn an output off
-	(ie. blank the screen but keep workspaces as-is), one can set DPMS to off.
+	Deprecated. Alias for _power_.
 
 *output* <name> max_render_time off|<msec>
 	Controls when sway composites the output, as a positive number of


### PR DESCRIPTION
The "dpms" command refers to VESA Display Power Management
Signaling, a deprecated standard. It's superseded by VESA DPM.

Instead of tying out command name to a particular standard, use the
neutral term "power".