### PR TITLE
input/seat: don't reset cursor in seat_configure_xcursor()

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1080,9 +1080,6 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 		}
 	}
 
-	// Reset the cursor so that we apply it to outputs that just appeared
-	cursor_set_image(seat->cursor, NULL, NULL);
-	cursor_set_image(seat->cursor, "default", NULL);
 	wlr_cursor_warp(seat->cursor->cursor, NULL, seat->cursor->cursor->x,
 		seat->cursor->cursor->y);
 }


### PR DESCRIPTION
This is handled by wlroots now.

References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4231