### PR TITLE
Use wlr_cursor_set_xcursor()

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1070,8 +1070,7 @@ void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	if (!image) {
 		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
 	} else if (!current_image || strcmp(current_image, image) != 0) {
-		wlr_xcursor_manager_set_cursor_image(cursor->xcursor_manager, image,
-				cursor->cursor);
+		wlr_cursor_set_xcursor(cursor->cursor, cursor->xcursor_manager, image);
 	}
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -252,7 +252,7 @@ void cursor_update_image(struct sway_cursor *cursor,
 }
 
 static void cursor_hide(struct sway_cursor *cursor) {
-	wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+	wlr_cursor_unset_image(cursor->cursor);
 	cursor->hidden = true;
 	wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
 }
@@ -1068,7 +1068,7 @@ void cursor_set_image(struct sway_cursor *cursor, const char *image,
 	}
 
 	if (!image) {
-		wlr_cursor_set_image(cursor->cursor, NULL, 0, 0, 0, 0, 0, 0);
+		wlr_cursor_unset_image(cursor->cursor);
 	} else if (!current_image || strcmp(current_image, image) != 0) {
 		wlr_cursor_set_xcursor(cursor->cursor, cursor->xcursor_manager, image);
 	}


### PR DESCRIPTION
wlr_xcursor_manager_set_cursor_image() is deprecated.

References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4170