### PR TITLE
tree/container: drop unnecessary check in container_get_siblings()

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1407,9 +1407,6 @@ list_t *container_get_siblings(struct sway_container *container) {
 	if (container->pending.parent) {
 		return container->pending.parent->pending.children;
 	}
-	if (container_is_scratchpad_hidden(container)) {
-		return NULL;
-	}
 	if (!container->pending.workspace) {
 		return NULL;
 	}


### PR DESCRIPTION
The check for container->pending.workspace already covers this.

References: https://github.com/swaywm/sway/pull/7315#issuecomment-1341716204