### PR TITLE
chase wlroots wlr_renderer_begin_buffer_pass change

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -616,7 +616,7 @@ static int output_repaint_timer_handler(void *data) {
 	}
 
 	struct wlr_render_pass *render_pass = wlr_renderer_begin_buffer_pass(
-		wlr_output->renderer, buffer);
+		wlr_output->renderer, buffer, NULL);
 	if (render_pass == NULL) {
 		wlr_buffer_unlock(buffer);
 		return false;


### PR DESCRIPTION
https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4159

> ../sway/desktop/output.c:618:47: error: too few arguments to function 'wlr_renderer_begin_buffer_pass'
>   618 |         struct wlr_render_pass *render_pass = wlr_renderer_begin_buffer_pass(
>       |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

encountered in [nixpkgs-wayland](https://github.com/nix-community/nixpkgs-wayland) update job


log showed that people used chase in their messages relating to fixing wlroots changes