### PR TITLE
launcher: use wlroots api to manipulate the token seat

### DIFF
--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -238,7 +238,7 @@ struct launcher_ctx *launcher_ctx_create_internal(void) {
 
 	struct wlr_xdg_activation_token_v1 *token =
 		wlr_xdg_activation_token_v1_create(server.xdg_activation_v1);
-	token->seat = seat->wlr_seat;
+	wlr_xdg_activation_token_v1_set_seat(token, seat->wlr_seat);
 
 	struct launcher_ctx *ctx = launcher_ctx_create(token, &ws->node);
 	if (!ctx) {


### PR DESCRIPTION
It isn't safe to manipulate the seat field directly, as the seat may be destroyed.

Ref: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4539

This is a small part of https://github.com/swaywm/sway/issues/7938#issuecomment-1913097949. Sway doesn't really do wlr_seat destroy handlers for whatever reason atm. This is a small part of fixing that.