### PR TITLE
view: check if the buffer was uploaded on save

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1422,7 +1422,7 @@ static void view_save_buffer_iterator(struct wlr_surface *surface,
 		int sx, int sy, void *data) {
 	struct sway_view *view = data;
 
-	if (surface && wlr_surface_has_buffer(surface)) {
+	if (surface && surface->buffer) {
 		wlr_buffer_lock(&surface->buffer->base);
 		struct sway_saved_buffer *saved_buffer = calloc(1, sizeof(struct sway_saved_buffer));
 		saved_buffer->buffer = surface->buffer;


### PR DESCRIPTION
wlr_surface_has_buffer() is insufficient; if a client has committed a buffer but it couldn't be applied, NULL deref happens in the next line.