### PR TITLE
output: Fallback to sorting workspaces alphabetically

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -9,6 +9,7 @@
 #include "sway/tree/workspace.h"
 #include "sway/server.h"
 #include "log.h"
+#include "stringop.h"
 #include "util.h"
 
 enum wlr_direction opposite_direction(enum wlr_direction d) {
@@ -404,7 +405,7 @@ static int sort_workspace_cmp_qsort(const void *_a, const void *_b) {
 	} else if (isdigit(b->name[0])) {
 		return 1;
 	}
-	return 0;
+	return lenient_strcmp(a->name, b->name);
 }
 
 void output_sort_workspaces(struct sway_output *output) {


### PR DESCRIPTION
Currently the order of unnumbered workspaces is the order they were created. This is a bit unintuitive for workflows where workspaces are created and named dynamically.

Instead of treating all unnumbered workspaces equal, fallback to sorting them alphabetically based on the name of the workspace. This will make the ordering more deterministic regardless of the order they were created.


This change will probably go unnoticed for a lot users since most people are using static workspace configuration connected to numbers. However it is a great improvement for workflows that create new workspaces on the fly with an associated name.