### PR TITLE
Use wl_signal_emit_mutable()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ subproject(
 
 jsonc = dependency('json-c', version: '>=0.13')
 pcre2 = dependency('libpcre2-8')
-wayland_server = dependency('wayland-server', version: '>=1.20.0')
+wayland_server = dependency('wayland-server', version: '>=1.21.0')
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_egl = dependency('wayland-egl')

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -49,7 +49,7 @@ struct sway_container *container_create(struct sway_view *view) {
 	c->outputs = create_list();
 
 	wl_signal_init(&c->events.destroy);
-	wl_signal_emit(&root->events.new_node, &c->node);
+	wl_signal_emit_mutable(&root->events.new_node, &c->node);
 
 	return c;
 }
@@ -104,7 +104,7 @@ void container_begin_destroy(struct sway_container *con) {
 		container_fullscreen_disable(con);
 	}
 
-	wl_signal_emit(&con->node.events.destroy, &con->node);
+	wl_signal_emit_mutable(&con->node.events.destroy, &con->node);
 
 	container_end_mouse_operation(con);
 

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -147,7 +147,7 @@ void output_enable(struct sway_output *output) {
 
 	input_manager_configure_xcursor();
 
-	wl_signal_emit(&root->events.new_node, &output->node);
+	wl_signal_emit_mutable(&root->events.new_node, &output->node);
 
 	arrange_layers(output);
 	arrange_root();
@@ -263,7 +263,7 @@ void output_disable(struct sway_output *output) {
 	}
 
 	sway_log(SWAY_DEBUG, "Disabling output '%s'", output->wlr_output->name);
-	wl_signal_emit(&output->events.disable, output);
+	wl_signal_emit_mutable(&output->events.disable, output);
 
 	output_evacuate(output);
 
@@ -287,7 +287,7 @@ void output_begin_destroy(struct sway_output *output) {
 		return;
 	}
 	sway_log(SWAY_DEBUG, "Destroying output '%s'", output->wlr_output->name);
-	wl_signal_emit(&output->node.events.destroy, &output->node);
+	wl_signal_emit_mutable(&output->node.events.destroy, &output->node);
 
 	output->node.destroying = true;
 	node_set_dirty(&output->node);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -847,7 +847,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 }
 
 void view_unmap(struct sway_view *view) {
-	wl_signal_emit(&view->events.unmap, view);
+	wl_signal_emit_mutable(&view->events.unmap, view);
 
 	wl_list_remove(&view->surface_new_subsurface.link);
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -114,7 +114,7 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 	output_sort_workspaces(output);
 
 	ipc_event_workspace(NULL, ws, "init");
-	wl_signal_emit(&root->events.new_node, &ws->node);
+	wl_signal_emit_mutable(&root->events.new_node, &ws->node);
 
 	return ws;
 }
@@ -142,7 +142,7 @@ void workspace_destroy(struct sway_workspace *workspace) {
 void workspace_begin_destroy(struct sway_workspace *workspace) {
 	sway_log(SWAY_DEBUG, "Destroying workspace '%s'", workspace->name);
 	ipc_event_workspace(NULL, workspace, "empty"); // intentional
-	wl_signal_emit(&workspace->node.events.destroy, &workspace->node);
+	wl_signal_emit_mutable(&workspace->node.events.destroy, &workspace->node);
 
 	if (workspace->output) {
 		workspace_detach(workspace);


### PR DESCRIPTION
This function fixes segfaults when emitting a signal potentially removes arbitrary listeners.