### PR TITLE
ipc: make get_deco_rect check config->hide_lone_tab

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -458,7 +458,9 @@ static void ipc_json_describe_workspace(struct sway_workspace *workspace,
 
 static void get_deco_rect(struct sway_container *c, struct wlr_box *deco_rect) {
 	enum sway_container_layout parent_layout = container_parent_layout(c);
-	bool tab_or_stack = parent_layout == L_TABBED || parent_layout == L_STACKED;
+	list_t *siblings = container_get_siblings(c);
+	bool tab_or_stack = (parent_layout == L_TABBED || parent_layout == L_STACKED)
+		&& ((siblings && siblings->length > 1) || !config->hide_lone_tab);
 	if (((!tab_or_stack || container_is_floating(c)) &&
 				c->current.border != B_NORMAL) ||
 			c->pending.fullscreen_mode != FULLSCREEN_NONE ||


### PR DESCRIPTION
Without this, the `IPC_GET_TREE` ipc call would return false information about the container's `deco_rect` and `rect` properties if `hide_edge_borders --i3` was in effect.