### PR TITLE
view: update wlr_toplevel size on client resizes

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -931,6 +931,11 @@ void view_update_size(struct sway_view *view) {
 	con->pending.content_width = view->geometry.width;
 	con->pending.content_height = view->geometry.height;
 	container_set_geometry_from_content(con);
+
+	// Update the next scheduled width/height so correct coordinates
+	// are sent on the next toplevel configure from wlroots.
+	wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
+		view->geometry.height);
 }
 
 void view_center_surface(struct sway_view *view) {


### PR DESCRIPTION
If a floating client resizes itself, sway updates several of its internal dimensions to match but not wlr_toplevel. This means that the next time wlroots sends a toplevel configure event, it can have wrong coordinates that resize the client back to its old size. To fix this, let's just use wlr_xdg_toplevel_set_size so the wlr_toplevel has the same dimensions as sway. Fixes #5266.