### PR TITLE
commands/move: Warp cursor after moving workspace to another output

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -686,6 +686,9 @@ static struct cmd_results *cmd_move_workspace(int argc, char **argv) {
 	arrange_output(old_output);
 	arrange_output(new_output);
 
+	struct sway_seat *seat = config->handler_context.seat;
+	seat_consider_warp_to_focus(seat);
+
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
 


### PR DESCRIPTION
This makes sway's behavior consistent with i3 when `mouse_warping` is set to any value besides `none`.

Fixes #7027.