### PR TITLE
Chore / Limit grimshot window grab

### DIFF
--- a/contrib/grimshot
+++ b/contrib/grimshot
@@ -143,7 +143,7 @@ elif [ "$SUBJECT" = "output" ] ; then
   OUTPUT=$(swaymsg -t get_outputs | jq -r '.[] | select(.focused)' | jq -r '.name')
   WHAT="$OUTPUT"
 elif [ "$SUBJECT" = "window" ] ; then
-  GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp)
+  GEOM=$(swaymsg -t get_tree | jq -r '.. | select(.pid? and .visible?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"' | slurp -r)
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
    exit 1


### PR DESCRIPTION
The `grimshot` script accepts option to screenshot current output, window or area, but the `window` option will also allow area shot If the user click and grab the mouse.

This change adds the `-r` option to slurt, so when using `grimshot window` it will only possible to select an existing window area.

From `slurp -r`

```
  -r           Restrict selection to predefined boxes.
```