### PR TITLE
input/seat: handle wlr_seat destroy

### DIFF
--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -118,6 +118,7 @@ struct sway_seat {
 
 	struct sway_input_method_relay im_relay;
 
+	struct wl_listener destroy;
 	struct wl_listener focus_destroy;
 	struct wl_listener new_node;
 	struct wl_listener request_start_drag;
@@ -150,8 +151,6 @@ struct sway_keyboard_shortcuts_inhibitor {
 };
 
 struct sway_seat *seat_create(const char *seat_name);
-
-void seat_destroy(struct sway_seat *seat);
 
 void seat_add_device(struct sway_seat *seat,
 		struct sway_input_device *device);

--- a/sway/config.c
+++ b/sway/config.c
@@ -191,7 +191,7 @@ static void destroy_removed_seats(struct sway_config *old_config,
 				seat_name_cmp, seat_config->name) < 0) {
 			seat = input_manager_get_seat(seat_config->name, false);
 			if (seat) {
-				seat_destroy(seat);
+				wlr_seat_destroy(seat->wlr_seat);
 			}
 		}
 	}


### PR DESCRIPTION
Doesn't work properly: IPC stuff is cleaned up in a wl_display destroy listener, and wlr_backend destroy happens after and tries to send IPC events…

Also if `input_manager_get_default_seat()` is called it might re-create the default seat after it's destroyed…