### PR TITLE
fix: don't treat 0x prefix as hex identifier

### DIFF
--- a/sway/commands/input/map_from_region.c
+++ b/sway/commands/input/map_from_region.c
@@ -11,11 +11,21 @@ static bool parse_coords(const char *str, double *x, double *y, bool *mm) {
 	*mm = false;
 
 	char *end;
-	*x = strtod(str, &end);
-	if (end[0] != 'x') {
-		return false;
+
+	// Check for "0x" prefix to avoid strtod treating the string as hex
+	if (str[0] == '0' && str[1] == 'x') {
+		if (strlen(str) < 3) {
+			return false;
+		}
+		*x = 0;
+		end = (char *)str + 2;
+	} else {
+		*x = strtod(str, &end);
+		if (end[0] != 'x') {
+			return false;
+		}
+		++end;
 	}
-	++end;
 
 	*y = strtod(end, &end);
 	if (end[0] == 'm') {


### PR DESCRIPTION
When using the `map_from_region` for pen tables, we will usually make the available area as big as possible while maintaining the proportions with the screen.

As most of the tablets uses a 16:10 ratios while the most popular screen ratios is still 16:9, the argument for most people should be `0x0 1x0.9` to have the maximum effective area.

However, the argument above won't work because the current code will treat `0x...` as a hexadecimal number, instead of setting both `x` and `y` to `0`.

This fix allows the use of the following syntax:
```
input type:tablet_tool {
	map_from_region 0x0 1x0.9
}
```