### PR TITLE
warp_to_constraint_cursor_hint: Handle NULL view

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1322,6 +1322,10 @@ static void warp_to_constraint_cursor_hint(struct sway_cursor *cursor) {
 		double sy = constraint->current.cursor_hint.y;
 
 		struct sway_view *view = view_from_wlr_surface(constraint->surface);
+		if (!view) {
+			return;
+		}
+
 		struct sway_container *con = view->container;
 
 		double lx = sx + con->pending.content_x - view->geometry.x;


### PR DESCRIPTION
This might be the wrong fix, but the crash is happening because the ->data field on an xwayland surface is NULL. A NULL data field is normal for unmanaged surfaces, however it seems clients can do weird things: They can create a cursor lock on a regular xwayland surface then make it unmanaged by calling override_redirect. In this case, the xwayland server should destroy the cursor lock, which is does, but does so in the wrong order making it try to dereference a NULL pointer after sway has acknowledged its new unmanaged status.

```
(gdb) bt full
0  0x000055fd91934861 in warp_to_constraint_cursor_hint (cursor=0x55fd93486c00)
    at ../sway/input/cursor.c:1243
        sy = 605
        lx = 6.9527431433545762e-310
        sx = 1272
        view = 0x0
        con = 0x7ffd1cdfe400
        ly = -6.949595189996421e+59
        constraint = 0x55fd93e7faa0
1  0x000055fd91934976 in handle_constraint_destroy (listener=0x55fd93f0fd58, data=0x55fd93e7faa0)
    at ../sway/input/cursor.c:1266
        sway_constraint = 0x55fd93f0fd30
        constraint = 0x55fd93e7faa0
        cursor = 0x55fd93486c00
2  0x00007fda8275bf6e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
3  0x00007fda82e57016 in pointer_constraint_destroy (constraint=0x55fd93e7faa0)
    at ../subprojects/wlroots/types/wlr_pointer_constraints_v1.c:49
4  0x00007fda82e570dc in pointer_constraint_destroy_resource (resource=0x55fd933cf8f0)
    at ../subprojects/wlroots/types/wlr_pointer_constraints_v1.c:66
        constraint = 0x55fd93e7faa0
5  0x00007fda8275d8ba in  () at /usr/lib/libwayland-server.so.0
6  0x00007fda8275f6a9 in wl_resource_destroy () at /usr/lib/libwayland-server.so.0
7  0x00007fda82e56fb3 in resource_destroy (client=0x55fd93ea52e0, resource=0x55fd933cf8f0)
    at ../subprojects/wlroots/types/wlr_pointer_constraints_v1.c:39
8  0x00007fda81d8f4f6 in  () at /usr/lib/libffi.so.8
9  0x00007fda81d8bf5e in  () at /usr/lib/libffi.so.8
10 0x00007fda81d8eb73 in ffi_call () at /usr/lib/libffi.so.8
11 0x00007fda8275aada in  () at /usr/lib/libwayland-server.so.0
12 0x00007fda8275f01c in  () at /usr/lib/libwayland-server.so.0
13 0x00007fda8275d9e2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
14 0x00007fda8275e197 in wl_display_run () at /usr/lib/libwayland-server.so.0
15 0x000055fd919264d3 in server_run (server=0x55fd919a3a80 <server>) at ../sway/server.c:320
16 0x000055fd91925457 in main (argc=1, argv=0x7ffd1cdfed98) at ../sway/main.c:411
        verbose = false
        debug = false
        validate = false
        allow_unsupported_gpu = false
        config_path = 0x0
        c = -1
```