### PR TITLE
handle_touch_cancel: fix begin default

### DIFF
--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -117,6 +117,10 @@ static void handle_touch_cancel(struct sway_seat *seat,
 		}
 	}
 
+	if (wl_list_empty(&e->point_events)) {
+		seatop_begin_default(seat);
+	}
+
 	if (e->surface) {
 		wlr_seat_touch_notify_cancel(seat->wlr_seat, e->surface);
 	}


### PR DESCRIPTION
I forgot to call seatop_begin_default in e8f7551e46052a8df04b630bf06565ca77f830fb. This prevents e.g. stylus devices from being usable immediately after they cancelled a touch point.