### PR TITLE
desktop/output: merge power management config on top of current one

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -719,9 +719,7 @@ void apply_output_config_to_outputs(struct output_config *oc) {
 	struct sway_output *sway_output, *tmp;
 	wl_list_for_each_safe(sway_output, tmp, &root->all_outputs, link) {
 		if (output_match_name_or_id(sway_output, oc->name)) {
-			char id[128];
-			output_get_identifier(id, sizeof(id), sway_output);
-			struct output_config *current = get_output_config(id, sway_output);
+			struct output_config *current = find_output_config(sway_output);
 			if (!current) {
 				// No stored output config matched, apply oc directly
 				sway_log(SWAY_DEBUG, "Applying oc directly");

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -644,6 +644,12 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 		oc->power = 1;
 		break;
 	}
-	oc = store_output_config(oc);
-	apply_output_config(oc, output);
+
+	struct output_config *current = find_output_config(output);
+	if (!current) {
+		current = new_output_config(oc->name);
+		merge_output_config(current, oc);
+	}
+	apply_output_config(current, output);
+	free_output_config(current);
 }


### PR DESCRIPTION
Don't replace an existing config with a blank one with just the
power field set.

Logic borrowed from apply_output_config_to_outputs().