### PR TITLE
fixing `meson build/` fail on debian

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -2,7 +2,7 @@ wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
 
 wayland_scanner_dep = dependency('wayland-scanner', native: true)
 wayland_scanner = find_program(
-	wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'),
+	wayland_scanner_dep.get_variable('wayland_scanner'),
 	native: true,
 )
 


### PR DESCRIPTION
Without this change, the `meson build/` step of compiling sway cannot be completed successfully. This is related to #7719 