### PR TITLE
input: Move wlr_pointer_gestures_v1 to sway_input_manager

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -35,7 +35,6 @@ struct sway_cursor {
 	pixman_region32_t confine; // invalid if active_constraint == NULL
 	bool active_confine_requires_warp;
 
-	struct wlr_pointer_gestures_v1 *pointer_gestures;
 	struct wl_listener hold_begin;
 	struct wl_listener hold_end;
 	struct wl_listener pinch_begin;

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -25,6 +25,7 @@ struct sway_input_manager {
 	struct wlr_keyboard_shortcuts_inhibit_manager_v1 *keyboard_shortcuts_inhibit;
 	struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard;
 	struct wlr_virtual_pointer_manager_v1 *virtual_pointer;
+	struct wlr_pointer_gestures_v1 *pointer_gestures;
 
 	struct wl_listener new_input;
 	struct wl_listener inhibit_activate;

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1154,9 +1154,6 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 	wl_list_init(&cursor->image_surface_destroy.link);
 	cursor->image_surface_destroy.notify = handle_image_surface_destroy;
 
-	// gesture events
-	cursor->pointer_gestures = wlr_pointer_gestures_v1_create(server.wl_display);
-
 	wl_signal_add(&wlr_cursor->events.hold_begin, &cursor->hold_begin);
 	cursor->hold_begin.notify = handle_pointer_hold_begin;
 	wl_signal_add(&wlr_cursor->events.hold_end, &cursor->hold_end);

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -495,6 +495,8 @@ struct sway_input_manager *input_manager_create(struct sway_server *server) {
 	wl_signal_add(&input->keyboard_shortcuts_inhibit->events.new_inhibitor,
 			&input->keyboard_shortcuts_inhibit_new_inhibitor);
 
+	input->pointer_gestures = wlr_pointer_gestures_v1_create(server->wl_display);
+
 	return input;
 }
 

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -949,7 +949,7 @@ static void handle_hold_begin(struct sway_seat *seat,
 		// ... otherwise forward to client
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_hold_begin(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->fingers);
 	}
 }
@@ -961,7 +961,7 @@ static void handle_hold_end(struct sway_seat *seat,
 	if (!gesture_tracker_check(&seatop->gestures, GESTURE_TYPE_HOLD)) {
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_hold_end(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->cancelled);
 		return;
 	}
@@ -994,7 +994,7 @@ static void handle_pinch_begin(struct sway_seat *seat,
 		// ... otherwise forward to client
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_pinch_begin(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->fingers);
 	}
 }
@@ -1010,7 +1010,7 @@ static void handle_pinch_update(struct sway_seat *seat,
 		// ... otherwise forward to client
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_pinch_update(
-			cursor->pointer_gestures,
+			server.input->pointer_gestures,
 			cursor->seat->wlr_seat,
 			event->time_msec, event->dx, event->dy,
 			event->scale, event->rotation);
@@ -1024,7 +1024,7 @@ static void handle_pinch_end(struct sway_seat *seat,
 	if (!gesture_tracker_check(&seatop->gestures, GESTURE_TYPE_PINCH)) {
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_pinch_end(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->cancelled);
 		return;
 	}
@@ -1057,7 +1057,7 @@ static void handle_swipe_begin(struct sway_seat *seat,
 		// ... otherwise forward to client
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_swipe_begin(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->fingers);
 	}
 }
@@ -1074,7 +1074,7 @@ static void handle_swipe_update(struct sway_seat *seat,
 		// ... otherwise forward to client
 		struct sway_cursor *cursor = seat->cursor;
 		wlr_pointer_gestures_v1_send_swipe_update(
-			cursor->pointer_gestures, cursor->seat->wlr_seat,
+			server.input->pointer_gestures, cursor->seat->wlr_seat,
 			event->time_msec, event->dx, event->dy);
 	}
 }
@@ -1085,7 +1085,7 @@ static void handle_swipe_end(struct sway_seat *seat,
 	struct seatop_default_event *seatop = seat->seatop_data;
 	if (!gesture_tracker_check(&seatop->gestures, GESTURE_TYPE_SWIPE)) {
 		struct sway_cursor *cursor = seat->cursor;
-		wlr_pointer_gestures_v1_send_swipe_end(cursor->pointer_gestures,
+		wlr_pointer_gestures_v1_send_swipe_end(server.input->pointer_gestures,
 			cursor->seat->wlr_seat, event->time_msec, event->cancelled);
 		return;
 	}


### PR DESCRIPTION
On multi-seat configurations a zwp_pointer_gestures_v1 global was created for every seat.

Instead, create the global once in the input manager, to be shared across all seats.