### PR TITLE
input: add Super as alternative for Mod4

### DIFF
--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -32,6 +32,7 @@ static struct modifier_key {
 	{ XKB_MOD_NAME_NUM, WLR_MODIFIER_MOD2 },
 	{ "Mod3", WLR_MODIFIER_MOD3 },
 	{ XKB_MOD_NAME_LOGO, WLR_MODIFIER_LOGO },
+	{ "Super", WLR_MODIFIER_LOGO },
 	{ "Mod5", WLR_MODIFIER_MOD5 },
 };
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -403,8 +403,8 @@ runtime.
 	For specifying modifier keys, you can use the XKB modifier names _Shift_,
 	_Lock_ (for Caps Lock), _Control_, _Mod1_ (for Alt), _Mod2_ (for Num Lock),
 	_Mod3_ (for XKB modifier Mod3), _Mod4_ (for the Logo key), and _Mod5_ (for
-	AltGr). In addition, you can use the aliases  _Ctrl_ (for Control) and _Alt_
-	(for Alt).
+	AltGr). In addition, you can use the aliases  _Ctrl_ (for Control), _Alt_
+	(for Alt), and _Super_ (for the Logo key).
 
 	Unless the flag _--locked_ is set, the command will not be run when a
 	screen locking program is active. If there is a matching binding with


### PR DESCRIPTION
This PR implements alternative human-readable names for the logo key (Mod4) as proposed in #8084.

Implemented in this PR are the names "Super", "Meta", and "Logo".

This is the first time the supported modifier names have been touched since #153, almost 9 years ago (besides moving the code around into different files and switching from wlc to wlroots).