### PR TITLE
input/keyboard: enable user-specific keymaps

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -755,6 +755,9 @@ struct xkb_keymap *sway_keyboard_compile_keymap(struct input_config *ic,
 	xkb_context_set_user_data(context, error);
 	xkb_context_set_log_fn(context, handle_xkb_context_log);
 
+	// This includes the $XDG_CONFIG_HOME/xkb in the lookup
+	xkb_context_include_path_append_default(context);
+
 	struct xkb_keymap *keymap = NULL;
 
 	if (ic && ic->xkb_file) {


### PR DESCRIPTION
This adds the xdg dirs to the lookup path when compiling xkb keymaps. With these the user can put custom symbol/rules files in $XDG_CONFIG_HOME/xkb to define user specific xkb options and layouts without modifying /usr/share/X11/xkb.

I was surprised to find this did not already work. If I have to include them, they're not exactly defaults now are they, libxkbcommon?

Fixes : #7229 #7270