### PR TITLE
output: wlr_backend_commit and wlr_swapchain_helper

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -690,8 +690,6 @@ struct output_config *new_output_config(const char *name);
 
 void merge_output_config(struct output_config *dst, struct output_config *src);
 
-bool apply_output_config(struct output_config *oc, struct sway_output *output);
-
 bool apply_output_configs(struct matched_output_config *configs,
 		size_t configs_len, bool test_only);
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -701,10 +701,6 @@ struct output_config *store_output_config(struct output_config *oc);
 
 struct output_config *find_output_config(struct sway_output *output);
 
-void apply_output_config_to_outputs(struct output_config *oc);
-
-void reset_outputs(void);
-
 void free_output_config(struct output_config *oc);
 
 bool spawn_swaybg(void);

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -292,6 +292,14 @@ struct output_config {
 };
 
 /**
+ * An output config pre-matched to an output
+ */
+struct matched_output_config {
+	struct sway_output *output;
+	struct output_config *config;
+};
+
+/**
  * Stores size of gaps for each side
  */
 struct side_gaps {
@@ -683,6 +691,9 @@ struct output_config *new_output_config(const char *name);
 void merge_output_config(struct output_config *dst, struct output_config *src);
 
 bool apply_output_config(struct output_config *oc, struct sway_output *output);
+
+bool apply_output_configs(struct matched_output_config *configs,
+		size_t configs_len, bool test_only);
 
 bool test_output_config(struct output_config *oc, struct sway_output *output);
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -688,8 +688,6 @@ const char *sway_output_scale_filter_to_string(enum scale_filter_mode scale_filt
 
 struct output_config *new_output_config(const char *name);
 
-void merge_output_config(struct output_config *dst, struct output_config *src);
-
 bool apply_output_configs(struct matched_output_config *configs,
 		size_t configs_len, bool test_only);
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -693,8 +693,6 @@ bool apply_output_configs(struct matched_output_config *configs,
 
 void apply_all_output_configs(void);
 
-bool test_output_config(struct output_config *oc, struct sway_output *output);
-
 struct output_config *store_output_config(struct output_config *oc);
 
 struct output_config *find_output_config(struct sway_output *output);

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -695,6 +695,8 @@ bool apply_output_config(struct output_config *oc, struct sway_output *output);
 bool apply_output_configs(struct matched_output_config *configs,
 		size_t configs_len, bool test_only);
 
+void apply_all_output_configs(void);
+
 bool test_output_config(struct output_config *oc, struct sway_output *output);
 
 struct output_config *store_output_config(struct output_config *oc);

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -103,13 +103,13 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 
 	bool background = output->background;
 
-	output = store_output_config(output);
+	store_output_config(output);
 
 	// If reloading, the output configs will be applied after reading the
 	// entire config and before the deferred commands so that an auto generated
 	// workspace name is not given to re-enabled outputs.
 	if (!config->reloading && !config->validating) {
-		apply_output_config_to_outputs(output);
+		apply_all_output_configs();
 		if (background) {
 			if (!spawn_swaybg()) {
 				return cmd_results_new(CMD_FAILURE,

--- a/sway/commands/output/toggle.c
+++ b/sway/commands/output/toggle.c
@@ -29,7 +29,7 @@ struct cmd_results *output_cmd_toggle(int argc, char **argv) {
 		config->handler_context.output_config->enabled = 1;
 	}
 
-	free(oc);
+	free_output_config(oc);
 	config->handler_context.leftovers.argc = argc;
 	config->handler_context.leftovers.argv = argv;
 	return NULL;

--- a/sway/config.c
+++ b/sway/config.c
@@ -532,7 +532,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		}
 		sway_switch_retrigger_bindings_for_all();
 
-		reset_outputs();
+		apply_all_output_configs();
 		spawn_swaybg();
 
 		config->reloading = false;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -809,6 +809,34 @@ out:
 	return ok;
 }
 
+void apply_all_output_configs(void) {
+	size_t configs_len = wl_list_length(&root->all_outputs);
+	struct matched_output_config *configs = calloc(configs_len, sizeof(*configs));
+	if (!configs) {
+		return;
+	}
+
+	int config_idx = 0;
+	struct sway_output *sway_output;
+	wl_list_for_each(sway_output, &root->all_outputs, link) {
+		if (sway_output == root->fallback_output) {
+			configs_len--;
+			continue;
+		}
+
+		struct matched_output_config *config = &configs[config_idx++];
+		config->output = sway_output;
+		config->config = find_output_config(sway_output);
+	}
+
+	apply_output_configs(configs, configs_len, false);
+	for (size_t idx = 0; idx < configs_len; idx++) {
+		struct matched_output_config *cfg = &configs[idx];
+		free_output_config(cfg->config);
+	}
+	free(configs);
+}
+
 void apply_output_config_to_outputs(struct output_config *oc) {
 	size_t configs_len = wl_list_length(&root->all_outputs);
 	struct matched_output_config *configs = calloc(configs_len, sizeof(*configs));

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -79,7 +79,7 @@ struct output_config *new_output_config(const char *name) {
 	return oc;
 }
 
-void merge_output_config(struct output_config *dst, struct output_config *src) {
+static void merge_output_config(struct output_config *dst, struct output_config *src) {
 	if (src->enabled != -1) {
 		dst->enabled = src->enabled;
 	}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -568,16 +568,6 @@ static bool finalize_output_config(struct output_config *oc, struct sway_output 
 	return true;
 }
 
-bool test_output_config(struct output_config *oc, struct sway_output *output) {
-	if (output == root->fallback_output) {
-		return false;
-	}
-
-	struct wlr_output_state pending = {0};
-	queue_output_config(oc, output, &pending);
-	return wlr_output_test_state(output->wlr_output, &pending);
-}
-
 static void default_output_config(struct output_config *oc,
 		struct wlr_output *wlr_output) {
 	oc->enabled = 1;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -568,36 +568,6 @@ static bool finalize_output_config(struct output_config *oc, struct sway_output 
 	return true;
 }
 
-bool apply_output_config(struct output_config *oc, struct sway_output *output) {
-	if (output == root->fallback_output) {
-		return false;
-	}
-
-	struct wlr_output_state pending = {0};
-	queue_output_config(oc, output, &pending);
-
-	sway_log(SWAY_DEBUG, "Committing output %s", output->wlr_output->name);
-	if (!wlr_output_commit_state(output->wlr_output, &pending)) {
-		// Failed to commit output changes, maybe the output is missing a CRTC.
-		// Leave the output disabled for now and try again when the output gets
-		// the mode we asked for.
-		sway_log(SWAY_ERROR, "Failed to commit output %s", output->wlr_output->name);
-		return false;
-	}
-
-	if (!finalize_output_config(oc, output)) {
-		return false;
-	}
-
-	// Reconfigure all devices, since input config may have been applied before
-	// this output came online, and some config items (like map_to_output) are
-	// dependent on an output being present.
-	input_manager_configure_all_input_mappings();
-	// Reconfigure the cursor images, since the scale may have changed.
-	input_manager_configure_xcursor();
-	return true;
-}
-
 bool test_output_config(struct output_config *oc, struct sway_output *output) {
 	if (output == root->fallback_output) {
 		return false;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -521,9 +521,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		sway_session_lock_add_output(server->session_lock.lock, output);
 	}
 
-	struct output_config *oc = find_output_config(output);
-	apply_output_config(oc, output);
-	free_output_config(oc);
+	apply_all_output_configs();
 
 	transaction_commit_dirty();
 
@@ -652,6 +650,6 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 		oc->power = 1;
 		break;
 	}
-	oc = store_output_config(oc);
-	apply_output_config(oc, output);
+	store_output_config(oc);
+	apply_all_output_configs();
 }


### PR DESCRIPTION
Use the new `wlr_backend_commit` and `wlr_swapchain_helper` to light up outputs and apply configuration changes.

Works in local testing, but as sway's output configuration system is a bit complicated it wouldn't hurt with more testing.