### PR TITLE
Output matching cleanup

### DIFF
--- a/common/gesture.c
+++ b/common/gesture.c
@@ -12,23 +12,6 @@
 
 const uint8_t GESTURE_FINGERS_ANY = 0;
 
-// Helper to easily allocate and format string
-static char *strformat(const char *format, ...) {
-	va_list args;
-	va_start(args, format);
-	int length = vsnprintf(NULL, 0, format, args) + 1;
-	va_end(args);
-
-	char *result = malloc(length);
-	if (result) {
-		va_start(args, format);
-		vsnprintf(result, length, format, args);
-		va_end(args);
-	}
-
-	return result;
-}
-
 char *gesture_parse(const char *input, struct gesture *output) {
 	// Clear output in case of failure
 	output->type = GESTURE_TYPE_NONE;
@@ -38,7 +21,7 @@ char *gesture_parse(const char *input, struct gesture *output) {
 	// Split input type, fingers and directions
 	list_t *split = split_string(input, ":");
 	if (split->length < 1 || split->length > 3) {
-		return strformat(
+		return format_str(
 				"expected <gesture>[:<fingers>][:direction], got %s",
 				input);
 	}
@@ -51,8 +34,8 @@ char *gesture_parse(const char *input, struct gesture *output) {
 	} else if (strcmp(split->items[0], "swipe") == 0) {
 		output->type = GESTURE_TYPE_SWIPE;
 	} else {
-		return strformat("expected hold|pinch|swipe, got %s",
-				split->items[0]);
+		return format_str("expected hold|pinch|swipe, got %s",
+				(const char *)split->items[0]);
 	}
 
 	// Parse optional arguments
@@ -67,7 +50,7 @@ char *gesture_parse(const char *input, struct gesture *output) {
 			next = split->length == 3 ? split->items[2] : NULL;
 		} else if (split->length == 3) {
 			// Fail here if argument can only be finger count
-			return strformat("expected 1-9, got %s", next);
+			return format_str("expected 1-9, got %s", next);
 		}
 
 		// If there is an argument left, try to parse as direction
@@ -95,7 +78,7 @@ char *gesture_parse(const char *input, struct gesture *output) {
 				} else if (strcmp(item, "counterclockwise") == 0) {
 					output->directions |= GESTURE_DIRECTION_COUNTERCLOCKWISE;
 				} else {
-					return strformat("expected direction, got %s", item);
+					return format_str("expected direction, got %s", item);
 				}
 			}
 			list_free_items_and_destroy(directions);
@@ -163,7 +146,7 @@ static char *gesture_directions_to_string(uint32_t directions) {
 			if (!result) {
 				result = strdup(name);
 			} else {
-				char *new = strformat("%s+%s", result, name);
+				char *new = format_str("%s+%s", result, name);
 				free(result);
 				result = new;
 			}
@@ -179,7 +162,7 @@ static char *gesture_directions_to_string(uint32_t directions) {
 
 char *gesture_to_string(struct gesture *gesture) {
 	char *directions = gesture_directions_to_string(gesture->directions);
-	char *result = strformat("%s:%u:%s",
+	char *result = format_str("%s:%u:%s",
 		gesture_type_string(gesture->type),
 		gesture->fingers, directions);
 	free(directions);

--- a/common/pango.c
+++ b/common/pango.c
@@ -84,18 +84,11 @@ void get_text_size(cairo_t *cairo, const PangoFontDescription *desc, int *width,
 		int *baseline, double scale, bool markup, const char *fmt, ...) {
 	va_list args;
 	va_start(args, fmt);
-	// Add one since vsnprintf excludes null terminator.
-	int length = vsnprintf(NULL, 0, fmt, args) + 1;
+	char *buf = vformat_str(fmt, args);
 	va_end(args);
-
-	char *buf = malloc(length);
 	if (buf == NULL) {
-		sway_log(SWAY_ERROR, "Failed to allocate memory");
 		return;
 	}
-	va_start(args, fmt);
-	vsnprintf(buf, length, fmt, args);
-	va_end(args);
 
 	PangoLayout *layout = get_pango_layout(cairo, desc, buf, scale, markup);
 	pango_cairo_update_layout(cairo, layout);
@@ -104,6 +97,7 @@ void get_text_size(cairo_t *cairo, const PangoFontDescription *desc, int *width,
 		*baseline = pango_layout_get_baseline(layout) / PANGO_SCALE;
 	}
 	g_object_unref(layout);
+
 	free(buf);
 }
 
@@ -125,18 +119,11 @@ void render_text(cairo_t *cairo, const PangoFontDescription *desc,
 		double scale, bool markup, const char *fmt, ...) {
 	va_list args;
 	va_start(args, fmt);
-	// Add one since vsnprintf excludes null terminator.
-	int length = vsnprintf(NULL, 0, fmt, args) + 1;
+	char *buf = vformat_str(fmt, args);
 	va_end(args);
-
-	char *buf = malloc(length);
 	if (buf == NULL) {
-		sway_log(SWAY_ERROR, "Failed to allocate memory");
 		return;
 	}
-	va_start(args, fmt);
-	vsnprintf(buf, length, fmt, args);
-	va_end(args);
 
 	PangoLayout *layout = get_pango_layout(cairo, desc, buf, scale, markup);
 	cairo_font_options_t *fo = cairo_font_options_create();
@@ -146,5 +133,6 @@ void render_text(cairo_t *cairo, const PangoFontDescription *desc,
 	pango_cairo_update_layout(cairo, layout);
 	pango_cairo_show_layout(cairo, layout);
 	g_object_unref(layout);
+
 	free(buf);
 }

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include <ctype.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -327,4 +328,36 @@ bool expand_path(char **path) {
 	*path = join_args(p.we_wordv, p.we_wordc);
 	wordfree(&p);
 	return true;
+}
+
+char *vformat_str(const char *fmt, va_list args) {
+	char *str = NULL;
+	va_list args_copy;
+	va_copy(args_copy, args);
+
+	int len = vsnprintf(NULL, 0, fmt, args);
+	if (len < 0) {
+		sway_log_errno(SWAY_ERROR, "vsnprintf(\"%s\") failed", fmt);
+		goto out;
+	}
+
+	str = malloc(len + 1);
+	if (str == NULL) {
+		sway_log_errno(SWAY_ERROR, "malloc() failed");
+		goto out;
+	}
+
+	vsnprintf(str, len + 1, fmt, args_copy);
+
+out:
+	va_end(args_copy);
+	return str;
+}
+
+char *format_str(const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	char *str = vformat_str(fmt, args);
+	va_end(args);
+	return str;
 }

--- a/include/pango.h
+++ b/include/pango.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cairo.h>
 #include <pango/pangocairo.h>
+#include "stringop.h"
 
 /**
  * Utility function which escape characters a & < > ' ".
@@ -16,9 +17,9 @@ size_t escape_markup_text(const char *src, char *dest);
 PangoLayout *get_pango_layout(cairo_t *cairo, const PangoFontDescription *desc,
 		const char *text, double scale, bool markup);
 void get_text_size(cairo_t *cairo, const PangoFontDescription *desc, int *width, int *height,
-		int *baseline, double scale, bool markup, const char *fmt, ...);
+		int *baseline, double scale, bool markup, const char *fmt, ...) _SWAY_ATTRIB_PRINTF(8, 9);
 void get_text_metrics(const PangoFontDescription *desc, int *height, int *baseline);
 void render_text(cairo_t *cairo, PangoFontDescription *desc,
-		double scale, bool markup, const char *fmt, ...);
+		double scale, bool markup, const char *fmt, ...) _SWAY_ATTRIB_PRINTF(5, 6);
 
 #endif

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -5,6 +5,12 @@
 #include <stddef.h>
 #include "list.h"
 
+#ifdef __GNUC__
+#define _SWAY_ATTRIB_PRINTF(start, end) __attribute__((format(printf, start, end)))
+#else
+#define _SWAY_ATTRIB_PRINTF(start, end)
+#endif
+
 void strip_whitespace(char *str);
 void strip_quotes(char *str);
 
@@ -30,5 +36,8 @@ char *argsep(char **stringp, const char *delim, char *matched_delim);
 
 // Expand a path using shell replacements such as $HOME and ~
 bool expand_path(char **path);
+
+char *vformat_str(const char *fmt, va_list args) _SWAY_ATTRIB_PRINTF(1, 0);
+char *format_str(const char *fmt, ...) _SWAY_ATTRIB_PRINTF(1, 2);
 
 #endif

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -3,6 +3,7 @@
 
 #include <wlr/util/edges.h>
 #include "config.h"
+#include "stringop.h"
 
 struct sway_container;
 
@@ -76,7 +77,7 @@ struct cmd_results *config_commands_command(char *exec);
 /**
  * Allocates a cmd_results object.
  */
-struct cmd_results *cmd_results_new(enum cmd_status status, const char *error, ...);
+struct cmd_results *cmd_results_new(enum cmd_status status, const char *error, ...) _SWAY_ATTRIB_PRINTF(2, 3);
 /**
  * Frees a cmd_results object.
  */

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -12,6 +12,7 @@
 #include "../include/config.h"
 #include "gesture.h"
 #include "list.h"
+#include "stringop.h"
 #include "swaynag.h"
 #include "tree/container.h"
 #include "sway/input/tablet.h"
@@ -625,7 +626,7 @@ void run_deferred_bindings(void);
 /**
  * Adds a warning entry to the swaynag instance used for errors.
  */
-void config_add_swaynag_warning(char *fmt, ...);
+void config_add_swaynag_warning(char *fmt, ...) _SWAY_ATTRIB_PRINTF(1, 2);
 
 /**
  * Free config struct

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -96,6 +96,9 @@ void output_damage_box(struct sway_output *output, struct wlr_box *box);
 void output_damage_whole_container(struct sway_output *output,
 	struct sway_container *con);
 
+bool output_match_name_or_id(struct sway_output *output,
+	const char *name_or_id);
+
 // this ONLY includes the enabled outputs
 struct sway_output *output_by_name_or_id(const char *name_or_id);
 

--- a/include/sway/swaynag.h
+++ b/include/sway/swaynag.h
@@ -1,6 +1,7 @@
 #ifndef _SWAY_SWAYNAG_H
 #define _SWAY_SWAYNAG_H
 #include <wayland-server-core.h>
+#include "stringop.h"
 
 struct swaynag_instance {
 	struct wl_client *client;
@@ -21,7 +22,7 @@ bool swaynag_spawn(const char *swaynag_command,
 // Write a log message to swaynag->fd[1]. This will fail when swaynag->detailed
 // is false.
 void swaynag_log(const char *swaynag_command, struct swaynag_instance *swaynag,
-		const char *fmt, ...);
+		const char *fmt, ...) _SWAY_ATTRIB_PRINTF(3, 4);
 
 // If swaynag->detailed, close swaynag->fd[1] so swaynag displays
 void swaynag_show(struct swaynag_instance *swaynag);

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ add_project_arguments(
 		'-Wno-unused-parameter',
 		'-Wno-unused-result',
 		'-Wno-missing-braces',
+		'-Wno-format-zero-length',
 		'-Wundef',
 		'-Wvla',
 	],

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -381,10 +381,13 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 	sway_log(SWAY_INFO, "Config command: %s", exec);
 	const struct cmd_handler *handler = find_core_handler(argv[0]);
 	if (!handler || !handler->handle) {
-		const char *error = handler
-			? "Command '%s' is shimmed, but unimplemented"
-			: "Unknown/invalid command '%s'";
-		results = cmd_results_new(CMD_INVALID, error, argv[0]);
+		if (handler) {
+			results = cmd_results_new(CMD_INVALID,
+				"Command '%s' is shimmed, but unimplemented", argv[0]);
+		} else {
+			results = cmd_results_new(CMD_INVALID,
+				"Unknown/invalid command '%s'", argv[0]);
+		}
 		goto cleanup;
 	}
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -489,20 +489,10 @@ struct cmd_results *cmd_results_new(enum cmd_status status,
 	}
 	results->status = status;
 	if (format) {
-		char *error = NULL;
 		va_list args;
 		va_start(args, format);
-		int slen = vsnprintf(NULL, 0, format, args);
+		results->error = vformat_str(format, args);
 		va_end(args);
-		if (slen > 0) {
-			error = malloc(slen + 1);
-			if (error != NULL) {
-				va_start(args, format);
-				vsnprintf(error, slen + 1, format, args);
-				va_end(args);
-			}
-		}
-		results->error = error;
 	} else {
 		results->error = NULL;
 	}

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -17,7 +17,7 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, err_str);
+		error = cmd_results_new(CMD_INVALID, "%s", err_str);
 		free(err_str);
 		return error;
 	}

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -73,12 +73,10 @@ struct cmd_results *cmd_bar(int argc, char **argv) {
 		}
 		++argv; --argc;
 	} else if (config->reading && !config->current_bar) {
-		int len = snprintf(NULL, 0, "bar-%d", config->bars->length) + 1;
-		id = malloc(len * sizeof(char));
+		id = format_str("bar-%d", config->bars->length);
 		if (!id) {
 			return cmd_results_new(CMD_FAILURE, "Unable to allocate bar id");
 		}
-		snprintf(id, len, "bar-%d", config->bars->length);
 	} else if (!config->reading && strcmp(argv[0], "mode") != 0 &&
 			strcmp(argv[0], "hidden_state") != 0) {
 		if (is_subcommand(argv[0])) {

--- a/sway/commands/bar/bind.c
+++ b/sway/commands/bar/bind.c
@@ -96,7 +96,7 @@ static struct cmd_results *bar_cmd_bind(int argc, char **argv, bool code,
 	}
 	if (message) {
 		free_bar_binding(binding);
-		error = cmd_results_new(CMD_INVALID, message);
+		error = cmd_results_new(CMD_INVALID, "%s", message);
 		free(message);
 		return error;
 	} else if (!binding->button) {

--- a/sway/commands/bar/tray_bind.c
+++ b/sway/commands/bar/tray_bind.c
@@ -26,7 +26,7 @@ static struct cmd_results *tray_bind(int argc, char **argv, bool code) {
 	}
 	if (message) {
 		free(binding);
-		error = cmd_results_new(CMD_INVALID, message);
+		error = cmd_results_new(CMD_INVALID, "%s", message);
 		free(message);
 		return error;
 	} else if (!binding->button) {

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -127,7 +127,7 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 		if (!button) {
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, message);
+					cmd_results_new(CMD_INVALID, "%s", message);
 				free(message);
 				return error;
 			} else {
@@ -143,7 +143,7 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 		if (!button) {
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, message);
+					cmd_results_new(CMD_INVALID, "%s", message);
 				free(message);
 				return error;
 			} else {
@@ -182,7 +182,7 @@ static struct cmd_results *identify_key(const char* name, bool first_key,
 			uint32_t button = get_mouse_bindsym(name, &message);
 			if (message) {
 				struct cmd_results *error =
-					cmd_results_new(CMD_INVALID, message);
+					cmd_results_new(CMD_INVALID, "%s", message);
 				free(message);
 				return error;
 			} else if (button) {
@@ -539,7 +539,7 @@ struct cmd_results *cmd_bind_or_unbind_switch(int argc, char **argv,
 		free_switch_binding(binding);
 		return cmd_results_new(CMD_FAILURE,
 				"Invalid %s command (expected binding with the form "
-				"<switch>:<state>)", bindtype, argc);
+				"<switch>:<state>)", bindtype);
 	}
 	if (strcmp(split->items[0], "tablet") == 0) {
 		binding->type = WLR_SWITCH_TYPE_TABLET_MODE;
@@ -549,7 +549,8 @@ struct cmd_results *cmd_bind_or_unbind_switch(int argc, char **argv,
 		free_switch_binding(binding);
 		return cmd_results_new(CMD_FAILURE,
 				"Invalid %s command (expected switch binding: "
-				"unknown switch %s)", bindtype, split->items[0]);
+				"unknown switch %s)", bindtype,
+				(const char *)split->items[0]);
 	}
 	if (strcmp(split->items[1], "on") == 0) {
 		binding->trigger = SWAY_SWITCH_TRIGGER_ON;
@@ -562,7 +563,7 @@ struct cmd_results *cmd_bind_or_unbind_switch(int argc, char **argv,
 		return cmd_results_new(CMD_FAILURE,
 				"Invalid %s command "
 				"(expected switch state: unknown state %s)",
-				bindtype, split->items[1]);
+				bindtype, (const char *)split->items[1]);
 	}
 	list_free_items_and_destroy(split);
 

--- a/sway/commands/floating_minmax_size.c
+++ b/sway/commands/floating_minmax_size.c
@@ -23,16 +23,16 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	char *err;
 	int width = (int)strtol(argv[0], &err, 10);
 	if (*err) {
-		return cmd_results_new(CMD_INVALID, cmd_name, usage);
+		return cmd_results_new(CMD_INVALID, usage);
 	}
 
 	if (strcmp(argv[1], "x") != 0) {
-		return cmd_results_new(CMD_INVALID, cmd_name, usage);
+		return cmd_results_new(CMD_INVALID, usage);
 	}
 
 	int height = (int)strtol(argv[2], &err, 10);
 	if (*err) {
-		return cmd_results_new(CMD_INVALID, cmd_name, usage);
+		return cmd_results_new(CMD_INVALID, usage);
 	}
 
 	*config_width = width;

--- a/sway/commands/floating_minmax_size.c
+++ b/sway/commands/floating_minmax_size.c
@@ -23,16 +23,16 @@ static struct cmd_results *handle_command(int argc, char **argv, char *cmd_name,
 	char *err;
 	int width = (int)strtol(argv[0], &err, 10);
 	if (*err) {
-		return cmd_results_new(CMD_INVALID, usage);
+		return cmd_results_new(CMD_INVALID, "%s", usage);
 	}
 
 	if (strcmp(argv[1], "x") != 0) {
-		return cmd_results_new(CMD_INVALID, usage);
+		return cmd_results_new(CMD_INVALID, "%s", usage);
 	}
 
 	int height = (int)strtol(argv[2], &err, 10);
 	if (*err) {
-		return cmd_results_new(CMD_INVALID, usage);
+		return cmd_results_new(CMD_INVALID, "%s", usage);
 	}
 
 	*config_width = width;

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -14,7 +14,7 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, err_str);
+		error = cmd_results_new(CMD_INVALID, "%s", err_str);
 		free(err_str);
 		return error;
 	}

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -20,7 +20,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	}
 
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	if (strcmp(argv[0], "none") == 0) {
@@ -38,7 +38,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		config->hide_edge_borders = E_NONE;
 		config->hide_edge_borders_smart = ESMART_NO_GAPS;
 	} else {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 	config->hide_lone_tab = hide_lone_tab;
 

--- a/sway/commands/input/map_to_region.c
+++ b/sway/commands/input/map_to_region.c
@@ -49,5 +49,5 @@ struct cmd_results *input_cmd_map_to_region(int argc, char **argv) {
 error:
 	free(ic->mapped_to_region);
 	ic->mapped_to_region = NULL;
-	return cmd_results_new(CMD_FAILURE, errstr);
+	return cmd_results_new(CMD_FAILURE, "%s", errstr);
 }

--- a/sway/commands/input/scroll_button.c
+++ b/sway/commands/input/scroll_button.c
@@ -21,7 +21,7 @@ struct cmd_results *input_cmd_scroll_button(int argc, char **argv) {
 	char *message = NULL;
 	uint32_t button = get_mouse_button(*argv, &message);
 	if (message) {
-		error = cmd_results_new(CMD_INVALID, message);
+		error = cmd_results_new(CMD_INVALID, "%s", message);
 		free(message);
 		return error;
 	} else if (button == SWAY_SCROLL_UP || button == SWAY_SCROLL_DOWN

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -153,7 +153,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 				workspace->output);
 	}
 	if (new_layout == L_NONE) {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 	if (new_layout != old_layout) {
 		if (container) {

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -470,7 +470,7 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 			if (strcasecmp(argv[1], "number") == 0) {
 				// move [window|container] [to] "workspace number x"
 				if (argc < 3) {
-					return cmd_results_new(CMD_INVALID, expected_syntax);
+					return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 				}
 				if (!isdigit(argv[2][0])) {
 					return cmd_results_new(CMD_INVALID,
@@ -530,7 +530,7 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 		}
 		destination = &dest_con->node;
 	} else {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	if (destination->type == N_CONTAINER &&
@@ -829,7 +829,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	}
 
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, expected_position_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_position_syntax);
 	}
 
 	bool absolute = false;
@@ -839,19 +839,19 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 		++argv;
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, expected_position_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_position_syntax);
 	}
 	if (strcmp(argv[0], "position") == 0) {
 		--argc;
 		++argv;
 	}
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, expected_position_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_position_syntax);
 	}
 	if (strcmp(argv[0], "cursor") == 0 || strcmp(argv[0], "mouse") == 0 ||
 			strcmp(argv[0], "pointer") == 0) {
 		if (absolute) {
-			return cmd_results_new(CMD_INVALID, expected_position_syntax);
+			return cmd_results_new(CMD_INVALID, "%s", expected_position_syntax);
 		}
 		return cmd_move_to_position_pointer(container);
 	} else if (strcmp(argv[0], "center") == 0) {
@@ -873,7 +873,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	}
 
 	if (argc < 2) {
-		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, "%s", expected_position_syntax);
 	}
 
 	struct movement_amount lx = { .amount = 0, .unit = MOVEMENT_UNIT_INVALID };
@@ -886,7 +886,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	}
 
 	if (argc < 1) {
-		return cmd_results_new(CMD_FAILURE, expected_position_syntax);
+		return cmd_results_new(CMD_FAILURE, "%s", expected_position_syntax);
 	}
 
 	struct movement_amount ly = { .amount = 0, .unit = MOVEMENT_UNIT_INVALID };
@@ -895,7 +895,7 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	argc -= num_consumed_args;
 	argv += num_consumed_args;
 	if (argc > 0) {
-		return cmd_results_new(CMD_INVALID, expected_position_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_position_syntax);
 	}
 	if (ly.unit == MOVEMENT_UNIT_INVALID) {
 		return cmd_results_new(CMD_INVALID, "Invalid y position specified");
@@ -1041,13 +1041,13 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 	}
 
 	if (!argc) {
-		return cmd_results_new(CMD_INVALID, expected_full_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_full_syntax);
 	}
 
 	// Only `move [window|container] [to] workspace` supports
 	// `--no-auto-back-and-forth` so treat others as invalid syntax
 	if (no_auto_back_and_forth && strcasecmp(argv[0], "workspace") != 0) {
-		return cmd_results_new(CMD_INVALID, expected_full_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_full_syntax);
 	}
 
 	if (strcasecmp(argv[0], "workspace") == 0 ||
@@ -1061,5 +1061,5 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 			strcasecmp(argv[1], "position") == 0)) {
 		return cmd_move_to_position(argc, argv);
 	}
-	return cmd_results_new(CMD_INVALID, expected_full_syntax);
+	return cmd_results_new(CMD_INVALID, "%s", expected_full_syntax);
 }

--- a/sway/commands/no_focus.c
+++ b/sway/commands/no_focus.c
@@ -13,7 +13,7 @@ struct cmd_results *cmd_no_focus(int argc, char **argv) {
 	char *err_str = NULL;
 	struct criteria *criteria = criteria_parse(argv[0], &err_str);
 	if (!criteria) {
-		error = cmd_results_new(CMD_INVALID, err_str);
+		error = cmd_results_new(CMD_INVALID, "%s", err_str);
 		free(err_str);
 		return error;
 	}

--- a/sway/commands/rename.c
+++ b/sway/commands/rename.c
@@ -26,7 +26,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 				"Can't run this command while there's no outputs connected.");
 	}
 	if (strcasecmp(argv[0], "workspace") != 0) {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	int argn = 1;
@@ -65,7 +65,7 @@ struct cmd_results *cmd_rename(int argc, char **argv) {
 	++argn; // move past "to"
 
 	if (argn >= argc) {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	char *new_name = join_args(argv + argn, argc - argn);

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -415,7 +415,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (width.unit == MOVEMENT_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 	}
 
@@ -427,10 +427,10 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 		}
 		int num_consumed_args = parse_movement_amount(argc, argv, &height);
 		if (argc > num_consumed_args) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 		if (width.unit == MOVEMENT_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 	}
 
@@ -462,7 +462,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		"[<amount> px|ppt [or <amount> px|ppt]]'";
 	uint32_t axis = parse_resize_axis(*argv);
 	if (axis == WLR_EDGE_NONE) {
-		return cmd_results_new(CMD_INVALID, usage);
+		return cmd_results_new(CMD_INVALID, "%s", usage);
 	}
 	--argc; ++argv;
 
@@ -473,7 +473,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 		argc -= num_consumed_args;
 		argv += num_consumed_args;
 		if (first_amount.unit == MOVEMENT_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 	} else {
 		first_amount.amount = 10;
@@ -483,7 +483,7 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 	// "or"
 	if (argc) {
 		if (strcmp(*argv, "or") != 0) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 		--argc; ++argv;
 	}
@@ -493,10 +493,10 @@ static struct cmd_results *cmd_resize_adjust(int argc, char **argv,
 	if (argc) {
 		int num_consumed_args = parse_movement_amount(argc, argv, &second_amount);
 		if (argc > num_consumed_args) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 		if (second_amount.unit == MOVEMENT_UNIT_INVALID) {
-			return cmd_results_new(CMD_INVALID, usage);
+			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 	} else {
 		second_amount.amount = 0;
@@ -566,5 +566,5 @@ struct cmd_results *cmd_resize(int argc, char **argv) {
 	const char usage[] = "Expected 'resize <shrink|grow> "
 		"<width|height|up|down|left|right> [<amount>] [px|ppt]'";
 
-	return cmd_results_new(CMD_INVALID, usage);
+	return cmd_results_new(CMD_INVALID, "%s", usage);
 }

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -18,7 +18,7 @@ static struct cmd_results *handle_command(struct sway_cursor *cursor,
 		int argc, char **argv) {
 	if (strcasecmp(argv[0], "move") == 0) {
 		if (argc < 3) {
-			return cmd_results_new(CMD_INVALID, expected_syntax);
+			return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 		}
 		int delta_x = strtol(argv[1], NULL, 10);
 		int delta_y = strtol(argv[2], NULL, 10);
@@ -27,7 +27,7 @@ static struct cmd_results *handle_command(struct sway_cursor *cursor,
 		wlr_seat_pointer_notify_frame(cursor->seat->wlr_seat);
 	} else if (strcasecmp(argv[0], "set") == 0) {
 		if (argc < 3) {
-			return cmd_results_new(CMD_INVALID, expected_syntax);
+			return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 		}
 		// map absolute coords (0..1,0..1) to root container coords
 		float x = strtof(argv[1], NULL) / root->width;
@@ -37,7 +37,7 @@ static struct cmd_results *handle_command(struct sway_cursor *cursor,
 		wlr_seat_pointer_notify_frame(cursor->seat->wlr_seat);
 	} else {
 		if (argc < 2) {
-			return cmd_results_new(CMD_INVALID, expected_syntax);
+			return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 		}
 		struct cmd_results *error = NULL;
 		if ((error = press_or_release(cursor, argv[0], argv[1]))) {
@@ -92,14 +92,14 @@ static struct cmd_results *press_or_release(struct sway_cursor *cursor,
 	} else if (strcasecmp(action, "release") == 0) {
 		state = WLR_BUTTON_RELEASED;
 	} else {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	char *message = NULL;
 	button = get_mouse_button(button_str, &message);
 	if (message) {
 		struct cmd_results *error =
-			cmd_results_new(CMD_INVALID, message);
+			cmd_results_new(CMD_INVALID, "%s", message);
 		free(message);
 		return error;
 	} else if (button == SWAY_SCROLL_UP || button == SWAY_SCROLL_DOWN

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -46,7 +46,7 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 	}
 
 	if (strcasecmp(argv[0], "container") || strcasecmp(argv[1], "with")) {
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	struct sway_container *current = config->handler_context.container;
@@ -65,7 +65,7 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 		other = root_find_container(test_mark, value);
 	} else {
 		free(value);
-		return cmd_results_new(CMD_INVALID, expected_syntax);
+		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 
 	if (!other) {

--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -61,7 +61,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	const char expected[] = "Expected 'workspace <name> gaps "
 		"inner|outer|horizontal|vertical|top|right|bottom|left <px>'";
 	if (gaps_location == 0) {
-		return cmd_results_new(CMD_INVALID, expected);
+		return cmd_results_new(CMD_INVALID, "%s", expected);
 	}
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO,
@@ -79,7 +79,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 	char *end;
 	int amount = strtol(argv[gaps_location + 2], &end, 10);
 	if (strlen(end)) {
-		return cmd_results_new(CMD_FAILURE, expected);
+		return cmd_results_new(CMD_FAILURE, "%s", expected);
 	}
 
 	bool valid = false;
@@ -110,7 +110,7 @@ static struct cmd_results *cmd_workspace_gaps(int argc, char **argv,
 		}
 	}
 	if (!valid) {
-		return cmd_results_new(CMD_INVALID, expected);
+		return cmd_results_new(CMD_INVALID, "%s", expected);
 	}
 
 	// Prevent invalid gaps configurations.
@@ -174,7 +174,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 
 		if (root->fullscreen_global) {
-			return cmd_results_new(CMD_FAILURE, "workspace",
+			return cmd_results_new(CMD_FAILURE,
 				"Can't switch workspaces while fullscreen global");
 		}
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -924,23 +924,18 @@ void config_add_swaynag_warning(char *fmt, ...) {
 	if (config->reading && !config->validating) {
 		va_list args;
 		va_start(args, fmt);
-		size_t length = vsnprintf(NULL, 0, fmt, args) + 1;
+		char *str = vformat_str(fmt, args);
 		va_end(args);
-
-		char *temp = malloc(length + 1);
-		if (!temp) {
-			sway_log(SWAY_ERROR, "Failed to allocate buffer for warning.");
+		if (str == NULL) {
 			return;
 		}
-
-		va_start(args, fmt);
-		vsnprintf(temp, length, fmt, args);
-		va_end(args);
 
 		swaynag_log(config->swaynag_command, &config->swaynag_config_errors,
 			"Warning on line %i (%s) '%s': %s",
 			config->current_config_line_number, config->current_config_path,
-			config->current_config_line, temp);
+			config->current_config_line, str);
+
+		free(str);
 	}
 }
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -162,13 +162,10 @@ static void merge_id_on_name(struct output_config *oc) {
 	char id[128];
 	output_get_identifier(id, sizeof(id), output);
 
-	size_t size = snprintf(NULL, 0, "%s on %s", id, name) + 1;
-	char *id_on_name = malloc(size);
+	char *id_on_name = format_str("%s on %s", id, name);
 	if (!id_on_name) {
-		sway_log(SWAY_ERROR, "Failed to allocate id on name string");
 		return;
 	}
-	snprintf(id_on_name, size, "%s on %s", id, name);
 
 	int i = list_seq_find(config->output_configs, output_name_cmp, id_on_name);
 	if (i >= 0) {
@@ -633,9 +630,7 @@ static struct output_config *get_output_config(char *identifier,
 	struct output_config *oc_name = NULL;
 	struct output_config *oc_id = NULL;
 
-	size_t length = snprintf(NULL, 0, "%s on %s", identifier, name) + 1;
-	char *id_on_name = malloc(length);
-	snprintf(id_on_name, length, "%s on %s", identifier, name);
+	char *id_on_name = format_str("%s on %s", identifier, name);
 	int i = list_seq_find(config->output_configs, output_name_cmp, id_on_name);
 	if (i >= 0) {
 		oc_id_on_name = config->output_configs->items[i];

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -153,28 +153,22 @@ static void merge_wildcard_on_all(struct output_config *wildcard) {
 }
 
 static void merge_id_on_name(struct output_config *oc) {
-	char *id_on_name = NULL;
-	char id[128];
-	char *name = NULL;
-	struct sway_output *output;
-	wl_list_for_each(output, &root->all_outputs, link) {
-		name = output->wlr_output->name;
-		output_get_identifier(id, sizeof(id), output);
-		if (strcmp(name, oc->name) == 0 || strcmp(id, oc->name) == 0) {
-			size_t length = snprintf(NULL, 0, "%s on %s", id, name) + 1;
-			id_on_name = malloc(length);
-			if (!id_on_name) {
-				sway_log(SWAY_ERROR, "Failed to allocate id on name string");
-				return;
-			}
-			snprintf(id_on_name, length, "%s on %s", id, name);
-			break;
-		}
-	}
-
-	if (!id_on_name) {
+	struct sway_output *output = all_output_by_name_or_id(oc->name);
+	if (output == NULL) {
 		return;
 	}
+
+	const char *name = output->wlr_output->name;
+	char id[128];
+	output_get_identifier(id, sizeof(id), output);
+
+	size_t size = snprintf(NULL, 0, "%s on %s", id, name) + 1;
+	char *id_on_name = malloc(size);
+	if (!id_on_name) {
+		sway_log(SWAY_ERROR, "Failed to allocate id on name string");
+		return;
+	}
+	snprintf(id_on_name, size, "%s on %s", id, name);
 
 	int i = list_seq_find(config->output_configs, output_name_cmp, id_on_name);
 	if (i >= 0) {

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -722,12 +722,11 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 	// this is during startup then there will be no container and config
 	// will be applied during normal "new output" event from wlroots.
 	bool wildcard = strcmp(oc->name, "*") == 0;
-	char id[128];
 	struct sway_output *sway_output, *tmp;
 	wl_list_for_each_safe(sway_output, tmp, &root->all_outputs, link) {
-		char *name = sway_output->wlr_output->name;
-		output_get_identifier(id, sizeof(id), sway_output);
-		if (wildcard || !strcmp(name, oc->name) || !strcmp(id, oc->name)) {
+		if (output_match_name_or_id(sway_output, oc->name)) {
+			char id[128];
+			output_get_identifier(id, sizeof(id), sway_output);
 			struct output_config *current = get_output_config(id, sway_output);
 			if (!current) {
 				// No stored output config matched, apply oc directly

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -36,8 +36,12 @@
 #include <wlr/types/wlr_drm_lease_v1.h>
 #endif
 
-static bool output_match_name_or_id(struct sway_output *output,
+bool output_match_name_or_id(struct sway_output *output,
 		const char *name_or_id) {
+	if (strcmp(name_or_id, "*") == 0) {
+		return true;
+	}
+
 	char identifier[128];
 	output_get_identifier(identifier, sizeof(identifier), output);
 	return strcasecmp(identifier, name_or_id) == 0

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -36,13 +36,18 @@
 #include <wlr/types/wlr_drm_lease_v1.h>
 #endif
 
+static bool output_match_name_or_id(struct sway_output *output,
+		const char *name_or_id) {
+	char identifier[128];
+	output_get_identifier(identifier, sizeof(identifier), output);
+	return strcasecmp(identifier, name_or_id) == 0
+		|| strcasecmp(output->wlr_output->name, name_or_id) == 0;
+}
+
 struct sway_output *output_by_name_or_id(const char *name_or_id) {
 	for (int i = 0; i < root->outputs->length; ++i) {
 		struct sway_output *output = root->outputs->items[i];
-		char identifier[128];
-		output_get_identifier(identifier, sizeof(identifier), output);
-		if (strcasecmp(identifier, name_or_id) == 0
-				|| strcasecmp(output->wlr_output->name, name_or_id) == 0) {
+		if (output_match_name_or_id(output, name_or_id)) {
 			return output;
 		}
 	}
@@ -52,10 +57,7 @@ struct sway_output *output_by_name_or_id(const char *name_or_id) {
 struct sway_output *all_output_by_name_or_id(const char *name_or_id) {
 	struct sway_output *output;
 	wl_list_for_each(output, &root->all_outputs, link) {
-		char identifier[128];
-		output_get_identifier(identifier, sizeof(identifier), output);
-		if (strcasecmp(identifier, name_or_id) == 0
-				|| strcasecmp(output->wlr_output->name, name_or_id) == 0) {
+		if (output_match_name_or_id(output, name_or_id)) {
 			return output;
 		}
 	}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1273,11 +1273,7 @@ uint32_t get_mouse_bindsym(const char *name, char **error) {
 		// Get event code from name
 		int code = libevdev_event_code_from_name(EV_KEY, name);
 		if (code == -1) {
-			size_t len = snprintf(NULL, 0, "Unknown event %s", name) + 1;
-			*error = malloc(len);
-			if (*error) {
-				snprintf(*error, len, "Unknown event %s", name);
-			}
+			*error = format_str("Unknown event %s", name);
 			return 0;
 		}
 		return code;
@@ -1299,13 +1295,8 @@ uint32_t get_mouse_bindcode(const char *name, char **error) {
 	}
 	const char *event = libevdev_event_code_get_name(EV_KEY, code);
 	if (!event || strncmp(event, "BTN_", strlen("BTN_")) != 0) {
-		size_t len = snprintf(NULL, 0, "Event code %d (%s) is not a button",
-				code, event ? event : "(null)") + 1;
-		*error = malloc(len);
-		if (*error) {
-			snprintf(*error, len, "Event code %d (%s) is not a button",
-					code, event ? event : "(null)");
-		}
+		*error = format_str("Event code %d (%s) is not a button",
+			code, event ? event : "(null)");
 		return 0;
 	}
 	return code;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -80,15 +80,7 @@ char *input_device_get_identifier(struct wlr_input_device *device) {
 		}
 	}
 
-	const char *fmt = "%d:%d:%s";
-	int len = snprintf(NULL, 0, fmt, vendor, product, name) + 1;
-	char *identifier = malloc(len);
-	if (!identifier) {
-		sway_log(SWAY_ERROR, "Unable to allocate unique input device name");
-		return NULL;
-	}
-
-	snprintf(identifier, len, fmt, vendor, product, name);
+	char *identifier = format_str("%d:%d:%s", vendor, product, name);
 	free(name);
 	return identifier;
 }

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -145,22 +145,16 @@ void swaynag_log(const char *swaynag_command, struct swaynag_instance *swaynag,
 
 	va_list args;
 	va_start(args, fmt);
-	size_t length = vsnprintf(NULL, 0, fmt, args) + 1;
+	char *str = vformat_str(fmt, args);
 	va_end(args);
-
-	char *temp = malloc(length + 1);
-	if (!temp) {
+	if (!str) {
 		sway_log(SWAY_ERROR, "Failed to allocate buffer for swaynag log entry.");
 		return;
 	}
 
-	va_start(args, fmt);
-	vsnprintf(temp, length, fmt, args);
-	va_end(args);
+	write(swaynag->fd[1], str, strlen(str));
 
-	write(swaynag->fd[1], temp, length);
-
-	free(temp);
+	free(str);
 }
 
 void swaynag_show(struct swaynag_instance *swaynag) {

--- a/swaybar/tray/host.c
+++ b/swaybar/tray/host.c
@@ -10,6 +10,7 @@
 #include "swaybar/tray/tray.h"
 #include "list.h"
 #include "log.h"
+#include "stringop.h"
 
 static const char *watcher_path = "/StatusNotifierWatcher";
 
@@ -138,12 +139,10 @@ static int handle_new_watcher(sd_bus_message *msg,
 
 bool init_host(struct swaybar_host *host, char *protocol,
 		struct swaybar_tray *tray) {
-	size_t len = snprintf(NULL, 0, "org.%s.StatusNotifierWatcher", protocol) + 1;
-	host->watcher_interface = malloc(len);
+	host->watcher_interface = format_str("org.%s.StatusNotifierWatcher", protocol);
 	if (!host->watcher_interface) {
 		return false;
 	}
-	snprintf(host->watcher_interface, len, "org.%s.StatusNotifierWatcher", protocol);
 
 	sd_bus_slot *reg_slot = NULL, *unreg_slot = NULL, *watcher_slot = NULL;
 	int ret = sd_bus_match_signal(tray->bus, &reg_slot, host->watcher_interface,
@@ -173,13 +172,10 @@ bool init_host(struct swaybar_host *host, char *protocol,
 	}
 
 	pid_t pid = getpid();
-	size_t service_len = snprintf(NULL, 0, "org.%s.StatusNotifierHost-%d",
-			protocol, pid) + 1;
-	host->service = malloc(service_len);
+	host->service = format_str("org.%s.StatusNotifierHost-%d", protocol, pid);
 	if (!host->service) {
 		goto error;
 	}
-	snprintf(host->service, service_len, "org.%s.StatusNotifierHost-%d", protocol, pid);
 	ret = sd_bus_request_name(tray->bus, host->service, 0);
 	if (ret < 0) {
 		sway_log(SWAY_DEBUG, "Failed to acquire service name: %s", strerror(-ret));

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -40,9 +40,7 @@ static list_t *get_basedirs(void) {
 	data_dirs = strdup(data_dirs);
 	char *dir = strtok(data_dirs, ":");
 	do {
-		size_t path_len = snprintf(NULL, 0, "%s/icons", dir) + 1;
-		char *path = malloc(path_len);
-		snprintf(path, path_len, "%s/icons", dir);
+		char *path = format_str("%s/icons", dir);
 		list_add(basedirs, path);
 	} while ((dir = strtok(NULL, ":")));
 	free(data_dirs);
@@ -206,13 +204,7 @@ static const char *entry_handler(char *group, char *key, char *value,
  */
 static struct icon_theme *read_theme_file(char *basedir, char *theme_name) {
 	// look for index.theme file
-	size_t path_len = snprintf(NULL, 0, "%s/%s/index.theme", basedir,
-			theme_name) + 1;
-	char *path = malloc(path_len);
-	if (!path) {
-		return NULL;
-	}
-	snprintf(path, path_len, "%s/%s/index.theme", basedir, theme_name);
+	char *path = format_str("%s/%s/index.theme", basedir, theme_name);
 	FILE *theme_file = fopen(path, "r");
 	free(path);
 	if (!theme_file) {
@@ -416,26 +408,20 @@ static char *find_icon_in_subdir(char *name, char *basedir, char *theme,
 #endif
 	};
 
-	size_t path_len = snprintf(NULL, 0, "%s/%s/%s/%s.EXT", basedir, theme,
-			subdir, name) + 1;
-	char *path = malloc(path_len);
-
 	for (size_t i = 0; i < sizeof(extensions) / sizeof(*extensions); ++i) {
-		snprintf(path, path_len, "%s/%s/%s/%s.%s", basedir, theme, subdir,
-				name, extensions[i]);
+		char *path = format_str("%s/%s/%s/%s.%s",
+			basedir, theme, subdir, name, extensions[i]);
 		if (access(path, R_OK) == 0) {
 			return path;
 		}
+		free(path);
 	}
 
-	free(path);
 	return NULL;
 }
 
 static bool theme_exists_in_basedir(char *theme, char *basedir) {
-	size_t path_len = snprintf(NULL, 0, "%s/%s", basedir, theme) + 1;
-	char *path = malloc(path_len);
-	snprintf(path, path_len, "%s/%s", basedir, theme);
+	char *path = format_str("%s/%s", basedir, theme);
 	bool ret = dir_exists(path);
 	free(path);
 	return ret;

--- a/swaybar/tray/watcher.c
+++ b/swaybar/tray/watcher.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include "list.h"
 #include "log.h"
+#include "stringop.h"
 #include "swaybar/tray/watcher.h"
 
 static const char *obj_path = "/StatusNotifierWatcher";
@@ -76,9 +77,7 @@ static int register_sni(sd_bus_message *msg, void *data, sd_bus_error *error) {
 			service = service_or_path;
 			path = "/StatusNotifierItem";
 		}
-		size_t id_len = snprintf(NULL, 0, "%s%s", service, path) + 1;
-		id = malloc(id_len);
-		snprintf(id, id_len, "%s%s", service, path);
+		id = format_str("%s%s", service, path);
 	}
 
 	if (list_seq_find(watcher->items, cmp_id, id) == -1) {
@@ -159,9 +158,7 @@ struct swaybar_watcher *create_watcher(char *protocol, sd_bus *bus) {
 		return NULL;
 	}
 
-	size_t len = snprintf(NULL, 0, "org.%s.StatusNotifierWatcher", protocol) + 1;
-	watcher->interface = malloc(len);
-	snprintf(watcher->interface, len, "org.%s.StatusNotifierWatcher", protocol);
+	watcher->interface = format_str("org.%s.StatusNotifierWatcher", protocol);
 
 	sd_bus_slot *signal_slot = NULL, *vtable_slot = NULL;
 	int ret = sd_bus_add_object_vtable(bus, &vtable_slot, obj_path,


### PR DESCRIPTION
Centralize output matching in a single function. Will make it easier to add more logic to it later, e.g. to match port names or sink tags.