### PR TITLE
Document create_output and unplug in man pages

### DIFF
--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -131,6 +131,11 @@ must be separated by one space. For example:
 	As opposed to the _enable_ and _disable_ commands, the output keeps its
 	current workspaces and windows.
 
+*output* <name> unplug
+	Removes the specified headless output.
+
+	To create a headless output see *create_output* in *swaymsg*(1).
+
 *output* <name> dpms on|off|toggle
 	Deprecated. Alias for _power_.
 

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -65,6 +65,10 @@ _swaymsg_ [options...] [message]
 	  anything beyond that point as an option. For example, use
 	  _swaymsg -- mark --add test_ instead of _swaymsg mark --add test_.
 
+*create_output*
+	Creates a new headless output by the name of HEADLESS-x where x is a
+	is initially 1. Each subsequent usage will increment x by 1. 
+
 *get\_workspaces*
 	Gets a list of workspaces and their status.
 


### PR DESCRIPTION
Documents the commands for using virtual inputs in the manual pages.