### PR TITLE
More options for querying and changing opacity

### DIFF
--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -17,19 +17,46 @@ struct cmd_results *cmd_opacity(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "No current container");
 	}
 
+	enum { SET, PLUS, MINUS, MUL, DIV } op = SET;
+	char *argval = argv[0];
+
+	if (argc == 1) {
+		if (!strcasecmp(argv[0], "get")) {
+			return cmd_results_new(CMD_SUCCESS, "%f", con->alpha);
+		}
+	} else {
+		if ((error = checkarg(argc, "opacity", EXPECTED_EQUAL_TO, 2))) {
+			return error;
+		}
+		if (!strcasecmp(argv[0], "set")) {
+			op = SET;
+		} else if (!strcasecmp(argv[0], "plus")) {
+			op = PLUS;
+		} else if (!strcasecmp(argv[0], "minus")) {
+			op = MINUS;
+		} else if (!strcasecmp(argv[0], "mul")) {
+			op = MUL;
+		} else if (!strcasecmp(argv[0], "div")) {
+			op = DIV;
+		} else {
+			return cmd_results_new(CMD_INVALID,
+				"Expected: get,set|plus|minus|mul|div <0..1>: %s", argv[0]);
+		}
+		argval = argv[1];
+	}
+
 	char *err;
-	float val = strtof(argc == 1 ? argv[0] : argv[1], &err);
+	float val = strtof(argval, &err);
 	if (*err) {
 		return cmd_results_new(CMD_INVALID, "opacity float invalid");
 	}
 
-	if (!strcasecmp(argv[0], "plus")) {
-		val = con->alpha + val;
-	} else if (!strcasecmp(argv[0], "minus")) {
-		val = con->alpha - val;
-	} else if (argc > 1 && strcasecmp(argv[0], "set")) {
-		return cmd_results_new(CMD_INVALID,
-				"Expected: set|plus|minus <0..1>: %s", argv[0]);
+	switch (op) {
+		case SET: break;
+		case PLUS: val += con->alpha; break;
+		case MINUS: val -= con->alpha; break;
+		case MUL: val *= con->alpha; break;
+		case DIV: val = con->alpha / val; break;
 	}
 
 	if (val < 0 || val > 1) {


### PR DESCRIPTION
Similar to #7173 I wanted a nicer way to get control over opacity of windows.  These changes makes it easy to get the opacity of the current window, e.g., via:
```sh
swaymsg -r opacity get
```
as well as providing more options for altering it via `mul` and `div` subcommands, e.g.,:
```sh
swaymsg opacity mul 1.25
swaymsg opacity div 1.25
```
As per the commit message, human senses tend to work on a log-scale; hence multiplicative changes like this tend to feel smoother than linear changes (i.e. via the existing `plus` and `minus`).

This change doesn't expose the opacity in the `get_tree` output as I didn't need it, but could likely add that in if somebody cares about it.