### PR TITLE
Add `floating` and `scratchpad_state` properties to GET_TREE to restore IPC parity with i3

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -288,6 +288,7 @@ static json_object *ipc_json_create_node(int id, const char* type, char *name,
 	json_object_object_add(object, "focus", focus);
 	json_object_object_add(object, "fullscreen_mode", json_object_new_int(0));
 	json_object_object_add(object, "sticky", json_object_new_boolean(false));
+	json_object_object_add(object, "floating", NULL);
 
 	return object;
 }
@@ -675,7 +676,8 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 static void ipc_json_describe_container(struct sway_container *c, json_object *object) {
 	json_object_object_add(object, "name",
 			c->title ? json_object_new_string(c->title) : NULL);
-	if (container_is_floating(c)) {
+	bool floating = container_is_floating(c);
+	if (floating) {
 		json_object_object_add(object, "type",
 				json_object_new_string("floating_con"));
 	}
@@ -692,6 +694,10 @@ static void ipc_json_describe_container(struct sway_container *c, json_object *o
 		view_is_urgent(c->view) : container_has_urgent_child(c);
 	json_object_object_add(object, "urgent", json_object_new_boolean(urgent));
 	json_object_object_add(object, "sticky", json_object_new_boolean(c->is_sticky));
+
+	// sway doesn't track the floating reason, so we can't use "auto_on" or "user_off"
+	json_object_object_add(object, "floating",
+			json_object_new_string(floating ? "user_on" : "auto_off"));
 
 	json_object_object_add(object, "fullscreen_mode",
 			json_object_new_int(c->pending.fullscreen_mode));

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -289,6 +289,7 @@ static json_object *ipc_json_create_node(int id, const char* type, char *name,
 	json_object_object_add(object, "fullscreen_mode", json_object_new_int(0));
 	json_object_object_add(object, "sticky", json_object_new_boolean(false));
 	json_object_object_add(object, "floating", NULL);
+	json_object_object_add(object, "scratchpad_state", NULL);
 
 	return object;
 }
@@ -701,6 +702,10 @@ static void ipc_json_describe_container(struct sway_container *c, json_object *o
 
 	json_object_object_add(object, "fullscreen_mode",
 			json_object_new_int(c->pending.fullscreen_mode));
+
+	// sway doesn't track if window was resized in scratchpad, so we can't use "changed"
+	json_object_object_add(object, "scratchpad_state",
+			json_object_new_string(!c->scratchpad ? "none" : "fresh"));
 
 	struct sway_node *parent = node_get_parent(&c->node);
 	struct wlr_box parent_box = {0, 0, 0, 0};

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -376,6 +376,9 @@ node and will have the following properties:
 :  integer
 :  (Only containers and views) The fullscreen mode of the node. 0 means none, 1 means
    full workspace, and 2 means global fullscreen
+|- floating
+:  string
+:  Floating state of container. Can be either "auto_off" or "user_on"
 |- app_id
 :  string
 :  (Only views) For an xdg-shell view, the name of the application, if set.

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -379,6 +379,9 @@ node and will have the following properties:
 |- floating
 :  string
 :  Floating state of container. Can be either "auto_off" or "user_on"
+|- scratchpad_state
+:  string
+:  Whether the window is in the scratchpad. Can be either "none" or "fresh"
 |- app_id
 :  string
 :  (Only views) For an xdg-shell view, the name of the application, if set.


### PR DESCRIPTION
See: https://i3wm.org/docs/ipc.html