### PR TITLE
Added splith and splitv to workspace_layout command

### DIFF
--- a/sway/commands/workspace_layout.c
+++ b/sway/commands/workspace_layout.c
@@ -9,13 +9,17 @@ struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
 	}
 	if (strcasecmp(argv[0], "default") == 0) {
 		config->default_layout = L_NONE;
+	} else if (strcasecmp(argv[0], "splith") == 0) {
+		config->default_layout = L_HORIZ;
+	} else if (strcasecmp(argv[0], "splitv") == 0) {
+		config->default_layout = L_VERT;
 	} else if (strcasecmp(argv[0], "stacking") == 0) {
 		config->default_layout = L_STACKED;
 	} else if (strcasecmp(argv[0], "tabbed") == 0) {
 		config->default_layout = L_TABBED;
 	} else {
 		return cmd_results_new(CMD_INVALID,
-				"Expected 'workspace_layout <default|stacking|tabbed>'");
+				"Expected 'workspace_layout <default|splith|splitv|stacking|tabbed>'");
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -88,7 +88,7 @@ The following commands may only be used in the configuration file.
 	It can be disabled by setting the command to a single dash:
 	_swaynag\_command -_
 
-*workspace_layout* default|stacking|tabbed
+*workspace_layout* default|splith|splitv|stacking|tabbed
 	Specifies the initial layout for new containers in an empty workspace.
 
 *xwayland* enable|disable|force


### PR DESCRIPTION
This PR extends the `workspace_layout` command such that one can set `splith` or `splitv` as the default workspace layout. This is for example useful if you are on an ultra-width screen where you have enough space to position new containers next to each other by default.