### PR TITLE
swaynag: fix NULL font description 

### DIFF
--- a/include/swaynag/types.h
+++ b/include/swaynag/types.h
@@ -4,7 +4,6 @@
 struct swaynag_type {
 	char *name;
 
-	char *font; // Used for debugging.
 	PangoFontDescription *font_description;
 	char *output;
 	uint32_t anchors;

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -226,10 +226,8 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			break;
 		case 'f': // Font
 			if (type) {
-				free(type->font);
 				pango_font_description_free(type->font_description);
-				type->font = strdup(optarg);
-				type->font_description = pango_font_description_from_string(type->font);
+				type->font_description = pango_font_description_from_string(optarg);
 			}
 			break;
 		case 'l': // Detailed Message

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -98,7 +98,9 @@ int main(int argc, char **argv) {
 	sway_log(SWAY_DEBUG, "Anchors: %" PRIu32, swaynag.type->anchors);
 	sway_log(SWAY_DEBUG, "Type: %s", swaynag.type->name);
 	sway_log(SWAY_DEBUG, "Message: %s", swaynag.message);
-	sway_log(SWAY_DEBUG, "Font: %s", swaynag.type->font);
+	char *font = pango_font_description_to_string(swaynag.type->font_description);
+	sway_log(SWAY_DEBUG, "Font: %s", font);
+	free(font);
 	sway_log(SWAY_DEBUG, "Buttons");
 	for (int i = 0; i < swaynag.buttons->length; i++) {
 		struct swaynag_button *button = swaynag.buttons->items[i];

--- a/swaynag/types.c
+++ b/swaynag/types.c
@@ -32,9 +32,8 @@ struct swaynag_type *swaynag_type_new(const char *name) {
 
 void swaynag_types_add_default(list_t *types) {
 	struct swaynag_type *type_defaults = swaynag_type_new("<defaults>");
-	type_defaults->font = strdup("pango:Monospace 10");
 	type_defaults->font_description =
-		pango_font_description_from_string(type_defaults->font);
+		pango_font_description_from_string("pango:Monospace 10");
 	type_defaults->anchors = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP
 		| ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT
 		| ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
@@ -90,10 +89,6 @@ struct swaynag_type *swaynag_type_get(list_t *types, char *name) {
 void swaynag_type_merge(struct swaynag_type *dest, struct swaynag_type *src) {
 	if (!dest || !src) {
 		return;
-	}
-
-	if (src->font) {
-		dest->font = strdup(src->font);
 	}
 
 	if (src->font_description) {
@@ -178,7 +173,6 @@ void swaynag_type_merge(struct swaynag_type *dest, struct swaynag_type *src) {
 
 void swaynag_type_free(struct swaynag_type *type) {
 	free(type->name);
-	free(type->font);
 	pango_font_description_free(type->font_description);
 	free(type->output);
 	free(type);

--- a/swaynag/types.c
+++ b/swaynag/types.c
@@ -33,6 +33,8 @@ struct swaynag_type *swaynag_type_new(const char *name) {
 void swaynag_types_add_default(list_t *types) {
 	struct swaynag_type *type_defaults = swaynag_type_new("<defaults>");
 	type_defaults->font = strdup("pango:Monospace 10");
+	type_defaults->font_description =
+		pango_font_description_from_string(type_defaults->font);
 	type_defaults->anchors = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP
 		| ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT
 		| ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
@@ -92,6 +94,10 @@ void swaynag_type_merge(struct swaynag_type *dest, struct swaynag_type *src) {
 
 	if (src->font) {
 		dest->font = strdup(src->font);
+	}
+
+	if (src->font_description) {
+		dest->font_description = pango_font_description_copy(src->font_description);
 	}
 
 	if (src->output) {
@@ -173,6 +179,7 @@ void swaynag_type_merge(struct swaynag_type *dest, struct swaynag_type *src) {
 void swaynag_type_free(struct swaynag_type *type) {
 	free(type->name);
 	free(type->font);
+	pango_font_description_free(type->font_description);
 	free(type->output);
 	free(type);
 }


### PR DESCRIPTION
The font description was only set if provided on the CLI. It was
left NULL for the defaults and when reading from the config file.

Closes: https://github.com/swaywm/sway/issues/7186 

cc @WhyNotHugo 