### PR TITLE
sway-ipc(7): Escape backslashes correctly in GET_CONFIG output

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1046,7 +1046,7 @@ An object with a single string property containing the contents of the config
 *Example Reply:*
 ```
 {
-	"config": "set $mod Mod4\nbindsym $mod+q exit\n"
+	"config": "set $mod Mod4\\nbindsym $mod+q exit\\n"
 }
 ```
 


### PR DESCRIPTION
Without this change, i see the following in the sway-ipc manpage:

```

   9. GET_CONFIG
       MESSAGE
       Retrieve the contents of the config that was last loaded

       REPLY
       An object with a single string property containing the contents of  the
       config

       Example Reply:
           {
                "config": "set $mod Mod4nbindsym $mod+q exitn"
           }
```