### PR TITLE
Allow Sway to register Xorg fallbacks to Wayland

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+X-GDM-SessionRegisters=true


### PR DESCRIPTION
Approximately three years ago a mechanism was added to increase the reliability of session handling with Wayland (when handled GDM) by removing the need for timeout checks. ([1])

This mechanism utilizes the format extension scheme defined in the Freedesktop.org "Desktop Entry Specification" ([2]) allowing for the addition of new key/value configuration pairs.  This is designed to limit the scope of effect.

[1]: https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/67
[2]: https://specifications.freedesktop.org/desktop-entry-spec/latest/