### PR TITLE
commands: lift restrictions on toggle all outputs

### DIFF
--- a/sway/commands/output/power.c
+++ b/sway/commands/output/power.c
@@ -16,8 +16,14 @@ struct cmd_results *output_cmd_power(int argc, char **argv) {
 	if (strcasecmp(argv[0], "toggle") == 0) {
 		const char *oc_name = config->handler_context.output_config->name;
 		if (strcmp(oc_name, "*") == 0) {
-			return cmd_results_new(CMD_INVALID,
-				"Cannot apply toggle to all outputs");
+			for (int i = 0; i < config->output_configs->length; i++) {
+				struct output_config *oc = config->output_configs->items[i];
+				oc->power = !oc->power;
+			}
+
+			config->handler_context.leftovers.argc = argc - 1;
+			config->handler_context.leftovers.argv = argv + 1;
+			return NULL;
 		}
 
 		struct sway_output *sway_output = all_output_by_name_or_id(oc_name);

--- a/sway/commands/output/toggle.c
+++ b/sway/commands/output/toggle.c
@@ -7,29 +7,31 @@ struct cmd_results *output_cmd_toggle(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "Missing output config");
 	}
 
-	struct output_config *oc = config->handler_context.output_config;
-
-	if (strcmp(oc->name, "*") == 0) {
-		return cmd_results_new(CMD_INVALID,
-				"Cannot apply toggle to all outputs.");
-	}
-
-	struct sway_output *sway_output = all_output_by_name_or_id(oc->name);
-
-	if (sway_output == NULL) {
-		return cmd_results_new(CMD_FAILURE,
-				"Cannot apply toggle to unknown output %s", oc->name);
-	}
-
-	oc = find_output_config(sway_output);
-
-	if (!oc || oc->enabled != 0) {
-		config->handler_context.output_config->enabled = 0;
+	if (strcmp(config->handler_context.output_config->name, "*") == 0) {
+		for (int i = 0; i < config->output_configs->length; i++) {
+			struct output_config *oc = config->output_configs->items[i];
+			oc->enabled = !oc->enabled;
+		}
 	} else {
-		config->handler_context.output_config->enabled = 1;
+		struct output_config *oc = config->handler_context.output_config;
+		struct sway_output *sway_output = all_output_by_name_or_id(oc->name);
+
+		if (sway_output == NULL) {
+			return cmd_results_new(CMD_FAILURE,
+					"Cannot apply toggle to unknown output %s", oc->name);
+		}
+
+		oc = find_output_config(sway_output);
+
+		if (!oc || oc->enabled != 0) {
+			config->handler_context.output_config->enabled = 0;
+		} else {
+			config->handler_context.output_config->enabled = 1;
+		}
+
+		free(oc);
 	}
 
-	free(oc);
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
 	return NULL;


### PR DESCRIPTION
Toggle all outputs on and off based on the state of the first output. Useful in key bindings, because toggling all outputs can't perform concurrently. The delay adds up.

Such command is semantically valid and useful in practice, so the restrictions should be lifted.