### PR TITLE
Fix damage-ring bounds not being set when unplugging -> plugging in monitor

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -825,7 +825,6 @@ static void update_output_manager_config(struct sway_server *server) {
 			config_head->state.x = output_box.x;
 			config_head->state.y = output_box.y;
 		}
-	
 	}
 
 	wlr_output_manager_v1_set_configuration(server->output_manager_v1, config);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -825,6 +825,10 @@ static void update_output_manager_config(struct sway_server *server) {
 			config_head->state.x = output_box.x;
 			config_head->state.y = output_box.y;
 		}
+	
+		int width, height;
+		wlr_output_transformed_resolution(output->wlr_output, &width, &height);
+		wlr_damage_ring_set_bounds(&output->damage_ring, width, height);
 	}
 
 	wlr_output_manager_v1_set_configuration(server->output_manager_v1, config);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -826,9 +826,6 @@ static void update_output_manager_config(struct sway_server *server) {
 			config_head->state.y = output_box.y;
 		}
 	
-		int width, height;
-		wlr_output_transformed_resolution(output->wlr_output, &width, &height);
-		wlr_damage_ring_set_bounds(&output->damage_ring, width, height);
 	}
 
 	wlr_output_manager_v1_set_configuration(server->output_manager_v1, config);
@@ -1031,6 +1028,15 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	transaction_commit_dirty();
 
+	struct sway_output *tmp_output;
+	wl_list_for_each(tmp_output, &root->all_outputs, link) {
+		if (tmp_output == root->fallback_output) {
+			continue;
+		}
+		int width, height;
+		wlr_output_transformed_resolution(tmp_output->wlr_output, &width, &height);
+		wlr_damage_ring_set_bounds(&tmp_output->damage_ring, width, height);
+	}
 	update_output_manager_config(server);
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1000,9 +1000,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	}
 	output->server = server;
 	wlr_damage_ring_init(&output->damage_ring);
-	int width, height;
-	wlr_output_transformed_resolution(output->wlr_output, &width, &height);
-	wlr_damage_ring_set_bounds(&output->damage_ring, width, height);
 
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->destroy.notify = handle_destroy;
@@ -1028,15 +1025,9 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 
 	transaction_commit_dirty();
 
-	struct sway_output *tmp_output;
-	wl_list_for_each(tmp_output, &root->all_outputs, link) {
-		if (tmp_output == root->fallback_output) {
-			continue;
-		}
-		int width, height;
-		wlr_output_transformed_resolution(tmp_output->wlr_output, &width, &height);
-		wlr_damage_ring_set_bounds(&tmp_output->damage_ring, width, height);
-	}
+	int width, height;
+	wlr_output_transformed_resolution(output->wlr_output, &width, &height);
+	wlr_damage_ring_set_bounds(&output->damage_ring, width, height);
 	update_output_manager_config(server);
 }
 


### PR DESCRIPTION
#7524 was a partial fix. Seems like this is still an issue when unplugging and plugging the monitor back in.

I'm not sure if it's a good fix due to the `update_output_manager_config` function being called from other places though.