### PR TITLE
container_floating_set_default_size: Store workspace size box on the stack

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -787,11 +787,11 @@ void container_floating_set_default_size(struct sway_container *con) {
 	int min_width, max_width, min_height, max_height;
 	floating_calculate_constraints(&min_width, &max_width,
 			&min_height, &max_height);
-	struct wlr_box *box = calloc(1, sizeof(struct wlr_box));
-	workspace_get_box(con->pending.workspace, box);
+	struct wlr_box box;
+	workspace_get_box(con->pending.workspace, &box);
 
-	double width = fmax(min_width, fmin(box->width * 0.5, max_width));
-	double height = fmax(min_height, fmin(box->height * 0.75, max_height));
+	double width = fmax(min_width, fmin(box.width * 0.5, max_width));
+	double height = fmax(min_height, fmin(box.height * 0.75, max_height));
 	if (!con->view) {
 		con->pending.width = width;
 		con->pending.height = height;
@@ -800,8 +800,6 @@ void container_floating_set_default_size(struct sway_container *con) {
 		con->pending.content_height = height;
 		container_set_geometry_from_content(con);
 	}
-
-	free(box);
 }
 
 


### PR DESCRIPTION
A trivial patch I had floating around for a really long time.