### PR TITLE
reduces redundant containers

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -134,8 +134,14 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	// Operate on parent container, like i3.
 	if (container) {
 		container = container->pending.parent;
+		// If parent has only a singe child operate on its parent and
+		// flatten once, like i3
 		if (container && container->pending.children->length == 1) {
-			container = container->pending.parent;
+			struct sway_container *child = container->pending.children->items[0];
+			struct sway_container *parent = container->pending.parent;
+			container_replace(container, child);
+			container_begin_destroy(container);
+			container = parent;
 		}
 	}
 

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -134,6 +134,9 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	// Operate on parent container, like i3.
 	if (container) {
 		container = container->pending.parent;
+		if (container && container->pending.children->length == 1) {
+			container = container->pending.parent;
+		}
 	}
 
 	// We could be working with a container OR a workspace. These are different


### PR DESCRIPTION
Applying layout changes to the parent of the parent, in case the parent only has a single child, stops the creation of a chain of single child containers. 

fixes #7945 