### PR TITLE
ci: install hwdata-dev on Alpine

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -20,7 +20,7 @@ packages:
   - xcb-util-image-dev
   - xcb-util-wm-dev
   - xwayland-dev
-  - hwdata
+  - hwdata-dev
 sources:
   - https://github.com/swaywm/sway
   - https://gitlab.freedesktop.org/wlroots/wlroots.git


### PR DESCRIPTION
We're missing the pkg-config file so the DRM backend gets disabled.