### PR TITLE
root: free non_desktop_outputs list on root_destroy

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -50,6 +50,7 @@ struct sway_root *root_create(void) {
 void root_destroy(struct sway_root *root) {
 	wl_list_remove(&root->output_layout_change.link);
 	list_free(root->scratchpad);
+	list_free(root->non_desktop_outputs);
 	list_free(root->outputs);
 	wlr_output_layout_destroy(root->output_layout);
 	free(root);


### PR DESCRIPTION
This fixes a memory leak because the non_desktop_outputs list was not freed when the root was destroyed.