### PR TITLE
Check return value of wlr_renderer_begin()

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -1044,7 +1044,9 @@ void output_render(struct sway_output *output, struct timespec *when,
 		fullscreen_con = workspace->current.fullscreen;
 	}
 
-	wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
+	if (!wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height)) {
+		return;
+	}
 
 	if (debug.damage == DAMAGE_RERENDER) {
 		int width, height;


### PR DESCRIPTION
Since [1], wlr_renderer_begin() can fail. Check its return value and bail.

This fixes an assertion error (when begin() fails and then we try to render something) after a GPU reset.

[1]: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/a541c9510a4cf544313bc9b0503d75820b42444e