### PR TITLE
Strip quotes in bindsym --input-device=...

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -372,6 +372,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 					strlen("--input-device=")) == 0) {
 			free(binding->input);
 			binding->input = strdup(argv[0] + strlen("--input-device="));
+			strip_quotes(binding->input);
 		} else if (strcmp("--no-warn", argv[0]) == 0) {
 			warn = false;
 		} else if (strcmp("--no-repeat", argv[0]) == 0) {


### PR DESCRIPTION
If the input device is quoted, which is common when using variables in the
config file, those quotes must be ignored here, or the input device will be
ignored.

Fixes #7029.