### PR TITLE
swaynag: handle wayland-cursor failures

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -153,8 +153,16 @@ static void update_cursor(struct swaynag_seat *seat) {
 	}
 	pointer->cursor_theme = wl_cursor_theme_load(
 		cursor_theme, cursor_size * swaynag->scale, swaynag->shm);
+	if (!pointer->cursor_theme) {
+		sway_log(SWAY_ERROR, "Failed to load cursor theme");
+		return;
+	}
 	struct wl_cursor *cursor =
 		wl_cursor_theme_get_cursor(pointer->cursor_theme, "default");
+	if (!cursor) {
+		sway_log(SWAY_ERROR, "Failed to get default cursor from theme");
+		return;
+	}
 	pointer->cursor_image = cursor->images[0];
 	wl_surface_set_buffer_scale(pointer->cursor_surface,
 			swaynag->scale);


### PR DESCRIPTION
Same as 92244c87dbb8 ("swaybar: handle wayland-cursor failures") but for swaynag.

Closes: https://github.com/swaywm/sway/issues/7671