### PR TITLE
tree/view: Do not clip to geometry if using CSD

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -927,11 +927,14 @@ void view_update_size(struct sway_view *view) {
 void view_center_and_clip_surface(struct sway_view *view) {
 	struct sway_container *con = view->container;
 
+	bool clip_to_geometry = true;
+
 	if (container_is_floating(con)) {
 		// We always center the current coordinates rather than the next, as the
 		// geometry immediately affects the currently active rendering.
 		int x = (int) fmax(0, (con->current.content_width - view->geometry.width) / 2);
 		int y = (int) fmax(0, (con->current.content_height - view->geometry.height) / 2);
+		clip_to_geometry = !view->using_csd;
 
 		wlr_scene_node_set_position(&view->content_tree->node, x, y);
 	} else {
@@ -940,12 +943,16 @@ void view_center_and_clip_surface(struct sway_view *view) {
 
 	// only make sure to clip the content if there is content to clip
 	if (!wl_list_empty(&con->view->content_tree->children)) {
-		wlr_scene_subsurface_tree_set_clip(&con->view->content_tree->node, &(struct wlr_box){
-			.x = con->view->geometry.x,
-			.y = con->view->geometry.y,
-			.width = con->current.content_width,
-			.height = con->current.content_height,
-		});
+		struct wlr_box clip = {0};
+		if (clip_to_geometry) {
+			clip = (struct wlr_box){
+				.x = con->view->geometry.x,
+				.y = con->view->geometry.y,
+				.width = con->current.content_width,
+				.height = con->current.content_height,
+			};
+		}
+		wlr_scene_subsurface_tree_set_clip(&con->view->content_tree->node, &clip);
 	}
 }
 


### PR DESCRIPTION
As of commit 9da295c11, surfaces of `xdg_toplevel`s are clipped to a region defined by the geometry. This causes drop shadows of floating windows to be cut off, as seen with gnome-calculator against a white background:
![image](https://github.com/swaywm/sway/assets/1455481/b729bfb6-876d-46cc-90d5-028d4db6528e)
This PR will avoid clipping if a `sway_view` is in a floating container and using CSD.