### PR TITLE
sway-ipc.7: typo stacked->stacking

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -322,7 +322,7 @@ node and will have the following properties:
 :  Number of pixels used for the border width
 |- layout
 :  string
-:  The node's layout. It can either be _splith_, _splitv_, _stacked_,
+:  The node's layout. It can either be _splith_, _splitv_, _stacking_,
    _tabbed_, or _output_
 |- orientation
 :  string


### PR DESCRIPTION
```
layout string  - The node's layout. It can either  be splith,  splitv, stacked, tabbed, or output
```

Correct to *stacking*

---
Edit: this may just be an inconsistency, as 'stacked' is used in the ipc response here https://github.com/swaywm/sway/blob/89f85312687b7fd1777c936e169e6400cee0a4b4/sway/ipc-json.c#L54

I defer to the experts.