### PR TITLE
Switch default menu to wmenu

### DIFF
--- a/config.in
+++ b/config.in
@@ -18,7 +18,7 @@ set $term foot
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.
-set $menu dmenu_path | dmenu | xargs swaymsg exec --
+set $menu dmenu_path | wmenu | xargs swaymsg exec --
 
 ### Output configuration
 #


### PR DESCRIPTION
Switch the default menu to wmeny (https://sr.ht/~adnano/wmenu), a Wayland-native alternative to dmenu. This removes the dependency on Xwayland for the default config.

wmenu is small (same scope as dmenu) and has the same flags as dmenu. One downside is that it's not widely packaged by distributions yet.

We still depend on dmenu_path.