### PR TITLE
seat: Don't try to activate an unmapped view

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -351,8 +351,8 @@ static struct sway_container *view_container_at(struct sway_node *parent,
 		.height = container->pending.height,
 	};
 
-	if (wlr_box_contains_point(&box, lx, ly)) {
-		surface_at_view(parent->sway_container, lx, ly, surface, sx, sy);
+	if (container->view->surface && wlr_box_contains_point(&box, lx, ly)) {
+		surface_at_view(container, lx, ly, surface, sx, sy);
 		return container;
 	}
 


### PR DESCRIPTION
Sway does not remove a view from the view tree instantly after a surface is unmapped: It has to wait for a transaction to finish. This creates an opportunity for input events to come in that try to dereference a surface from an unmapped view.

Reproducible with one of those computer mice that have a zero resistance scroll wheel and scrubbing mpv to the end so that mpv reaches the end of the video file and closes while continuing the scroll.

```
0  0x0000561c14e957e8 in seat_is_input_allowed (seat=0x561c177fb680, surface=0x0) at ../sway/input/seat.c:1068
        client = 0x561c184fc3c0
1  0x0000561c14e93053 in seat_send_activate (node=0x561c184fc3c0, seat=0x561c177fb680) at ../sway/input/seat.c:127
2  0x0000561c14e9335b in seat_send_focus (node=0x561c184fc3c0, seat=0x561c177fb680) at ../sway/input/seat.c:195
        view = 0x561c177fb680
3  0x0000561c14e95cb1 in seat_set_workspace_focus (seat=0x561c177fb680, node=0x561c184fc3c0) at ../sway/input/seat.c:1197
        last_focus = 0x561c1826c700
        last_workspace = 0x561c17d016d0
        new_workspace = 0x0
        container = 0x561c184fc3c0
        new_output = 0x0
        new_output_last_ws = 0x0
4  0x0000561c14e95fca in seat_set_focus (seat=0x561c177fb680, node=0x561c184fc3c0) at ../sway/input/seat.c:1268
5  0x0000561c14e9929c in handle_pointer_axis (seat=0x561c177fb680, event=0x7ffdf0d94d40) at ../sway/input/seatop_default.c:735
        new_focus = 0x561c184fc3c0
        layout = L_NONE
        input_device = 0x561c178b3ff0
        ic = 0x561c178745d0
        cursor = 0x561c177fbdf0
        e = 0x561c186ca340
        surface = 0x0
        sx = 1340.280056476593
        sy = 354.24998700618744
        node = 0x561c184fc3c0
        cont = 0x561c184fc3c0
        edge = WLR_EDGE_NONE
        on_border = false
        on_titlebar = true
        on_titlebar_border = false
        on_contents = false
        on_workspace = false
        scroll_factor = 1
        handled = false
        keyboard = 0x561c1789e8e0
        modifiers = 0
        device = 0x561c179ef3a8
        dev_id = 0x561c18732260 "1133:49291:Logitech_G502_HERO_Gaming_Mouse"
        button = 768
        binding = 0x0
6  0x0000561c14e96cfe in seatop_pointer_axis (seat=0x561c177fb680, event=0x7ffdf0d94d40) at ../sway/input/seat.c:1581
7  0x0000561c14e8cf82 in dispatch_cursor_axis (cursor=0x561c177fbdf0, event=0x7ffdf0d94d40) at ../sway/input/cursor.c:368
8  0x0000561c14e8cfd7 in handle_pointer_axis (listener=0x561c177fbf98, data=0x7ffdf0d94d40) at ../sway/input/cursor.c:375
        cursor = 0x561c177fbdf0
        event = 0x7ffdf0d94d40
9  0x00007f69226faf6e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
10 0x00007f6922de10d5 in handle_pointer_axis (listener=0x561c178d9650, data=0x7ffdf0d94d40) at ../subprojects/wlroots/types/wlr_cursor.c:469
        event = 0x7ffdf0d94d40
        device = 0x561c178d95d0
11 0x00007f69226faf6e in wl_signal_emit_mutable () at /usr/lib/libwayland-server.so.0
12 0x00007f6922daa6b8 in handle_pointer_axis_value120 (event=0x561c1845b060, pointer=0x561c179ef3a8, source=WLR_AXIS_SOURCE_WHEEL) at ../subprojects/wlroots/backend/libinput/pointer.c:160
        i = 0
        pevent = 0x561c1845b060
        wlr_event = {pointer = 0x561c179ef3a8, time_msec = 277761620, source = WLR_AXIS_SOURCE_WHEEL, orientation = WLR_AXIS_ORIENTATION_VERTICAL, delta = -15, delta_discrete = -120}
        axes = {LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL, LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL}
13 0x00007f6922da9b9e in handle_libinput_event (backend=0x561c16c7dff0, event=0x561c1845b060) at ../subprojects/wlroots/backend/libinput/events.c:184
        libinput_dev = 0x561c178f2570
        dev = 0x561c179ef220
        event_type = LIBINPUT_EVENT_POINTER_SCROLL_WHEEL
14 0x00007f6922da8b49 in handle_libinput_readable (fd=45, mask=1, _backend=0x561c16c7dff0) at ../subprojects/wlroots/backend/libinput/backend.c:58
        backend = 0x561c16c7dff0
        ret = 0
        event = 0x561c1845b060
15 0x00007f69226fc9e2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
16 0x00007f69226fd197 in wl_display_run () at /usr/lib/libwayland-server.so.0
17 0x0000561c14e815bb in server_run (server=0x561c14efea60 <server>) at ../sway/server.c:320
18 0x0000561c14e8053f in main (argc=1, argv=0x7ffdf0d951b8) at ../sway/main.c:411
        verbose = false
        debug = false
        validate = false
        allow_unsupported_gpu = false
        config_path = 0x0
        c = -1
```