### PR TITLE
add --allow-other flag for keybindings

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -50,6 +50,7 @@ enum binding_flags {
 	BINDING_INHIBITED = 1 << 7, // keyboard only: ignore shortcut inhibitor
 	BINDING_NOREPEAT = 1 << 8, // keyboard only; do not trigger when repeating a held key
 	BINDING_EXACT = 1 << 9, // gesture only; only trigger on exact match
+	BINDING_ALLOWOTHER = 1 << 10, // keyboard only; allow other keys to be pressed at the same time
 };
 
 /**

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -377,6 +377,8 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			warn = false;
 		} else if (strcmp("--no-repeat", argv[0]) == 0) {
 			binding->flags |= BINDING_NOREPEAT;
+		} else if (strcmp("--allow-other", argv[0]) == 0) {
+			binding->flags |= BINDING_ALLOWOTHER;
 		} else {
 			break;
 		}

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -389,8 +389,8 @@ runtime.
 		for_window <criteria> move container to output <output>
 
 *bindsym* [--whole-window] [--border] [--exclude-titlebar] [--release] [--locked] \
-[--to-code] [--input-device=<device>] [--no-warn] [--no-repeat] [Group<1-4>+]<key combo> \
-<command>
+[--to-code] [--input-device=<device>] [--no-warn] [--no-repeat] [--allow-other] \
+[Group<1-4>+]<key combo> <command>
 	Binds _key combo_ to execute the sway command _command_ when pressed. You
 	may use XKB key names here (*wev*(1) is a good tool for discovering these).
 	With the flag _--release_, the command is executed when the key combo is
@@ -418,6 +418,11 @@ runtime.
 	Unless the flag _--no-repeat_ is set, the command will be run
 	repeatedly when the key is held, according to the repeat
 	settings specified in the input configuration.
+
+	If _--allow-other_ is set, any key sequence containing this key sequence
+	may trigger this binding. For example, a single-key binding with
+	_--allow-other_ set may be executed upon the simultaneous press of one
+	or more keys, one of which is the binding's key.
 
 	Bindings to keysyms are layout-dependent. This can be changed with the
 	_--to-code_ flag. In this case, the keysyms will be translated into the


### PR DESCRIPTION
This flag allows other keys to be pressed at the same time as the binding. This acts as follows:
- All key modifiers not explicitly listed in the binding are ignored. The binding's modifiers are still required to be pressed.
- All keys not listed in the binding are ignored, the binding is triggered as long as the keys in the binding are a subset of the keys pressed.
- If other keys are pressed between press and release, release is still triggered.

The particular use case for me is Mumble push-to-talk.

In games, you often talk at the same time as doing something else in-game. Before, I had this rather abysmal config since sway doesn't support ignoring key modifiers for bindings (I have a mouse button that I use for PTT programmed to Scroll Lock, a mostly unused key, to make sure games don't do anything when I press the key):

```
bindsym --inhibited --no-repeat Scroll_Lock exec mumble rpc starttalking
bindsym --inhibited --no-repeat control+Scroll_Lock exec mumble rpc starttalking
bindsym --inhibited --no-repeat control+lock+Scroll_Lock exec mumble rpc starttalking
bindsym --inhibited --no-repeat control+mod1+Scroll_Lock exec mumble rpc starttalking
bindsym --inhibited --no-repeat control+mod1+mod4+Scroll_Lock exec mumble rpc starttalking
bindsym --inhibited --no-repeat control+mod2+Scroll_Lock exec mumble rpc starttalking
...continues for a total of 33 lines, plus the same for stoptalking:
bindsym --inhibited --no-repeat --release Scroll_Lock exec mumble rpc stoptalking
...
```

However, this had one major issue - if I pressed any other key between the press and release of Scroll_Lock, the release binding wouldn't execute, and my microphone would be kept active until someone tells me about it and I press the key again, just to release it and execute the release binding. This PR introduces a flag for what I consider ideal push to talk behavior.

The reason this is necessary in the first place is because on X, there is some part of the spec that allows intercepting all keypresses which Mumble uses. There's no such thing on Wayland, closest thing I could find is [this merged PR for xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal/pull/711), but I don't think there's an easy way to make xdg-desktop-portal-wlr support it without a completely new Wayland protocol supported by wlroots, and Mumble doesn't use the xdg-desktop-portal global shortcuts API yet anyway. See https://github.com/emersion/xdg-desktop-portal-wlr/issues/240

This fills the last major gap I had in experience between X and Wayland. Understandably, i3 doesn't have this feature because it isn't necessary there. Feedback is welcome on making this apply to more situations than just push to talk (or on getting a better name). If the xdg-desktop-portal solution is preferred (and feasible), I'm fine with closing this and using this as a patch until xdg-desktop-portal-wlr becomes more mature.

Closes #6456

Prior art: #6616 #6920