### PR TITLE
ipc: add support for output event

### DIFF
--- a/include/sway/ipc-server.h
+++ b/include/sway/ipc-server.h
@@ -21,5 +21,6 @@ void ipc_event_mode(const char *mode, bool pango);
 void ipc_event_shutdown(const char *reason);
 void ipc_event_binding(struct sway_binding *binding);
 void ipc_event_input(const char *change, struct sway_input_device *device);
+void ipc_event_output(void);
 
 #endif

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -20,6 +20,7 @@
 #include "sway/desktop/transaction.h"
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/ipc-server.h"
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/server.h"
@@ -789,6 +790,8 @@ static void update_output_manager_config(struct sway_server *server) {
 	}
 
 	wlr_output_manager_v1_set_configuration(server->output_manager_v1, config);
+
+	ipc_event_output();
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -508,6 +508,20 @@ void ipc_event_input(const char *change, struct sway_input_device *device) {
 	json_object_put(json);
 }
 
+void ipc_event_output(void) {
+	if (!ipc_has_event_listeners(IPC_EVENT_OUTPUT)) {
+		return;
+	}
+	sway_log(SWAY_DEBUG, "Sending output event");
+
+	json_object *json = json_object_new_object();
+	json_object_object_add(json, "change", json_object_new_string("unspecified"));
+
+	const char *json_string = json_object_to_json_string(json);
+	ipc_send_event(json_string, IPC_EVENT_OUTPUT);
+	json_object_put(json);
+}
+
 int ipc_client_handle_writable(int client_fd, uint32_t mask, void *data) {
 	struct ipc_client *client = data;
 

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1445,6 +1445,9 @@ available:
 :  workspace
 :[ Sent whenever an event involving a workspace occurs such as initialization
    of a new workspace or a different workspace gains focus
+|- 0x80000001
+:  output
+:  Sent when outputs are updated
 |- 0x80000002
 :  mode
 :  Sent whenever the binding mode changes
@@ -1562,6 +1565,20 @@ The following change types are currently available:
 		"nodes": [
 		]
 	}
+}
+```
+
+## 0x80000001. OUTPUT
+
+Sent whenever an output is added, removed, or its configuration is changed.
+The event is a single object with the property _change_, which is a string
+containing the reason for the change. Currently, the only value for _change_ is
+_unspecified_.
+
+*Example Event:*
+```
+{
+	"change": "unspecified"
 }
 ```
 


### PR DESCRIPTION
For compatibility with i3 [1].

[1]: https://i3wm.org/docs/ipc.html#_output_event