### PR TITLE
Fix pointer events for ext-session-lock surfaces

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -97,6 +97,24 @@ struct sway_node *node_at_coords(
 	double ox = lx, oy = ly;
 	wlr_output_layout_output_coords(root->output_layout, wlr_output, &ox, &oy);
 
+	if (server.session_lock.locked) {
+		if (server.session_lock.lock == NULL) {
+			return NULL;
+		}
+		struct wlr_session_lock_surface_v1 *lock_surf;
+		wl_list_for_each(lock_surf, &server.session_lock.lock->surfaces, link) {
+			if (lock_surf->output != wlr_output) {
+				continue;
+			}
+
+			*surface = wlr_surface_surface_at(lock_surf->surface, ox, oy, sx, sy);
+			if (*surface != NULL) {
+				return NULL;
+			}
+		}
+		return NULL;
+	}
+
 	// layer surfaces on the overlay layer are rendered on top
 	if ((*surface = layer_surface_at(output,
 				&output->layers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1089,9 +1089,20 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 
 bool seat_is_input_allowed(struct sway_seat *seat,
 		struct wlr_surface *surface) {
+	if (server.session_lock.locked) {
+		if (server.session_lock.lock == NULL) {
+			return false;
+		}
+		struct wlr_session_lock_surface_v1 *lock_surf;
+		wl_list_for_each(lock_surf, &server.session_lock.lock->surfaces, link) {
+			if (lock_surf->surface == surface) {
+				return true;
+			}
+		}
+		return false;
+	}
 	struct wl_client *client = wl_resource_get_client(surface->resource);
-	return seat->exclusive_client == client ||
-		(seat->exclusive_client == NULL && !server.session_lock.locked);
+	return seat->exclusive_client == client || seat->exclusive_client == NULL;
 }
 
 static void send_unfocus(struct sway_container *con, void *data) {


### PR DESCRIPTION
We were never sending any pointer event to ext-session-lock surfaces.