### PR TITLE
Clear held keybinding when clicking mouse buttons with modifiers

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -9,6 +9,7 @@
 #include <wlr/util/edges.h>
 #include "sway/config.h"
 #include "sway/input/input-manager.h"
+#include "sway/input/keyboard.h"
 #include "sway/input/tablet.h"
 #include "sway/input/text_input.h"
 
@@ -368,5 +369,8 @@ keyboard_shortcuts_inhibitor_get_for_surface(const struct sway_seat *seat,
  */
 struct sway_keyboard_shortcuts_inhibitor *
 keyboard_shortcuts_inhibitor_get_for_focused_surface(const struct sway_seat *seat);
+
+struct sway_keyboard *sway_keyboard_for_wlr_keyboard(struct sway_seat *seat,
+		struct wlr_keyboard *wlr_keyboard);
 
 #endif

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -130,7 +130,7 @@ static void seat_send_activate(struct sway_node *node, struct sway_seat *seat) {
 	}
 }
 
-static struct sway_keyboard *sway_keyboard_for_wlr_keyboard(
+struct sway_keyboard *sway_keyboard_for_wlr_keyboard(
 		struct sway_seat *seat, struct wlr_keyboard *wlr_keyboard) {
 	struct sway_seat_device *seat_device;
 	wl_list_for_each(seat_device, &seat->devices, link) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -368,6 +368,11 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		return;
 	}
 
+	// Clear pending keyboard bindings, if any
+	if (state == WL_POINTER_BUTTON_STATE_PRESSED && modifiers != 0) {
+		sway_keyboard_for_wlr_keyboard(seat, keyboard)->held_binding = NULL;
+	}
+
 	// Handle clicking an empty workspace
 	if (node && node->type == N_WORKSPACE) {
 		if (state == WL_POINTER_BUTTON_STATE_PRESSED) {


### PR DESCRIPTION
When handling a button click with one or more modifiers, or using the mouse with the floating modifier, assume that the modifiers are not intended as a standalone keybinding, and clear the held_binding from the keyboard. This way it is possible to use a single modifier (e.g. Super) as main modifier, floating modifier, and as a standalone keybinding (with --release). Fixes #4505