### PR TITLE
swaynag: call swaynag_destroy on clean exit

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -58,6 +58,7 @@ struct swaynag_button {
 struct swaynag_details {
 	bool visible;
 	char *message;
+	char *details_text;
 
 	int x;
 	int y;
@@ -67,7 +68,7 @@ struct swaynag_details {
 	int offset;
 	int visible_lines;
 	int total_lines;
-	struct swaynag_button button_details;
+	struct swaynag_button *button_details;
 	struct swaynag_button button_up;
 	struct swaynag_button button_down;
 };

--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -243,8 +243,8 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 			break;
 		case 'L': // Detailed Button Text
 			if (swaynag) {
-				free(swaynag->details.button_details.text);
-				swaynag->details.button_details.text = strdup(optarg);
+				free(swaynag->details.details_text);
+				swaynag->details.details_text = strdup(optarg);
 			}
 			break;
 		case 'm': // Message

--- a/swaynag/main.c
+++ b/swaynag/main.c
@@ -29,10 +29,12 @@ int main(int argc, char **argv) {
 	wl_list_init(&swaynag.outputs);
 	wl_list_init(&swaynag.seats);
 
-	struct swaynag_button button_close = { 0 };
-	button_close.text = strdup("X");
-	button_close.type = SWAYNAG_ACTION_DISMISS;
-	list_add(swaynag.buttons, &button_close);
+	struct swaynag_button *button_close = calloc(1, sizeof(struct swaynag_button));
+	button_close->text = strdup("X");
+	button_close->type = SWAYNAG_ACTION_DISMISS;
+	list_add(swaynag.buttons, button_close);
+
+	swaynag.details.details_text = strdup("Toggle details");
 
 	char *config_path = NULL;
 	bool debug = false;
@@ -54,8 +56,6 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	swaynag.details.button_details.text = strdup("Toggle details");
-	swaynag.details.button_details.type = SWAYNAG_ACTION_EXPAND;
 
 	if (argc > 1) {
 		struct swaynag_type *type_args = swaynag_type_new("<args>");
@@ -88,10 +88,11 @@ int main(int argc, char **argv) {
 	swaynag_type_merge(type, swaynag_type_get(types, "<args>"));
 	swaynag.type = type;
 
-	swaynag_types_free(types);
-
 	if (swaynag.details.message) {
-		list_add(swaynag.buttons, &swaynag.details.button_details);
+		swaynag.details.button_details = calloc(1, sizeof(struct swaynag_button));
+		swaynag.details.button_details->text = strdup(swaynag.details.details_text);
+		swaynag.details.button_details->type = SWAYNAG_ACTION_EXPAND;
+		list_add(swaynag.buttons, swaynag.details.button_details);
 	}
 
 	sway_log(SWAY_DEBUG, "Output: %s", swaynag.type->output);
@@ -111,11 +112,9 @@ int main(int argc, char **argv) {
 
 	swaynag_setup(&swaynag);
 	swaynag_run(&swaynag);
-	return status;
 
 cleanup:
 	swaynag_types_free(types);
-	free(swaynag.details.button_details.text);
 	swaynag_destroy(&swaynag);
 	return status;
 }

--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -483,10 +483,6 @@ void swaynag_run(struct swaynag *swaynag) {
 			&& wl_display_dispatch(swaynag->display) != -1) {
 		// This is intentionally left blank
 	}
-
-	if (swaynag->display) {
-		wl_display_disconnect(swaynag->display);
-	}
 }
 
 void swaynag_destroy(struct swaynag *swaynag) {
@@ -501,6 +497,7 @@ void swaynag_destroy(struct swaynag *swaynag) {
 	}
 	list_free(swaynag->buttons);
 	free(swaynag->details.message);
+	free(swaynag->details.details_text);
 	free(swaynag->details.button_up.text);
 	free(swaynag->details.button_down.text);
 
@@ -540,5 +537,9 @@ void swaynag_destroy(struct swaynag *swaynag) {
 
 	if (swaynag->shm) {
 		wl_shm_destroy(swaynag->shm);
+	}
+
+	if (swaynag->display) {
+		wl_display_disconnect(swaynag->display);
 	}
 }


### PR DESCRIPTION
This fixes a few memory leaks.

Quoting commit message:
> And fix the fallout of the swaynag_destroy having evolved without being tested:
> * wl_display_disconnect was called too early
> * `button_close` and `swaynag.details.button_details` needed to be heap allocated, since they are added to swaynag.buttons, > and all entries of swaynag.buttons are freed in swaynag_destroy
> * To keep things simpler, disconnect the lifetime of the 'Toggle details' button text config setting from the button itself.

