### PR TITLE
7394: apply new adaptive sync value

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1034,6 +1034,7 @@ static void output_manager_apply(struct sway_server *server,
 		oc->y = config_head->state.y;
 		oc->transform = config_head->state.transform;
 		oc->scale = config_head->state.scale;
+		oc->adaptive_sync = config_head->state.adaptive_sync_enabled;
 
 		if (test_only) {
 			ok &= test_output_config(oc, output);


### PR DESCRIPTION
fixes #7394

Test cases:
* zwlr_output_configuration_head_v1_set_adaptive_sync 0->0, no change
* 0->1, enabled
* 1->0, disabled
* 1->1, no change

Similar tests with an incapable display resulted in `"Adaptive sync failed, ignoring"` messages as expected.