### PR TITLE
add --smart-titles flag to hide_edge_borders

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -556,6 +556,7 @@ struct sway_config {
 	enum edge_border_types hide_edge_borders;
 	enum edge_border_smart_types hide_edge_borders_smart;
 	bool hide_lone_tab;
+	bool hide_lone_title;
 
 	// border colors
 	struct {

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -369,6 +369,8 @@ void view_execute_criteria(struct sway_view *view);
  */
 bool view_is_visible(struct sway_view *view);
 
+bool view_is_only_visible(struct sway_view *view);
+
 void view_set_urgent(struct sway_view *view, bool enable);
 
 bool view_is_urgent(struct sway_view *view);

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -13,7 +13,13 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	}
 
 	bool hide_lone_tab = false;
-	if (strcmp(*argv, "--i3") == 0) {
+	bool hide_lone_title = false;
+	if (strcmp(*argv, "--smart-titles") == 0) {
+		hide_lone_tab = true;
+		hide_lone_title = true;
+		++argv;
+		--argc;
+	} else if (strcmp(*argv, "--i3") == 0) {
 		hide_lone_tab = true;
 		++argv;
 		--argc;
@@ -41,6 +47,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 	config->hide_lone_tab = hide_lone_tab;
+	config->hide_lone_title = hide_lone_title;
 
 	arrange_root();
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -298,6 +298,7 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_edge_borders = E_NONE;
 	config->hide_edge_borders_smart = ESMART_OFF;
 	config->hide_lone_tab = false;
+	config->hide_lone_title = false;
 
 	config->has_focused_tab_title = false;
 

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -718,9 +718,11 @@ static void render_containers_linear(struct render_context *ctx, struct parent_d
 			}
 
 			if (state->border == B_NORMAL) {
-				render_titlebar(ctx, child, floor(state->x),
-						floor(state->y), state->width, colors,
-						title_texture, marks_texture);
+				if(!config->hide_lone_title || !view_is_only_visible(view)) {
+					render_titlebar(ctx, child, floor(state->x),
+							floor(state->y), state->width, colors,
+							title_texture, marks_texture);
+				}
 			} else if (state->border == B_PIXEL) {
 				render_top_border(ctx, child, colors);
 			}

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -741,10 +741,11 @@ The default colors are:
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps ...).
 
-*hide_edge_borders* [--i3] none|vertical|horizontal|both|smart|smart_no_gaps
+*hide_edge_borders* [--i3 | --smart-titles] none|vertical|horizontal|both|smart|smart_no_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_. The
 	_--i3_ option enables i3-compatible behavior to hide the title bar on
-	tabbed and stacked containers with one child. The _smart_|_smart_no_gaps_
+	tabbed and stacked containers with one child. The --smart-titles option
+	hide the title bar on workspaces with only one child. The _smart_|_smart_no_gaps_
 	options are equivalent to setting _smart_borders_ smart|no_gaps and
 	_hide_edge_borders_ none.
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -217,7 +217,7 @@ bool view_ancestor_is_only_visible(struct sway_view *view) {
 	return only_visible;
 }
 
-static bool view_is_only_visible(struct sway_view *view) {
+bool view_is_only_visible(struct sway_view *view) {
 	struct sway_container *con = view->container;
 	while (con) {
 		enum sway_container_layout layout = container_parent_layout(con);
@@ -344,8 +344,14 @@ void view_autoconfigure(struct sway_view *view) {
 			height = con->pending.height - y_offset
 				- con->pending.border_thickness * con->pending.border_bottom;
 		} else {
-			y = con->pending.y + container_titlebar_height();
-			height = con->pending.height - container_titlebar_height()
+			int titlebar_height;
+			if (config->hide_lone_title && view_is_only_visible(view)) {
+				titlebar_height = con->pending.border_thickness * con->pending.border_top + y_offset;
+			} else {
+				titlebar_height = container_titlebar_height();
+			}
+			y = con->pending.y + titlebar_height;
+			height = con->pending.height - titlebar_height
 				- con->pending.border_thickness * con->pending.border_bottom;
 		}
 		break;


### PR DESCRIPTION
Hi, 

This extend the `--i3` flag to hide title bars on any kind of container.