### PR TITLE
view: re-apply criteria when window gets unmapped

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -882,6 +882,8 @@ void view_unmap(struct sway_view *view) {
 
 	wl_list_remove(&view->surface_new_subsurface.link);
 
+	view->executed_criteria->length = 0;
+
 	if (view->urgent_timer) {
 		wl_event_source_remove(view->urgent_timer);
 		view->urgent_timer = NULL;


### PR DESCRIPTION
Remove any existing executed criteria items at unmap time. If a window gets unmapped but not destroyed, we want to reapply 'for_window' criteria. Fixes #6905.