### PR TITLE
swaybar: don't set current workspace as not visible

### DIFF
--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -207,7 +207,7 @@ static void workspace_next(struct swaybar *bar, struct swaybar_output *output,
 		}
 	}
 
-	if (new) {
+	if (new && new != active) {
 		ipc_send_workspace_command(bar, new->name);
 
 		// Since we're asking Sway to switch to 'new', it should become visible.


### PR DESCRIPTION
When there's only one workspace open, swaybar will mark it as not visible if the user scrolls on it and eventually incorrectly fail the `active->visible` assert. Fix this by making sure that new and current workspace aren't the same.