### PR TITLE
Add support for touch cancel events

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -53,6 +53,7 @@ struct sway_cursor {
 
 	struct wl_listener touch_down;
 	struct wl_listener touch_up;
+	struct wl_listener touch_cancel;
 	struct wl_listener touch_motion;
 	struct wl_listener touch_frame;
 	bool simulating_pointer_from_touch;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -44,6 +44,8 @@ struct sway_seatop_impl {
 			struct wlr_touch_up_event *event);
 	void (*touch_down)(struct sway_seat *seat,
 			struct wlr_touch_down_event *event, double lx, double ly);
+	void (*touch_cancel)(struct sway_seat *seat,
+			struct wlr_touch_cancel_event *event);
 	void (*tablet_tool_motion)(struct sway_seat *seat,
 			struct sway_tablet_tool *tool, uint32_t time_msec);
 	void (*tablet_tool_tip)(struct sway_seat *seat, struct sway_tablet_tool *tool,
@@ -337,6 +339,9 @@ void seatop_touch_up(struct sway_seat *seat,
 
 void seatop_touch_down(struct sway_seat *seat,
 		struct wlr_touch_down_event *event, double lx, double ly);
+
+void seatop_touch_cancel(struct sway_seat *seat,
+		struct wlr_touch_cancel_event *event);
 
 void seatop_rebase(struct sway_seat *seat, uint32_t time_msec);
 

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1638,6 +1638,12 @@ void seatop_touch_down(struct sway_seat *seat, struct wlr_touch_down_event *even
 	}
 }
 
+void seatop_touch_cancel(struct sway_seat *seat, struct wlr_touch_cancel_event *event) {
+	if (seat->seatop_impl->touch_cancel) {
+		seat->seatop_impl->touch_cancel(seat, event);
+	}
+}
+
 void seatop_tablet_tool_tip(struct sway_seat *seat,
 		struct sway_tablet_tool *tool, uint32_t time_msec,
 		enum wlr_tablet_tool_tip_state state) {

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -104,6 +104,24 @@ static void handle_touch_down(struct sway_seat *seat,
 	}
 }
 
+static void handle_touch_cancel(struct sway_seat *seat,
+		struct wlr_touch_cancel_event *event) {
+	struct seatop_down_event *e = seat->seatop_data;
+	struct seatop_touch_point_event *point_event, *tmp;
+
+	wl_list_for_each_safe(point_event, tmp, &e->point_events, link) {
+		if (point_event->touch_id == event->touch_id) {
+			wl_list_remove(&point_event->link);
+			free(point_event);
+			break;
+		}
+	}
+
+	if (e->surface) {
+		wlr_seat_touch_notify_cancel(seat->wlr_seat, e->surface);
+	}
+}
+
 static void handle_pointer_axis(struct sway_seat *seat,
 		struct wlr_pointer_axis_event *event) {
 	struct sway_input_device *input_device =
@@ -189,6 +207,7 @@ static const struct sway_seatop_impl seatop_impl = {
 	.touch_motion = handle_touch_motion,
 	.touch_up = handle_touch_up,
 	.touch_down = handle_touch_down,
+	.touch_cancel = handle_touch_cancel,
 	.unref = handle_unref,
 	.end = handle_end,
 	.allow_set_cursor = true,


### PR DESCRIPTION
https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/37f42e2d introduces touch cancel events to wlroots. At the moment touch sequences that are cancelled by libinput are not terminated by a cancel or end event. The only way client applications can become aware of this is by tracking touch ids. When a new touch sequence is started that reuses a previously cancelled touch id, said application can assume that the previous touch sequence was cancelled. However, this approach introduces a range of other issues. See https://github.com/xournalpp/xournalpp/pull/4852 for the original motivation.

I've performed some rudimentary tests on a Surface Go running a 6.2 mainline kernel. Do you have any wishes for an exhaustive test plan?