### PR TITLE
Support libinput's 1.21 new dwtp option

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -252,6 +252,7 @@ sway_cmd input_cmd_click_method;
 sway_cmd input_cmd_drag;
 sway_cmd input_cmd_drag_lock;
 sway_cmd input_cmd_dwt;
+sway_cmd input_cmd_dwtp;
 sway_cmd input_cmd_events;
 sway_cmd input_cmd_left_handed;
 sway_cmd input_cmd_map_from_region;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -150,6 +150,7 @@ struct input_config {
 	int drag;
 	int drag_lock;
 	int dwt;
+	int dwtp;
 	int left_handed;
 	int middle_emulation;
 	int natural_scroll;

--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,7 @@ gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 pixman = dependency('pixman-1')
 glesv2 = dependency('glesv2')
 libevdev = dependency('libevdev')
-libinput = dependency('libinput', version: '>=1.6.0')
+libinput = dependency('libinput', version: '>=1.21.0')
 xcb = dependency('xcb', required: get_option('xwayland'))
 drm_full = dependency('libdrm') # only needed for drm_fourcc.h
 drm = drm_full.partial_dependency(compile_args: true, includes: true)

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -14,6 +14,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "drag", input_cmd_drag },
 	{ "drag_lock", input_cmd_drag_lock },
 	{ "dwt", input_cmd_dwt },
+	{ "dwtp", input_cmd_dwtp },
 	{ "events", input_cmd_events },
 	{ "left_handed", input_cmd_left_handed },
 	{ "map_from_region", input_cmd_map_from_region },

--- a/sway/commands/input/dwtp.c
+++ b/sway/commands/input/dwtp.c
@@ -1,0 +1,25 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_dwtp(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "dwtp", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	if (parse_boolean(argv[0], true)) {
+		ic->dwtp = LIBINPUT_CONFIG_DWTP_ENABLED;
+	} else {
+		ic->dwtp = LIBINPUT_CONFIG_DWTP_DISABLED;
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -25,6 +25,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->drag = INT_MIN;
 	input->drag_lock = INT_MIN;
 	input->dwt = INT_MIN;
+	input->dwtp = INT_MIN;
 	input->send_events = INT_MIN;
 	input->click_method = INT_MIN;
 	input->middle_emulation = INT_MIN;
@@ -60,6 +61,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->dwt != INT_MIN) {
 		dst->dwt = src->dwt;
+	}
+	if (src->dwtp != INT_MIN) {
+		dst->dwtp = src->dwtp;
 	}
 	if (src->left_handed != INT_MIN) {
 		dst->left_handed = src->left_handed;

--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -166,6 +166,16 @@ static bool set_dwt(struct libinput_device *device, bool dwt) {
 	return true;
 }
 
+static bool set_dwtp(struct libinput_device *device, bool dwtp) {
+	if (!libinput_device_config_dwtp_is_available(device) ||
+			libinput_device_config_dwtp_get_enabled(device) == dwtp) {
+		return false;
+	}
+	sway_log(SWAY_DEBUG, "dwtp_set_enabled(%d)", dwtp);
+	log_status(libinput_device_config_dwtp_set_enabled(device, dwtp));
+	return true;
+}
+
 static bool set_calibration_matrix(struct libinput_device *dev, float mat[6]) {
 	if (!libinput_device_config_calibration_has_matrix(dev)) {
 		return false;
@@ -255,6 +265,9 @@ bool sway_input_configure_libinput_device(struct sway_input_device *input_device
 	if (ic->dwt != INT_MIN) {
 		changed |= set_dwt(device, ic->dwt);
 	}
+	if (ic->dwtp != INT_MIN) {
+		changed |= set_dwtp(device, ic->dwtp);
+	}
 	if (ic->calibration_matrix.configured) {
 		changed |= set_calibration_matrix(device, ic->calibration_matrix.matrix);
 	}
@@ -302,6 +315,8 @@ void sway_input_reset_libinput_device(struct sway_input_device *input_device) {
 		libinput_device_config_scroll_get_default_button(device));
 	changed |= set_dwt(device,
 		libinput_device_config_dwt_get_default_enabled(device));
+	changed |= set_dwtp(device,
+		libinput_device_config_dwtp_get_default_enabled(device));
 
 	float matrix[6];
 	libinput_device_config_calibration_get_default_matrix(device, matrix);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1000,6 +1000,19 @@ static json_object *describe_libinput_device(struct libinput_device *device) {
 		json_object_object_add(object, "dwt", json_object_new_string(dwt));
 	}
 
+	if (libinput_device_config_dwtp_is_available(device)) {
+		const char *dwtp = "unknown";
+		switch (libinput_device_config_dwtp_get_enabled(device)) {
+		case LIBINPUT_CONFIG_DWTP_ENABLED:
+			dwtp = "enabled";
+			break;
+		case LIBINPUT_CONFIG_DWTP_DISABLED:
+			dwtp = "disabled";
+			break;
+		}
+		json_object_object_add(object, "dwtp", json_object_new_string(dwtp));
+	}
+
 	if (libinput_device_config_calibration_has_matrix(device)) {
 		float matrix[6];
 		libinput_device_config_calibration_get_matrix(device, matrix);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -157,6 +157,7 @@ sway_sources = files(
 	'commands/input/drag.c',
 	'commands/input/drag_lock.c',
 	'commands/input/dwt.c',
+	'commands/input/dwtp.c',
 	'commands/input/events.c',
 	'commands/input/left_handed.c',
 	'commands/input/map_from_region.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -147,6 +147,10 @@ The following commands may only be used in the configuration file.
 *input* <identifier> dwt enabled|disabled
 	Enables or disables disable-while-typing for the specified input device.
 
+*input* <identifier> dwtp enabled|disabled
+	Enables or disables disable-while-trackpointing for the specified input
+	device.
+
 *input* <identifier> events enabled|disabled|disabled_on_external_mouse|toggle [<toggle-modes>]
 	Enables or disables send_events for specified input device. Disabling
 	send_events disables the input device.

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1197,6 +1197,10 @@ following properties will be included for devices that support them:
 |- dwt
 :  string
 :  Whether disable-while-typing is enabled. It can be _enabled_ or _disabled_
+|- dwtp
+:  string
+:  Whether disable-while-trackpointing is enabled. It can be _enabled_ or
+  _disabled_
 |- calibration_matrix
 :  array
 :  An array of 6 floats representing the calibration matrix for absolute
@@ -1236,7 +1240,8 @@ following properties will be included for devices that support them:
 			"click_method": "button_areas",
 			"middle_emulation": "disabled",
 			"scroll_method": "edge",
-			"dwt": "enabled"
+			"dwt": "enabled",
+			"dwtp": "enabled"
 		}
 	},
 	{
@@ -1363,7 +1368,8 @@ one seat. Each object has the following properties:
 					"click_method": "button_areas",
 					"middle_emulation": "disabled",
 					"scroll_method": "edge",
-					"dwt": "enabled"
+					"dwt": "enabled",
+					"dwtp": "enabled"
 				}
 			},
 			{


### PR DESCRIPTION
Support the new dwtp (disable while trackpointing) option introduced in libinput 1.21, allowing users to control whether the trackpoint (like those in Thinkpads, but not only) should be disabled while using the keyboard/touchpad.

See: https://gitlab.freedesktop.org/libinput/libinput/-/issues/731