### PR TITLE
Set withdrawn state for xwayland views on hidden workspaces

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -44,6 +44,7 @@ struct sway_view_impl {
 	void (*set_tiled)(struct sway_view *view, bool tiled);
 	void (*set_fullscreen)(struct sway_view *view, bool fullscreen);
 	void (*set_resizing)(struct sway_view *view, bool resizing);
+	void (*set_withdrawn)(struct sway_view *view, bool withdrawn);
 	bool (*wants_floating)(struct sway_view *view);
 	void (*for_each_surface)(struct sway_view *view,
 		wlr_surface_iterator_func_t iterator, void *user_data);
@@ -365,6 +366,8 @@ void view_execute_criteria(struct sway_view *view);
 bool view_is_visible(struct sway_view *view);
 
 void view_set_urgent(struct sway_view *view, bool enable);
+
+void view_set_withdrawn(struct sway_view *view, bool withdrawn);
 
 bool view_is_urgent(struct sway_view *view);
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -212,12 +212,25 @@ static void transaction_add_node(struct sway_transaction *transaction,
 	}
 }
 
+void container_iterator(struct sway_container *con, void *data) {
+	bool *is_current = data;
+	if (con->view) {
+		view_set_withdrawn(con->view, !*is_current);
+	}
+}
+
+void workspace_iterator(struct sway_workspace *ws, void *data) {
+	bool is_current = workspace_is_visible(ws);
+	workspace_for_each_container(ws, container_iterator, &is_current);
+}
+
 static void apply_output_state(struct sway_output *output,
 		struct sway_output_state *state) {
 	output_damage_whole(output);
 	list_free(output->current.workspaces);
 	memcpy(&output->current, state, sizeof(struct sway_output_state));
 	output_damage_whole(output);
+	output_for_each_workspace(output, workspace_iterator, NULL);
 }
 
 static void apply_workspace_state(struct sway_workspace *ws,

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -293,6 +293,16 @@ static void set_fullscreen(struct sway_view *view, bool fullscreen) {
 	wlr_xwayland_surface_set_fullscreen(surface, fullscreen);
 }
 
+static void set_withdrawn(struct sway_view *view, bool withdrawn) {
+	if (xwayland_view_from_view(view) == NULL) {
+		return;
+	}
+	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
+	if (surface->withdrawn != withdrawn) {
+		wlr_xwayland_surface_set_withdrawn(surface, withdrawn);
+	}
+}
+
 static bool wants_floating(struct sway_view *view) {
 	if (xwayland_view_from_view(view) == NULL) {
 		return false;
@@ -392,6 +402,7 @@ static const struct sway_view_impl view_impl = {
 	.set_activated = set_activated,
 	.set_tiled = set_tiled,
 	.set_fullscreen = set_fullscreen,
+	.set_withdrawn = set_withdrawn,
 	.wants_floating = wants_floating,
 	.is_transient_for = is_transient_for,
 	.close = _close,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -431,6 +431,12 @@ void view_set_tiled(struct sway_view *view, bool tiled) {
 	}
 }
 
+void view_set_withdrawn(struct sway_view *view, bool withdrawn) {
+	if (view->impl->set_withdrawn) {
+		view->impl->set_withdrawn(view, withdrawn);
+	}
+}
+
 void view_close(struct sway_view *view) {
 	if (view->impl->close) {
 		view->impl->close(view);


### PR DESCRIPTION
References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4057

The current implementation is a huge hack and some filtering may be needed for eg sticky views.

Mutter does this and I'm trying to get Wine to recognize withdrawn state as minimized. https://gitlab.winehq.org/wine/wine/-/merge_requests/2343