### PR TITLE
Fix moving a container to an empty workspace with non-default workspace_layout

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -113,6 +113,9 @@ void workspace_detach(struct sway_workspace *workspace);
 struct sway_container *workspace_add_tiling(struct sway_workspace *workspace,
 		struct sway_container *con);
 
+void workspace_attach_tiling(struct sway_workspace *ws,
+		struct sway_container *con);
+
 void workspace_add_floating(struct sway_workspace *workspace,
 		struct sway_container *con);
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -213,7 +213,7 @@ static void container_move_to_workspace(struct sway_container *container,
 	} else {
 		container_detach(container);
 		if (workspace_is_empty(workspace) && container->pending.children) {
-			workspace_unwrap_children(workspace, container);
+			workspace_attach_tiling(workspace, container);
 		} else {
 			container->pending.width = container->pending.height = 0;
 			container->width_fraction = container->height_fraction = 0;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -734,7 +734,7 @@ static void set_workspace(struct sway_container *container, void *data) {
 	container->pending.workspace = container->pending.parent->pending.workspace;
 }
 
-static void workspace_attach_tiling(struct sway_workspace *ws,
+void workspace_attach_tiling(struct sway_workspace *ws,
 		struct sway_container *con) {
 	list_add(ws->tiling, con);
 	con->pending.workspace = ws;


### PR DESCRIPTION
When a container with children is moved to a different workspace its layout should not change, but currently if the destination workspace is empty, each child of the container gets "split" (wrapped in a tabbing / stacking container) if the `workspace_layout` option is not default.