### PR TITLE
layer_shell: Fix typo of return instead of continue

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -63,7 +63,7 @@ static void arrange_surface(struct sway_output *output, const struct wlr_box *fu
 		}
 
 		if (!surface->scene->layer_surface->initialized) {
-			return;
+			continue;
 		}
 
 		wlr_scene_layer_surface_v1_configure(surface->scene, full_area, usable_area);


### PR DESCRIPTION
Otherwise we would skip arranging the rest of the surfaces if one of them isn't initialized.