### PR TITLE
Propagate success/failure of swaybg execution

### DIFF
--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -111,7 +111,10 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	if (!config->reloading && !config->validating) {
 		apply_output_config_to_outputs(output);
 		if (background) {
-			spawn_swaybg();
+			if (!spawn_swaybg()) {
+				return cmd_results_new(CMD_FAILURE,
+					"Failed to apply background configuration");
+			}
 		}
 	}
 

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -822,7 +822,9 @@ static bool _spawn_swaybg(char **command) {
 			setenv("WAYLAND_SOCKET", wayland_socket_str, true);
 
 			execvp(command[0], command);
-			sway_log_errno(SWAY_ERROR, "execvp failed");
+			sway_log_errno(SWAY_ERROR, "failed to execute '%s' "
+				"(background configuration probably not applied)",
+				command[0]);
 			_exit(EXIT_FAILURE);
 		}
 		_exit(EXIT_SUCCESS);
@@ -832,12 +834,13 @@ static bool _spawn_swaybg(char **command) {
 		sway_log_errno(SWAY_ERROR, "close failed");
 		return false;
 	}
-	if (waitpid(pid, NULL, 0) < 0) {
+	int fork_status = 0;
+	if (waitpid(pid, &fork_status, 0) < 0) {
 		sway_log_errno(SWAY_ERROR, "waitpid failed");
 		return false;
 	}
 
-	return true;
+	return WIFEXITED(fork_status) && WEXITSTATUS(fork_status) == EXIT_SUCCESS;
 }
 
 bool spawn_swaybg(void) {


### PR DESCRIPTION
This PR checks if the execution of swaybg was successful by checking the return value of `spawn_swaybg`.

However, this is not sufficient to fix the issue that success is reported if the command does not exist (incorrect value of `swaybg_command` in config or `swaybg` is not installed).
The failure of the forked `swaybg` process is not propagated.
Unfortunately, checking for this error is not entirely trivial since `swaybg` does not return if it is successful.
Thus, I added a timeout after which `swaybg`'s execution is considered successful (if it didn't fail before).

This has the drawback that (at least on my system) I got the following error message up to four times (failure) or up to two times (success) following the execution of a `bg` command:

```
00:00:08.457 [ERROR] [wlr] [backend/drm/atomic.c:72] connector DP-1: Atomic commit failed: Device or resource busy
```

Probably also caused by this, the display flickers temporarily (very briefly) when changing the background on failure (didn't notice it on success).

One way to maybe shorten this timeout would be to send a signal on startup in `swaybg`.
But even then, the `sway` process has to wait for that signal with some given timeout which will probably lead to the same issue.
I personally wouldn't like this solution since it unnecessarily increases complexity with little benefit.

Another solution would be to implement a `--dry-run` flag in `swaybg` to check if it is available and if everything else with the call is fine.
However, this wouldn't really check the actual call.
One other benefit would be that invalid/missing images could be noticed.
Currently, this is reported as success because `swaybg` does not return if an image does not exist.

Related to #7779.