### PR TITLE
ipc: consider all titlebar cases for window_rect

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -578,9 +578,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	bool visible = view_is_visible(c->view);
 	json_object_object_add(object, "visible", json_object_new_boolean(visible));
 
+	bool has_titlebar = c->title_bar.tree->node.enabled;
 	struct wlr_box window_box = {
 		c->pending.content_x - c->pending.x,
-		(c->current.border == B_PIXEL) ? c->pending.content_y - c->pending.y : 0,
+		has_titlebar ? 0 : c->pending.content_y - c->pending.y,
 		c->pending.content_width,
 		c->pending.content_height
 	};


### PR DESCRIPTION
Tabbed or stacked containers with more than one child always have a titlebar.

19df2e590602abe0b5e1b53bc11debdb37be3fbe changed `rect` to exclude the titlebar, but overlooked this case, causing my screenshot script to miscalculate the coordinates of the window contents.