### PR TITLE
criteria: be lenient on window_role and instance too

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -287,7 +287,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 		switch (criteria->instance->match_type) {
 		case PATTERN_FOCUSED:
-			if (focused && strcmp(instance, view_get_instance(focused))) {
+			if (focused && lenient_strcmp(instance, view_get_instance(focused))) {
 				return false;
 			}
 			break;
@@ -307,7 +307,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 
 		switch (criteria->window_role->match_type) {
 		case PATTERN_FOCUSED:
-			if (focused && strcmp(window_role, view_get_window_role(focused))) {
+			if (focused && lenient_strcmp(window_role, view_get_window_role(focused))) {
 				return false;
 			}
 			break;


### PR DESCRIPTION
This extends #5822 to window_role and instance properties too, which may also be NULL for non-xwayland views. Fixes a crash like:

<details>
<summary>swaymsg '[instance=__focused__]' nop</summary>

```
#0  0x00007f125115470f in  () at /usr/lib/libc.so.6
#1  0x00005601e3af8907 in criteria_matches_view (criteria=0x5601e5a2d020, view=0x5601e5900b70) at ../sway/sway/criteria.c:290
        instance = 0x5601e3b4f617 ""
        seat = <optimized out>
        focus = <optimized out>
        focused = 0x5601e53ddf10
#2  0x00005601e3af8f42 in criteria_get_containers_iterator (container=0x5601e5991220, data=0x7ffcabe000c0) at ../sway/sway/criteria.c:411
        match_data = 0x7ffcabe000c0
#3  0x00005601e3b40838 in workspace_for_each_container (ws=0x5601e5990860, f=f@entry=0x5601e3af8f20 <criteria_get_containers_iterator>, data=data@entry=0x7ffcabe000c0) at ../sway/sway/tree/workspace.c:714
        i = 0
#4  0x00005601e3b40927 in root_for_each_container (f=0x5601e3af8f20 <criteria_get_containers_iterator>, data=0x7ffcabe000c0) at ../sway/sway/tree/output.c:369
        i = 0
#5  0x00005601e3afed11 in criteria_get_containers (criteria=0x5601e5a2d020) at ../sway/sway/criteria.c:427
        matches = 0x5601e5f4c7e0
        data = {criteria = 0x5601e5a2d020, matches = 0x5601e5f4c7e0}
        error = 0x0
        criteria = 0x5601e5a2d020
        argc = -442314720
        argv = <optimized out>
        handler = <optimized out>
        cmd = <optimized out>
        matched_delim = 59 ';'
        containers = <optimized out>
        using_criteria = false
        exec = 0x5601e62e57a0 "[instance=__focused__] nop"
        head = 0x5601e62e57a0 "[instance=__focused__] nop"
        res_list = <optimized out>
        __PRETTY_FUNCTION__ = "execute_command"
#6  execute_command (_exec=_exec@entry=0x5601e62cc090 "[instance=__focused__] nop", seat=0x5601e526d980, seat@entry=0x0, con=con@entry=0x0) at ../sway/sway/commands.c:245
        error = 0x0
        criteria = 0x5601e5a2d020
        argc = -442314720
        argv = <optimized out>
        handler = <optimized out>
        cmd = <optimized out>
        matched_delim = 59 ';'
        containers = <optimized out>
        using_criteria = false
        exec = 0x5601e62e57a0 "[instance=__focused__] nop"
        head = 0x5601e62e57a0 "[instance=__focused__] nop"
        res_list = <optimized out>
        __PRETTY_FUNCTION__ = "execute_command"
#7  0x00005601e3afffb7 in ipc_client_handle_command (client=0x5601e62e2930, payload_length=<optimized out>, payload_type=IPC_COMMAND) at ../sway/sway/ipc-server.c:578
        line = <optimized out>
        res_list = <optimized out>
        json = <optimized out>
        length = <optimized out>
        buf = 0x5601e62cc090 "[instance=__focused__] nop"
        __PRETTY_FUNCTION__ = "ipc_client_handle_command"
#8  0x00005601e3b01744 in ipc_client_handle_readable (mask=<optimized out>, data=0x5601e62e2930, client_fd=101) at ../sway/sway/ipc-server.c:263
        pending_length = <optimized out>
        read_available = 40
        buf = "i3-ipc\032\000\000\000\000\000\000"
        received = <optimized out>
        client = 0x5601e62e2930
#9  ipc_client_handle_readable (client_fd=101, mask=<optimized out>, data=0x5601e62e2930) at ../sway/sway/ipc-server.c:203
        client = 0x5601e62e2930
#10 0x00007f12513839e2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#11 0x00007f1251384197 in wl_display_run () at /usr/lib/libwayland-server.so.0
#12 0x00005601e3af7ca3 in server_run (server=<optimized out>) at ../sway/sway/server.c:329
        config_path = 0x0
        c = <optimized out>
        validate = false
        debug = false
        allow_unsupported_gpu = false
        verbose = false
#13 main (argc=<optimized out>, argv=0x7ffcabe00698) at ../sway/sway/main.c:411
        config_path = 0x0
        c = <optimized out>
        validate = false
        debug = false
        allow_unsupported_gpu = false
        verbose = false
```
</details>

Reported on #sway irc:

> [23:12:09](irc:///%23sway?timestamp=2022-12-08T06%3A12%3A09.000Z) <[tkna](irc:///tkna,isuser)> n0r: Running this seems to crash sway `swaymsg "[instance=\"__focused__\"] nop"` https://paste.rs/Zox