### PR TITLE
swaynag/config.c: fix build against gcc-14 (-Walloc-size)

### DIFF
--- a/swaynag/config.c
+++ b/swaynag/config.c
@@ -166,7 +166,7 @@ int swaynag_parse_options(int argc, char **argv, struct swaynag *swaynag,
 					fprintf(stderr, "Missing action for button %s\n", optarg);
 					return EXIT_FAILURE;
 				}
-				struct swaynag_button *button = calloc(sizeof(struct swaynag_button), 1);
+				struct swaynag_button *button = calloc(1, sizeof(struct swaynag_button));
 				if (!button) {
 					perror("calloc");
 					return EXIT_FAILURE;


### PR DESCRIPTION
`gcc-14` added a new `-Walloc-size` warning that makes sure that size of an individual element matches size of a pointed type:

        https://gcc.gnu.org/PR71219

`sway` triggers it on `calloc()` calls where member size is used as `1` (instead of member count):

    swaynag/config.c:169:65: error: allocation of insufficient size '1'
     for type 'struct swaynag_button' with size '48' [-Werror=alloc-size]
      169 | struct swaynag_button *button = calloc(sizeof(struct swaynag_button), 1);