### PR TITLE
xdg-activation: fix urgency when the client does not specify a seat

### DIFF
--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -33,11 +33,8 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 	}
 
 	struct wlr_seat *wlr_seat = event->token->seat;
-	// The requesting seat may have been destroyed.
-	if (wlr_seat) {
-		struct sway_seat *seat = wlr_seat->data;
-		view_request_activate(view, seat);
-	}
+	struct sway_seat *seat = wlr_seat ? wlr_seat->data : NULL;
+	view_request_activate(view, seat);
 }
 
 void xdg_activation_v1_handle_new_token(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
xdg-activation is now too strict in only allowing tokens with a seat to activate a surface. Clients may rely on this behavior for urgency hints. The seat argument is still useful in case the client does provide a seat so we can activate it on the desired seat.