### PR TITLE
added new option in Sway config - 'disable_titlebar' (for branch 1.9)

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -124,6 +124,7 @@ sway_cmd cmd_create_output;
 sway_cmd cmd_default_border;
 sway_cmd cmd_default_floating_border;
 sway_cmd cmd_default_orientation;
+sway_cmd cmd_disable_titlebar;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -532,6 +532,7 @@ struct sway_config {
 	bool validating;
 	bool auto_back_and_forth;
 	bool show_marks;
+	bool disable_titlebar;
 	enum alignment title_align;
 	bool primary_selection;
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -58,6 +58,7 @@ static const struct cmd_handler handlers[] = {
 	{ "client.urgent", cmd_client_urgent },
 	{ "default_border", cmd_default_border },
 	{ "default_floating_border", cmd_default_floating_border },
+	{ "disable_titlebar", cmd_disable_titlebar },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
 	{ "floating_maximum_size", cmd_floating_maximum_size },

--- a/sway/commands/disable_titlebar.c
+++ b/sway/commands/disable_titlebar.c
@@ -1,0 +1,14 @@
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "util.h"
+
+struct cmd_results *cmd_disable_titlebar(int argc, char **argv) {
+    struct cmd_results *error = NULL;
+    if ((error = checkarg(argc, "disable_titlebar", EXPECTED_EQUAL_TO, 1))) {
+        return error;
+    }
+
+    config->disable_titlebar = parse_boolean(argv[0], config->disable_titlebar);
+
+    return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -270,6 +270,7 @@ static void config_defaults(struct sway_config *config) {
 	config->auto_back_and_forth = false;
 	config->reading = false;
 	config->show_marks = true;
+	config->disable_titlebar = false;
 	config->title_align = ALIGN_LEFT;
 	config->tiling_drag = true;
 	config->tiling_drag_threshold = 9;

--- a/sway/desktop/render.c
+++ b/sway/desktop/render.c
@@ -716,7 +716,7 @@ static void render_containers_linear(struct render_context *ctx, struct parent_d
 				marks_texture = child->marks_unfocused;
 			}
 
-			if (state->border == B_NORMAL) {
+			if (state->border == B_NORMAL && !config->disable_titlebar) {
 				render_titlebar(ctx, child, floor(state->x),
 						floor(state->y), state->width, colors,
 						title_texture, marks_texture);
@@ -790,8 +790,10 @@ static void render_containers_tabbed(struct render_context *ctx, struct parent_d
 			tab_width = parent->box.width - tab_width * i;
 		}
 
-		render_titlebar(ctx, child, x, parent->box.y, tab_width,
-				colors, title_texture, marks_texture);
+		if (!config->disable_titlebar) {
+			render_titlebar(ctx, child, x, parent->box.y, tab_width,
+					colors, title_texture, marks_texture);
+		}
 
 		if (child == current) {
 			current_colors = colors;
@@ -851,9 +853,11 @@ static void render_containers_stacked(struct render_context *ctx, struct parent_
 			marks_texture = child->marks_unfocused;
 		}
 
-		int y = parent->box.y + titlebar_height * i;
-		render_titlebar(ctx, child, parent->box.x, y,
-				parent->box.width, colors, title_texture, marks_texture);
+		if (!config->disable_titlebar) {
+			int y = parent->box.y + titlebar_height * i;
+			render_titlebar(ctx, child, parent->box.x, y,
+					parent->box.width, colors, title_texture, marks_texture);
+		}
 
 		if (child == current) {
 			current_colors = colors;
@@ -949,7 +953,7 @@ static void render_floating_container(struct render_context *ctx,
 			marks_texture = con->marks_unfocused;
 		}
 
-		if (con->current.border == B_NORMAL) {
+		if (con->current.border == B_NORMAL && !config->disable_titlebar) {
 			render_titlebar(ctx, con, floor(con->current.x),
 					floor(con->current.y), con->current.width, colors,
 					title_texture, marks_texture);

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -51,6 +51,7 @@ sway_sources = files(
 	'commands/default_border.c',
 	'commands/default_floating_border.c',
 	'commands/default_orientation.c',
+        'commands/disable_titlebar.c',
 	'commands/exit.c',
 	'commands/exec.c',
 	'commands/exec_always.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -726,6 +726,9 @@ The default colors are:
 	should be greater than titlebar_border_thickness. If _vertical_ value is
 	not specified it is set to the _horizontal_ value.
 
+*disable_titlebar* yes|no.
+	Remove titlebar. Default is _no_.
+
 *for_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -670,6 +670,10 @@ void container_update_representation(struct sway_container *con) {
 }
 
 size_t container_titlebar_height(void) {
+	if(config->disable_titlebar) {
+		return 0;
+	}
+	
 	return config->font_height + config->titlebar_v_padding * 2;
 }
 


### PR DESCRIPTION
If the team releases minor version 1.9x, this option will help many people enjoy this WM.  
Sway releases come out approximately every year and are tied to Wlroots releases. A whole year without the ability to turn off the title! =( 

There are too many changes in the Master branch, as well as in Wlroots-dev. I'll create another pull request for the master branch later. Sway-dev doesn't compile at the moment...

