### PR TITLE
xdg_shell: don't update wlr_toplevel if the container has no size yet

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -294,8 +294,11 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		memcpy(&view->geometry, &new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
 			view_update_size(view);
-			wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
-				view->geometry.height);
+			// Only set the toplevel size the current container actually has a size.
+			if (view->container->current.width) {
+				wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
+					view->geometry.height);
+			}
 			transaction_commit_dirty_client();
 		} else {
 			view_center_surface(view);


### PR DESCRIPTION
3d5ae9813d390ea747462fc0026ee43b7c77d0f2 added logic to change the underlying wlr_toplevel size for floating containers, but it does it even when the pending state is fullscreen. This shouldn't be done there because sway's internal size will not be incorrect and there are cases when clients have no idea which output they are going to end up on (like setting fullscreen during initialization) and thus cannot know the correct size in advance.

cc @rpigott: Sorry, I didn't realize that my commit broke this edge case. Easy reproduction would be `mpv --fs video.mkv` and it should be the wrong size if the video size doesn't match your monitor's size. Should affect any other application that initially launches fullscreen as well.