### PR TITLE
Improve proprietary driver detection

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -163,6 +163,8 @@ struct sway_debug {
 
 extern struct sway_debug debug;
 
+extern bool allow_unsupported_gpu;
+
 bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);
 bool server_start(struct sway_server *server);

--- a/meson.build
+++ b/meson.build
@@ -77,8 +77,7 @@ pixman = dependency('pixman-1')
 libevdev = dependency('libevdev')
 libinput = wlroots_features['libinput_backend'] ? dependency('libinput', version: '>=1.21.0') : null_dep
 xcb = dependency('xcb', required: get_option('xwayland'))
-drm_full = dependency('libdrm') # only needed for drm_fourcc.h
-drm = drm_full.partial_dependency(compile_args: true, includes: true)
+drm = dependency('libdrm')
 libudev = wlroots_features['libinput_backend'] ? dependency('libudev') : null_dep
 math = cc.find_library('m')
 rt = cc.find_library('rt')

--- a/sway/main.c
+++ b/sway/main.c
@@ -49,32 +49,6 @@ void sig_handler(int signal) {
 	sway_terminate(EXIT_SUCCESS);
 }
 
-void detect_proprietary(int allow_unsupported_gpu) {
-	FILE *f = fopen("/proc/modules", "r");
-	if (!f) {
-		return;
-	}
-	char *line = NULL;
-	size_t line_size = 0;
-	while (getline(&line, &line_size, f) != -1) {
-		if (strncmp(line, "nvidia ", 7) == 0) {
-			if (allow_unsupported_gpu) {
-				sway_log(SWAY_ERROR,
-						"!!! Proprietary Nvidia drivers are in use !!!");
-			} else {
-				sway_log(SWAY_ERROR,
-					"Proprietary Nvidia drivers are NOT supported. "
-					"Use Nouveau. To launch sway anyway, launch with "
-					"--unsupported-gpu and DO NOT report issues.");
-				exit(EXIT_FAILURE);
-			}
-			break;
-		}
-	}
-	free(line);
-	fclose(f);
-}
-
 void run_as_ipc_client(char *command, char *socket_path) {
 	int socketfd = ipc_open_socket(socket_path);
 	uint32_t len = strlen(command);
@@ -243,7 +217,7 @@ static const char usage[] =
 	"\n";
 
 int main(int argc, char **argv) {
-	static bool verbose = false, debug = false, validate = false, allow_unsupported_gpu = false;
+	static bool verbose = false, debug = false, validate = false;
 
 	char *config_path = NULL;
 
@@ -351,7 +325,6 @@ int main(int argc, char **argv) {
 		return 0;
 	}
 
-	detect_proprietary(allow_unsupported_gpu);
 	increase_nofile_limit();
 
 	// handle SIGTERM signals

--- a/sway/main.c
+++ b/sway/main.c
@@ -70,18 +70,6 @@ void detect_proprietary(int allow_unsupported_gpu) {
 			}
 			break;
 		}
-		if (strstr(line, "fglrx")) {
-			if (allow_unsupported_gpu) {
-				sway_log(SWAY_ERROR,
-						"!!! Proprietary AMD drivers are in use !!!");
-			} else {
-				sway_log(SWAY_ERROR, "Proprietary AMD drivers do NOT support "
-					"Wayland. Use radeon. To try anyway, launch sway with "
-					"--unsupported-gpu and DO NOT report issues.");
-				exit(EXIT_FAILURE);
-			}
-			break;
-		}
 	}
 	free(line);
 	fclose(f);

--- a/sway/server.c
+++ b/sway/server.c
@@ -128,16 +128,25 @@ static void detect_proprietary(struct wlr_backend *backend, void *data) {
 		return;
 	}
 
+	bool is_unsupported = false;
 	if (strcmp(version->name, "nvidia-drm") == 0) {
-		if (allow_unsupported_gpu) {
-			sway_log(SWAY_ERROR, "!!! Proprietary Nvidia drivers are in use !!!");
-		} else {
-			sway_log(SWAY_ERROR,
-				"Proprietary Nvidia drivers are NOT supported. "
-				"Use Nouveau. To launch sway anyway, launch with "
-				"--unsupported-gpu and DO NOT report issues.");
-			exit(EXIT_FAILURE);
+		is_unsupported = true;
+		sway_log(SWAY_ERROR, "!!! Proprietary Nvidia drivers are in use !!!");
+		if (!allow_unsupported_gpu) {
+			sway_log(SWAY_ERROR, "Use Nouveau instead");
 		}
+	}
+
+	if (strcmp(version->name, "evdi") == 0) {
+		is_unsupported = true;
+		sway_log(SWAY_ERROR, "!!! Proprietary DisplayLink drivers are in use !!!");
+	}
+
+	if (!allow_unsupported_gpu && is_unsupported) {
+		sway_log(SWAY_ERROR,
+			"Proprietary drivers are NOT supported. To launch sway anyway, "
+			"launch with --unsupported-gpu and DO NOT report issues.");
+		exit(EXIT_FAILURE);
 	}
 
 	drmFreeVersion(version);


### PR DESCRIPTION
Use the DRM API instead of `/proc/modules`, and add DisplayLink.

Depends on https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4493