### PR TITLE
config/output: drop enabling flag

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -50,7 +50,7 @@ struct sway_output {
 	enum wl_output_subpixel detected_subpixel;
 	enum scale_filter_mode scale_filter;
 
-	bool enabling, enabled;
+	bool enabled;
 	list_t *workspaces;
 
 	struct sway_output_state current;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -510,9 +510,6 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 
 	struct wlr_output *wlr_output = output->wlr_output;
 
-	// Flag to prevent the output mode event handler from calling us
-	output->enabling = (!oc || oc->enabled);
-
 	struct wlr_output_state pending = {0};
 	queue_output_config(oc, output, &pending);
 
@@ -522,11 +519,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output) {
 		// Leave the output disabled for now and try again when the output gets
 		// the mode we asked for.
 		sway_log(SWAY_ERROR, "Failed to commit output %s", wlr_output->name);
-		output->enabling = false;
 		return false;
 	}
-
-	output->enabling = false;
 
 	if (oc && !oc->enabled) {
 		sway_log(SWAY_DEBUG, "Disabling output %s", oc->name);


### PR DESCRIPTION
This was useful when wlroots backends were updating the current mode on their own. This is no longer the case.