### PR TITLE
Add a DesktopNames key

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
This is required for XDG_CURRENT_DESKTOP to be defined correctly and exported into the current session by DMs

See also [Debian Bug #1021545](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1021545) and the discussion on the [Freedesktop Bug Tracker #85938](https://bugs.freedesktop.org/show_bug.cgi?id=85938#c7)