### PR TITLE
input: Rename WLR_INPUT_DEVICE_TABLET_TOOL to WLR_INPUT_DEVICE_TABLET

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -243,7 +243,7 @@ static enum sway_input_idle_source idle_source_from_device(
 		return IDLE_SOURCE_POINTER;
 	case WLR_INPUT_DEVICE_TOUCH:
 		return IDLE_SOURCE_TOUCH;
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		return IDLE_SOURCE_TABLET_TOOL;
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		return IDLE_SOURCE_TABLET_PAD;
@@ -518,7 +518,7 @@ static void apply_mapping_from_region(struct wlr_input_device *device,
 	double x1 = region->x1, x2 = region->x2;
 	double y1 = region->y1, y2 = region->y2;
 
-	if (region->mm && device->type == WLR_INPUT_DEVICE_TABLET_TOOL) {
+	if (region->mm && device->type == WLR_INPUT_DEVICE_TABLET) {
 		struct wlr_tablet *tablet = wlr_tablet_from_input_device(device);
 		if (tablet->width_mm == 0 || tablet->height_mm == 0) {
 			return;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -111,7 +111,7 @@ const char *input_device_get_type(struct sway_input_device *device) {
 		return "keyboard";
 	case WLR_INPUT_DEVICE_TOUCH:
 		return "touch";
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		return "tablet_tool";
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		return "tablet_pad";

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -607,7 +607,7 @@ static void seat_update_capabilities(struct sway_seat *seat) {
 		case WLR_INPUT_DEVICE_TOUCH:
 			caps |= WL_SEAT_CAPABILITY_TOUCH;
 			break;
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			caps |= WL_SEAT_CAPABILITY_POINTER;
 			break;
 		case WLR_INPUT_DEVICE_SWITCH:
@@ -665,7 +665,7 @@ static const char *get_builtin_output_name(void) {
 static bool is_touch_or_tablet_tool(struct sway_seat_device *seat_device) {
 	switch (seat_device->input_device->wlr_device->type) {
 	case WLR_INPUT_DEVICE_TOUCH:
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		return true;
 	default:
 		return false;
@@ -680,7 +680,7 @@ static void seat_apply_input_mapping(struct sway_seat *seat,
 	switch (sway_device->input_device->wlr_device->type) {
 	case WLR_INPUT_DEVICE_POINTER:
 	case WLR_INPUT_DEVICE_TOUCH:
-	case WLR_INPUT_DEVICE_TABLET_TOOL:
+	case WLR_INPUT_DEVICE_TABLET:
 		break;
 	default:
 		return; // these devices don't support mappings
@@ -873,7 +873,7 @@ void seat_configure_device(struct sway_seat *seat,
 		case WLR_INPUT_DEVICE_TOUCH:
 			seat_configure_touch(seat, seat_device);
 			break;
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			seat_configure_tablet_tool(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:
@@ -912,7 +912,7 @@ void seat_reset_device(struct sway_seat *seat,
 		case WLR_INPUT_DEVICE_TOUCH:
 			seat_reset_input_config(seat, seat_device);
 			break;
-		case WLR_INPUT_DEVICE_TABLET_TOOL:
+		case WLR_INPUT_DEVICE_TABLET:
 			seat_reset_input_config(seat, seat_device);
 			break;
 		case WLR_INPUT_DEVICE_TABLET_PAD:


### PR DESCRIPTION
wlroots has changed the naming, causing the following build errors when building:

error: ‘WLR_INPUT_DEVICE_TABLET_TOOL’ undeclared