### PR TITLE
input/text_input: parent wlr_box may be uninitialized

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -300,7 +300,7 @@ static void input_popup_update(struct sway_input_popup *popup) {
 	struct wlr_box cursor_area = text_input->input->current.cursor_rectangle;
 
 	struct wlr_box output_box;
-	struct wlr_box parent;
+	struct wlr_box parent = {0};
 	struct wlr_layer_surface_v1 *layer_surface =
 		wlr_layer_surface_v1_try_from_wlr_surface(focused_surface);
 	struct wlr_scene_tree *relative_parent;


### PR DESCRIPTION
Fixes the following error:
```
../sway/input/text_input.c: In function ‘input_popup_update’:
../sway/input/text_input.c:364:13: error: ‘parent.width’ may be used uninitialized [-Werror=maybe-uninitialized]
  364 |         int x2 = parent.x + cursor_area.x + cursor_area.width;
      |             ^~
../sway/input/text_input.c:303:24: note: ‘parent.width’ was declared here
  303 |         struct wlr_box parent;
      |                        ^~~~~~
../sway/input/text_input.c:366:13: error: ‘parent.height’ may be used uninitialized [-Werror=maybe-uninitialized]
  366 |         int y2 = parent.y + cursor_area.y + cursor_area.height;
      |             ^~
../sway/input/text_input.c:303:24: note: ‘parent.height’ was declared here
  303 |         struct wlr_box parent;
      |                        ^~~~~~
cc1: all warnings being treated as errors
```