### PR TITLE
Workspace criterion also applies to containers

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -1031,7 +1031,7 @@ The following attributes may be matched with:
 	applications and requires XWayland.
 
 *workspace*
-	Compare against the workspace name for this view. Can be a regular
+	Compare against the workspace name for this container. Can be a regular
 	expression. If the value is \_\_focused\_\_, then all the views on the
 	currently focused workspace matches.
 


### PR DESCRIPTION
The workspace criterion did only apply to views, now it also applies to containers.

Fixes #7218 