### PR TITLE
Make the login manager set XDG_CURRENT_DESKTOP

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway


### PR DESCRIPTION
According to the FreeDesktop specification at
<https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html>, DesktopNames signals to the login manager what XDG_CURRENT_DESKTOP shall be set to.

This commit has been successfully tested with GDM.