### PR TITLE
swaybar: fix configuration bug with binding_mode_indicator and workspace_indicators

### DIFF
--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -426,12 +426,9 @@ bool ipc_initialize(struct swaybar *bar) {
 	}
 	free(res);
 
-	struct swaybar_config *config = bar->config;
-	char subscribe[128]; // suitably large buffer
-	len = snprintf(subscribe, 128,
-			"[ \"barconfig_update\" , \"bar_state_update\" %s %s ]",
-			config->binding_mode_indicator ? ", \"mode\"" : "",
-			config->workspace_buttons ? ", \"workspace\"" : "");
+	char *subscribe =
+		"[ \"barconfig_update\", \"bar_state_update\", \"mode\", \"workspace\" ]";
+	len = strlen(subscribe);
 	free(ipc_single_command(bar->ipc_event_socketfd,
 			IPC_SUBSCRIBE, subscribe, &len));
 	return true;


### PR DESCRIPTION
This fix resolves a bug where setting `binding_mode_indicator` or `workspace_indicators` to `no` in the config prevented them from being properly enabled with `swaymsg bar bar-0 binding_mode_indicator on` or `swaymsg bar bar-0 workspace_indicators on`.

The fix that I implemented simply removes the guards that restrict swaybar's event subscriptions to only the required events. Would it be preferable to reintroduce the guards and have swaybar close and resubscribe the socket on configuration updates, so that it only subscribes to required events?