### PR TITLE
Draft: tablet: add tablet tool scroll support

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -63,6 +63,7 @@ struct sway_cursor {
 	struct wl_listener tool_tip;
 	struct wl_listener tool_proximity;
 	struct wl_listener tool_button;
+	struct wl_listener tool_axis_scroll;
 	bool simulating_pointer_from_tool_tip;
 	bool simulating_pointer_from_tool_button;
 	uint32_t tool_buttons;

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -48,6 +48,8 @@ struct sway_seatop_impl {
 			struct wlr_touch_cancel_event *event);
 	void (*tablet_tool_motion)(struct sway_seat *seat,
 			struct sway_tablet_tool *tool, uint32_t time_msec);
+	void (*tablet_tool_axis_scroll)(struct sway_seat *seat,
+			struct sway_tablet_tool *tool, struct wlr_tablet_tool_axis_scroll_event *event);
 	void (*tablet_tool_tip)(struct sway_seat *seat, struct sway_tablet_tool *tool,
 			uint32_t time_msec, enum wlr_tablet_tool_tip_state state);
 	void (*end)(struct sway_seat *seat);
@@ -298,6 +300,10 @@ void seatop_pointer_motion(struct sway_seat *seat, uint32_t time_msec);
 
 void seatop_pointer_axis(struct sway_seat *seat,
 		struct wlr_pointer_axis_event *event);
+
+void seatop_tablet_tool_axis_scroll(struct sway_seat *seat,
+		struct sway_tablet_tool *tool,
+		struct wlr_tablet_tool_axis_scroll_event *event);
 
 void seatop_tablet_tool_tip(struct sway_seat *seat,
 		struct sway_tablet_tool *tool, uint32_t time_msec,

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -724,6 +724,38 @@ static void handle_tool_proximity(struct wl_listener *listener, void *data) {
 		0, 0, event->time_msec);
 }
 
+static void handle_tool_axis_scroll(struct wl_listener *listener, void *data) {
+	struct sway_cursor *cursor = wl_container_of(listener, cursor, tool_axis_scroll);
+	struct wlr_tablet_tool_axis_scroll_event *event = data;
+	cursor_handle_activity_from_device(cursor, &event->tablet->base);
+
+	struct sway_tablet_tool *sway_tool = event->tool->data;
+	struct wlr_tablet_v2_tablet *tablet_v2 = sway_tool->tablet->tablet_v2;
+	struct sway_seat *seat = cursor->seat;
+
+
+	double sx, sy;
+	struct wlr_surface *surface = NULL;
+	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y,
+		&surface, &sx, &sy);
+
+	if (surface && wlr_surface_accepts_tablet_v2(tablet_v2, surface)) {
+		sway_log(SWAY_DEBUG, "axis_scroll, accepts tablet");
+		seatop_tablet_tool_axis_scroll(cursor->seat, sway_tool, event);
+	} else {
+		struct wlr_pointer_axis_event simulated_pointer_event = {
+			.pointer = NULL, // FIXME
+			.time_msec = event->time_msec,
+			.source = event->source,
+			.orientation = event->orientation,
+			.delta = event->delta,
+			.delta_discrete = 0,
+		};
+		seatop_pointer_axis(cursor->seat, &simulated_pointer_event);
+		sway_log(SWAY_DEBUG, "axis_scroll, simulating");
+	}
+}
+
 static void handle_tool_button(struct wl_listener *listener, void *data) {
 	struct sway_cursor *cursor = wl_container_of(listener, cursor, tool_button);
 	struct wlr_tablet_tool_button_event *event = data;
@@ -1139,6 +1171,9 @@ struct sway_cursor *sway_cursor_create(struct sway_seat *seat) {
 
 	wl_signal_add(&wlr_cursor->events.tablet_tool_proximity, &cursor->tool_proximity);
 	cursor->tool_proximity.notify = handle_tool_proximity;
+
+	wl_signal_add(&wlr_cursor->events.tablet_tool_axis_scroll, &cursor->tool_axis_scroll);
+	cursor->tool_axis_scroll.notify = handle_tool_axis_scroll;
 
 	wl_signal_add(&wlr_cursor->events.tablet_tool_button, &cursor->tool_button);
 	cursor->tool_button.notify = handle_tool_button;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1576,6 +1576,14 @@ void seatop_pointer_axis(struct sway_seat *seat,
 	}
 }
 
+void seatop_tablet_tool_axis_scroll(struct sway_seat *seat,
+		struct sway_tablet_tool *tool,
+		struct wlr_tablet_tool_axis_scroll_event *event) {
+	if (seat->seatop_impl->tablet_tool_axis_scroll) {
+		seat->seatop_impl->tablet_tool_axis_scroll(seat, tool, event);
+	}
+}
+
 void seatop_touch_motion(struct sway_seat *seat, struct wlr_touch_motion_event *event,
 		double lx, double ly) {
 	if (seat->seatop_impl->touch_motion) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -795,10 +795,26 @@ static void handle_pointer_axis(struct sway_seat *seat,
 
 	if (!handled) {
 		wlr_seat_pointer_notify_axis(cursor->seat->wlr_seat, event->time_msec,
-			event->orientation, scroll_factor * event->delta, 
+			event->orientation, scroll_factor * event->delta,
 			roundf(scroll_factor * event->delta_discrete), event->source,
 			event->relative_direction);
 	}
+}
+
+static void handle_tablet_tool_axis_scroll(struct sway_seat *seat,
+		struct sway_tablet_tool *tool, struct wlr_tablet_tool_axis_scroll_event *event) {
+	// FIXME: Do nothing except pass it to clients for now
+	struct sway_input_device *input_device =
+		event->tablet ? event->tablet->base.data : NULL;
+	struct input_config *ic =
+		input_device ? input_device_get_config(input_device) : NULL;
+	float scroll_factor =
+		(ic == NULL || ic->scroll_factor == FLT_MIN) ? 1.0f : ic->scroll_factor;
+
+	wlr_tablet_v2_tablet_tool_notify_scroll(tool->tablet_v2_tool, event->time_msec,
+			event->orientation, scroll_factor * event->delta,
+			event->source,
+			event->relative_direction);
 }
 
 /*------------------------------------\
@@ -1128,6 +1144,7 @@ static const struct sway_seatop_impl seatop_impl = {
 	.pointer_axis = handle_pointer_axis,
 	.tablet_tool_tip = handle_tablet_tool_tip,
 	.tablet_tool_motion = handle_tablet_tool_motion,
+	.tablet_tool_axis_scroll = handle_tablet_tool_axis_scroll,
 	.hold_begin = handle_hold_begin,
 	.hold_end = handle_hold_end,
 	.pinch_begin = handle_pinch_begin,

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -140,6 +140,22 @@ static void handle_pointer_axis(struct sway_seat *seat,
 		event->relative_direction);
 }
 
+static void handle_tablet_tool_axis_scroll(struct sway_seat *seat,
+		struct sway_tablet_tool *tool, struct wlr_tablet_tool_axis_scroll_event *event) {
+	struct sway_input_device *input_device =
+		event->tablet ? event->tablet->base.data : NULL;
+	struct input_config *ic =
+		input_device ? input_device_get_config(input_device) : NULL;
+	float scroll_factor =
+		(ic == NULL || ic->scroll_factor == FLT_MIN) ? 1.0f : ic->scroll_factor;
+
+	wlr_tablet_v2_tablet_tool_notify_scroll(tool->tablet_v2_tool, event->time_msec,
+			event->orientation, scroll_factor * event->delta,
+			event->source,
+			event->relative_direction);
+	seatop_begin_default(seat);
+}
+
 static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		struct wlr_input_device *device, uint32_t button,
 		enum wl_pointer_button_state state) {
@@ -208,6 +224,7 @@ static const struct sway_seatop_impl seatop_impl = {
 	.pointer_axis = handle_pointer_axis,
 	.tablet_tool_tip = handle_tablet_tool_tip,
 	.tablet_tool_motion = handle_tablet_tool_motion,
+	.tablet_tool_axis_scroll = handle_tablet_tool_axis_scroll,
 	.touch_motion = handle_touch_motion,
 	.touch_up = handle_touch_up,
 	.touch_down = handle_touch_down,


### PR DESCRIPTION
This aims at implementing #5854.

For tablets that don't have finger features and no wheels, sliders, etc., it can be annoying to scroll on applications that are not specifically designed for tablet use in minds, when you just want to use the tablet instead of the mouse for everyday life.

This is my first attempt at implementing tablet tool scroll, and a way to open the discussion for the tablet tool scroll API. Sorry if things are still in a draft state, I will edit things according to your comments.

This MR doesn't support (for now at least) scroll button lock. I don't know if this is something that I should try to add or not for now.

# Related MRs:
- sway (this MR)
- libinput: https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/981
- wayland-protocols: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/288
- wlroots: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4598
- mutter (TODO):
- kwin (TODO):
- GTK (TODO):
- QT (TODO):


# Implementation explanations:

For now at least, don't treat the tablet tool scroll as a compositor shortcuts for example. As this is a non-discrete scroll, this would be difficult to implement window rotating with it for example.

I wasn't sure about the `seatop_down` / `seatop_default` thing, so I basically handed up copying what `handle_tablet_tool_tip` did. Please tell me if this is wrong.

Also, there is a specific point I'm struggling with about the `wlr_pointer_axis_event.pointer` element, I will create a comment below to expand on it.

Pipeline is failing because of libinput API changes required to make tablet tool scroll work. I'm not sure about how to handle this from a CI point of view.