### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Ronan Pigott <ronan@rjp.ie> <rpigott@berkeley.edu>


### PR DESCRIPTION
See `gitmailmap(5)`.

This is a way to keep contact info up to date in git blame/log etc. I'm not sure if anyone else has contributed under two emails but they of course could be added. There are also some old commits from @emersion using a different git user which could also be corrected with a mailmap line if desired.