### PR TITLE
swaybar: handle wayland-cursor failures

### DIFF
--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -81,8 +81,16 @@ void update_cursor(struct swaybar_seat *seat) {
 	int scale = pointer->current ? pointer->current->scale : 1;
 	pointer->cursor_theme = wl_cursor_theme_load(
 		cursor_theme, cursor_size * scale, seat->bar->shm);
+	if (!pointer->cursor_theme) {
+		sway_log(SWAY_ERROR, "Failed to load cursor theme");
+		return;
+	}
 	struct wl_cursor *cursor;
 	cursor = wl_cursor_theme_get_cursor(pointer->cursor_theme, "default");
+	if (!cursor) {
+		sway_log(SWAY_ERROR, "Failed to get default cursor from theme");
+		return;
+	}
 	pointer->cursor_image = cursor->images[0];
 	wl_surface_set_buffer_scale(pointer->cursor_surface, scale);
 	wl_surface_attach(pointer->cursor_surface,


### PR DESCRIPTION
This fixes a rare crash when [`wl_cursor_theme_get_cursor`](https://gitlab.freedesktop.org/wayland/wayland/-/blob/6d3334657180f3663b8d83636f4d1bc2097492d2/cursor/wayland-cursor.c#L439-449) fails and returns NULL. This crash will not happen under normal usage -- I suspect the one computer I have for which this happens has a broken set of cursor config files. Still, even in that situation I think it is better to print an error than segfault or suddenly exit.