### PR TITLE
chase wlroots 'presentation-time: add separate helper for zero-copy '

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -530,7 +530,7 @@ static bool scan_out_fullscreen_view(struct sway_output *output,
 		return false;
 	}
 
-	wlr_presentation_surface_sampled_on_output(server.presentation, surface,
+	wlr_presentation_surface_scanned_out_on_output(server.presentation, surface,
 		wlr_output);
 
 	return wlr_output_commit_state(wlr_output, pending);

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -150,7 +150,7 @@ static void render_surface_iterator(struct sway_output *output,
 	render_texture(data->ctx, texture,
 		&src_box, &dst_box, &clip_box, surface->current.transform, alpha);
 
-	wlr_presentation_surface_sampled_on_output(server.presentation, surface,
+	wlr_presentation_surface_textured_on_output(server.presentation, surface,
 		wlr_output);
 }
 


### PR DESCRIPTION
```
sway-unwrapped> ../sway/desktop/render.c: In function 'render_surface_iterator':
sway-unwrapped> ../sway/desktop/render.c:153:9: error: implicit declaration of function 'wlr_presentation_surface_sampled_on_output'; did you mean 'wlr_presentation_surface_textured_on_output'? [-Werror=implicit-function-declaration]
sway-unwrapped>   153 |         wlr_presentation_surface_sampled_on_output(server.presentation, surface,
sway-unwrapped>       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sway-unwrapped>       |         wlr_presentation_surface_textured_on_output
```

https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/67447d6cb407ac5b6405b4dbae01a38567feb111

I don't know if it should be
`wlr_presentation_surface_textured_on_output`
or
`wlr_presentation_surface_scanned_out_on_output`

@emersion Please advice