### PR TITLE
idle-inhibit-v1: simplify with server global

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -2,7 +2,6 @@
 #define _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_idle.h>
-#include "sway/server.h"
 
 enum sway_idle_inhibit_mode {
 	INHIBIT_IDLE_APPLICATION,  // Application set inhibitor (when visible)
@@ -16,12 +15,9 @@ struct sway_idle_inhibit_manager_v1 {
 	struct wlr_idle_inhibit_manager_v1 *wlr_manager;
 	struct wl_listener new_idle_inhibitor_v1;
 	struct wl_list inhibitors;
-
-	struct wlr_idle *idle;
 };
 
 struct sway_idle_inhibitor_v1 {
-	struct sway_idle_inhibit_manager_v1 *manager;
 	struct wlr_idle_inhibitor_v1 *wlr_inhibitor;
 	struct sway_view *view;
 	enum sway_idle_inhibit_mode mode;
@@ -33,8 +29,7 @@ struct sway_idle_inhibitor_v1 {
 bool sway_idle_inhibit_v1_is_active(
 	struct sway_idle_inhibitor_v1 *inhibitor);
 
-void sway_idle_inhibit_v1_check_active(
-	struct sway_idle_inhibit_manager_v1 *manager);
+void sway_idle_inhibit_v1_check_active(void);
 
 void sway_idle_inhibit_v1_user_inhibitor_register(struct sway_view *view,
 		enum sway_idle_inhibit_mode mode);
@@ -48,6 +43,6 @@ struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_application_inhibitor_for_vi
 void sway_idle_inhibit_v1_user_inhibitor_destroy(
 		struct sway_idle_inhibitor_v1 *inhibitor);
 
-struct sway_idle_inhibit_manager_v1 *sway_idle_inhibit_manager_v1_create(
-	struct wl_display *wl_display, struct wlr_idle *idle);
+bool sway_idle_inhibit_manager_v1_init(void);
+
 #endif

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -21,6 +21,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include "config.h"
 #include "list.h"
+#include "sway/desktop/idle_inhibit_v1.h"
 #if HAVE_XWAYLAND
 #include "sway/xwayland.h"
 #endif
@@ -53,7 +54,7 @@ struct sway_server {
 
 	struct wlr_idle *idle;
 	struct wlr_idle_notifier_v1 *idle_notifier_v1;
-	struct sway_idle_inhibit_manager_v1 *idle_inhibit_manager_v1;
+	struct sway_idle_inhibit_manager_v1 idle_inhibit_manager_v1;
 
 	struct wlr_layer_shell_v1 *layer_shell;
 	struct wl_listener layer_shell_surface;

--- a/sway/commands/inhibit_idle.c
+++ b/sway/commands/inhibit_idle.c
@@ -41,7 +41,7 @@ struct cmd_results *cmd_inhibit_idle(int argc, char **argv) {
 			sway_idle_inhibit_v1_user_inhibitor_destroy(inhibitor);
 		} else {
 			inhibitor->mode = mode;
-			sway_idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
+			sway_idle_inhibit_v1_check_active();
 		}
 	} else if (!clear) {
 		sway_idle_inhibit_v1_user_inhibitor_register(con->view, mode);

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -12,7 +12,7 @@
 static void destroy_inhibitor(struct sway_idle_inhibitor_v1 *inhibitor) {
 	wl_list_remove(&inhibitor->link);
 	wl_list_remove(&inhibitor->destroy.link);
-	sway_idle_inhibit_v1_check_active(inhibitor->manager);
+	sway_idle_inhibit_v1_check_active();
 	free(inhibitor);
 }
 
@@ -35,7 +35,6 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 		return;
 	}
 
-	inhibitor->manager = manager;
 	inhibitor->mode = INHIBIT_IDLE_APPLICATION;
 	inhibitor->wlr_inhibitor = wlr_inhibitor;
 	wl_list_insert(&manager->inhibitors, &inhibitor->link);
@@ -43,33 +42,34 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 	inhibitor->destroy.notify = handle_destroy;
 	wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->destroy);
 
-	sway_idle_inhibit_v1_check_active(manager);
+	sway_idle_inhibit_v1_check_active();
 }
 
 void sway_idle_inhibit_v1_user_inhibitor_register(struct sway_view *view,
 		enum sway_idle_inhibit_mode mode) {
+	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
+
 	struct sway_idle_inhibitor_v1 *inhibitor =
 		calloc(1, sizeof(struct sway_idle_inhibitor_v1));
 	if (!inhibitor) {
 		return;
 	}
 
-	inhibitor->manager = server.idle_inhibit_manager_v1;
 	inhibitor->mode = mode;
 	inhibitor->view = view;
-	wl_list_insert(&inhibitor->manager->inhibitors, &inhibitor->link);
+	wl_list_insert(&manager->inhibitors, &inhibitor->link);
 
 	inhibitor->destroy.notify = handle_destroy;
 	wl_signal_add(&view->events.unmap, &inhibitor->destroy);
 
-	sway_idle_inhibit_v1_check_active(inhibitor->manager);
+	sway_idle_inhibit_v1_check_active();
 }
 
 struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
 		struct sway_view *view) {
+	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
 	struct sway_idle_inhibitor_v1 *inhibitor;
-	wl_list_for_each(inhibitor, &server.idle_inhibit_manager_v1->inhibitors,
-			link) {
+	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
 		if (inhibitor->mode != INHIBIT_IDLE_APPLICATION &&
 				inhibitor->view == view) {
 			return inhibitor;
@@ -80,9 +80,9 @@ struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_user_inhibitor_for_view(
 
 struct sway_idle_inhibitor_v1 *sway_idle_inhibit_v1_application_inhibitor_for_view(
 		struct sway_view *view) {
+	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
 	struct sway_idle_inhibitor_v1 *inhibitor;
-	wl_list_for_each(inhibitor, &server.idle_inhibit_manager_v1->inhibitors,
-			link) {
+	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
 		if (inhibitor->mode == INHIBIT_IDLE_APPLICATION &&
 				view_from_wlr_surface(inhibitor->wlr_inhibitor->surface) == view) {
 			return inhibitor;
@@ -131,8 +131,8 @@ bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 	return false;
 }
 
-void sway_idle_inhibit_v1_check_active(
-		struct sway_idle_inhibit_manager_v1 *manager) {
+void sway_idle_inhibit_v1_check_active(void) {
+	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
 	struct sway_idle_inhibitor_v1 *inhibitor;
 	bool inhibited = false;
 	wl_list_for_each(inhibitor, &manager->inhibitors, link) {
@@ -140,28 +140,22 @@ void sway_idle_inhibit_v1_check_active(
 			break;
 		}
 	}
-	wlr_idle_set_enabled(manager->idle, NULL, !inhibited);
+	wlr_idle_set_enabled(server.idle, NULL, !inhibited);
 	wlr_idle_notifier_v1_set_inhibited(server.idle_notifier_v1, inhibited);
 }
 
-struct sway_idle_inhibit_manager_v1 *sway_idle_inhibit_manager_v1_create(
-		struct wl_display *wl_display, struct wlr_idle *idle) {
-	struct sway_idle_inhibit_manager_v1 *manager =
-		calloc(1, sizeof(struct sway_idle_inhibit_manager_v1));
-	if (!manager) {
-		return NULL;
+bool sway_idle_inhibit_manager_v1_init(void) {
+	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
+
+	manager->wlr_manager = wlr_idle_inhibit_v1_create(server.wl_display);
+	if (!manager->wlr_manager) {
+		return false;
 	}
 
-	manager->wlr_manager = wlr_idle_inhibit_v1_create(wl_display);
-	if (!manager->wlr_manager) {
-		free(manager);
-		return NULL;
-	}
-	manager->idle = idle;
 	wl_signal_add(&manager->wlr_manager->events.new_inhibitor,
 		&manager->new_idle_inhibitor_v1);
 	manager->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
 	wl_list_init(&manager->inhibitors);
 
-	return manager;
+	return true;
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -344,7 +344,7 @@ static void transaction_progress(void) {
 	server.queued_transaction = NULL;
 
 	if (!server.pending_transaction) {
-		sway_idle_inhibit_v1_check_active(server.idle_inhibit_manager_v1);
+		sway_idle_inhibit_v1_check_active();
 		return;
 	}
 

--- a/sway/server.c
+++ b/sway/server.c
@@ -130,8 +130,7 @@ bool server_init(struct sway_server *server) {
 
 	server->idle = wlr_idle_create(server->wl_display);
 	server->idle_notifier_v1 = wlr_idle_notifier_v1_create(server->wl_display);
-	server->idle_inhibit_manager_v1 =
-		sway_idle_inhibit_manager_v1_create(server->wl_display, server->idle);
+	sway_idle_inhibit_manager_v1_init();
 
 	server->layer_shell = wlr_layer_shell_v1_create(server->wl_display,
 		SWAY_LAYER_SHELL_VERSION);


### PR DESCRIPTION
We only have a single running server, no need to keep track of multiple server instances. Also no need to support multiple idle inhibit managers.