### PR TITLE
Fix crash in xdg_activation_v1.c

### DIFF
--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -11,6 +11,9 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 
 	struct wlr_xdg_surface *xdg_surface =
 		wlr_xdg_surface_from_wlr_surface(event->surface);
+	if (xdg_surface == NULL) {
+		return;
+	}
 	struct sway_view *view = xdg_surface->data;
 	if (!xdg_surface->mapped || view == NULL) {
 		return;


### PR DESCRIPTION
wlr_xdg_surface_from_wlr_surface() can return a NULL pointer, so check for NULL before dereferencing it.

I have managed to get the NULL pointer and trigger a sway crash using dosbox 0.74.3. To reproduce, create a `dosbox.conf` with the following contents:
```
[sdl]
output=opengl
```
and run `SDL_VIDEODRIVER=wayland dosbox -conf dosbox.conf`