### PR TITLE
Use wlr_texture_set introduced by latest wlroots

### DIFF
--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -303,7 +303,7 @@ static void render_saved_view(struct sway_view *view,
 
 	struct sway_saved_buffer *saved_buf;
 	wl_list_for_each(saved_buf, &view->saved_buffers, link) {
-		if (!saved_buf->buffer->texture) {
+		if (!saved_buf->buffer->texture_set) {
 			continue;
 		}
 
@@ -343,8 +343,14 @@ static void render_saved_view(struct sway_view *view,
 		}
 		scale_box(&dst_box, wlr_output->scale);
 
-		render_texture(wlr_output, damage, saved_buf->buffer->texture,
-			&saved_buf->source_box, &dst_box, matrix, alpha);
+		struct wlr_texture *texture = wlr_texture_set_get_tex_for_renderer(
+				saved_buf->buffer->texture_set, wlr_output->renderer);
+		if (!texture) {
+			continue;
+		}
+
+		render_texture(wlr_output, damage, texture, &saved_buf->source_box,
+				&dst_box, matrix, alpha);
 	}
 
 	// FIXME: we should set the surface that this saved buffer originates from


### PR DESCRIPTION
This change is the sway component of wlroots merge request [Allow scanning out fullscreen surfaces on secondary GPUs](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4055).

This change uses the `wlr_texture_set` object introduced to help with multi-GPU copies. Instead of simply referencing the `wlr_texture` we instead are provided a `wlr_texture_set` and will query a `wlr_texture` for the renderer in use. For more details please see the main merge request linked above.

Obviously this should not be merged until the wlroots changes are merged.