### PR TITLE
Deprecate seat idle_wake

### DIFF
--- a/sway/commands/seat/idle.c
+++ b/sway/commands/seat/idle.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <strings.h>
 #include <stdint.h>
+#include "log.h"
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/input/seat.h"
@@ -69,5 +70,10 @@ struct cmd_results *seat_cmd_idle_wake(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Invalid idle source");
 	}
 	config->handler_context.seat_config->idle_wake_sources = sources;
+	sway_log(SWAY_INFO, "Warning: seat idle_wake is deprecated");
+	if (config->reading) {
+		config_add_swaynag_warning("seat idle_wake is deprecated. "
+			"Only seat idle_inhibit is supported.");
+	}
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -100,22 +100,11 @@ void seat_destroy(struct sway_seat *seat) {
 
 void seat_idle_notify_activity(struct sway_seat *seat,
 		enum sway_input_idle_source source) {
-	uint32_t mask = seat->idle_inhibit_sources;
-	struct wlr_idle_timeout *timeout;
-	int ntimers = 0, nidle = 0;
-	wl_list_for_each(timeout, &server.idle->idle_timers, link) {
-		++ntimers;
-		if (timeout->idle_state) {
-			++nidle;
-		}
+	if ((source & seat->idle_inhibit_sources) == 0) {
+		return;
 	}
-	if (nidle == ntimers) {
-		mask = seat->idle_wake_sources;
-	}
-	if ((source & mask) > 0) {
-		wlr_idle_notify_activity(server.idle, seat->wlr_seat);
-		wlr_idle_notifier_v1_notify_activity(server.idle_notifier_v1, seat->wlr_seat);
-	}
+	wlr_idle_notify_activity(server.idle, seat->wlr_seat);
+	wlr_idle_notifier_v1_notify_activity(server.idle_notifier_v1, seat->wlr_seat);
 }
 
 /**

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -268,12 +268,6 @@ correct seat.
 	"keyboard", "pointer", "touchpad", "touch", "tablet_pad", "tablet_tool",
 	and "switch". The default behavior is to prevent idle on any event.
 
-*seat* <name> idle_wake <sources...>
-	Sets the set of input event sources which can wake the seat from
-	its idle state, as a space separated list of source names. Valid names are
-	"keyboard", "pointer", "touchpad", "touch", "tablet_pad", "tablet_tool",
-	and "switch". The default behavior is to wake from idle on any event.
-
 *seat* <name> keyboard_grouping none|smart
 	Set how the keyboards in the seat are grouped together. Currently, there
 	are two options. _none_ will disable all keyboard grouping. This will make


### PR DESCRIPTION
Sway has two knobs to control idling:

- seat idle_inhibit: when the seat is active (ie. not idle), this extends the active state. When the seat is idle, this is ignored.
- seat idle_wake: when the seat is idle, this wakes up the seat. When the seat is active, this is ignored.

The motivation for the deprecation is two-fold:

- The concept of "seat idle state" is ill-defined. Each idle-notify-v1 client will pass a different idle timeout. With the old logic, a seat was declared idle if and only if all idle-notify-v1 timeouts have expired. However, if only a portion of the timeouts have expired, then some clients would wake up, and the rest would stay active. This is inconsistent with the definition of idle_inhibit/idle_wake: idle_inhibit was used for clients which are waking up.
- It never worked properly with the new idle-notify-v1 protocol and no-one noticed. Only the legacy KDE idle protocol is taken into account, but that protocol is not used anymore.