### PR TITLE
man: document supported modifier names

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -400,6 +400,12 @@ runtime.
 	only be available for that group. By default, if you overwrite a binding,
 	swaynag will give you a warning. To silence this, use the _--no-warn_ flag.
 
+	For specifying modifier keys, you can use the XKB modifier names _Shift_,
+	_Lock_ (for Caps Lock), _Control_, _Mod1_ (for Alt), _Mod2_ (for Num Lock),
+	_Mod3_ (for XKB modifier Mod3), _Mod4_ (for the Logo key), and _Mod5_ (for
+	AltGr). In addition, you can use the aliases  _Ctrl_ (for Control) and _Alt_
+	(for Alt).
+
 	Unless the flag _--locked_ is set, the command will not be run when a
 	screen locking program is active. If there is a matching binding with
 	and without _--locked_, the one with will be preferred when locked and the


### PR DESCRIPTION
This  PR documents the existing modifier names supported by sway as part of the description of `bindsym` in the man page `sway(5)`.

Intended to be merged before #8085.