### PR TITLE
Raise error on non-accessible background file

### DIFF
--- a/sway/commands/output/background.c
+++ b/sway/commands/output/background.c
@@ -123,7 +123,10 @@ struct cmd_results *output_cmd_background(int argc, char **argv) {
 					src);
 			config_add_swaynag_warning("Unable to access background file '%s'",
 					src);
+			struct cmd_results *result = cmd_results_new(CMD_FAILURE,
+					"unable to access background file '%s'", src);
 			free(src);
+			return result;
 		} else {
 			output->background = src;
 			output->background_option = strdup(mode);


### PR DESCRIPTION
This changes the output of `swaymsg` to indicate the failure to set the background image:
```
[
  {
    "success": false,
    "parse_error": false,
    "error": "unable to access background file '/path/to/file'"
  }
]
```

This change will also lead to not applying other output options when a command like `swaymsg -r 'output * bg /non/accessible/file scale 1'` is executed.
However, I think that is an improvement in user experience - if they should be run independently of each others success, they could be split into two `swaymsg` calls.

Closes #7859