### PR TITLE
Add render_format to get_outputs IPC command

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -197,4 +197,6 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 
 struct sway_output_non_desktop *output_non_desktop_create(struct wlr_output *wlr_output);
 
+const char *sway_render_format_to_string(uint32_t render_format);
+
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -199,4 +199,6 @@ struct sway_output_non_desktop *output_non_desktop_create(struct wlr_output *wlr
 
 const char *sway_render_format_to_string(uint32_t render_format);
 
+int sway_render_format_to_bit_depth(uint32_t render_format);
+
 #endif

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -377,6 +377,18 @@ static const uint32_t *bit_depth_preferences[] = {
 	},
 };
 
+int sway_render_format_to_bit_depth(uint32_t render_format) {
+	switch (render_format) {
+		case DRM_FORMAT_XRGB2101010:
+		case DRM_FORMAT_XBGR2101010:
+			return 10;
+		case DRM_FORMAT_XRGB8888:
+			return 8;
+		default:
+			return -1;
+	}
+}
+
 const char *sway_render_format_to_string(uint32_t render_format) {
 	switch (render_format) {
 		case DRM_FORMAT_XRGB2101010:
@@ -389,7 +401,7 @@ const char *sway_render_format_to_string(uint32_t render_format) {
 			return "INVALID";
 		default:
 			return "UNKNOWN";
-		}
+	}
 }
 
 static void queue_output_config(struct output_config *oc,

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -377,6 +377,21 @@ static const uint32_t *bit_depth_preferences[] = {
 	},
 };
 
+const char *sway_render_format_to_string(uint32_t render_format) {
+	switch (render_format) {
+		case DRM_FORMAT_XRGB2101010:
+			return "XRGB2101010";
+		case DRM_FORMAT_XBGR2101010:
+			return "XBGR2101010";
+		case DRM_FORMAT_XRGB8888:
+			return "XRGB8888";
+		case DRM_FORMAT_INVALID:
+			return "INVALID";
+		default:
+			return "UNKNOWN";
+		}
+}
+
 static void queue_output_config(struct output_config *oc,
 		struct sway_output *output, struct wlr_output_state *pending) {
 	if (output == root->fallback_output) {

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -693,6 +693,9 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 			const char *render_format = sway_render_format_to_string(output->wlr_output->render_format);
 			json_object_object_add(output_json, "render_format", json_object_new_string(render_format));
 
+			const int bit_depth = sway_render_format_to_bit_depth(output->wlr_output->render_format);
+			json_object_object_add(output_json, "render_bit_depth", json_object_new_int(bit_depth));
+
 			json_object_array_add(outputs, output_json);
 		}
 		struct sway_output *output;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -689,6 +689,10 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 
 			const char *subpixel = sway_wl_output_subpixel_to_string(output->wlr_output->subpixel);
 			json_object_object_add(output_json, "subpixel_hinting", json_object_new_string(subpixel));
+
+			const char *render_format = sway_render_format_to_string(output->wlr_output->render_format);
+			json_object_object_add(output_json, "render_format", json_object_new_string(render_format));
+
 			json_object_array_add(outputs, output_json);
 		}
 		struct sway_output *output;

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -226,6 +226,9 @@ following properties:
 |- subpixel_hinting
 :  string
 :  The subpixel hinting currently in use on the output. This can be _rgb_, _bgr_, _vrgb_, _vbgr_, or _none_
+|- render_bit_depth
+:  integer
+:  The render bit depth currently in use on the output.
 |- render_format
 :  string
 :  The render format currently in use on the output.

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -225,7 +225,10 @@ following properties:
 :  The scale currently in use on the output or _-1_ for disabled outputs
 |- subpixel_hinting
 :  string
-:  The subpixel hinting current in use on the output. This can be _rgb_, _bgr_, _vrgb_, _vbgr_, or _none_
+:  The subpixel hinting currently in use on the output. This can be _rgb_, _bgr_, _vrgb_, _vbgr_, or _none_
+|- render_format
+:  string
+:  The render format currently in use on the output.
 |- transform
 :  string
 :  The transform currently in use for the output. This can be _normal_, _90_,
@@ -258,6 +261,7 @@ following properties:
 		"primary": false,
 		"scale": 1.0,
 		"subpixel_hinting": "rgb",
+		"render_format": "XRGB8888",
 		"transform": "normal",
 		"current_workspace": "1",
 		"modes": [

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -194,14 +194,14 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(o, "current_workspace", &ws);
 	json_object_object_get_ex(o, "non_desktop", &non_desktop);
 	json_object *make, *model, *serial, *scale, *scale_filter, *subpixel,
-		*render_format, *transform, *max_render_time, *adaptive_sync_status;
+		*bit_depth, *transform, *max_render_time, *adaptive_sync_status;
 	json_object_object_get_ex(o, "make", &make);
 	json_object_object_get_ex(o, "model", &model);
 	json_object_object_get_ex(o, "serial", &serial);
 	json_object_object_get_ex(o, "scale", &scale);
 	json_object_object_get_ex(o, "scale_filter", &scale_filter);
 	json_object_object_get_ex(o, "subpixel_hinting", &subpixel);
-	json_object_object_get_ex(o, "render_format", &render_format);
+	json_object_object_get_ex(o, "render_bit_depth", &bit_depth);
 	json_object_object_get_ex(o, "transform", &transform);
 	json_object_object_get_ex(o, "max_render_time", &max_render_time);
 	json_object_object_get_ex(o, "adaptive_sync_status", &adaptive_sync_status);
@@ -233,7 +233,7 @@ static void pretty_print_output(json_object *o) {
 			"  Scale factor: %f\n"
 			"  Scale filter: %s\n"
 			"  Subpixel hinting: %s\n"
-			"  Render format: %s\n"
+			"  Render bit depth: %d\n"
 			"  Transform: %s\n"
 			"  Workspace: %s\n",
 			json_object_get_string(name),
@@ -249,7 +249,7 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_double(scale),
 			json_object_get_string(scale_filter),
 			json_object_get_string(subpixel),
-			json_object_get_string(render_format),
+			json_object_get_int(bit_depth),
 			json_object_get_string(transform),
 			json_object_get_string(ws)
 		);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -194,13 +194,14 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(o, "current_workspace", &ws);
 	json_object_object_get_ex(o, "non_desktop", &non_desktop);
 	json_object *make, *model, *serial, *scale, *scale_filter, *subpixel,
-		*transform, *max_render_time, *adaptive_sync_status;
+		*render_format, *transform, *max_render_time, *adaptive_sync_status;
 	json_object_object_get_ex(o, "make", &make);
 	json_object_object_get_ex(o, "model", &model);
 	json_object_object_get_ex(o, "serial", &serial);
 	json_object_object_get_ex(o, "scale", &scale);
 	json_object_object_get_ex(o, "scale_filter", &scale_filter);
 	json_object_object_get_ex(o, "subpixel_hinting", &subpixel);
+	json_object_object_get_ex(o, "render_format", &render_format);
 	json_object_object_get_ex(o, "transform", &transform);
 	json_object_object_get_ex(o, "max_render_time", &max_render_time);
 	json_object_object_get_ex(o, "adaptive_sync_status", &adaptive_sync_status);
@@ -232,6 +233,7 @@ static void pretty_print_output(json_object *o) {
 			"  Scale factor: %f\n"
 			"  Scale filter: %s\n"
 			"  Subpixel hinting: %s\n"
+			"  Render format: %s\n"
 			"  Transform: %s\n"
 			"  Workspace: %s\n",
 			json_object_get_string(name),
@@ -247,6 +249,7 @@ static void pretty_print_output(json_object *o) {
 			json_object_get_double(scale),
 			json_object_get_string(scale_filter),
 			json_object_get_string(subpixel),
+			json_object_get_string(render_format),
 			json_object_get_string(transform),
 			json_object_get_string(ws)
 		);


### PR DESCRIPTION
Addresses https://github.com/swaywm/sway/issues/6681

I'm returning the `render_format` instead of `render_bit_depth` as that's what's ultimately used by `wlroots`.

Tested on top of `1.8.1` (I'm running/building on Fedora 38 and didn't want to rebuild all the dependencies) but nothing stands out as incompatible on `master`.

```
% swaymsg output HDMI-A-1 render_bit_depth 8
% ./build/swaymsg/swaymsg -t get_outputs
Output HDMI-A-1 'Guangxi Century Innovation Display Electronics Co., Ltd 27M2V 0000000000000'
  Current mode: 3840x2160 @ 60.000 Hz
  Position: 0,0
  Scale factor: 1.500000
  Scale filter: linear
  Subpixel hinting: unknown
  Render format: XRGB8888
  Transform: normal
  Workspace: 5
  Max render time: off
  Adaptive sync: disabled
  Available modes:
    3840x2160 @ 60.000 Hz
    3840x2160 @ 59.940 Hz
    ...
% swaymsg -t get_outputs | jq -r '.[] | .render_format'
XRGB8888

% swaymsg output HDMI-A-1 render_bit_depth 10
% ./build/swaymsg/swaymsg -t get_outputs
Output HDMI-A-1 'Guangxi Century Innovation Display Electronics Co., Ltd 27M2V 0000000000000'
  Current mode: 3840x2160 @ 60.000 Hz
  Position: 0,0
  Scale factor: 1.500000
  Scale filter: linear
  Subpixel hinting: unknown
  Render format: XRGB2101010
  Transform: normal
  Workspace: 5
  Max render time: off
  Adaptive sync: disabled
  Available modes:
    3840x2160 @ 60.000 Hz
    3840x2160 @ 59.940 Hz
    ...
% swaymsg -t get_outputs | jq -r '.[] | .render_format'
XRGB2101010
```