### PR TITLE
commands/move: do not force focus on the moved container

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -769,15 +769,6 @@ static struct cmd_results *cmd_move_in_direction(
 		ipc_event_window(container, "move");
 	}
 
-	// Hack to re-focus container
-	seat_set_raw_focus(config->handler_context.seat, &new_ws->node);
-	seat_set_focus_container(config->handler_context.seat, container);
-
-	if (old_ws != new_ws) {
-		ipc_event_workspace(old_ws, new_ws, "focus");
-		workspace_detect_urgent(old_ws);
-		workspace_detect_urgent(new_ws);
-	}
 	container_end_mouse_operation(container);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);


### PR DESCRIPTION
My code archaeology isn't good enough to determine what this is here for, but it isn't correct. We should be able to move containers in a direction without focusing them. AFAICT i3 doesn't do this, so we shouldn't either.

This fixes ipc commands like move \<dir\> with criteria that apply to containers which are not the current focus.