### PR TITLE
gamma_control_v1: handle destroyed output

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -1102,6 +1102,11 @@ void handle_gamma_control_set_gamma(struct wl_listener *listener, void *data) {
 	const struct wlr_gamma_control_manager_v1_set_gamma_event *event = data;
 
 	struct sway_output *output = event->output->data;
+
+	if(!output) {
+		return;
+	}
+
 	output->gamma_lut_changed = true;
 	wlr_output_schedule_frame(output->wlr_output);
 }


### PR DESCRIPTION
In case a display is unplugged, the sway output may be removed from the userdata before the gamma_control can be reset. In this case we can't schedule a commit on the output, simply return within the function.

backtrace full:
```
  #0  handle_gamma_control_set_gamma (listener=0x4856a8 <server+616>, data=0x7ffce1ed59c0) at ../sway/desktop/output.c:1105
          server = 0x485440 <server>
          event = 0x7ffce1ed59c0
          output = 0x0
  #1  0x00007f430d1dca0c in wl_signal_emit_mutable ()
     from /nix/store/ky1g6ylzr2m4bq8fy0gzrnqmjr6948k5-wayland-1.22.0/lib/libwayland-server.so.0
  No symbol table info available.
  #2  0x00007f430d142370 in gamma_control_destroy (gamma_control=0x29eb9b0) at ../types/wlr_gamma_control_v1.c:37
          manager = 0x27e33e0
          output = 0x2a10770
          event = {output = 0x2a10770, control = 0x0}
  #3  0x00007f430d14239b in gamma_control_handle_output_destroy (listener=<optimized out>, data=<optimized out>)
      at ../types/wlr_gamma_control_v1.c:59
          gamma_control = <optimized out>
  #4  0x00007f430d1dca0c in wl_signal_emit_mutable ()
     from /nix/store/ky1g6ylzr2m4bq8fy0gzrnqmjr6948k5-wayland-1.22.0/lib/libwayland-server.so.0
  No symbol table info available.
  #5  0x00007f430d12a0e0 in wlr_output_destroy (output=output@entry=0x2a10770) at ../types/output/output.c:384
          cursor = <optimized out>
          tmp_cursor = <optimized out>
          layer = <optimized out>
          tmp_layer = <optimized out>
  #6  0x00007f430d114ecf in disconnect_drm_connector (conn=conn@entry=0x2a10770) at ../backend/drm/drm.c:1757
          __PRETTY_FUNCTION__ = "disconnect_drm_connector"
  #7  0x00007f430d117078 in scan_drm_connectors (drm=drm@entry=0x1eebab0, event=event@entry=0x7ffce1ed5c1c) at ../backend/drm/drm.c:1597
          c = <optimized out>
          wlr_conn = 0x2a10770
          drm_conn = 0x2e760d0
          conn_id = <optimized out>
          index = 4
          i = 4
          res = 0x2e761f0
          seen_len = 5
          seen = {true, true, true, true, true, false}
          new_outputs_len = 0
          new_outputs = 0x7ffce1ed5ab0
          conn = <optimized out>
          tmp_conn = <optimized out>
          index = <optimized out>
  #8  0x00007f430d113425 in handle_dev_change (listener=0x1eebbb0, data=0x7ffce1ed5c18) at ../backend/drm/backend.c:157
          drm = 0x1eebab0
          change = 0x7ffce1ed5c18
  #9  0x00007f430d1dca0c in wl_signal_emit_mutable ()
     from /nix/store/ky1g6ylzr2m4bq8fy0gzrnqmjr6948k5-wayland-1.22.0/lib/libwayland-server.so.0
  No symbol table info available.
  #10 0x00007f430d111696 in handle_udev_event (fd=<optimized out>, mask=<optimized out>, data=<optimized out>)
      at ../backend/session/session.c:213
          event = {type = WLR_DEVICE_HOTPLUG, {hotplug = {connector_id = 0, prop_id = 0}}}
          devnum = <optimized out>
          dev = 0x1ed9460
          session = <optimized out>
          udev_dev = 0x2e70db0
          sysname = 0x2e73c60 "card0"
          devnode = <optimized out>
          action = 0x7f430d6677b5 "change"
          seat = <optimized out>
          __PRETTY_FUNCTION__ = "handle_udev_event"
  #11 0x00007f430d1de8e2 in wl_event_loop_dispatch ()
     from /nix/store/ky1g6ylzr2m4bq8fy0gzrnqmjr6948k5-wayland-1.22.0/lib/libwayland-server.so.0
  No symbol table info available.
  #12 0x00007f430d1dc445 in wl_display_run () from /nix/store/ky1g6ylzr2m4bq8fy0gzrnqmjr6948k5-wayland-1.22.0/lib/libwayland-server.so.0
  No symbol table info available.
  #13 0x000000000041daa5 in server_run (server=server@entry=0x485440 <server>) at ../sway/server.c:338
  No locals.
  #14 0x000000000041cf4d in main (argc=<optimized out>, argv=0x7ffce1ed5fe8) at ../sway/main.c:415
          verbose = false
          debug = false
          validate = false
          allow_unsupported_gpu = false
          config_path = 0x0
        c = <optimized out>
```
where event->output->data is NULL:
```
  (gdb) p event->output->data
  $5 = (void *) 0x0
```
Created as draft since I haven't tested this yet, I'll be at an external monitor shortly.