### PR TITLE
Disable primary clipboard option

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -165,6 +165,7 @@ sway_cmd cmd_no_focus;
 sway_cmd cmd_output;
 sway_cmd cmd_permit;
 sway_cmd cmd_popup_during_fullscreen;
+sway_cmd cmd_primary_selection;
 sway_cmd cmd_reject;
 sway_cmd cmd_reload;
 sway_cmd cmd_rename;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -530,6 +530,7 @@ struct sway_config {
 	bool auto_back_and_forth;
 	bool show_marks;
 	enum alignment title_align;
+	bool primary_selection;
 
 	bool tiling_drag;
 	int tiling_drag_threshold;
@@ -719,7 +720,7 @@ void free_workspace_config(struct workspace_config *wsc);
 /**
  * Updates the value of config->font_height based on the metrics for title's
  * font as reported by pango.
- * 
+ *
  * If the height has changed, all containers will be rearranged to take on the
  * new size.
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -82,6 +82,7 @@ static const struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "primary_selection", cmd_primary_selection },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/primary_selection.c
+++ b/sway/commands/primary_selection.c
@@ -1,0 +1,23 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "util.h"
+
+struct cmd_results *cmd_primary_selection(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "primary_selection", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	bool primary_selection = parse_boolean(argv[0], true);
+
+	if (config->reloading && config->primary_selection != primary_selection) {
+		return cmd_results_new(CMD_FAILURE,
+				"primary_selection can only be enabled/disabled at launch");
+	}
+
+	config->primary_selection = parse_boolean(argv[0], true);
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -273,6 +273,7 @@ static void config_defaults(struct sway_config *config) {
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;
+	config->primary_selection = true;
 
 	config->smart_gaps = SMART_GAPS_OFF;
 	config->gaps_inner = 0;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -86,6 +86,7 @@ sway_sources = files(
 	'commands/nop.c',
 	'commands/output.c',
 	'commands/popup_during_fullscreen.c',
+	'commands/primary_selection.c',
 	'commands/reload.c',
 	'commands/rename.c',
 	'commands/resize.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -210,7 +210,6 @@ bool server_init(struct sway_server *server) {
 	wlr_export_dmabuf_manager_v1_create(server->wl_display);
 	wlr_screencopy_manager_v1_create(server->wl_display);
 	wlr_data_control_manager_v1_create(server->wl_display);
-	wlr_primary_selection_v1_device_manager_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
 	server->content_type_manager_v1 =
@@ -307,6 +306,10 @@ bool server_start(struct sway_server *server) {
 		}
 	}
 #endif
+
+	if (config->primary_selection) {
+		wlr_primary_selection_v1_device_manager_create(server->wl_display);
+	}
 
 	sway_log(SWAY_INFO, "Starting backend on wayland display '%s'",
 			server->socket);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -807,6 +807,10 @@ The default colors are:
 	dialog will not be rendered. If _leave_fullscreen_, the view will exit
 	fullscreen mode and the dialog will be rendered.
 
+*primary_selection* enabled|disabled
+	Enable or disable the primary selection clipboard. May only be configured
+	at launch. Default is _enabled_.
+
 *set* $<name> <value>
 	Sets variable $_name_ to _value_. You can use the new variable in the
 	arguments of future commands. When the variable is used, it can be escaped


### PR DESCRIPTION
See https://github.com/swaywm/sway/issues/4511. This PR builds on https://github.com/swaywm/sway/pull/6897 which seems to have stalled, and I have kept @t1lde's contributions in the commit history.

I have attempted to address @emersion's feedback in https://github.com/swaywm/sway/pull/6897. Firstly, the `config` option is stored as `bool`. Secondly, I make the `primary_selection` only configurable at launch (similar to `xwayland`). This allows me to destroy the primary selection global after the config is loaded.

I couldn't think of a clean way to avoid creating the global at all, since `server_init()` creates the global and the default seat, and then registers listeners. After that, the configuration is loaded in `load_main_config()`. So I hope destroying the global after loading the config is an acceptable compromise.