### PR TITLE
Add 16f option to render_bit_depth command

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -258,6 +258,7 @@ enum render_bit_depth {
 	RENDER_BIT_DEPTH_DEFAULT, // the default is currently 8
 	RENDER_BIT_DEPTH_8,
 	RENDER_BIT_DEPTH_10,
+	RENDER_BIT_DEPTH_16F,
 };
 
 /**

--- a/sway/commands/output/render_bit_depth.c
+++ b/sway/commands/output/render_bit_depth.c
@@ -17,9 +17,12 @@ struct cmd_results *output_cmd_render_bit_depth(int argc, char **argv) {
 	} else if (strcmp(*argv, "10") == 0) {
 		config->handler_context.output_config->render_bit_depth =
 			RENDER_BIT_DEPTH_10;
+	} else if (strcmp(*argv, "16f") == 0 || strcmp(*argv, "16F") == 0) {
+		config->handler_context.output_config->render_bit_depth =
+			RENDER_BIT_DEPTH_16F;
 	} else {
 		return cmd_results_new(CMD_INVALID,
-			"Invalid bit depth. Must be a value in (8|10).");
+			"Invalid bit depth. Must be a value in (8|10|16f).");
 	}
 
 	config->handler_context.leftovers.argc = argc - 1;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -376,6 +376,11 @@ static const uint32_t *bit_depth_preferences[] = {
 		DRM_FORMAT_XRGB8888,
 		DRM_FORMAT_INVALID,
 	},
+	[RENDER_BIT_DEPTH_16F] = (const uint32_t []){
+		DRM_FORMAT_XBGR16161616F,
+		DRM_FORMAT_XRGB8888,
+		DRM_FORMAT_INVALID,
+	},
 };
 
 static void queue_output_config(struct output_config *oc,

--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -165,9 +165,10 @@ must be separated by one space. For example:
 	adaptive sync can improve latency, but can cause flickering on some
 	hardware.
 
-*output* <name> render_bit_depth 8|10
+*output* <name> render_bit_depth 8|10|16f
 	Controls the color channel bit depth at which frames are rendered; the
-	default is currently 8 bits per channel.
+	default is currently 8 bits per channel. The "16f" option requests
+	color channels encoded in half-precision floating point format.
 
 	Setting higher values will not have an effect if hardware and software lack
 	support for such bit depths. Successfully increasing the render bit depth


### PR DESCRIPTION
This change adds an option to let sway render onto XBGR16161616F buffers, assuming hardware and drivers support this. 

To test that this works, run `swaymsg output 'output-name' render_bit_depth 16f`. If hardware and drivers support this, then one can check that it has worked with 'drm_info' and search the output for 'framebuffer'; with Intel drivers, the framebuffer info for the primary plane being used should say `Format: XBGR16161616F `; with AMD, if I recall correctly, it is slightly different; a 'Bit depth" field should have value 64.

If Sway hangs or has corrupt output when `...  render_bit_depth 16f` is run, running Sway with the environment variable `WLR_DRM_NO_MODIFIERS=1` may resolve the issue.

