### PR TITLE
ipc: Fix window_rect.y with hide_edge_borders

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -577,7 +577,7 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 
 	struct wlr_box window_box = {
 		c->pending.content_x - c->pending.x,
-		(c->current.border == B_PIXEL) ? c->current.border_thickness : 0,
+		(c->current.border == B_PIXEL) ? c->pending.content_y - c->pending.y : 0,
 		c->pending.content_width,
 		c->pending.content_height
 	};

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -337,8 +337,9 @@ node and will have the following properties:
    this, but borders are included.
 |- window_rect
 :  object
-:  The geometry of the contents inside the node. The window decorations are
-   excluded from this calculation, but borders are included.
+:  The geometry of the content inside the node. These coordinates are relative
+   to the node itself. Window decorations and borders are outside the
+   _window_rect_
 |- deco_rect
 :  object
 :  The geometry of the decorations for the node relative to the parent node


### PR DESCRIPTION
I'm using `border pixel` with `hide_edge_borders both` and noticed that `window_rect.y` was incorrectly offset for some windows.

## Issue

`window_rect.y` is currently set to `border_thickness` for windows with `border pixel`.

This is correct if there is a top border (exaggerated here with `border pixel 10`):

![image](https://user-images.githubusercontent.com/14021/216825086-95d8786c-2df7-4654-ba62-0e50611a3842.png)

...but it is not correct if top border is not drawn:

![hide-edge-borders-both](https://user-images.githubusercontent.com/14021/216825210-076afe24-80b9-4c55-911c-accf6c8bdd96.png)

This means that windows adjacent to top screen edge return incorrect `window_rect.y` in this configuration.

## Solution

Compute the actual `y` offset into the container for windows with `border pixel`.

I also updated the man page section about `window_rect`. Previously it said that `borders are included` but that was not correct.

## What I tested

* With `hide_edge_borders both`:
    * Window with `border pixel 10`, adjacent to top screen edge
        * Expected: `window_rect.y == 0`
    * Window with `border pixel 10`, not adjacent to top screen edge
        * Expected: `window_rect.y == 10`
    * Window with `border normal`, placed wherever
        * Expected: `window_rect.y == 0`
* With `hide_edge_borders none`:
    * Window with `border pixel 10`, adjacent to top screen edge
        * Expected: `window_rect.y == 10`
    * Window with `border pixel 10`, not adjacent to top screen edge
        * Expected: `window_rect.y == 10`
    * Window with `border normal`, placed wherever
        * Expected: `window_rect.y == 0`