### PR TITLE
Remove unused render_background_image and move load_background_image to swaybar

### DIFF
--- a/common/background-image.c
+++ b/common/background-image.c
@@ -104,7 +104,7 @@ static cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(
 }
 #endif // HAVE_GDK_PIXBUF
 
-cairo_surface_t *load_background_image(const char *path) {
+cairo_surface_t *load_image(const char *path) {
 	cairo_surface_t *image;
 #if HAVE_GDK_PIXBUF
 	GError *err = NULL;

--- a/common/background-image.c
+++ b/common/background-image.c
@@ -1,28 +1,11 @@
 #include <assert.h>
 #include "background-image.h"
-#include "cairo_util.h"
+#include "config.h"
 #include "log.h"
+
 #if HAVE_GDK_PIXBUF
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #endif
-
-enum background_mode parse_background_mode(const char *mode) {
-	if (strcmp(mode, "stretch") == 0) {
-		return BACKGROUND_MODE_STRETCH;
-	} else if (strcmp(mode, "fill") == 0) {
-		return BACKGROUND_MODE_FILL;
-	} else if (strcmp(mode, "fit") == 0) {
-		return BACKGROUND_MODE_FIT;
-	} else if (strcmp(mode, "center") == 0) {
-		return BACKGROUND_MODE_CENTER;
-	} else if (strcmp(mode, "tile") == 0) {
-		return BACKGROUND_MODE_TILE;
-	} else if (strcmp(mode, "solid_color") == 0) {
-		return BACKGROUND_MODE_SOLID_COLOR;
-	}
-	sway_log(SWAY_ERROR, "Unsupported background mode: %s", mode);
-	return BACKGROUND_MODE_INVALID;
-}
 
 #if HAVE_GDK_PIXBUF
 static cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(
@@ -150,71 +133,4 @@ cairo_surface_t *load_background_image(const char *path) {
 		return NULL;
 	}
 	return image;
-}
-
-void render_background_image(cairo_t *cairo, cairo_surface_t *image,
-		enum background_mode mode, int buffer_width, int buffer_height) {
-	double width = cairo_image_surface_get_width(image);
-	double height = cairo_image_surface_get_height(image);
-
-	cairo_save(cairo);
-	switch (mode) {
-	case BACKGROUND_MODE_STRETCH:
-		cairo_scale(cairo,
-				(double)buffer_width / width,
-				(double)buffer_height / height);
-		cairo_set_source_surface(cairo, image, 0, 0);
-		break;
-	case BACKGROUND_MODE_FILL: {
-		double window_ratio = (double)buffer_width / buffer_height;
-		double bg_ratio = width / height;
-
-		if (window_ratio > bg_ratio) {
-			double scale = (double)buffer_width / width;
-			cairo_scale(cairo, scale, scale);
-			cairo_set_source_surface(cairo, image,
-					0, (double)buffer_height / 2 / scale - height / 2);
-		} else {
-			double scale = (double)buffer_height / height;
-			cairo_scale(cairo, scale, scale);
-			cairo_set_source_surface(cairo, image,
-					(double)buffer_width / 2 / scale - width / 2, 0);
-		}
-		break;
-	}
-	case BACKGROUND_MODE_FIT: {
-		double window_ratio = (double)buffer_width / buffer_height;
-		double bg_ratio = width / height;
-
-		if (window_ratio > bg_ratio) {
-			double scale = (double)buffer_height / height;
-			cairo_scale(cairo, scale, scale);
-			cairo_set_source_surface(cairo, image,
-					(double)buffer_width / 2 / scale - width / 2, 0);
-		} else {
-			double scale = (double)buffer_width / width;
-			cairo_scale(cairo, scale, scale);
-			cairo_set_source_surface(cairo, image,
-					0, (double)buffer_height / 2 / scale - height / 2);
-		}
-		break;
-	}
-	case BACKGROUND_MODE_CENTER:
-		cairo_set_source_surface(cairo, image,
-				(double)buffer_width / 2 - width / 2,
-				(double)buffer_height / 2 - height / 2);
-		break;
-	case BACKGROUND_MODE_TILE: {
-		cairo_pattern_t *pattern = cairo_pattern_create_for_surface(image);
-		cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
-		cairo_set_source(cairo, pattern);
-		break;
-	}
-	case BACKGROUND_MODE_SOLID_COLOR:
-	case BACKGROUND_MODE_INVALID:
-		assert(0);
-		break;
-	}
-	cairo_paint(cairo);
-	cairo_restore(cairo);
 }

--- a/common/meson.build
+++ b/common/meson.build
@@ -1,7 +1,6 @@
 lib_sway_common = static_library(
 	'sway-common',
 	files(
-		'background-image.c',
 		'cairo.c',
 		'gesture.c',
 		'ipc-client.c',
@@ -14,7 +13,6 @@ lib_sway_common = static_library(
 	),
 	dependencies: [
 		cairo,
-		gdk_pixbuf,
 		pango,
 		pangocairo,
 		wayland_client.partial_dependency(compile_args: true)

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -2,6 +2,6 @@
 #define _SWAY_BACKGROUND_IMAGE_H
 #include <cairo.h>
 
-cairo_surface_t *load_background_image(const char *path);
+cairo_surface_t *load_image(const char *path);
 
 #endif

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -1,20 +1,7 @@
 #ifndef _SWAY_BACKGROUND_IMAGE_H
 #define _SWAY_BACKGROUND_IMAGE_H
-#include "cairo_util.h"
+#include <cairo.h>
 
-enum background_mode {
-	BACKGROUND_MODE_STRETCH,
-	BACKGROUND_MODE_FILL,
-	BACKGROUND_MODE_FIT,
-	BACKGROUND_MODE_CENTER,
-	BACKGROUND_MODE_TILE,
-	BACKGROUND_MODE_SOLID_COLOR,
-	BACKGROUND_MODE_INVALID,
-};
-
-enum background_mode parse_background_mode(const char *mode);
 cairo_surface_t *load_background_image(const char *path);
-void render_background_image(cairo_t *cairo, cairo_surface_t *image,
-		enum background_mode mode, int buffer_width, int buffer_height);
 
 #endif

--- a/include/swaybar/image.h
+++ b/include/swaybar/image.h
@@ -1,5 +1,5 @@
-#ifndef _SWAY_BACKGROUND_IMAGE_H
-#define _SWAY_BACKGROUND_IMAGE_H
+#ifndef _SWAYBAR_IMAGE_H
+#define _SWAYBAR_IMAGE_H
 #include <cairo.h>
 
 cairo_surface_t *load_image(const char *path);

--- a/swaybar/image.c
+++ b/swaybar/image.c
@@ -1,7 +1,7 @@
 #include <assert.h>
-#include "background-image.h"
 #include "config.h"
 #include "log.h"
+#include "swaybar/image.h"
 
 #if HAVE_GDK_PIXBUF
 #include <gdk-pixbuf/gdk-pixbuf.h>

--- a/swaybar/meson.build
+++ b/swaybar/meson.build
@@ -26,6 +26,7 @@ executable(
 		'bar.c',
 		'config.c',
 		'i3bar.c',
+		'image.c',
 		'input.c',
 		'ipc.c',
 		'main.c',

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -431,7 +431,7 @@ static void reload_sni(struct swaybar_sni *sni, char *icon_theme,
 		list_free(icon_search_paths);
 		if (icon_path) {
 			cairo_surface_destroy(sni->icon);
-			sni->icon = load_background_image(icon_path);
+			sni->icon = load_image(icon_path);
 			free(icon_path);
 			return;
 		}

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -7,12 +7,12 @@
 #include <string.h>
 #include "swaybar/bar.h"
 #include "swaybar/config.h"
+#include "swaybar/image.h"
 #include "swaybar/input.h"
 #include "swaybar/tray/host.h"
 #include "swaybar/tray/icon.h"
 #include "swaybar/tray/item.h"
 #include "swaybar/tray/tray.h"
-#include "background-image.h"
 #include "cairo_util.h"
 #include "list.h"
 #include "log.h"


### PR DESCRIPTION
As swaybg/swaylock are no longer part of this repository, `render_background_image` can be dropped.

Since `load_background_image` is only used by swaybar, move it out of `common/` into `swaybar/` , and give it a better name.
