### PR TITLE
sway{,bar}: use default font hint style

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -508,7 +508,6 @@ static void render_titlebar_text_texture(struct sway_output *output,
 	cairo_t *c = cairo_create(dummy_surface);
 	cairo_set_antialias(c, CAIRO_ANTIALIAS_BEST);
 	cairo_font_options_t *fo = cairo_font_options_create();
-	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 	if (output->wlr_output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
 		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
 	} else {

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -774,14 +774,12 @@ void render_frame(struct swaybar_output *output) {
 	ctx.cairo = cairo;
 
 	cairo_font_options_t *fo = cairo_font_options_create();
-	cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 	cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_GRAY);
 	ctx.textaa_safe = fo;
 	if (output->subpixel == WL_OUTPUT_SUBPIXEL_NONE) {
 		ctx.textaa_sharp = ctx.textaa_safe;
 	} else {
 		fo = cairo_font_options_create();
-		cairo_font_options_set_hint_style(fo, CAIRO_HINT_STYLE_FULL);
 		cairo_font_options_set_antialias(fo, CAIRO_ANTIALIAS_SUBPIXEL);
 		cairo_font_options_set_subpixel_order(fo,
 			to_cairo_subpixel_order(output->subpixel));


### PR DESCRIPTION
CAIRO_HINT_STYLE_FULL attempts to maximize contrast at the expense of fidelity, this makes most fonts that haven't been hand hinted, which makes up the majority of fonts out there, appear much worse.

In the absence of explicitly set hint style, cairo will default to CAIRO_HINT_STYLE_SLIGHT, which attempts to improve contrast while retaining fidelity to the original shapes, which is what we want.

Current text rendering on swaybar:
![image](https://user-images.githubusercontent.com/6298234/221406262-633a811c-fa77-4cac-8c9b-d2dce9c999ad.png)

Current text rendering on sway: 
![image](https://user-images.githubusercontent.com/6298234/221407003-e4cf2753-b231-4f9d-a8d1-698c57864274.png)

After this change:
![image](https://user-images.githubusercontent.com/6298234/221406297-566a4be9-0c3b-488e-a803-450a8b09dca7.png)

There are, of course, downsides to this. This only really matters at small sizes, like anything less than 10pt. Text objectively looks (only) slightly worse at higher sizes, so there's a trade off here. However, sway only renders text in container title bars which most likely doesn't want to be super huge anyway, and there will probably be not many users with a status bar that covers 5-10% of their screen height.

Slight hinting, single-color antialiasing: 
![image](https://user-images.githubusercontent.com/6298234/221406749-2870dbf6-bdb2-475d-bd0c-881db67a456e.png)

Slight hinting, subpixel antialiasing:
![image](https://user-images.githubusercontent.com/6298234/221406761-3942bef9-bce3-4f23-ae7a-0695fc5bfe53.png)

Full hinting, single-color antialiasing:
![image](https://user-images.githubusercontent.com/6298234/221406789-243cd77b-b9e1-4bcf-a2e5-0d8bad9da344.png)

Full hinting with subpixel antialiasing is actually the same as slight hinting weirdly though, the second deleted line in swaybar/render.c doesn't change the text in any way.

I wonder if it's better to add a toggle and let the user decide instead...