### PR TITLE
input: Propagate modifiers to clients with only pointer focus

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -795,6 +795,8 @@ static void handle_pointer_axis(struct sway_seat *seat,
 	free(dev_id);
 
 	if (!handled) {
+		wlr_seat_client_notify_modifiers(cursor->seat->wlr_seat,
+			cursor->seat->wlr_seat->pointer_state.focused_client);
 		wlr_seat_pointer_notify_axis(cursor->seat->wlr_seat, event->time_msec,
 			event->orientation, scroll_factor * event->delta, 
 			roundf(scroll_factor * event->delta_discrete), event->source,


### PR DESCRIPTION
When focus_follows_mouse is off, it is possible to hover and/or scroll windows without giving them keyboard focus.  However, attempts to use Ctrl+scroll on such clients will not work correctly because the keyboard modifiers are not available.  This patch propagates modifier state to the client with pointer focus ~~when it gains focus and when the state changes~~ before sending axis events.

https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/259 discusses permitting this behavior at the protocol level.