### PR TITLE
Fix build with wlroots DRM backend disabled

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -10,7 +10,6 @@
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
 #include <wlr/types/wlr_input_method_v2.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
-#include <wlr/types/wlr_drm_lease_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>


### PR DESCRIPTION
The header is not installed by wlroots when the DRM backend is disabled. We don't need it here, so don't include it.

Closes: https://github.com/swaywm/sway/issues/7943