### PR TITLE
feat: set xdg-current-desktop envirenment in main.c

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -256,7 +256,7 @@ static const char usage[] =
 
 int main(int argc, char **argv) {
 	static bool verbose = false, debug = false, validate = false, allow_unsupported_gpu = false;
-
+	setenv("XDG_CURRENT_DESKTOP", "sway", 0);
 	char *config_path = NULL;
 
 	int c;


### PR DESCRIPTION
Then the env will be sway as default, not needed to be set by people
I think it should be better
