### PR TITLE
Fix layer old damage not being offset by the monitor layout coords

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -312,6 +312,8 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 	bool extent_changed =
 		memcmp(&old_extent, &layer->extent, sizeof(struct wlr_box)) != 0;
 	if (extent_changed || layer_changed) {
+		old_extent.x += output->lx;
+		old_extent.y += output->ly;
 		output_damage_box(output, &old_extent);
 		output_damage_surface(output, layer->geo.x, layer->geo.y,
 			layer_surface->surface, true);


### PR DESCRIPTION
Issue in question:

https://github.com/swaywm/sway/assets/35975961/236f6a6a-d03c-4560-9334-3982e9aaddcc

To reproduce:

1. Open sway with two outputs
2. Run rofi-wayland, `rofi -show drun`
3. Type something in so that there are no results and hit enter
4. If the bug doesn't appear, wait a few seconds