### PR TITLE
man: make it explicit that swaybg is required for background config

### DIFF
--- a/sway/sway-output.5.scd
+++ b/sway/sway-output.5.scd
@@ -101,10 +101,12 @@ must be separated by one space. For example:
 	the specified file cannot be accessed or if the image does not fill the entire
 	output, a fallback color may be provided to cover the rest of the output.
 	_fallback_color_ should be specified as _#RRGGBB_. Alpha is not supported.
+	**swaybg** is required to be installed.
 
 *output* <name> background|bg <color> solid_color
 	Sets the background of the given output to the specified color. _color_
-	should be specified as _#RRGGBB_. Alpha is not supported.
+	should be specified as _#RRGGBB_. Alpha is not supported. **swaybg** is
+	required to be installed.
 
 *output* <name> transform <transform> [clockwise|anticlockwise]
 	Sets the background transform to the given value. Can be one of "90", "180",


### PR DESCRIPTION
I couldn't work out why the background wasn't working with my arch setup with sway

Only after running it in debug and seeing this error message, I came across this post

https://github.com/swaywm/sway/issues/4090

Double checked the man page and nothing stated that `swaybg` was required.