### PR TITLE
Add support for security-context-v1

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -114,6 +114,10 @@ struct sway_server {
 	struct wlr_text_input_manager_v3 *text_input;
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 	struct wlr_content_type_manager_v1 *content_type_manager_v1;
+	struct wlr_data_control_manager_v1 *data_control_manager_v1;
+	struct wlr_screencopy_manager_v1 *screencopy_manager_v1;
+	struct wlr_export_dmabuf_manager_v1 *export_dmabuf_manager_v1;
+	struct wlr_security_context_manager_v1 *security_context_manager_v1;
 
 	struct wlr_xdg_activation_v1 *xdg_activation_v1;
 	struct wl_listener xdg_activation_v1_request_activate;

--- a/sway/server.c
+++ b/sway/server.c
@@ -24,8 +24,9 @@
 #include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
-#include <wlr/types/wlr_single_pixel_buffer_v1.h>
+#include <wlr/types/wlr_security_context_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
+#include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_viewporter.h>
@@ -73,6 +74,25 @@ static void handle_drm_lease_request(struct wl_listener *listener, void *data) {
 }
 #endif
 
+static bool is_privileged(const struct wl_global *global) {
+	return
+		global == server.output_manager_v1->global ||
+		global == server.output_power_manager_v1->global ||
+		global == server.input_method->global ||
+		global == server.foreign_toplevel_manager->global ||
+		global == server.data_control_manager_v1->global ||
+		global == server.screencopy_manager_v1->global ||
+		global == server.export_dmabuf_manager_v1->global ||
+		global == server.security_context_manager_v1->global ||
+		global == server.gamma_control_manager_v1->global ||
+		global == server.layer_shell->global ||
+		global == server.session_lock.manager->global ||
+		global == server.input->inhibit->global ||
+		global == server.input->keyboard_shortcuts_inhibit->global ||
+		global == server.input->virtual_keyboard->global ||
+		global == server.input->virtual_pointer->global;
+}
+
 static bool filter_global(const struct wl_client *client,
 		const struct wl_global *global, void *data) {
 #if HAVE_XWAYLAND
@@ -81,6 +101,15 @@ static bool filter_global(const struct wl_client *client,
 		return xwayland->server != NULL && client == xwayland->server->client;
 	}
 #endif
+
+	// Restrict usage of privileged protocols to unsandboxed clients
+	// TODO: add a way for users to configure an allow-list
+	const struct wlr_security_context_v1_state *security_context =
+		wlr_security_context_manager_v1_lookup_client(
+		server.security_context_manager_v1, (struct wl_client *)client);
+	if (is_privileged(global)) {
+		return security_context == NULL;
+	}
 
 	return true;
 }
@@ -226,9 +255,10 @@ bool server_init(struct sway_server *server) {
 	}
 #endif
 
-	wlr_export_dmabuf_manager_v1_create(server->wl_display);
-	wlr_screencopy_manager_v1_create(server->wl_display);
-	wlr_data_control_manager_v1_create(server->wl_display);
+	server->export_dmabuf_manager_v1 = wlr_export_dmabuf_manager_v1_create(server->wl_display);
+	server->screencopy_manager_v1 = wlr_screencopy_manager_v1_create(server->wl_display);
+	server->data_control_manager_v1 = wlr_data_control_manager_v1_create(server->wl_display);
+	server->security_context_manager_v1 = wlr_security_context_manager_v1_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);
 	wlr_single_pixel_buffer_manager_v1_create(server->wl_display);
 	server->content_type_manager_v1 =


### PR DESCRIPTION
As a first step, deny access to privileged protocols to sandboxed
apps.

References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3589  
Depends on #7647