### PR TITLE
Fix memory leak of fallback_output and associated lists

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -854,9 +854,6 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 
 	wlr_damage_ring_finish(&output->damage_ring);
 
-	output->wlr_output->data = NULL;
-	output->wlr_output = NULL;
-
 	transaction_commit_dirty();
 
 	update_output_manager_config(server);

--- a/sway/server.c
+++ b/sway/server.c
@@ -285,6 +285,9 @@ void server_fini(struct sway_server *server) {
 	wl_display_destroy_clients(server->wl_display);
 	wl_display_destroy(server->wl_display);
 	list_free(server->dirty_nodes);
+	list_free(root->fallback_output->workspaces);
+	list_free(root->fallback_output->current.workspaces);
+	free(root->fallback_output);
 }
 
 bool server_start(struct sway_server *server) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -230,10 +230,6 @@ void output_destroy(struct sway_output *output) {
 				"Tried to free output which wasn't marked as destroying")) {
 		return;
 	}
-	if (!sway_assert(output->wlr_output == NULL,
-				"Tried to free output which still had a wlr_output")) {
-		return;
-	}
 	if (!sway_assert(output->node.ntxnrefs == 0, "Tried to free output "
 				"which is still referenced by transactions")) {
 		return;


### PR DESCRIPTION
This fixes memory leak of fallback_output because it was never freed during the shutdown procedure.

This also fixes the memory leaks of lists associated with fallback_output.

This also removes one assertion condition because it was passed by just setting a pointer reference to null but it left the heap content in place.