### PR TITLE
seat: Set keyboard if seat keyboard is NULL

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -1070,6 +1070,13 @@ void sway_keyboard_configure(struct sway_keyboard *keyboard) {
 		}
 	}
 
+	// If the seat has no active keyboard, set this one
+	struct wlr_seat *seat = keyboard->seat_device->sway_seat->wlr_seat;
+	struct wlr_keyboard *current_keyboard = seat->keyboard_state.keyboard;
+	if (current_keyboard == NULL) {
+		wlr_seat_set_keyboard(seat, keyboard->wlr);
+	}
+
 	wl_list_remove(&keyboard->keyboard_key.link);
 	wl_signal_add(&keyboard->wlr->events.key, &keyboard->keyboard_key);
 	keyboard->keyboard_key.notify = handle_keyboard_key;


### PR DESCRIPTION
sway sends wl_keyboard.enter on seat focus change and when a keyboard active on a seat is configured. If all keyboards are removed and a keyboard is added back without changing the focused client, no new notify event would be sent despite having keyboard focus. This could lead to key events without notify, which is a protocol violation.

As a quick fix, when configuring a keyboard on a seat where no keyboard is currently active, activate the keyboard so that a focused surface will receive a notify event.

Regressed by: e1b268af98edeb09e570e8855ef64f0719cbafe2
Closes: https://github.com/swaywm/sway/issues/7330