### PR TITLE
Calculate tiled resizing amount from parent/workspace

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -253,12 +253,27 @@ static struct cmd_results *resize_adjust_tiled(uint32_t axis,
 		amount->unit = MOVEMENT_UNIT_PPT;
 	}
 	if (amount->unit == MOVEMENT_UNIT_PPT) {
+        struct sway_container *parent = current->pending.parent;
 		float pct = amount->amount / 100.0f;
 
 		if (is_horizontal(axis)) {
-			amount->amount = (float)current->pending.width * pct;
+            while (parent && parent->pending.layout != L_HORIZ) {
+                parent = parent->pending.parent;
+            }
+            if (parent) {
+                amount->amount = (float)parent->pending.width * pct;
+            } else {
+                amount->amount = (float)current->pending.workspace->width * pct;
+            }
 		} else {
-			amount->amount = (float)current->pending.height * pct;
+            while (parent && parent->pending.layout != L_VERT) {
+                parent = parent->pending.parent;
+            }
+            if (parent) {
+                amount->amount = (float)parent->pending.height * pct;
+            } else {
+                amount->amount = (float)current->pending.workspace->height * pct;
+            }
 		}
 	}
 


### PR DESCRIPTION
i3 shrinks/grows tiled windows according to screen size for ppt unit. So, for i3 compatibility, I've changed how sway calculates resizing amount for tiled windows.

Resolves: #7593

You can find the demonstration of default behaviour on issue #7593 and here is after this change:

https://github.com/swaywm/sway/assets/17731403/3e9a200c-10e7-4fb4-94d7-c1e9ee99a99a

Note: This is my first time trying to contribute to open source. Please feel free for suggestions/advices. 😇 

