### PR TITLE
Make floating_modifier respect shortcuts_inhibitor

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -507,6 +507,7 @@ struct sway_config {
 	struct bar_config *current_bar;
 	uint32_t floating_mod;
 	bool floating_mod_inverse;
+	bool floating_mod_inhibited;
 	uint32_t dragging_key;
 	uint32_t resizing_key;
 	char *floating_scroll_up_cmd;

--- a/sway/commands/floating_modifier.c
+++ b/sway/commands/floating_modifier.c
@@ -19,13 +19,22 @@ struct cmd_results *cmd_floating_modifier(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "Invalid modifier");
 	}
 
-	if (argc == 1 || strcasecmp(argv[1], "normal") == 0) {
-		config->floating_mod_inverse = false;
-	} else if (strcasecmp(argv[1], "inverse") == 0) {
-		config->floating_mod_inverse = true;
-	} else {
-		return cmd_results_new(CMD_INVALID,
-				"Usage: floating_modifier <mod> [inverse|normal]");
+	argv++;
+	argc--;
+	while (argc > 0)
+	{
+		if (strcasecmp(argv[0], "normal") == 0) {
+			config->floating_mod_inverse = false;
+		} else if (strcasecmp(argv[0], "inverse") == 0) {
+			config->floating_mod_inverse = true;
+		} else if (strcasecmp(argv[0], "--inhibited") == 0){
+			config->floating_mod_inhibited = true;
+		} else {
+			return cmd_results_new(CMD_INVALID,
+					"Usage: floating_modifier <mod> [inverse|normal [--inhibited]");
+		}
+		argv++;
+		argc--;
 	}
 
 	config->floating_mod = mod;

--- a/sway/config.c
+++ b/sway/config.c
@@ -242,6 +242,7 @@ static void config_defaults(struct sway_config *config) {
 
 	config->floating_mod = 0;
 	config->floating_mod_inverse = false;
+	config->floating_mod_inhibited = false;
 	config->dragging_key = BTN_LEFT;
 	config->resizing_key = BTN_RIGHT;
 

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -247,8 +247,12 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 		bool is_floating_or_child = container_is_floating_or_child(cont);
 		bool is_fullscreen_or_child = container_is_fullscreen_or_child(cont);
 		struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat->wlr_seat);
+		struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor =
+			keyboard_shortcuts_inhibitor_get_for_focused_surface(seat);
+		bool shortcuts_inhibited = sway_inhibitor && sway_inhibitor->inhibitor->active;
 		bool mod_pressed = keyboard &&
-			(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod);
+			(wlr_keyboard_get_modifiers(keyboard) & config->floating_mod)
+			&& (!shortcuts_inhibited || config->floating_mod_inhibited);
 
 		// Handle beginning floating move
 		if (is_floating_or_child && !is_fullscreen_or_child && mod_pressed) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -403,7 +403,12 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 
 	// Handle tiling resize via mod
-	bool mod_pressed = modifiers & config->floating_mod;
+	struct sway_keyboard_shortcuts_inhibitor *sway_inhibitor =
+		keyboard_shortcuts_inhibitor_get_for_focused_surface(seat);
+	bool shortcuts_inhibited = sway_inhibitor && sway_inhibitor->inhibitor->active;
+	bool mod_pressed = modifiers & config->floating_mod && (!shortcuts_inhibited
+		|| config->floating_mod_inhibited);
+
 	if (cont && !is_floating_or_child && mod_pressed &&
 			state == WL_POINTER_BUTTON_STATE_PRESSED) {
 		uint32_t btn_resize = config->floating_mod_inverse ?


### PR DESCRIPTION
floating_modifier is currently triggered when the modifier is pressed,
and when a mouse's left or right button is pressed even if there is an
existing shortcuts_inhibitor.  This changes the default behavior to only
change the current seatop when there is no active shortcuts_inhibitor.
I've added an additional optional `--inhibited` option to the
`floating_modifier` command.  When `--inhibited` is passed, the seatop
is changed regardless of if there is an active shortcuts_inhibitor.