### PR TITLE
Allow approximate output refresh rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 test/
 build/
 build-*/
+.cache/
 .lvimrc
 config-debug
 wayland-*-protocol.*


### PR DESCRIPTION
This PR adds a proposal to solve issue #7599.

It replaces the previous behavior which required an exact match of the output refresh rate by choosing the refresh rate that is closest to the specified target refresh rate (up to a difference of 1Hz). The limit of 1Hz is arbitrarily chosen, other suggestions are also welcome.

Otherwise, if there is no match, the fallback to the highest available refresh rate (for the same resolution) is kept as before.

As discussed in the issue, I also made the logging more verbose to provide additional information about the mode that gets activated in the end.

Additionally, I added the directory `.cache/` to the `.gitignore` which is the default cache directory generated by the `clangd` language server. If you want to have this change in a separate PR or don't want it at all, I can remove it from this PR.

Resolves #7599.