### PR TITLE
Chase wlroots!4097

### DIFF
--- a/sway/commands/output/transform.c
+++ b/sway/commands/output/transform.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "log.h"
 #include "sway/output.h"
+#include <wlr/util/transform.h>
 
 static enum wl_output_transform invert_rotation_direction(
 		enum wl_output_transform t) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -16,6 +16,7 @@
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/util/region.h>
+#include <wlr/util/transform.h>
 #include "config.h"
 #include "log.h"
 #include "sway/config.h"

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -13,6 +13,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/util/region.h>
+#include <wlr/util/transform.h>
 #include "log.h"
 #include "config.h"
 #include "sway/config.h"


### PR DESCRIPTION
Fix #7830

With [MR4097](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4097) for wlroots

Header for wl_output_transform helpers have been moved to `include/wlr/util/transform.h`. Causing building with clang to fail with implicit function declarations error.