### PR TITLE
Add support for external launcher clients with xdg activation

### DIFF
--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -6,7 +6,7 @@
 
 struct launcher_ctx {
 	pid_t pid;
-	char *name;
+	char *fallback_name;
 	struct wlr_xdg_activation_token_v1 *token;
 	struct wl_listener token_destroy;
 
@@ -26,7 +26,10 @@ void launcher_ctx_consume(struct launcher_ctx *ctx);
 
 void launcher_ctx_destroy(struct launcher_ctx *ctx);
 
-struct launcher_ctx *launcher_ctx_create(void);
+struct launcher_ctx *launcher_ctx_create_internal(void);
+
+struct launcher_ctx *launcher_ctx_create(
+	struct wlr_xdg_activation_token_v1 *token, struct sway_node *node);
 
 const char *launcher_ctx_get_token_name(struct launcher_ctx *ctx);
 

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -114,6 +114,7 @@ struct sway_server {
 
 	struct wlr_xdg_activation_v1 *xdg_activation_v1;
 	struct wl_listener xdg_activation_v1_request_activate;
+	struct wl_listener xdg_activation_v1_new_token;
 
 	struct wl_list pending_launcher_ctxs; // launcher_ctx::link
 
@@ -174,6 +175,8 @@ void handle_server_decoration(struct wl_listener *listener, void *data);
 void handle_xdg_decoration(struct wl_listener *listener, void *data);
 void handle_pointer_constraint(struct wl_listener *listener, void *data);
 void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
+	void *data);
+void xdg_activation_v1_handle_new_token(struct wl_listener *listener,
 	void *data);
 
 void set_rr_scheduling(void);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -271,7 +271,7 @@ void view_set_activated(struct sway_view *view, bool activated);
 /**
  * Called when the view requests to be focused.
  */
-void view_request_activate(struct sway_view *view);
+void view_request_activate(struct sway_view *view, struct sway_seat *seat);
 
 /**
  * If possible, instructs the client to change their decoration mode.

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -63,7 +63,7 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	}
 
 	pid_t pid, child;
-	struct launcher_ctx *ctx = launcher_ctx_create();
+	struct launcher_ctx *ctx = launcher_ctx_create_internal();
 	// Fork process
 	if ((pid = fork()) == 0) {
 		// Fork child process again

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -630,7 +630,7 @@ static void handle_request_activate(struct wl_listener *listener, void *data) {
 	if (!xsurface->mapped) {
 		return;
 	}
-	view_request_activate(view);
+	view_request_activate(view, NULL);
 
 	transaction_commit_dirty();
 }

--- a/sway/server.c
+++ b/sway/server.c
@@ -225,6 +225,10 @@ bool server_init(struct sway_server *server) {
 		xdg_activation_v1_handle_request_activate;
 	wl_signal_add(&server->xdg_activation_v1->events.request_activate,
 		&server->xdg_activation_v1_request_activate);
+	server->xdg_activation_v1_new_token.notify =
+		xdg_activation_v1_handle_new_token;
+	wl_signal_add(&server->xdg_activation_v1->events.new_token,
+		&server->xdg_activation_v1_new_token);
 
 	wl_list_init(&server->pending_launcher_ctxs);
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -366,12 +366,14 @@ void view_set_activated(struct sway_view *view, bool activated) {
 	}
 }
 
-void view_request_activate(struct sway_view *view) {
+void view_request_activate(struct sway_view *view, struct sway_seat *seat) {
 	struct sway_workspace *ws = view->container->pending.workspace;
 	if (!ws) { // hidden scratchpad container
 		return;
 	}
-	struct sway_seat *seat = input_manager_current_seat();
+	if (!seat) {
+		seat = input_manager_current_seat();
+	}
 
 	switch (config->focus_on_window_activation) {
 	case FOWA_SMART:

--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -1,6 +1,7 @@
 #include <wlr/types/wlr_xdg_activation_v1.h>
 #include "sway/desktop/launcher.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 
 void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		void *data) {
@@ -36,5 +37,17 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 	if (wlr_seat) {
 		struct sway_seat *seat = wlr_seat->data;
 		view_request_activate(view, seat);
+	}
+}
+
+void xdg_activation_v1_handle_new_token(struct wl_listener *listener, void *data) {
+	struct wlr_xdg_activation_token_v1 *token = data;
+	struct sway_seat *seat = token->seat ? token->seat->data :
+		input_manager_current_seat();
+
+	struct sway_workspace *ws = seat_get_focused_workspace(seat);
+	if (ws) {
+		launcher_ctx_create(token, &ws->node);
+		return;
 	}
 }

--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -31,5 +31,10 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		return;
 	}
 
-	view_request_activate(view);
+	struct wlr_seat *wlr_seat = event->token->seat;
+	// The requesting seat may have been destroyed.
+	if (wlr_seat) {
+		struct sway_seat *seat = wlr_seat->data;
+		view_request_activate(view, seat);
+	}
 }


### PR DESCRIPTION
This allows a launcher client to request an activation token useful for startup notifications. For a compatible launcher, see fuzzel [1].

For the time being, we use these in exactly the same way we would our own internal launch contexts except they cannot be pid matched. If the launched client supports startup notifications I'd consider that a positive. We also get a little more info from the launcher than we have on our own, i.e. the intended app_id. We might consider restricting matches to the given app_id.

Depends on [2].

[1] https://codeberg.org/dnkl/fuzzel/pulls/195 (merged)
[2] https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3907 (merged)