### PR TITLE
input: focus container when scrolling on titlebar

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -708,6 +708,7 @@ static void handle_pointer_axis(struct sway_seat *seat,
 
 	// Scrolling on a tabbed or stacked title bar (handled as press event)
 	if (!handled && (on_titlebar || on_titlebar_border)) {
+		struct sway_node *new_focus;
 		enum sway_container_layout layout = container_parent_layout(cont);
 		if (layout == L_TABBED || layout == L_STACKED) {
 			struct sway_node *tabcontainer = node_get_parent(node);
@@ -724,14 +725,16 @@ static void handle_pointer_axis(struct sway_seat *seat,
 
 			struct sway_container *new_sibling_con = siblings->items[desired];
 			struct sway_node *new_sibling = &new_sibling_con->node;
-			struct sway_node *new_focus =
-				seat_get_focus_inactive(seat, new_sibling);
 			// Use the focused child of the tabbed/stacked container, not the
 			// container the user scrolled on.
-			seat_set_focus(seat, new_focus);
-			transaction_commit_dirty();
-			handled = true;
+			new_focus = seat_get_focus_inactive(seat, new_sibling);
+		} else {
+			new_focus = seat_get_focus_inactive(seat, &cont->node);
 		}
+
+		seat_set_focus(seat, new_focus);
+		transaction_commit_dirty();
+		handled = true;
 	}
 
 	// Handle mouse bindings - x11 mouse buttons 4-7 - release event


### PR DESCRIPTION
Fixes #6503.

Tested to behave the same as i3 wrt. inactive containers in this layout:

![image](https://user-images.githubusercontent.com/1403503/194790856-91b052b0-1a45-48f7-8e13-5d540162b374.png)
