### PR TITLE
Drop support for KDE's idle protocol

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -1,7 +1,6 @@
 #ifndef _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
 #define _SWAY_DESKTOP_IDLE_INHIBIT_V1_H
 #include <wlr/types/wlr_idle_inhibit_v1.h>
-#include <wlr/types/wlr_idle.h>
 
 enum sway_idle_inhibit_mode {
 	INHIBIT_IDLE_APPLICATION,  // Application set inhibitor (when visible)

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -52,7 +52,6 @@ struct sway_server {
 	struct wl_listener new_output;
 	struct wl_listener output_layout_change;
 
-	struct wlr_idle *idle;
 	struct wlr_idle_notifier_v1 *idle_notifier_v1;
 	struct sway_idle_inhibit_manager_v1 idle_inhibit_manager_v1;
 

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include "log.h"
 #include "sway/desktop/idle_inhibit_v1.h"
@@ -140,7 +139,6 @@ void sway_idle_inhibit_v1_check_active(void) {
 			break;
 		}
 	}
-	wlr_idle_set_enabled(server.idle, NULL, !inhibited);
 	wlr_idle_notifier_v1_set_inhibited(server.idle_notifier_v1, inhibited);
 }
 

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -8,7 +8,6 @@
 #include <strings.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_tablet_v2.h>

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -4,7 +4,6 @@
 #include <wlr/config.h>
 #include <wlr/backend/multi.h>
 #include <wlr/interfaces/wlr_keyboard.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <xkbcommon/xkbcommon-names.h>

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -7,7 +7,6 @@
 #include <wlr/config.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -103,7 +102,6 @@ void seat_idle_notify_activity(struct sway_seat *seat,
 	if ((source & seat->idle_inhibit_sources) == 0) {
 		return;
 	}
-	wlr_idle_notify_activity(server.idle, seat->wlr_seat);
 	wlr_idle_notifier_v1_notify_activity(server.idle_notifier_v1, seat->wlr_seat);
 }
 

--- a/sway/input/switch.c
+++ b/sway/input/switch.c
@@ -1,6 +1,5 @@
 #include "sway/config.h"
 #include "sway/input/switch.h"
-#include <wlr/types/wlr_idle.h>
 #include "log.h"
 
 struct sway_switch *sway_switch_create(struct sway_seat *seat,

--- a/sway/server.c
+++ b/sway/server.c
@@ -17,7 +17,6 @@
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_linux_dmabuf_v1.h>
@@ -145,7 +144,6 @@ bool server_init(struct sway_server *server) {
 
 	wlr_xdg_output_manager_v1_create(server->wl_display, root->output_layout);
 
-	server->idle = wlr_idle_create(server->wl_display);
 	server->idle_notifier_v1 = wlr_idle_notifier_v1_create(server->wl_display);
 	sway_idle_inhibit_manager_v1_init();
 


### PR DESCRIPTION
We support the standard idle-notify protocol since Sway 1.8: https://github.com/swaywm/sway/commit/9400bd963c59fd59f597c1477b8021a82ca0a72e

~~Depends on #7641~~