### PR TITLE
Fix memory leak

### DIFF
--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 	wl_list_init(&swaynag.outputs);
 	wl_list_init(&swaynag.seats);
 
-	struct swaynag_button button_close = { 0 };
+	static struct swaynag_button button_close = { 0 };
 	button_close.text = strdup("X");
 	button_close.type = SWAYNAG_ACTION_DISMISS;
 	list_add(swaynag.buttons, &button_close);
@@ -115,6 +115,7 @@ int main(int argc, char **argv) {
 
 cleanup:
 	swaynag_types_free(types);
+	free(button_close.text);
 	free(swaynag.details.button_details.text);
 	swaynag_destroy(&swaynag);
 	return status;


### PR DESCRIPTION
I built sway with Address Sanitizer enabled (`meson build/ -Db_sanitize=address`) and multiple potential memory leaks were found. This fixes one of them. `button_close.text = strdup("X");` creates a pointer to allocated memory that should be freed upon cleanup. 