### PR TITLE
Fix stacking and visibility for Xwayland unmanaged children

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -171,6 +171,7 @@ struct sway_xwayland_unmanaged {
 	struct wl_list link;
 
 	int lx, ly;
+	bool visible;
 
 	struct wl_listener request_activate;
 	struct wl_listener request_configure;
@@ -181,6 +182,7 @@ struct sway_xwayland_unmanaged {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 	struct wl_listener override_redirect;
+	struct wl_listener set_parent;
 };
 #endif
 struct sway_view_child;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -239,6 +239,9 @@ void output_unmanaged_for_each_surface(struct sway_output *output,
 		void *user_data) {
 	struct sway_xwayland_unmanaged *unmanaged_surface;
 	wl_list_for_each(unmanaged_surface, unmanaged, link) {
+		if (!unmanaged_surface->visible) {
+			continue;
+		}
 		struct wlr_xwayland_surface *xsurface =
 			unmanaged_surface->wlr_xwayland_surface;
 		double ox = unmanaged_surface->lx - output->lx;

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -277,7 +277,9 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 
 	wlr_xwayland_surface_activate(surface, activated);
-	wlr_xwayland_surface_restack(surface, NULL, XCB_STACK_MODE_ABOVE);
+	if (activated) {
+		wlr_xwayland_surface_restack(surface, NULL, XCB_STACK_MODE_ABOVE);
+	}
 
 	struct sway_xwayland_unmanaged *unmanaged;
 	wl_list_for_each(unmanaged, &root->xwayland_unmanaged, link) {
@@ -285,7 +287,9 @@ static void set_activated(struct sway_view *view, bool activated) {
 		if (!is_surface_transient_for(unmanaged_surface, view)) {
 			continue;
 		}
-		wlr_xwayland_surface_restack(unmanaged_surface, NULL, XCB_STACK_MODE_ABOVE);
+		if (activated) {
+			wlr_xwayland_surface_restack(unmanaged_surface, NULL, XCB_STACK_MODE_ABOVE);
+		}
 	}
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -124,6 +124,9 @@ struct sway_node *node_at_coords(
 	struct wl_list *unmanaged = &root->xwayland_unmanaged;
 	struct sway_xwayland_unmanaged *unmanaged_surface;
 	wl_list_for_each_reverse(unmanaged_surface, unmanaged, link) {
+		if (!unmanaged_surface->visible) {
+			continue;
+		}
 		struct wlr_xwayland_surface *xsurface =
 			unmanaged_surface->wlr_xwayland_surface;
 


### PR DESCRIPTION
I couldn't give up so easily after all. :P With lessons learned from #7477, here's a couple small fixes that will make Fusion 360 behave a little better. There are still two outstanding problems which hurt its usability:
- Xshape support is needed
- For some reason, the client will unset OR on the surfaces when it receives clicks, which breaks input because sway moves them. Even if I hack the event handler to ignore the change, the client will unmap and remap the surfaces a lot, causing flicker. I have no idea how to fix this at the moment but ~~it doesn't seem to happen in i3 nor mutter~~ it happens in i3 too but at least the window doesn't move there.