### PR TITLE
shortcuts_inhibitor: default to disabled

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -209,7 +209,7 @@ enum seat_config_allow_constrain {
 };
 
 enum seat_config_shortcuts_inhibit {
-	SHORTCUTS_INHIBIT_DEFAULT, // the default is currently enabled
+	SHORTCUTS_INHIBIT_DEFAULT, // the default is currently disabled
 	SHORTCUTS_INHIBIT_ENABLE,
 	SHORTCUTS_INHIBIT_DISABLE,
 };

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -363,7 +363,7 @@ static void handle_keyboard_shortcuts_inhibit_new_inhibitor(
 		}
 	}
 
-	if (inhibit == SHORTCUTS_INHIBIT_DISABLE) {
+	if (inhibit != SHORTCUTS_INHIBIT_ENABLE) {
 		/**
 		 * Here we deny to honour the inhibitor by never sending the
 		 * activate signal. We can not, however, destroy the inhibitor


### PR DESCRIPTION
Feels a little odd to me that this one defaults to enabled. Defaulting to disabled will reduce surprises from abusive clients like chroium: #7106. Users can of course enable the inhibitor with shortcuts_inhibitor enable. Thoughts?