### PR TITLE
desktop/layer-shell: don't configure uninitialized surfaces

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -131,6 +131,9 @@ static void arrange_layer(struct sway_output *output, struct wl_list *list,
 			&full_area.width, &full_area.height);
 	wl_list_for_each(sway_layer, list, link) {
 		struct wlr_layer_surface_v1 *layer = sway_layer->layer_surface;
+		if (!layer->initialized) {
+			continue;
+		}
 		struct wlr_layer_surface_v1_state *state = &layer->current;
 		if (exclusive != (state->exclusive_zone > 0)) {
 			continue;


### PR DESCRIPTION
Fixes "A configure is sent to an uninitialized wlr_layer_surface_v1" errors.

Closes: https://github.com/swaywm/sway/issues/7855