### PR TITLE
hide_cursor when-typing: do not hide cursor when buttons are pressed

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -225,7 +225,10 @@ void cursor_notify_key_press(struct sway_cursor *cursor) {
 	}
 
 	if (cursor->hide_when_typing == HIDE_WHEN_TYPING_ENABLE) {
-		cursor_hide(cursor);
+		if (cursor->pressed_button_count == 0) {
+			// Do not hide cursor unless all buttons are released
+			cursor_hide(cursor);
+		}
 	}
 }
 


### PR DESCRIPTION
This was already done for timeout based hiding in #4424.
Now the `hide_cursor when-typing enabled` setting will also not hide the cursor unless all buttons are released.

This fixes #7383, #6297, #7399.

I'm not sure if doing that check every time a key is pressed is the best way though.