### PR TITLE
root: Try to preserve relative positions of floating containers

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -113,6 +113,11 @@ struct sway_container {
 	// Hidden scratchpad containers have a NULL parent.
 	bool scratchpad;
 
+	// Stores last output size and position for adjusting coordinates of
+	// scratchpad windows.
+	// Unused for non-scratchpad windows.
+	struct wlr_box transform;
+
 	float alpha;
 
 	struct wlr_texture *title_focused;
@@ -195,6 +200,9 @@ size_t container_titlebar_height(void);
 
 void floating_calculate_constraints(int *min_width, int *max_width,
 		int *min_height, int *max_height);
+
+void floating_fix_coordinates(struct sway_container *con,
+		struct wlr_box *old, struct wlr_box *new);
 
 void container_floating_resize_and_center(struct sway_container *con);
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -206,9 +206,17 @@ static void container_move_to_workspace(struct sway_container *container,
 		container_detach(container);
 		workspace_add_floating(workspace, container);
 		container_handle_fullscreen_reparent(container);
-		// If changing output, center it within the workspace
+		// If changing output, adjust the coordinates of the window.
 		if (old_output != workspace->output && !container->pending.fullscreen_mode) {
-			container_floating_move_to_center(container);
+			struct wlr_box workspace_box, old_workspace_box;
+			workspace_get_box(workspace, &workspace_box);
+			workspace_get_box(old_workspace, &old_workspace_box);
+			floating_fix_coordinates(container, &old_workspace_box, &workspace_box);
+			if (container->scratchpad && workspace->output) {
+				struct wlr_box output_box;
+				output_get_box(workspace->output, &output_box);
+				container->transform = workspace_box;
+			}
 		}
 	} else {
 		container_detach(container);


### PR DESCRIPTION
Should fix https://github.com/swaywm/sway/issues/5308 and https://github.com/swaywm/sway/issues/6561. The translation behavior also applies to all floating containers (not just those on the scratchpad), since that's what i3 does.

I've been dogfooding this for the past week on a setup with monitors of different aspect ratios without issue.

`floating_fix_coordinates` is adapted from [the same in i3](https://github.com/i3/i3/blob/d26ddcbfe5f0ead61cc55c1f596692d9a89e71f9/src/floating.c#L799).