### PR TITLE
Add the DesktopNames key to the sway.desktop session file

### DIFF
--- a/sway.desktop
+++ b/sway.desktop
@@ -3,3 +3,4 @@ Name=Sway
 Comment=An i3-compatible Wayland compositor
 Exec=sway
 Type=Application
+DesktopNames=sway;wlroots


### PR DESCRIPTION
According to
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html, to set the value of XDG_CURRENT_DESKTOP, a DesktopNames key is required in the session file.  And the value of XDG_CURRENT_DESKTOP is used to run xdg-desktop-portal*. 

If this value is not set, xdg-desktop-portal-wlr will not run at login.

The value of XDG_CURRENT_DESKTOP is set by the login manager, but from my research, some of them are supported and some are not.

In sddm, I confirmed that it is supported.