### PR TITLE
Dynamic max render time

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -21,6 +21,9 @@
 
 // TODO: Refactor this shit
 
+#define MAX_RENDER_TIME_OFF 0
+#define MAX_RENDER_TIME_AUTO -2
+
 /**
  * Describes a variable created via the `set` command.
  */

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -55,6 +55,14 @@ struct sway_output {
 	uint32_t refresh_nsec;
 	int max_render_time; // In milliseconds
 	struct wl_event_source *repaint_timer;
+
+	struct timespec render_begin_time;
+	struct wlr_render_timestamp *render_end_ts;
+
+	int auto_max_render_time; // in milliseconds
+	// TODO: Make this adjustable:
+	uint8_t render_time_window[60];
+	int render_time_window_index;
 };
 
 struct sway_output_non_desktop {

--- a/sway/commands/output/max_render_time.c
+++ b/sway/commands/output/max_render_time.c
@@ -12,7 +12,9 @@ struct cmd_results *output_cmd_max_render_time(int argc, char **argv) {
 
 	int max_render_time;
 	if (!strcmp(*argv, "off")) {
-		max_render_time = 0;
+		max_render_time = MAX_RENDER_TIME_OFF;
+	} else if (!strcmp(*argv, "auto")) {
+		max_render_time = MAX_RENDER_TIME_AUTO;
 	} else {
 		char *end;
 		max_render_time = strtol(*argv, &end, 10);

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -571,6 +571,10 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		sway_log(SWAY_DEBUG, "Set %s max render time to %d",
 			oc->name, oc->max_render_time);
 		output->max_render_time = oc->max_render_time;
+	} else if (oc && oc->max_render_time == MAX_RENDER_TIME_AUTO) {
+		sway_log(SWAY_DEBUG, "Set %s max render time to auto",
+			oc->name);
+		output->max_render_time = -1;
 	}
 
 	// Reconfigure all devices, since input config may have been applied before
@@ -608,7 +612,7 @@ static void default_output_config(struct output_config *oc,
 	struct sway_output *output = wlr_output->data;
 	oc->subpixel = output->detected_subpixel;
 	oc->transform = WL_OUTPUT_TRANSFORM_NORMAL;
-	oc->max_render_time = 0;
+	oc->max_render_time = MAX_RENDER_TIME_OFF;
 }
 
 static struct output_config *get_output_config(char *identifier,

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -342,7 +342,14 @@ static void ipc_json_describe_enabled_output(struct sway_output *output,
 		json_object_object_add(object, "percent", json_object_new_double(percent));
 	}
 
-	json_object_object_add(object, "max_render_time", json_object_new_int(output->max_render_time));
+	int max_render_time;
+	if (output->max_render_time == -1) {
+		max_render_time = -output->auto_max_render_time;
+	} else {
+		max_render_time = output->max_render_time;
+	}
+	json_object_object_add(object, "max_render_time",
+		json_object_new_int(max_render_time));
 }
 
 json_object *ipc_json_describe_disabled_output(struct sway_output *output) {

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -249,8 +249,15 @@ static void pretty_print_output(json_object *o) {
 		);
 
 		int max_render_time_int = json_object_get_int(max_render_time);
+
 		printf("  Max render time: ");
-		printf(max_render_time_int == 0 ? "off\n" : "%d ms\n", max_render_time_int);
+		if (max_render_time_int == 0) {
+			printf("off\n");
+		} else if (max_render_time_int > 0) {
+			printf("%d ms\n", max_render_time_int);
+		} else {
+			printf("%d ms (auto)\n", -max_render_time_int);
+		}
 
 		printf("  Adaptive sync: %s\n",
 			json_object_get_string(adaptive_sync_status));


### PR DESCRIPTION
This adds automatic detection of output `max_render_time`.

Requirement: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3737