### PR TITLE
Security context based criteria

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -48,6 +48,8 @@ struct criteria {
 	char urgent; // 'l' for latest or 'o' for oldest
 	struct pattern *workspace;
 	pid_t pid;
+	struct pattern *sandbox_app_id;
+	struct pattern *sandbox_engine;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_output_power_management_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
+#include <wlr/types/wlr_security_context_v1.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_text_input_v3.h>
@@ -77,6 +78,8 @@ struct sway_server {
 	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager;
 	struct wl_listener xdg_decoration;
 	struct wl_list xdg_decorations; // sway_xdg_decoration::link
+
+	struct wlr_security_context_manager_v1 *security_context_manager;
 
 	struct wlr_drm_lease_v1_manager *drm_lease_manager;
 	struct wl_listener drm_lease_request;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -30,6 +30,8 @@ enum sway_view_prop {
 	VIEW_PROP_X11_WINDOW_ID,
 	VIEW_PROP_X11_PARENT_ID,
 #endif
+	VIEW_PROP_SANDBOX_APP_ID,
+	VIEW_PROP_SANDBOX_ENGINE,
 };
 
 struct sway_view_impl {
@@ -231,6 +233,10 @@ const char *view_get_app_id(struct sway_view *view);
 const char *view_get_class(struct sway_view *view);
 
 const char *view_get_instance(struct sway_view *view);
+
+const char *view_get_sandbox_app_id(struct sway_view *view);
+
+const char *view_get_sandbox_engine(struct sway_view *view);
 
 uint32_t view_get_x11_window_id(struct sway_view *view);
 

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_security_context_v1.h>
 #include <wlr/util/edges.h>
 #include "log.h"
 #include "sway/decoration.h"
@@ -136,6 +137,24 @@ static const char *get_string_prop(struct sway_view *view,
 		return view->wlr_xdg_toplevel->title;
 	case VIEW_PROP_APP_ID:
 		return view->wlr_xdg_toplevel->app_id;
+	case VIEW_PROP_SANDBOX_APP_ID: {
+		struct wl_client *client = wl_resource_get_client(view->surface->resource);
+		const struct wlr_security_context_v1_state *state = wlr_security_context_manager_v1_lookup_client(server.security_context_manager, client);
+		if (state == NULL) {
+			return NULL;
+		}
+
+		return state->app_id;
+	}
+	case VIEW_PROP_SANDBOX_ENGINE: {
+		struct wl_client *client = wl_resource_get_client(view->surface->resource);
+		const struct wlr_security_context_v1_state *state = wlr_security_context_manager_v1_lookup_client(server.security_context_manager, client);
+		if (state == NULL) {
+			return NULL;
+		}
+
+		return state->sandbox_engine;
+	}
 	default:
 		return NULL;
 	}

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -541,6 +541,14 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "inhibit_idle",
 		json_object_new_boolean(view_inhibit_idle(c->view)));
 
+	const char *sandbox_engine = view_get_sandbox_engine(c->view);
+	json_object_object_add(object, "sandbox_engine",
+			sandbox_engine ? json_object_new_string(sandbox_engine) : NULL);
+
+	const char *sandbox_app_id = view_get_sandbox_app_id(c->view);
+	json_object_object_add(object, "sandbox_app_id",
+			sandbox_app_id ? json_object_new_string(sandbox_app_id) : NULL);
+
 	json_object *idle_inhibitors = json_object_new_object();
 
 	struct sway_idle_inhibitor_v1 *user_inhibitor =

--- a/sway/server.c
+++ b/sway/server.c
@@ -23,6 +23,7 @@
 #include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
+#include <wlr/types/wlr_security_context_v1.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_subcompositor.h>
@@ -201,6 +202,7 @@ bool server_init(struct sway_server *server) {
 	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
+	wlr_security_context_manager_v1_create(server->wl_display);
 
 	struct wlr_xdg_foreign_registry *foreign_registry =
 		wlr_xdg_foreign_registry_create(server->wl_display);

--- a/sway/server.c
+++ b/sway/server.c
@@ -202,7 +202,7 @@ bool server_init(struct sway_server *server) {
 	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
-	wlr_security_context_manager_v1_create(server->wl_display);
+	server->security_context_manager = wlr_security_context_manager_v1_create(server->wl_display);
 
 	struct wlr_xdg_foreign_registry *foreign_registry =
 		wlr_xdg_foreign_registry_create(server->wl_display);

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -396,6 +396,12 @@ node and will have the following properties:
 :  (Only views) An object containing the state of the _application_ and _user_ idle inhibitors.
     _application_ can be _enabled_ or _none_.
     _user_ can be _focus_, _fullscreen_, _open_, _visible_ or _none_.
+|- sandbox_engine
+:  string
+:  (Only views) The sandbox engine used by this view.
+|- sandbox_app_id
+:  string
+:  (Only views) The app ID of this view, as provided by the sandbox engine.
 |- window
 :  integer
 :  (Only xwayland views) The X11 window ID for the xwayland view

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -1026,6 +1026,17 @@ The following attributes may be matched with:
 	expression. If the value is \_\_focused\_\_, then all the views on the
 	currently focused workspace matches.
 
+*sandbox_app_id*
+	Compare against the sandboxed app id for this view. Can be a regular
+	expression. If the value is \_\_focused\_\_, then the sandboxed app id must
+	be the same as that of the currently focused window.
+
+*sandbox_engine*
+	Compare against the sandbox engine for this view. Can be a regular
+	expression. If the value is \_\_focused\_\_, then the sandbox engine must be
+	the same as that of the currently focused window.
+
+
 # SEE ALSO
 
 *sway*(1) *sway-input*(5) *sway-output*(5) *sway-bar*(5) *sway-ipc*(7)

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -362,6 +362,10 @@ set|plus|minus|toggle <amount>
 		%instance - The X11 instance (applicable to xwayland windows only) ++
 		%shell - The protocol the window is using (typically xwayland or
 			xdg_shell)
+		%sandbox_app_id - The app ID of this window, as passed in by the
+			sandboxing engine (this may differ from %app_id)
+		%sandbox_engine - The name of the engine that the client of this
+			window is sandboxed with
 
 	This command is typically used with *for_window* criteria. For example:
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1259,6 +1259,12 @@ static size_t parse_title_format(struct sway_view *view, char *buffer) {
 		} else if (strncmp(next, "%app_id", 7) == 0) {
 			len += append_prop(buffer, view_get_app_id(view));
 			format += 7;
+		} else if (strncmp(next, "%sandbox_app_id", 15) == 0) {
+			len += append_prop(buffer, view_get_sandbox_app_id(view));
+			format += 15;
+		} else if (strncmp(next, "%sandbox_engine", 15) == 0) {
+			len += append_prop(buffer, view_get_sandbox_engine(view));
+			format += 15;
 		} else if (strncmp(next, "%class", 6) == 0) {
 			len += append_prop(buffer, view_get_class(view));
 			format += 6;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -97,6 +97,20 @@ const char *view_get_app_id(struct sway_view *view) {
 	return NULL;
 }
 
+const char *view_get_sandbox_app_id(struct sway_view *view) {
+	if (view->impl->get_string_prop) {
+		return view->impl->get_string_prop(view, VIEW_PROP_SANDBOX_APP_ID);
+	}
+	return NULL;
+}
+
+const char *view_get_sandbox_engine(struct sway_view *view) {
+	if (view->impl->get_string_prop) {
+		return view->impl->get_string_prop(view, VIEW_PROP_SANDBOX_ENGINE);
+	}
+	return NULL;
+}
+
 const char *view_get_class(struct sway_view *view) {
 	if (view->impl->get_string_prop) {
 		return view->impl->get_string_prop(view, VIEW_PROP_CLASS);


### PR DESCRIPTION
(builds on #7041. this requires a slightly updated version of the wlroots patches, which are currently only [on my fork](https://gitlab.freedesktop.org/puckipedia/wlroots/-/tree/security-context-fixes))

This adds `sandbox_engine` and `sandbox_app_id` to the supported window criteria, as well as `format_title` tokens and the JSON IPC representation for a view.