### PR TITLE
view: drop ext_foreign_destroy

### DIFF
--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -85,7 +85,6 @@ struct sway_view {
 	struct wlr_box geometry;
 
 	struct wlr_ext_foreign_toplevel_handle_v1 *ext_foreign_toplevel;
-	struct wl_listener ext_foreign_destroy;
 
 	struct wlr_foreign_toplevel_handle_v1 *foreign_toplevel;
 	struct wl_listener foreign_activate_request;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -765,8 +765,6 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	};
 	view->ext_foreign_toplevel =
 		wlr_ext_foreign_toplevel_handle_v1_create(server.foreign_toplevel_list, &foreign_toplevel_state);
-	wl_signal_add(&view->ext_foreign_toplevel->events.destroy,
-			&view->ext_foreign_destroy);
 
 	view->foreign_toplevel =
 		wlr_foreign_toplevel_handle_v1_create(server.foreign_toplevel_manager);


### PR DESCRIPTION
It's not used and causes a crash when a view is destroyed.