### PR TITLE
Feature: targeted exec

### DIFF
--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -26,7 +26,7 @@ void launcher_ctx_consume(struct launcher_ctx *ctx);
 
 void launcher_ctx_destroy(struct launcher_ctx *ctx);
 
-struct launcher_ctx *launcher_ctx_create_internal(void);
+struct launcher_ctx *launcher_ctx_create_internal(struct sway_node *node);
 
 struct launcher_ctx *launcher_ctx_create(
 	struct wlr_xdg_activation_token_v1 *token, struct sway_node *node);

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -63,7 +63,8 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	}
 
 	pid_t pid, child;
-	struct launcher_ctx *ctx = launcher_ctx_create_internal();
+	struct sway_workspace *ws = config->handler_context.workspace;
+	struct launcher_ctx *ctx = launcher_ctx_create_internal(&ws->node);
 	// Fork process
 	if ((pid = fork()) == 0) {
 		// Fork child process again

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -228,19 +228,22 @@ struct launcher_ctx *launcher_ctx_create(struct wlr_xdg_activation_token_v1 *tok
 }
 
 // Creates a context with a new token for the internal launcher
-struct launcher_ctx *launcher_ctx_create_internal() {
+struct launcher_ctx *launcher_ctx_create_internal(struct sway_node *node) {
 	struct sway_seat *seat = input_manager_current_seat();
-	struct sway_workspace *ws = seat_get_focused_workspace(seat);
-	if (!ws) {
-		sway_log(SWAY_DEBUG, "Failed to create launch context. No workspace.");
-		return NULL;
+	if (!node) {
+		struct sway_workspace *ws = seat_get_focused_workspace(seat);
+		if (!ws) {
+			sway_log(SWAY_DEBUG, "Failed to create launch context. No workspace.");
+			return NULL;
+		}
+		node = &ws->node;
 	}
 
 	struct wlr_xdg_activation_token_v1 *token =
 		wlr_xdg_activation_token_v1_create(server.xdg_activation_v1);
 	token->seat = seat->wlr_seat;
 
-	struct launcher_ctx *ctx = launcher_ctx_create(token, &ws->node);
+	struct launcher_ctx *ctx = launcher_ctx_create(token, node);
 	if (!ctx) {
 		wlr_xdg_activation_token_v1_destroy(token);
 		return NULL;


### PR DESCRIPTION
Currently, new windows are workspace-matched to the ws that was active at the time they were launched, with some fallbacks in place in case we can't determine that. With this patch, we use the handler context workspace instead. By default this is the same behavior, but it enables criteria to affect exec statements.

```
[workspace=3] exec foot
```

launches foot on workspace 3. Sort of.

Criteria actually match nodes, not workspaces, so if the workspace is unpopulated you get an error instead. Even worse, if the workspace _is_ populated with more than one node, you launch a new foot client for each existing match, doubling the clients each execution, yielding a fun new variety of forkbomb.

But it feels kinda slick so maybe it should be allowed. I think it's genuinely useful to match marked containers, at least, which are guaranteed to be unique.

I also think there's a good case to be made the launch context should track the handler context node instead of workspace node. All the logic is there and it would make the behavior more consistent for slow clients, e.g. right now launching a slow client before switching workspaces puts that client on the original workspace, so perhaps launching a slow client before moving between containers should also target the original container when placing the new window.  Could potentially help scripting around #1005 too.