### PR TITLE
input/tablet: handle focusing NULL surface

### DIFF
--- a/include/sway/input/tablet.h
+++ b/include/sway/input/tablet.h
@@ -63,7 +63,7 @@ void sway_configure_tablet_pad(struct sway_tablet_pad *tablet_pad);
 
 void sway_tablet_pad_destroy(struct sway_tablet_pad *tablet_pad);
 
-void sway_tablet_pad_notify_enter(struct sway_tablet_pad *tablet_pad,
+void sway_tablet_pad_set_focus(struct sway_tablet_pad *tablet_pad,
 		struct wlr_surface *surface);
 
 #endif

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -177,11 +177,11 @@ static void seat_keyboard_notify_enter(struct sway_seat *seat,
 			state->pressed_keycodes, state->npressed, &keyboard->modifiers);
 }
 
-static void seat_tablet_pads_notify_enter(struct sway_seat *seat,
+static void seat_tablet_pads_set_focus(struct sway_seat *seat,
 		struct wlr_surface *surface) {
 	struct sway_seat_device *seat_device;
 	wl_list_for_each(seat_device, &seat->devices, link) {
-		sway_tablet_pad_notify_enter(seat_device->tablet_pad, surface);
+		sway_tablet_pad_set_focus(seat_device->tablet_pad, surface);
 	}
 }
 
@@ -205,7 +205,7 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 #endif
 
 		seat_keyboard_notify_enter(seat, view->surface);
-		seat_tablet_pads_notify_enter(seat, view->surface);
+		seat_tablet_pads_set_focus(seat, view->surface);
 		sway_input_method_relay_set_focus(&seat->im_relay, view->surface);
 
 		struct wlr_pointer_constraint_v1 *constraint =
@@ -1322,7 +1322,7 @@ void seat_set_focus_surface(struct sway_seat *seat,
 	}
 
 	sway_input_method_relay_set_focus(&seat->im_relay, surface);
-	seat_tablet_pads_notify_enter(seat, surface);
+	seat_tablet_pads_set_focus(seat, surface);
 }
 
 void seat_set_focus_layer(struct sway_seat *seat,

--- a/sway/input/tablet.c
+++ b/sway/input/tablet.c
@@ -342,14 +342,10 @@ static void handle_pad_tablet_surface_destroy(struct wl_listener *listener,
 	struct sway_tablet_pad *tablet_pad =
 		wl_container_of(listener, tablet_pad, surface_destroy);
 
-	wlr_tablet_v2_tablet_pad_notify_leave(tablet_pad->tablet_v2_pad,
-		tablet_pad->current_surface);
-	wl_list_remove(&tablet_pad->surface_destroy.link);
-	wl_list_init(&tablet_pad->surface_destroy.link);
-	tablet_pad->current_surface = NULL;
+	sway_tablet_pad_set_focus(tablet_pad, NULL);
 }
 
-void sway_tablet_pad_notify_enter(struct sway_tablet_pad *tablet_pad,
+void sway_tablet_pad_set_focus(struct sway_tablet_pad *tablet_pad,
 		struct wlr_surface *surface) {
 	if (!tablet_pad || !tablet_pad->tablet) {
 		return;
@@ -368,7 +364,8 @@ void sway_tablet_pad_notify_enter(struct sway_tablet_pad *tablet_pad,
 		tablet_pad->current_surface = NULL;
 	}
 
-	if (!wlr_surface_accepts_tablet_v2(tablet_pad->tablet->tablet_v2, surface)) {
+	if (surface == NULL ||
+			!wlr_surface_accepts_tablet_v2(tablet_pad->tablet->tablet_v2, surface)) {
 		return;
 	}
 
@@ -376,7 +373,6 @@ void sway_tablet_pad_notify_enter(struct sway_tablet_pad *tablet_pad,
 		tablet_pad->tablet->tablet_v2, surface);
 
 	tablet_pad->current_surface = surface;
-	wl_list_remove(&tablet_pad->surface_destroy.link);
 	tablet_pad->surface_destroy.notify = handle_pad_tablet_surface_destroy;
 	wl_signal_add(&surface->events.destroy, &tablet_pad->surface_destroy);
 }


### PR DESCRIPTION
Additionally, rename the function responsible for switching focus to match its behavior better.

---

Might fix https://github.com/swaywm/sway/issues/7369, which I can't reproduce.