### PR TITLE
Add support for layer-shell on_demand keyboard interactivity

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -104,8 +104,9 @@ struct sway_seat {
 	struct sway_workspace *workspace;
 	char *prev_workspace_name; // for workspace back_and_forth
 
-	// If the focused layer is set, views cannot receive keyboard focus
 	struct wlr_layer_surface_v1 *focused_layer;
+	// If the exclusive layer is set, views cannot receive keyboard focus
+	bool has_exclusive_layer;
 
 	// If exclusive_client is set, no other clients will receive input events
 	struct wl_client *exclusive_client;

--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -55,6 +55,10 @@ struct sway_layer_subsurface {
 };
 
 struct sway_output;
+
+struct wlr_layer_surface_v1 *toplevel_layer_surface_from_surface(
+		struct wlr_surface *surface);
+
 void arrange_layers(struct sway_output *output);
 
 struct sway_layer_surface *layer_from_wlr_layer_surface_v1(

--- a/sway/server.c
+++ b/sway/server.c
@@ -55,7 +55,7 @@
 #endif
 
 #define SWAY_XDG_SHELL_VERSION 2
-#define SWAY_LAYER_SHELL_VERSION 3
+#define SWAY_LAYER_SHELL_VERSION 4
 
 #if WLR_HAS_DRM_BACKEND
 static void handle_drm_lease_request(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Supersedes #5974 

Tested (from original PR) with gtk-layer-demo:

- [x] xdg toplevel + layer-surface/top/on-demand
- [x] xdg toplevel + layer-surface/top/on-demand + layer-surface/top/exclusive
- [x] xdg toplevel + layer-surface/top/on-demand + layer-surface/overlay/exclusive
- [x] layer-surface/top/exclusive + layer-surface/top/none: Should be able to interact with none layer, popups, and subsurfaces(buttons, no keyboard input)
- [x] focus_follows_mouse
- [x] layer-surface/top/on-demand + layer-surface/top/exclusive, on-demand only focused when focused inside of bounds while exclusive is focused otherwise (also outside of its bounds)
- [x] layer-surface/top/exclusive + layer-surface/top/exclusive: Layer has focus until the cursor enters/clicks within the other layers bounds
- [x] Keyboard input is only available for EXCLUSIVE and ON_DEMAND surfaces
- [x] Interact buttons in layers/subsurfaces/popups while NONE exclusive
- [x] Clicking on xdg_popups/layer sub-surfaces works with any mode
- [x] return keyboard focus after destroying on-demand layer surface

More test cases would be appreciated :)