### PR TITLE
launcher: track the seat in the launcher ctx

### DIFF
--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -3,12 +3,15 @@
 
 #include <stdlib.h>
 #include <wayland-server-core.h>
+#include "sway/input/seat.h"
 
 struct launcher_ctx {
 	pid_t pid;
 	char *fallback_name;
 	struct wlr_xdg_activation_token_v1 *token;
 	struct wl_listener token_destroy;
+	struct sway_seat *seat;
+	struct wl_listener seat_destroy;
 
 	bool activated;
 

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -67,6 +67,9 @@ void launcher_ctx_destroy(struct launcher_ctx *ctx) {
 	}
 	wl_list_remove(&ctx->node_destroy.link);
 	wl_list_remove(&ctx->token_destroy.link);
+	if (ctx->seat) {
+		wl_list_remove(&ctx->seat_destroy.link);
+	}
 	wl_list_remove(&ctx->link);
 	wlr_xdg_activation_token_v1_destroy(ctx->token);
 	free(ctx->fallback_name);
@@ -227,6 +230,12 @@ struct launcher_ctx *launcher_ctx_create(struct wlr_xdg_activation_token_v1 *tok
 	return ctx;
 }
 
+static void launch_ctx_handle_seat_destroy(struct wl_listener *listener, void *data) {
+	struct launcher_ctx *ctx = wl_container_of(listener, ctx, seat_destroy);
+	ctx->seat = NULL;
+	wl_list_remove(&ctx->seat_destroy.link);
+}
+
 // Creates a context with a new token for the internal launcher
 struct launcher_ctx *launcher_ctx_create_internal(void) {
 	struct sway_seat *seat = input_manager_current_seat();
@@ -238,13 +247,15 @@ struct launcher_ctx *launcher_ctx_create_internal(void) {
 
 	struct wlr_xdg_activation_token_v1 *token =
 		wlr_xdg_activation_token_v1_create(server.xdg_activation_v1);
-	token->seat = seat->wlr_seat;
 
 	struct launcher_ctx *ctx = launcher_ctx_create(token, &ws->node);
 	if (!ctx) {
 		wlr_xdg_activation_token_v1_destroy(token);
 		return NULL;
 	}
+	ctx->seat = seat;
+	ctx->seat_destroy.notify = launch_ctx_handle_seat_destroy;
+	wl_signal_add(&seat->wlr_seat->events.destroy, &ctx->seat_destroy);
 
 	return ctx;
 }


### PR DESCRIPTION
This is a more suitable place to track the requesting seat, since we are able to respond appropriately to destroy notifications.

---

This is an alternative to #7959.