### PR TITLE
Add a common popup management struct

### DIFF
--- a/include/sway/desktop/transaction.h
+++ b/include/sway/desktop/transaction.h
@@ -2,6 +2,7 @@
 #define _SWAY_TRANSACTION_H
 #include <stdint.h>
 #include <stdbool.h>
+#include <wlr/types/wlr_scene.h>
 
 /**
  * Transactions enable us to perform atomic layout updates.
@@ -57,5 +58,7 @@ bool transaction_notify_view_ready_by_serial(struct sway_view *view,
  */
 bool transaction_notify_view_ready_by_geometry(struct sway_view *view,
 		double x, double y, int width, int height);
+
+void arrange_popups(struct wlr_scene_tree *popups);
 
 #endif

--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include "sway/tree/view.h"
 
 struct sway_layer_surface {
 	struct wl_listener map;
@@ -14,10 +15,12 @@ struct sway_layer_surface {
 
 	bool mapped;
 
+	struct wlr_scene_tree *popups;
+	struct sway_popup_desc desc;
+
 	struct sway_output *output;
 	struct wlr_scene_layer_surface_v1 *scene;
 	struct wlr_scene_tree *tree;
-	struct wlr_scene_tree *popups;
 	struct wlr_layer_surface_v1 *layer_surface;
 };
 

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -174,12 +174,19 @@ struct sway_xwayland_unmanaged {
 };
 #endif
 
+struct sway_popup_desc {
+	struct wlr_scene_node *relative;
+	struct sway_view *view;
+};
+
 struct sway_xdg_popup {
 	struct sway_view *view;
 
 	struct wlr_scene_tree *scene_tree;
 	struct wlr_scene_tree *xdg_surface_tree;
 	struct wlr_xdg_popup *wlr_xdg_popup;
+
+	struct sway_popup_desc desc;
 
 	struct wl_listener surface_commit;
 	struct wl_listener new_popup;

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -85,6 +85,8 @@ void arrange_layers(struct sway_output *output) {
 		sway_log(SWAY_DEBUG, "Usable area changed, rearranging output");
 		output->usable_area = usable_area;
 		arrange_output(output);
+	} else {
+		arrange_popups(root->layers.popup);
 	}
 }
 

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -122,6 +122,16 @@ static struct sway_layer_surface *sway_layer_surface_create(
 		return NULL;
 	}
 
+	surface->desc.relative = &scene->tree->node;
+
+	if (!scene_descriptor_assign(&popups->node,
+			SWAY_SCENE_DESC_POPUP, &surface->desc)) {
+		sway_log(SWAY_ERROR, "Failed to allocate a popup scene descriptor");
+		wlr_scene_node_destroy(&popups->node);
+		free(surface);
+		return NULL;
+	}
+
 	surface->tree = scene->tree;
 	surface->scene = scene;
 	surface->layer_surface = scene->layer_surface;
@@ -224,10 +234,6 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 		arrange_layers(surface->output);
 		transaction_commit_dirty();
 	}
-
-	int lx, ly;
-	wlr_scene_node_coords(&surface->scene->tree->node, &lx, &ly);
-	wlr_scene_node_set_position(&surface->popups->node, lx, ly);
 }
 
 static void handle_map(struct wl_listener *listener, void *data) {

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -612,13 +612,9 @@ void arrange_popups(struct wlr_scene_tree *popups) {
 		struct sway_popup_desc *popup = scene_descriptor_try_get(node,
 			SWAY_SCENE_DESC_POPUP);
 
-		// the popup layer may have popups from layer_shell surfaces, in this
-		// case those don't have a scene descriptor, so lets skip those here.
-		if (popup) {
-			int lx, ly;
-			wlr_scene_node_coords(popup->relative, &lx, &ly);
-			wlr_scene_node_set_position(node, lx, ly);
-		}
+		int lx, ly;
+		wlr_scene_node_coords(popup->relative, &lx, &ly);
+		wlr_scene_node_set_position(node, lx, ly);
 	}
 }
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -609,17 +609,15 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 void arrange_popups(struct wlr_scene_tree *popups) {
 	struct wlr_scene_node *node;
 	wl_list_for_each(node, &popups->children, link) {
-		struct sway_xdg_popup *popup = scene_descriptor_try_get(node,
+		struct sway_popup_desc *popup = scene_descriptor_try_get(node,
 			SWAY_SCENE_DESC_POPUP);
 
 		// the popup layer may have popups from layer_shell surfaces, in this
 		// case those don't have a scene descriptor, so lets skip those here.
 		if (popup) {
-			struct wlr_scene_tree *tree = popup->view->content_tree;
-
 			int lx, ly;
-			wlr_scene_node_coords(&tree->node, &lx, &ly);
-			wlr_scene_node_set_position(&popup->scene_tree->node, lx, ly);
+			wlr_scene_node_coords(popup->relative, &lx, &ly);
+			wlr_scene_node_set_position(node, lx, ly);
 		}
 	}
 }

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -606,9 +606,9 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 	}
 }
 
-static void arrange_popup(struct wlr_scene_tree *popup) {
+void arrange_popups(struct wlr_scene_tree *popups) {
 	struct wlr_scene_node *node;
-	wl_list_for_each(node, &popup->children, link) {
+	wl_list_for_each(node, &popups->children, link) {
 		struct sway_xdg_popup *popup = scene_descriptor_try_get(node,
 			SWAY_SCENE_DESC_POPUP);
 
@@ -679,7 +679,7 @@ static void arrange_root(struct sway_root *root) {
 		}
 	}
 
-	arrange_popup(root->layers.popup);
+	arrange_popups(root->layers.popup);
 }
 
 /**

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -97,8 +97,11 @@ static struct sway_xdg_popup *popup_create(struct wlr_xdg_popup *wlr_popup,
 		return NULL;
 	}
 
+	popup->desc.relative = &view->content_tree->node;
+	popup->desc.view = view;
+
 	if (!scene_descriptor_assign(&popup->scene_tree->node,
-			SWAY_SCENE_DESC_POPUP, popup)) {
+			SWAY_SCENE_DESC_POPUP, &popup->desc)) {
 		sway_log(SWAY_ERROR, "Failed to allocate a popup scene descriptor");
 		wlr_scene_node_destroy(&popup->scene_tree->node);
 		free(popup);

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -92,7 +92,7 @@ struct sway_node *node_at_coords(
 			if (!con) {
 				struct sway_popup_desc *popup =
 					scene_descriptor_try_get(current, SWAY_SCENE_DESC_POPUP);
-				if (popup) {
+				if (popup && popup->view) {
 					con = popup->view->container;
 				}
 			}

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -90,7 +90,7 @@ struct sway_node *node_at_coords(
 			}
 
 			if (!con) {
-				struct sway_xdg_popup *popup =
+				struct sway_popup_desc *popup =
 					scene_descriptor_try_get(current, SWAY_SCENE_DESC_POPUP);
 				if (popup) {
 					con = popup->view->container;


### PR DESCRIPTION
We had this `SWAY_SCENE_DESC_POPUP` type floating around that would only handle popup arrangement for xdg_shell. This was originally created to have popups follow the location of views as they move.  I had the same concern for layer_shell, but I only moved popups for a layer shell when that layer shell has been committed. This is wrong because if a layer_shell commits, we could potentially arrange other layer shells to move and those popups wouldn't move as well. This system ties it all together into a common system. 

This is also a soft requirement for input_method popups as they have a similar concern.