### PR TITLE
Set opacity of scratchpad windows on exit in inactive-windows-transparency script

### DIFF
--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -32,9 +32,12 @@ def on_window_focus(inactive_opacity, ipc, event):
 
 
 def remove_opacity(ipc):
-    for workspace in ipc.get_tree().workspaces():
+    tree = ipc.get_tree()
+    for workspace in tree.workspaces():
         for w in workspace:
             w.command("opacity 1")
+    for w in tree.scratchpad():
+        w.command("opacity 1")
     ipc.main_quit()
     sys.exit(0)
 


### PR DESCRIPTION
`workspaces()` doesn't include windows in the scratchpad which means they're left transparent when the script exits. This just iterates over the scratchpad containers as well and resets their opacity.