### PR TITLE
render: Use wlroots scale filter

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,6 @@ wlroots = dependency('wlroots', version: wlroots_version)
 wlroots_features = {
 	'xwayland': false,
 	'libinput_backend': false,
-	'gles2_renderer': false,
 	'session': false,
 }
 foreach name, _ : wlroots_features
@@ -75,7 +74,6 @@ pango = dependency('pango')
 pangocairo = dependency('pangocairo')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 pixman = dependency('pixman-1')
-glesv2 = wlroots_features['gles2_renderer'] ? dependency('glesv2') : null_dep
 libevdev = dependency('libevdev')
 libinput = wlroots_features['libinput_backend'] ? dependency('libinput', version: '>=1.21.0') : null_dep
 xcb = dependency('xcb', required: get_option('xwayland'))

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -223,7 +223,6 @@ sway_deps = [
 	math,
 	pango,
 	pcre2,
-	glesv2,
 	pixman,
 	threads,
 	wayland_server,


### PR DESCRIPTION
The old solution only worked with gles2. The new built in wlroots solution works with all renderers!