### PR TITLE
Add support for cursor-shape-v1

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -145,4 +145,6 @@ uint32_t get_mouse_button(const char *name, char **error);
 
 const char *get_mouse_button_name(uint32_t button);
 
+void handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
+
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -120,6 +120,8 @@ struct sway_server {
 	struct wl_listener xdg_activation_v1_request_activate;
 	struct wl_listener xdg_activation_v1_new_token;
 
+	struct wl_listener request_set_cursor_shape;
+
 	struct wl_list pending_launcher_ctxs; // launcher_ctx::link
 
 	// The timeout for transactions, after which a transaction is applied

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -13,6 +13,7 @@ protocols = [
 	wl_protocol_dir / 'unstable/tablet/tablet-unstable-v2.xml',
 	wl_protocol_dir / 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml',
 	wl_protocol_dir / 'staging/content-type/content-type-v1.xml',
+	wl_protocol_dir / 'staging/cursor-shape/cursor-shape-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 	'idle.xml',
 	'wlr-input-inhibitor-unstable-v1.xml',

--- a/sway/server.c
+++ b/sway/server.c
@@ -11,6 +11,7 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_content_type_v1.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
@@ -44,6 +45,7 @@
 #include "sway/input/input-manager.h"
 #include "sway/output.h"
 #include "sway/server.h"
+#include "sway/input/cursor.h"
 #include "sway/tree/root.h"
 
 #if HAVE_XWAYLAND
@@ -234,6 +236,11 @@ bool server_init(struct sway_server *server) {
 		xdg_activation_v1_handle_new_token;
 	wl_signal_add(&server->xdg_activation_v1->events.new_token,
 		&server->xdg_activation_v1_new_token);
+
+	struct wlr_cursor_shape_manager_v1 *cursor_shape_manager =
+		wlr_cursor_shape_manager_v1_create(server->wl_display, 1);
+	server->request_set_cursor_shape.notify = handle_request_set_cursor_shape;
+	wl_signal_add(&cursor_shape_manager->events.request_set_shape, &server->request_set_cursor_shape);
 
 	wl_list_init(&server->pending_launcher_ctxs);
 


### PR DESCRIPTION
References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4106

~~TODO: animated cursors. Ideally `wlr_xcursor_manager` would be patched to support this.~~ `wlr_cursor` now supports animated cursors.