### PR TITLE
xdg-activation: deny activation if the token is incomplete

### DIFF
--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -14,6 +14,7 @@ struct launcher_ctx {
 	struct wl_listener seat_destroy;
 
 	bool activated;
+	bool had_focused_surface;
 
 	struct sway_node *node;
 	struct wl_listener node_destroy;

--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -3,12 +3,15 @@
 
 #include <stdlib.h>
 #include <wayland-server-core.h>
+#include "sway/input/seat.h"
 
 struct launcher_ctx {
 	pid_t pid;
 	char *fallback_name;
 	struct wlr_xdg_activation_token_v1 *token;
 	struct wl_listener token_destroy;
+	struct sway_seat *seat;
+	struct wl_listener seat_destroy;
 
 	bool activated;
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -242,6 +242,11 @@ void view_set_activated(struct sway_view *view, bool activated);
  */
 void view_request_activate(struct sway_view *view, struct sway_seat *seat);
 
+/*
+ * Called when the view requests urgent state
+ */
+void view_request_urgent(struct sway_view *view);
+
 /**
  * If possible, instructs the client to change their decoration mode.
  */

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -67,6 +67,9 @@ void launcher_ctx_destroy(struct launcher_ctx *ctx) {
 	}
 	wl_list_remove(&ctx->node_destroy.link);
 	wl_list_remove(&ctx->token_destroy.link);
+	if (ctx->seat) {
+		wl_list_remove(&ctx->seat_destroy.link);
+	}
 	wl_list_remove(&ctx->link);
 	wlr_xdg_activation_token_v1_destroy(ctx->token);
 	free(ctx->fallback_name);
@@ -227,6 +230,12 @@ struct launcher_ctx *launcher_ctx_create(struct wlr_xdg_activation_token_v1 *tok
 	return ctx;
 }
 
+static void launch_ctx_handle_seat_destroy(struct wl_listener *listener, void *data) {
+	struct launcher_ctx *ctx = wl_container_of(listener, ctx, seat_destroy);
+	ctx->seat = NULL;
+	wl_list_remove(&ctx->seat_destroy.link);
+}
+
 // Creates a context with a new token for the internal launcher
 struct launcher_ctx *launcher_ctx_create_internal(void) {
 	struct sway_seat *seat = input_manager_current_seat();
@@ -238,13 +247,15 @@ struct launcher_ctx *launcher_ctx_create_internal(void) {
 
 	struct wlr_xdg_activation_token_v1 *token =
 		wlr_xdg_activation_token_v1_create(server.xdg_activation_v1);
-	token->seat = seat->wlr_seat;
 
 	struct launcher_ctx *ctx = launcher_ctx_create(token, &ws->node);
 	if (!ctx) {
 		wlr_xdg_activation_token_v1_destroy(token);
 		return NULL;
 	}
+	ctx->seat = seat;
+	ctx->seat_destroy.notify = launch_ctx_handle_seat_destroy;
+	wl_signal_add(&seat->wlr_seat->events.destroy, &ctx->seat_destroy);
 
 	return ctx;
 }

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -216,6 +216,8 @@ struct launcher_ctx *launcher_ctx_create(struct wlr_xdg_activation_token_v1 *tok
 	ctx->fallback_name = strdup(fallback_name);
 	ctx->token = token;
 	ctx->node = node;
+	// Having surface set means that the focus check in wlroots has passed
+	ctx->had_focused_surface = token->surface != NULL;
 
 	ctx->node_destroy.notify = ctx_handle_node_destroy;
 	wl_signal_add(&ctx->node->events.destroy, &ctx->node_destroy);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -412,6 +412,12 @@ void view_request_activate(struct sway_view *view, struct sway_seat *seat) {
 	transaction_commit_dirty();
 }
 
+void view_request_urgent(struct sway_view *view) {
+	if (config->focus_on_window_activation != FOWA_NONE) {
+		view_set_urgent(view, true);
+	}
+}
+
 void view_set_csd_from_server(struct sway_view *view, bool enabled) {
 	sway_log(SWAY_DEBUG, "Telling view %p to set CSD to %i", view, enabled);
 	if (view->xdg_decoration) {

--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -44,8 +44,11 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		seat = ctx->token->seat ? ctx->token->seat->data : NULL;
 	}
 
-	if (seat) {
+	if (seat && ctx->had_focused_surface) {
 		view_request_activate(view, seat);
+	} else {
+		// The token is valid, but cannot be used to activate a window
+		view_request_urgent(view);
 	}
 }
 

--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -18,11 +18,15 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		return;
 	}
 
+	struct launcher_ctx *ctx = event->token->data;
+	if (ctx == NULL) {
+		return;
+	}
+
 	if (!xdg_surface->surface->mapped) {
 		// This is a startup notification. If we are tracking it, the data
 		// field is a launcher_ctx.
-		struct launcher_ctx *ctx = event->token->data;
-		if (!ctx || ctx->activated) {
+		if (ctx->activated) {
 			// This ctx has already been activated and cannot be used again
 			// for a startup notification. It will be destroyed
 			return;
@@ -33,9 +37,16 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		return;
 	}
 
-	struct wlr_seat *wlr_seat = event->token->seat;
-	struct sway_seat *seat = wlr_seat ? wlr_seat->data : NULL;
-	view_request_activate(view, seat);
+	// This is an activation request. If this context is internal we have ctx->seat.
+	struct sway_seat *seat = ctx->seat;
+	if (!seat) {
+		// Otherwise, use the seat indicated by the launcher client in set_serial
+		seat = ctx->token->seat ? ctx->token->seat->data : NULL;
+	}
+
+	if (seat) {
+		view_request_activate(view, seat);
+	}
 }
 
 void xdg_activation_v1_handle_new_token(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Where incomplete means that the requesting app did not provide a focused surface or a valid input event serial.
The token is still valid, so set the urgency instead.

See also #7446

***
This works exactly as I imagined. With `for_window [app_id=xxx] focus_on_window_activation focus`, the following happens:
A self-issued token without a serial (`QWindow::alert()` in Qt 6.6) can set urgency but does not switch workspace or bring the window forward.
A token from a click on mako notification allows the window to activate itself.

I'm not happy with the abuse of `launcher_ctx` (which may be not set) for an unrelated flag. Really don't see a way to avoid this, because it's too late to check if the token was fully validated in `request_activate`.
