### PR TITLE
Add debug flag to re-enable wl_drm

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -156,6 +156,7 @@ struct sway_debug {
 	bool noatomic;         // Ignore atomic layout updates
 	bool txn_timings;      // Log verbose messages about transactions
 	bool txn_wait;         // Always wait for the timeout before applying
+	bool legacy_wl_drm;    // Enable the legacy wl_drm interface
 };
 
 extern struct sway_debug debug;

--- a/sway/main.c
+++ b/sway/main.c
@@ -162,6 +162,8 @@ void enable_debug_flag(const char *flag) {
 		debug.txn_timings = true;
 	} else if (strncmp(flag, "txn-timeout=", 12) == 0) {
 		server.txn_timeout_ms = atoi(&flag[12]);
+	} else if (strcmp(flag, "legacy-wl-drm") == 0) {
+		debug.legacy_wl_drm = true;
 	} else {
 		sway_log(SWAY_ERROR, "Unknown debug flag: %s", flag);
 	}

--- a/sway/server.c
+++ b/sway/server.c
@@ -13,6 +13,7 @@
 #include <wlr/types/wlr_content_type_v1.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
@@ -190,6 +191,10 @@ bool server_init(struct sway_server *server) {
 	if (wlr_renderer_get_dmabuf_texture_formats(server->renderer) != NULL) {
 		server->linux_dmabuf_v1 = wlr_linux_dmabuf_v1_create_with_renderer(
 			server->wl_display, 4, server->renderer);
+	}
+	if (wlr_renderer_get_dmabuf_texture_formats(server->renderer) != NULL &&
+			debug.legacy_wl_drm) {
+		wlr_drm_create(server->wl_display, server->renderer);
 	}
 
 	server->allocator = wlr_allocator_autocreate(server->backend,


### PR DESCRIPTION
7e69a7076fc8 ("Drop wl_drm") has dropped wl_drm, however a lot of software wasn't quite ready for this (Xwayland, libva, amdvlk). Keep wl_drm disabled by default to pressure the wl_drm phase-out, but add a -Dlegacy-wl-drm flag for users to restore the previous behavior in the meantime.

References: https://github.com/swaywm/sway/issues/7897