### PR TITLE
view: send scale notification when the output is known

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -6,6 +6,7 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
+#include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_subcompositor.h>
@@ -739,6 +740,14 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 	if (!ws) {
 		ws = select_workspace(view);
+	}
+
+	if (ws && ws->output) {
+		// Once the output is determined, we can notify the client early about
+		// scale to reduce startup jitter.
+		float scale = ws->output->wlr_output->scale;
+		wlr_fractional_scale_v1_notify_scale(wlr_surface, scale);
+		wlr_surface_set_preferred_buffer_scale(wlr_surface, ceil(scale));
 	}
 
 	struct sway_seat *seat = input_manager_current_seat();


### PR DESCRIPTION
One of the nice things about explicit scale notifications is that it erases any confusion that would necessitate hacks like #6479. We should really take advantage of this to be nicer to fast clients, letting them know the intended scale as early as possible.

Ideally we would also send a better guess at the correct dimensions too, but that's a longstanding bug (can't find an issue for it though?) and a bit more of a hassle.

In practice, I observe the following less-than-ideal behavior on master: with the release of foot 1.15.2, my zsh prompt is reflowed after the first frame because the terminal initially has a larger number of columns than the 1.5 scale actually permits in the final window geometry. As a result, my zsh prompt begins on the second line instead of the first of a new terminal.