### PR TITLE
fix: remove redundant empty statement in main.c

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
 		case 'V': // verbose
 			verbose = true;
 			break;
-		case 'p': ; // --get-socketpath
+		case 'p': // --get-socketpath
 			if (getenv("SWAYSOCK")) {
 				printf("%s\n", getenv("SWAYSOCK"));
 				exit(EXIT_SUCCESS);


### PR DESCRIPTION
This semi-colon looks like a typo. Luckily, it has no effect on the code as it's treated as an empty statement leading the switch case.

Really straightforward nitpick change, was just something I was confused by when reading over the code.