### PR TITLE
xdg_shell: update wlr_toplevel size on client resizes

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -294,6 +294,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
 			view_update_size(view);
+			wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
+				view->geometry.height);
 			transaction_commit_dirty_client();
 		} else {
 			view_center_surface(view);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -931,11 +931,6 @@ void view_update_size(struct sway_view *view) {
 	con->pending.content_width = view->geometry.width;
 	con->pending.content_height = view->geometry.height;
 	container_set_geometry_from_content(con);
-
-	// Update the next scheduled width/height so correct coordinates
-	// are sent on the next toplevel configure from wlroots.
-	wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
-		view->geometry.height);
 }
 
 void view_center_surface(struct sway_view *view) {


### PR DESCRIPTION
Reverts #7676 and applies the logic to strictly xdg_shell and not xwayland to avoid some bad bugs there. cc @rpigott