### PR TITLE
allow no titlebar in tabbed mode

### DIFF
--- a/sway/commands/titlebar_padding.c
+++ b/sway/commands/titlebar_padding.c
@@ -7,24 +7,13 @@
 
 struct cmd_results *cmd_titlebar_padding(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "titlebar_padding", EXPECTED_AT_LEAST, 1))) {
-		return error;
-	}
-
 	char *inv;
 	int h_value = strtol(argv[0], &inv, 10);
-	if (*inv != '\0' || h_value < 0 || h_value < config->titlebar_border_thickness) {
-		return cmd_results_new(CMD_FAILURE, "Invalid size specified");
-	}
-
 	int v_value;
 	if (argc == 1) {
 		v_value = h_value;
 	} else {
 		v_value = strtol(argv[1], &inv, 10);
-		if (*inv != '\0' || v_value < 0 || v_value < config->titlebar_border_thickness) {
-			return cmd_results_new(CMD_FAILURE, "Invalid size specified");
-		}
 	}
 
 	config->titlebar_v_padding = v_value;


### PR DESCRIPTION
i just want the option to have no titlebar and just use keybinds to switch between them and cant see reason to not give the option