### PR TITLE
Hiding lone titlebar scenegraph

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -569,6 +569,7 @@ struct sway_config {
 	enum edge_border_types hide_edge_borders;
 	enum edge_border_smart_types hide_edge_borders_smart;
 	bool hide_lone_tab;
+	bool hide_lone_title;
 
 	// border colors
 	struct {

--- a/sway/commands/hide_edge_borders.c
+++ b/sway/commands/hide_edge_borders.c
@@ -13,7 +13,13 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 	}
 
 	bool hide_lone_tab = false;
-	if (strcmp(*argv, "--i3") == 0) {
+	bool hide_lone_title = false;
+	if (strcmp(*argv, "--smart-titles") == 0) {
+		hide_lone_tab = true;
+		hide_lone_title = true;
+		++argv;
+		--argc;
+	} else if (strcmp(*argv, "--i3") == 0) {
 		hide_lone_tab = true;
 		++argv;
 		--argc;
@@ -41,6 +47,7 @@ struct cmd_results *cmd_hide_edge_borders(int argc, char **argv) {
 		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}
 	config->hide_lone_tab = hide_lone_tab;
+	config->hide_lone_title = hide_lone_title;
 
 	arrange_root();
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -307,6 +307,7 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_edge_borders = E_NONE;
 	config->hide_edge_borders_smart = ESMART_OFF;
 	config->hide_lone_tab = false;
+	config->hide_lone_title = false;
 
 	config->has_focused_tab_title = false;
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -288,16 +288,12 @@ static void arrange_container(struct sway_container *con,
 
 static void arrange_children(enum sway_container_layout layout, list_t *children,
 		struct sway_container *active, struct wlr_scene_tree *content,
-		int width, int height, int gaps) {
-	int title_bar_height = container_titlebar_height();
+		int width, int height, int gaps, bool parent_asks_for_title_bars) {
 
 	if (layout == L_TABBED) {
-		struct sway_container *first = children->length == 1 ?
-			((struct sway_container *)children->items[0]) : NULL;
-		if (config->hide_lone_tab && first && first->view &&
-				first->current.border != B_NORMAL) {
-			title_bar_height = 0;
-		}
+		bool show_titlebar = parent_asks_for_title_bars || !config->hide_lone_tab ||
+			(children->length > 1) || (children->length == 1 && !((struct sway_container *) children->items[0])->view);
+		int title_bar_height = show_titlebar ? container_titlebar_height() : 0;
 
 		double w = (double) width / children->length;
 		int title_offset = 0;
@@ -315,7 +311,7 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 
 			int net_height = height - title_bar_height;
 			if (activated && width > 0 && net_height > 0) {
-				arrange_container(child, width, net_height, title_bar_height == 0, 0);
+				arrange_container(child, width, net_height, false, 0);
 			} else {
 				disable_container(child);
 			}
@@ -323,12 +319,9 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			title_offset = next_title_offset;
 		}
 	} else if (layout == L_STACKED) {
-		struct sway_container *first = children->length == 1 ?
-			((struct sway_container *)children->items[0]) : NULL;
-		if (config->hide_lone_tab && first && first->view &&
-				first->current.border != B_NORMAL) {
-			title_bar_height = 0;
-		}
+		bool show_titlebar = parent_asks_for_title_bars || !config->hide_lone_tab ||
+			(children->length > 1) || (children->length == 1 && !((struct sway_container *) children->items[0])->view);
+		int title_bar_height = show_titlebar ? container_titlebar_height() : 0;
 
 		int title_height = title_bar_height * children->length;
 
@@ -345,7 +338,7 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 
 			int net_height = height - title_height;
 			if (activated && width > 0 && net_height > 0) {
-				arrange_container(child, width, net_height, title_bar_height == 0, 0);
+				arrange_container(child, width, net_height, false, 0);
 			} else {
 				disable_container(child);
 			}
@@ -353,6 +346,8 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			y += title_bar_height;
 		}
 	} else if (layout == L_VERT) {
+		bool show_titlebar = parent_asks_for_title_bars || !config->hide_lone_tab ||
+			(children->length > 1);
 		int off = 0;
 		for (int i = 0; i < children->length; i++) {
 			struct sway_container *child = children->items[i];
@@ -362,13 +357,15 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_position(&child->scene_tree->node, 0, off);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
 			if (width > 0 && cheight > 0) {
-				arrange_container(child, width, cheight, true, gaps);
+				arrange_container(child, width, cheight, show_titlebar, gaps);
 				off += cheight + gaps;
 			} else {
 				disable_container(child);
 			}
 		}
 	} else if (layout == L_HORIZ) {
+		bool show_titlebar = parent_asks_for_title_bars || !config->hide_lone_tab ||
+			(children->length > 1);
 		int off = 0;
 		for (int i = 0; i < children->length; i++) {
 			struct sway_container *child = children->items[i];
@@ -378,7 +375,7 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_position(&child->scene_tree->node, off, 0);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
 			if (cwidth > 0 && height > 0) {
-				arrange_container(child, cwidth, height, true, gaps);
+				arrange_container(child, cwidth, height, show_titlebar, gaps);
 				off += cwidth + gaps;
 			} else {
 				disable_container(child);
@@ -464,7 +461,7 @@ static void arrange_container(struct sway_container *con,
 
 		arrange_children(con->current.layout, con->current.children,
 			con->current.focused_inactive_child, con->content_tree,
-			width, height, gaps);
+			width, height, gaps, title_bar);
 	}
 }
 
@@ -545,7 +542,7 @@ static void arrange_workspace_tiling(struct sway_workspace *ws,
 		int width, int height) {
 	arrange_children(ws->current.layout, ws->current.tiling,
 		ws->current.focused_inactive_child, ws->layers.tiling,
-		width, height, ws->gaps_inner);
+		width, height, ws->gaps_inner, false);
 }
 
 static void disable_workspace(struct sway_workspace *ws) {

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -788,10 +788,11 @@ The default colors are:
 	This affects new workspaces only, and is used when the workspace doesn't
 	have its own gaps settings (see: workspace <ws> gaps ...).
 
-*hide_edge_borders* [--i3] none|vertical|horizontal|both|smart|smart_no_gaps
+*hide_edge_borders* [--i3 | --smart-titles] none|vertical|horizontal|both|smart|smart_no_gaps
 	Hides window borders adjacent to the screen edges. Default is _none_. The
 	_--i3_ option enables i3-compatible behavior to hide the title bar on
-	tabbed and stacked containers with one child. The _smart_|_smart_no_gaps_
+	tabbed and stacked containers with one child. The --smart-titles option
+	hide the title bar on workspaces with only one child. The _smart_|_smart_no_gaps_
 	options are equivalent to setting _smart_borders_ smart|no_gaps and
 	_hide_edge_borders_ none.
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -404,8 +404,14 @@ void view_autoconfigure(struct sway_view *view) {
 			height = con->pending.height - y_offset
 				- con->pending.border_thickness * con->pending.border_bottom;
 		} else {
-			y = con->pending.y + container_titlebar_height();
-			height = con->pending.height - container_titlebar_height()
+			int titlebar_height;
+			if (config->hide_lone_title && view_is_only_visible(view)) {
+				titlebar_height = con->pending.border_thickness * con->pending.border_top + y_offset;
+			} else {
+				titlebar_height = container_titlebar_height();
+			}
+			y = con->pending.y + titlebar_height;
+			height = con->pending.height - titlebar_height
 				- con->pending.border_thickness * con->pending.border_bottom;
 		}
 		break;


### PR DESCRIPTION
this is a WIP PR, for comments and hopefully others joining in taking this feature onwards :) 

the render.c file was removed and the logic is switching to the scenegraph based implementation.

during my brief testing this seems to have worked, but the testing was limited as I got stumbled on another issue of the master branch - waybar was not showing after I create windows (#8075) so I reverted to the previous version for now.

a step towards resolving #8072 - hopefully :)