### PR TITLE
server: fix wlr_seat use-after-free on exit

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -399,6 +399,7 @@ void server_fini(struct sway_server *server) {
 	wlr_xwayland_destroy(server->xwayland.wlr_xwayland);
 #endif
 	wl_display_destroy_clients(server->wl_display);
+	wlr_backend_destroy(server->backend);
 	wl_display_destroy(server->wl_display);
 	list_free(server->dirty_nodes);
 }


### PR DESCRIPTION
Same as [1].

I originally tried to properly handle seat destruction, but that turned out to be a can of worms [2].

[1]: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4590
[2]: https://github.com/swaywm/sway/pull/8034