### PR TITLE
Fix bindswitch not executing all binds

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -464,7 +464,8 @@ runtime.
 	switches. Valid values for _state_ are _on_, _off_ and _toggle_. These
 	switches are on when the device lid is shut and when tablet mode is active
 	respectively. _toggle_ is also supported to run a command both when the
-	switch is toggled on or off.
+	switch is toggled on or off. _toggle_ is always dispatched before
+	dispatching _on_ and _off_.
 
 	Unless the flag _--locked_ is set, the command will not be run when a
 	screen locking program is active. If there is a matching binding with


### PR DESCRIPTION
If there was bindswitch on lid:toggle and either lid:on or lid:off (or both).
Only one bind was executed instead of two. E.g. if the lid is closed sway should
execute lid:on and lid:toggle binds. But it executed only one of them (the one
that appears later in the config).

This is a regression introduced here: 6afb392823d27ec69bedc8fd74263c3d072cca29.

Additionally, made toggle event always happen before on or off event. This is
more convenient instead of an arbitrary order. It is easier to implement and
more intuitive because conceptually, toggling of the state happens before
the target state is reached.