### PR TITLE
config/output: Fix store_output_config return

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -638,9 +638,11 @@ static void default_output_config(struct output_config *oc,
 	oc->max_render_time = 0;
 }
 
-static struct output_config *get_output_config(char *identifier,
-		struct sway_output *sway_output) {
+struct output_config *find_output_config(struct sway_output *sway_output) {
+	char identifier[128];
+	output_get_identifier(identifier, sizeof(identifier), sway_output);
 	const char *name = sway_output->wlr_output->name;
+
 	struct output_config *oc = NULL;
 
 	// Look for "id on name" output config, which will be stored if configs
@@ -693,16 +695,8 @@ found:;
 	return result;
 }
 
-struct output_config *find_output_config(struct sway_output *output) {
-	char id[128];
-	output_get_identifier(id, sizeof(id), output);
-	return get_output_config(id, output);
-}
-
 static void apply_output_config_to_output(struct output_config *oc, struct sway_output *sway_output) {
-	char id[128];
-	output_get_identifier(id, sizeof(id), sway_output);
-	struct output_config *current = get_output_config(id, sway_output);
+	struct output_config *current = find_output_config(sway_output);
 	if (!current) {
 		// No stored output config matched, apply oc directly
 		sway_log(SWAY_DEBUG, "Applying oc directly");

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -166,6 +166,7 @@ static struct output_config *merge_id_on_name(struct output_config *oc) {
 	char id[128];
 	output_get_identifier(id, sizeof(id), output);
 
+	struct output_config *new_oc = NULL;
 	char *id_on_name = format_str("%s on %s", id, name);
 	if (!id_on_name) {
 		return NULL;
@@ -174,38 +175,48 @@ static struct output_config *merge_id_on_name(struct output_config *oc) {
 	int i = list_seq_find(config->output_configs, output_name_cmp, id_on_name);
 	if (i >= 0) {
 		sway_log(SWAY_DEBUG, "Merging on top of existing id on name config");
-		merge_output_config(config->output_configs->items[i], oc);
-		free(id_on_name);
-		return config->output_configs->items[i];
+		new_oc = config->output_configs->items[i];
+		merge_output_config(new_oc, oc);
+		goto done;
 	}
 
 	// If both a name and identifier config, exist generate an id on name
-	struct output_config *ion_oc = NULL;
 	int ni = list_seq_find(config->output_configs, output_name_cmp, name);
 	int ii = list_seq_find(config->output_configs, output_name_cmp, id);
 	if ((ni >= 0 && ii >= 0) || (ni >= 0 && strcmp(oc->name, id) == 0)
 			|| (ii >= 0 && strcmp(oc->name, name) == 0)) {
-		ion_oc = new_output_config(id_on_name);
+		new_oc = new_output_config(id_on_name);
 		if (ni >= 0) {
-			merge_output_config(ion_oc, config->output_configs->items[ni]);
+			merge_output_config(new_oc, config->output_configs->items[ni]);
 		}
 		if (ii >= 0) {
-			merge_output_config(ion_oc, config->output_configs->items[ii]);
+			merge_output_config(new_oc, config->output_configs->items[ii]);
 		}
-		merge_output_config(ion_oc, oc);
-		list_add(config->output_configs, ion_oc);
+		merge_output_config(new_oc, oc);
+		list_add(config->output_configs, new_oc);
 		sway_log(SWAY_DEBUG, "Generated id on name output config \"%s\""
 			" (enabled: %d) (%dx%d@%fHz position %d,%d scale %f "
 			"transform %d) (bg %s %s) (power %d) (max render time: %d)",
-			ion_oc->name, ion_oc->enabled, ion_oc->width, ion_oc->height,
-			ion_oc->refresh_rate, ion_oc->x, ion_oc->y, ion_oc->scale,
-			ion_oc->transform, ion_oc->background,
-			ion_oc->background_option, ion_oc->power,
-			ion_oc->max_render_time);
+			new_oc->name, new_oc->enabled, new_oc->width, new_oc->height,
+			new_oc->refresh_rate, new_oc->x, new_oc->y, new_oc->scale,
+			new_oc->transform, new_oc->background,
+			new_oc->background_option, new_oc->power,
+			new_oc->max_render_time);
+		goto done;
 	}
 
+	// If only direct match exists, merge with that
+	if (ni >= 0 && strcmp(oc->name, name) == 0) {
+		new_oc = config->output_configs->items[ni];
+		merge_output_config(new_oc, oc);
+	} else if (ii >= 0 && strcmp(oc->name, id) == 0) {
+		new_oc = config->output_configs->items[ii];
+		merge_output_config(new_oc, oc);
+	}
+
+done:
 	free(id_on_name);
-	return ion_oc;
+	return new_oc;
 }
 
 struct output_config *store_output_config(struct output_config *oc) {


### PR DESCRIPTION
When we receive a new output config, we merge it with existing configurations. Make sure that the caller of store_output_config always receives the exactly the configuration that was stored.

Based on https://github.com/swaywm/sway/pull/8049.

Not tested.