### PR TITLE
swaynag: link with -lrt

### DIFF
--- a/swaynag/meson.build
+++ b/swaynag/meson.build
@@ -12,6 +12,7 @@ executable(
 		cairo,
 		pango,
 		pangocairo,
+		rt,
 		wayland_client,
 		wayland_cursor,
 	],


### PR DESCRIPTION
Fixes the following build error.

```
[299/303] Compiling C object swaynag/swaynag.p/config.c.o
[300/303] Compiling C object swaynag/swaynag.p/swaynag.c.o
[301/303] Linking target swaynag/swaynag
FAILED: swaynag/swaynag 
cc  -o swaynag/swaynag swaynag/swaynag.p/meson-generated_.._.._protocols_xdg-shell-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_xdg-output-unstable-v1-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_pointer-constraints-unstable-v1-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_tablet-unstable-v2-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_linux-dmabuf-unstable-v1-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_wlr-layer-shell-unstable-v1-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_idle-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_wlr-input-inhibitor-unstable-v1-protocol.c.o swaynag/swaynag.p/meson-generated_.._.._protocols_wlr-output-power-management-unstable-v1-protocol.c.o swaynag/swaynag.p/config.c.o swaynag/swaynag.p/main.c.o swaynag/swaynag.p/render.c.o swaynag/swaynag.p/swaynag.c.o swaynag/swaynag.p/types.c.o -flto -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -fdebug-prefix-map=/builddir/sway-1.8/build=. -Wl,-rpath,/usr/lib64 -Wl,-rpath-link,/usr/lib64 -Wl,--start-group common/libsway-common.a client/libsway-client.a /usr/lib/libcairo.so /usr/lib64/libpango-1.0.so /usr/lib64/libgobject-2.0.so /usr/lib64/libglib-2.0.so /usr/lib64/libharfbuzz.so /usr/lib64/libpangocairo-1.0.so /usr/lib64/libcairo.so /usr/lib64/libwayland-client.so /usr/lib64/libwayland-cursor.so /usr/lib64/libgdk_pixbuf-2.0.so -Wl,--end-group
/usr/bin/ld: /tmp/swaynag.BOxK2Q.ltrans0.ltrans.o: in function `render_frame.part.0':
<artificial>:(.text+0x2db1): undefined reference to `shm_open'
/usr/bin/ld: <artificial>:(.text+0x2dc8): undefined reference to `shm_unlink'
collect2: error: ld returned 1 exit status
[302/303] Linking target swaybar/swaybar
[303/303] Linking target sway/sway
ninja: build stopped: subcommand failed.
```