### PR TITLE
signal readiness to sd-daemon

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -26,6 +26,12 @@
 #include "stringop.h"
 #include "util.h"
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#elif HAVE_LIBELOGIND
+#include <elogind/sd-daemon.h>
+#endif
+
 static bool terminate_request = false;
 static int exit_value = 0;
 static struct rlimit original_nofile_rlimit = {0};
@@ -411,6 +417,11 @@ int main(int argc, char **argv) {
 	if (config->swaynag_config_errors.client != NULL) {
 		swaynag_show(&config->swaynag_config_errors);
 	}
+
+#if defined(HAVE_LIBSYSTEMD) || defined(HAVE_LIBELOGIND)
+	/* Signal systemd that we are ready to accept connections */
+	sd_notify(0, "READY=1");
+#endif
 
 	server_run(&server);
 

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -236,6 +236,10 @@ if have_xwayland
 	sway_sources += 'desktop/xwayland.c'
 endif
 
+if sdbus.found()
+	sway_deps += sdbus
+endif
+
 if wlroots_features['libinput_backend']
 	sway_sources += 'input/libinput.c'
 endif


### PR DESCRIPTION
This allows systemd to notice sway's startup is complete which allows, for example, the session manager to start Wayland programs in the right order. Without this signal, users have to go through rather horrible hacks to tell systemd that it can start further units.

I've been using `NotifyAccess=all` in the sway.service file and `exec systemd-notify --ready` in my sway config to emulate this, but it's racy and error-prone.

A particularly nasty bug triggered by `NotifyAccess=all` in particular is when podman starts and then terminates a container. In that context, conmon(8) ends up notifying systemd it's the session master and takes over thee "Main PID" field in systemd. When it dies, systemd believes the session is over and proceeds to kill the entire session. This is explained in more details in:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039857

This might not actually be the right place to do this. We call `server_run` right after, and maybe there would be a better place. But `server_run` only calls `wl_display_run` and that's part of the core `wayland` library. I'm not sure Wayland itself is a place to do this, so for now I'm scratching my own itch and doing this in Sway itself.