### PR TITLE
Fix SIGSEGV on output destroy

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -140,6 +140,9 @@ static struct sway_layer_surface *find_mapped_layer_by_client(
 		wl_list_for_each (node, &output->layers.shell_overlay->children, link) {
 			struct sway_layer_surface *surface = scene_descriptor_try_get(node,
 				SWAY_SCENE_DESC_LAYER_SHELL);
+			if (!surface) {
+				continue;
+			}
 
 			struct wlr_layer_surface_v1 *layer_surface = surface->layer_surface;
 			struct wl_resource *resource = layer_surface->resource;


### PR DESCRIPTION
Got a crash after waking my display (which causes a momentary unplug event):

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000000000423647 in find_mapped_layer_by_client (client=0x19dd8f0, ignore_output=0x0) at ../sway/desktop/layer_shell.c:144
144                             struct wlr_layer_surface_v1 *layer_surface = surface->layer_surface;
[Current thread is 1 (Thread 0x7f1f7c5b3ac0 (LWP 2473))]
(gdb) bt
#0  0x0000000000423647 in find_mapped_layer_by_client (client=0x19dd8f0, ignore_output=0x0) at ../sway/desktop/layer_shell.c:144
#1  0x000000000042379f in handle_node_destroy (listener=0x1aceae0, data=0x0) at ../sway/desktop/layer_shell.c:178
#2  0x00007f1f7d55adcc in wl_signal_emit_mutable (signal=<optimized out>, data=0x0) at ../src/wayland-server.c:2241
#3  0x00007f1f7dc543af in wlr_scene_node_destroy (node=0x1aa7e40) at ../subprojects/wlroots/types/scene/wlr_scene.c:93
#4  0x000000000042371e in handle_output_destroy (listener=0x1aceac8, data=0x10887c0) at ../sway/desktop/layer_shell.c:160
#5  0x00007f1f7d55adcc in wl_signal_emit_mutable (signal=<optimized out>, data=0x10887c0) at ../src/wayland-server.c:2241
#6  0x000000000046e01c in output_disable (output=0x10887c0) at ../sway/tree/output.c:296
#7  0x0000000000424c86 in begin_destroy (output=0x10887c0) at ../sway/desktop/output.c:360
#8  0x0000000000424d95 in handle_destroy (listener=0x10888c8, data=0x16fb7b0) at ../sway/desktop/output.c:386
#9  0x00007f1f7d55adcc in wl_signal_emit_mutable (signal=<optimized out>, data=0x16fb7b0) at ../src/wayland-server.c:2241
#10 0x00007f1f7dc4f761 in wlr_output_destroy (output=0x16fb7b0) at ../subprojects/wlroots/types/output/output.c:442
#11 0x00007f1f7dc314bb in disconnect_drm_connector (conn=0x16fb7b0) at ../subprojects/wlroots/backend/drm/drm.c:1805
#12 0x00007f1f7dc30e27 in scan_drm_connectors (drm=0x600770, event=0x7ffd28ffd610) at ../subprojects/wlroots/backend/drm/drm.c:1649
#13 0x00007f1f7dc2bb15 in handle_dev_change (listener=0x600868, data=0x7ffd28ffd60c) at ../subprojects/wlroots/backend/drm/backend.c:159
#14 0x00007f1f7d55adcc in wl_signal_emit_mutable (signal=<optimized out>, data=0x7ffd28ffd60c) at ../src/wayland-server.c:2241
#15 0x00007f1f7dc2935b in handle_udev_event (fd=8, mask=1, data=0x5fb3c0) at ../subprojects/wlroots/backend/session/session.c:213
#16 0x00007f1f7d55c8e2 in wl_event_loop_dispatch (loop=0x5fa630, timeout=timeout@entry=-1) at ../src/event-loop.c:1027
#17 0x00007f1f7d55d125 in wl_display_run (display=0x5fa540) at ../src/wayland-server.c:1493
#18 0x000000000042134f in server_run (server=0x49db80 <server>) at ../sway/server.c:441
#19 0x000000000041fb92 in main (argc=2, argv=0x7ffd28ffda48) at ../sway/main.c:372
(gdb) p surface
$1 = (struct sway_layer_surface *) 0x0
(gdb) p node
$2 = (struct wlr_scene_node *) 0x1aa7e40
(gdb) p *node
$3 = {type = WLR_SCENE_NODE_TREE, parent = 0x16dd9d0, link = {prev = 0x16dda40, next = 0x16dda40}, enabled = true, x = 0, y = 0, events = {destroy = {listener_list = {prev = 0x7ffd28ffd110, next = 0x1aceae0}}}, data = 0x0, addons = {addons = {prev = 0x1aa7e88, next = 0x1aa7e88}}, visible = {extents = {x1 = 0, y1 = 0, x2 = 0,
      y2 = 0}, data = 0x7f1f7d602990 <pixman_region32_empty_data_>}}
(gdb) p output
$4 = (struct sway_output *) 0x10887c0
(gdb) p *output
$5 = {node = {type = N_OUTPUT, {sway_root = 0x10887c0, sway_output = 0x10887c0, sway_workspace = 0x10887c0, sway_container = 0x10887c0}, id = 7, instruction = 0x0, ntxnrefs = 0, destroying = false, dirty = false, events = {destroy = {listener_list = {prev = 0x10887f0, next = 0x10887f0}}}}, layers = {shell_background = 0x16dd430,
    shell_bottom = 0x16dd550, tiling = 0x16dd670, fullscreen = 0x16dd790, shell_top = 0x16dd8b0, shell_overlay = 0x16dd9d0, session_lock = 0x16ddaf0}, fullscreen_background = 0x16ddc10, wlr_output = 0x16fb7b0, scene_output = 0x17dda40, server = 0x49db80 <server>, link = {prev = 0x1a56968, next = 0x10d1938}, usable_area = {x = 0,
    y = 36, width = 3840, height = 2124}, lx = 1920, ly = 0, width = 3840, height = 2160, detected_subpixel = WL_OUTPUT_SUBPIXEL_UNKNOWN, scale_filter = SCALE_FILTER_NEAREST, enabling = false, enabled = true, workspaces = 0x16ab180, current = {workspaces = 0x11c2040, active_workspace = 0x10878f0}, layout_destroy = {link = {
      prev = 0x10d1990, next = 0x1a569c0}, notify = 0x424d98 <handle_layout_destroy>}, destroy = {link = {prev = 0x16fb968, next = 0x7ffd28ffd360}, notify = 0x424d6b <handle_destroy>}, commit = {link = {prev = 0x17ddc18, next = 0x120a220}, notify = 0x424dc5 <handle_commit>}, present = {link = {prev = 0x16fb928, next = 0x16fb928},
    notify = 0x424e78 <handle_present>}, frame = {link = {prev = 0x16fb8d8, next = 0x16fb8d8}, notify = 0x424944 <handle_frame>}, request_state = {link = {prev = 0x16fb958, next = 0x16fb958}, notify = 0x424ef4 <handle_request_state>}, events = {disable = {listener_list = {prev = 0x7ffd28ffd230, next = 0x1aceac8}}},
  last_presentation = {tv_sec = 58615, tv_nsec = 802214000}, refresh_nsec = 16667500, max_render_time = 0, repaint_timer = 0x16cfd70, gamma_lut_changed = false}
(gdb) p output->layers.shell_overlay->children
$6 = {prev = 0x1aa7e50, next = 0x1aa7e50}
```