### PR TITLE
contrib/inactive-windows-transparency fixes

### DIFF
--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -19,11 +19,19 @@ def on_window_focus(args, ipc, event):
 
     focused = event.container
 
+
     # on_window_focus not called only when focused is changed,
     # but also when a window is moved
     if focused.id != prev_focused.id:
-        focused.command("opacity " + args.active_opacity)
-        prev_focused.command("opacity " + args.inactive_opacity)
+        if prev_focused.app_id in args.ignore:
+            prev_focused.command("opacity 1")
+        else:
+            prev_focused.command("opacity " + args.inactive_opacity)
+
+        if focused.app_id in args.ignore:
+            focused.command("opacity 1")
+        else: 
+            focused.command("opacity " + args.active_opacity)
         prev_focused = focused
 
 
@@ -58,6 +66,13 @@ if __name__ == "__main__":
         type=str,
         default=default_active_opacity,
         help="value between 0 and 1 denoting opacity for active windows",
+    )
+    parser.add_argument(
+        "--ignore",
+        type=str,
+        default=[],
+        help="List of applications to be ignored.",
+        nargs="+"
     )
     args = parser.parse_args()
 

--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -7,6 +7,7 @@ import argparse
 import i3ipc
 import signal
 import sys
+import re
 from functools import partial
 
 def on_window_focus(args, ipc, event):
@@ -18,20 +19,23 @@ def on_window_focus(args, ipc, event):
         return
 
     focused = event.container
-
-
     # on_window_focus not called only when focused is changed,
     # but also when a window is moved
     if focused.id != prev_focused.id:
         if prev_focused.app_id in args.ignore:
             prev_focused.command("opacity 1")
+        elif prev_focused.app_id in args.inactive_overrides.keys():
+            prev_focused.command("opacity " + args.inactive_overrides[prev_focused.app_id])
         else:
             prev_focused.command("opacity " + args.inactive_opacity)
 
         if focused.app_id in args.ignore:
             focused.command("opacity 1")
+        elif focused.app_id in args.active_overrides.keys():
+            focused.command("opacity " + args.active_overrides[focused.app_id])
         else: 
             focused.command("opacity " + args.active_opacity)
+
         prev_focused = focused
 
 
@@ -68,6 +72,22 @@ if __name__ == "__main__":
         help="value between 0 and 1 denoting opacity for active windows",
     )
     parser.add_argument(
+        "--inactive-overrides",
+        "-I",
+        type=str,
+        default=[],
+        help="List of appliations with their values that override the inactive opactity settings. (Example: -A firefox=0.9 kitty=0.8)",
+        nargs="+"
+    )
+    parser.add_argument(
+        "--active-overrides",
+        "-A",
+        type=str,
+        default=[],
+        help="List of appliations with their values that override the active opactity settings. (Example: -A firefox=0.9 kitty=0.8)",
+        nargs="+"
+    )
+    parser.add_argument(
         "--ignore",
         type=str,
         default=[],
@@ -75,6 +95,22 @@ if __name__ == "__main__":
         nargs="+"
     )
     args = parser.parse_args()
+
+    # Convert ovveride arguments of format app_id=opacity_value
+    # to dictionary of format "app_id": "opacity_value"
+    temp_inactive_overrides_dictionary = {}
+    for override in args.inactive_overrides:
+        app_id = re.search('\S*(?==)', override).group(0)
+        opacity_value = re.search('(?<==)\S*', override).group(0)
+        temp_inactive_overrides_dictionary[app_id] = opacity_value
+    args.inactive_overrides = temp_inactive_overrides_dictionary
+
+    temp_active_overrides_dictionary = {}
+    for override in args.active_overrides:
+        app_id = re.search('\S*(?==)', override).group(0)
+        opacity_value = re.search('(?<==)\S*', override).group(0)
+        temp_active_overrides_dictionary[app_id] = opacity_value
+    args.active_overrides = temp_active_overrides_dictionary
 
     ipc = i3ipc.Connection()
     prev_focused = None
@@ -84,6 +120,8 @@ if __name__ == "__main__":
             prev_focused = window
         else:
             window.command("opacity " + args.inactive_opacity)
+
+
     for sig in [signal.SIGINT, signal.SIGTERM]:
         signal.signal(sig, lambda signal, frame: remove_opacity(ipc))
     ipc.on("window::focus", partial(on_window_focus, args))

--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -32,9 +32,12 @@ def on_window_focus(inactive_opacity, ipc, event):
 
 
 def remove_opacity(ipc):
-    for workspace in ipc.get_tree().workspaces():
-        for w in workspace:
-            w.command("opacity 1")
+    tree = ipc.get_tree()
+    for workspace in tree.workspaces():
+        for window in workspace:
+            window.command("opacity 1")
+    for window in tree.scratchpad():
+        window.command("opacity 1")
     ipc.main_quit()
     sys.exit(0)
 

--- a/contrib/inactive-windows-transparency.py
+++ b/contrib/inactive-windows-transparency.py
@@ -13,7 +13,6 @@ from functools import partial
 
 def on_window_focus(inactive_opacity, ipc, event):
     global prev_focused
-    global prev_workspace
 
     focused_workspace = ipc.get_tree().find_focused()
 
@@ -21,14 +20,13 @@ def on_window_focus(inactive_opacity, ipc, event):
         return
 
     focused = event.container
-    workspace = focused_workspace.workspace().num
 
-    if focused.id != prev_focused.id:  # https://github.com/swaywm/sway/issues/2859
+    # on_window_focus not called only when focused is changed,
+    # but also when a window is moved
+    if focused.id != prev_focused.id:
         focused.command("opacity 1")
-        if workspace == prev_workspace:
-            prev_focused.command("opacity " + inactive_opacity)
+        prev_focused.command("opacity " + inactive_opacity)
         prev_focused = focused
-        prev_workspace = workspace
 
 
 def remove_opacity(ipc):
@@ -59,7 +57,6 @@ if __name__ == "__main__":
 
     ipc = i3ipc.Connection()
     prev_focused = None
-    prev_workspace = ipc.get_tree().find_focused().workspace().num
 
     for window in ipc.get_tree():
         if window.focused:


### PR DESCRIPTION
Pull request an attempt to collect a multitude of unresolved and conflicting pull requests into logical commits for one hassle-free merge. Namely:

### #6924 by aelfsyg
* set active opacity with `-a` or `--active-opacity`

Test: ./contrib/inactive-windows-transparency.py -a 0.9

* add a list of applications to ignore with `--ignore`

Test: ./contrib/inactive-windows-transparency.py --ignore firefox gimp

* override active opacity for specific applications with `-A` or `--active-overrides`

Test: ./contrib/inactive-windows-transparency.py -A firefox=0.95 gimp=1

* override inactive opacity for specific applications with `-I` or `--inactive-overrides`

Test: ./contrib/inactive-windows-transparency.py -I firefox=0.75 gimp=0.7

### #6500 by tstivers1990.
* show only one window as active when using multiple monitors

#### Test plan: 
Preparation: More than one outputs (monitor) is required. Start script, create two windows on each output.
Before: Move focus between outputs and observe that one window is active on each monitor.	
After: Move focus between outputs and observe that **only one** window is active.

### #7104 by anpandey
* properly reset opacity of hidden scratchpads upon exit
	
#### Test plan: 
Preparation: Start script, create scratchpad, and make sure that it is hidden.
Before: Stop script, open up scratchpad, and observe that it's opacity value remains.
After: Stop script, open up scratchpad, and observe that its opacity value **does not** remain.

---
Further explanations about each commit are expressed in their own commit message. If there is anything I've missed, just let me know.