### PR TITLE
Preferred signal format

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -298,6 +298,7 @@ sway_cmd output_cmd_subpixel;
 sway_cmd output_cmd_toggle;
 sway_cmd output_cmd_transform;
 sway_cmd output_cmd_unplug;
+sway_cmd output_cmd_color_format;
 
 sway_cmd seat_cmd_attach;
 sway_cmd seat_cmd_cursor;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -285,6 +285,7 @@ struct output_config {
 	int max_render_time; // In milliseconds
 	int adaptive_sync;
 	enum render_bit_depth render_bit_depth;
+	enum wlr_output_color_format color_format;
 
 	char *background;
 	char *background_option;

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -10,6 +10,7 @@ static const struct cmd_handler output_handlers[] = {
 	{ "adaptive_sync", output_cmd_adaptive_sync },
 	{ "background", output_cmd_background },
 	{ "bg", output_cmd_background },
+	{ "color_format", output_cmd_color_format },
 	{ "disable", output_cmd_disable },
 	{ "dpms", output_cmd_dpms },
 	{ "enable", output_cmd_enable },

--- a/sway/commands/output/color_format.c
+++ b/sway/commands/output/color_format.c
@@ -1,0 +1,48 @@
+#include <strings.h>
+#include <wlr/config.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+
+static bool parse_signal_format(const char *name, enum wlr_output_color_format *format)
+{
+	if (strcmp(name, "auto") == 0) {
+		*format = WLR_OUTPUT_COLOR_FORMAT_UNSPEC;
+		return true;
+	}
+	if (strcmp(name, "rgb") == 0) {
+		*format = WLR_OUTPUT_COLOR_FORMAT_RGB;
+		return true;
+	}
+	if (strcmp(name, "ycbcr444") == 0) {
+		*format = WLR_OUTPUT_COLOR_FORMAT_YCBCR444;
+		return true;
+	}
+	if (strcmp(name, "ycbcr422") == 0) {
+		*format = WLR_OUTPUT_COLOR_FORMAT_YCBCR422;
+		return true;
+	}
+	if (strcmp(name, "ycbcr420") == 0) {
+		*format = WLR_OUTPUT_COLOR_FORMAT_YCBCR420;
+		return true;
+	}
+	return false;
+}
+
+struct cmd_results *output_cmd_color_format(int argc, char **argv) {
+	if (!config->handler_context.output_config) {
+		return cmd_results_new(CMD_FAILURE, "Missing output config");
+	}
+
+	if (argc == 0) {
+		return cmd_results_new(CMD_INVALID, "Missing format argument");
+	}
+
+	if (!parse_signal_format(argv[0],
+				&config->handler_context.output_config->color_format)) {
+		return cmd_results_new(CMD_INVALID, "Invalid format");
+	}
+
+	config->handler_context.leftovers.argc = argc - 1;
+	config->handler_context.leftovers.argv = argv + 1;
+	return NULL;
+}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -140,6 +140,9 @@ void merge_output_config(struct output_config *dst, struct output_config *src) {
 	if (src->power != -1) {
 		dst->power = src->power;
 	}
+	if (src->color_format) {
+		dst->color_format = src->color_format;
+	}
 }
 
 static void merge_wildcard_on_all(struct output_config *wildcard) {
@@ -234,11 +237,11 @@ struct output_config *store_output_config(struct output_config *oc) {
 
 	sway_log(SWAY_DEBUG, "Config stored for output %s (enabled: %d) (%dx%d@%fHz "
 		"position %d,%d scale %f subpixel %s transform %d) (bg %s %s) (power %d) "
-		"(max render time: %d)",
+		"(max render time: %d), color format %d",
 		oc->name, oc->enabled, oc->width, oc->height, oc->refresh_rate,
 		oc->x, oc->y, oc->scale, sway_wl_output_subpixel_to_string(oc->subpixel),
 		oc->transform, oc->background, oc->background_option, oc->power,
-		oc->max_render_time);
+		oc->max_render_time, oc->color_format);
 
 	return oc;
 }
@@ -400,6 +403,11 @@ static void queue_output_config(struct output_config *oc,
 
 	sway_log(SWAY_DEBUG, "Turning on output %s", wlr_output->name);
 	wlr_output_state_set_enabled(pending, true);
+
+	if (oc && oc->color_format) {
+		wlr_output_state_set_color_format(pending, oc->color_format);
+		sway_log(SWAY_DEBUG, "Set preferred signal format to %d", oc->color_format);
+	}
 
 	if (oc && oc->drm_mode.type != 0 && oc->drm_mode.type != (uint32_t) -1) {
 		sway_log(SWAY_DEBUG, "Set %s modeline",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -203,6 +203,7 @@ sway_sources = files(
 	'commands/output/toggle.c',
 	'commands/output/transform.c',
 	'commands/output/unplug.c',
+	'commands/output/color_format.c',
 
 	'tree/arrange.c',
 	'tree/container.c',


### PR DESCRIPTION
This adds command to set and get the output color format for DRM outputs. See: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4509