### PR TITLE
new directive `include_one` 

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -144,6 +144,7 @@ sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
 sway_cmd cmd_hide_edge_borders;
 sway_cmd cmd_include;
+sway_cmd cmd_include_one;
 sway_cmd cmd_inhibit_idle;
 sway_cmd cmd_input;
 sway_cmd cmd_seat;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -614,7 +614,10 @@ bool load_main_config(const char *path, bool is_active, bool validating);
  * Loads an included config. Can only be used after load_main_config.
  */
 void load_include_configs(const char *path, struct sway_config *config,
-		struct swaynag_instance *swaynag);
+		struct swaynag_instance *swaynag, bool flag);
+
+void load_include_one_config(const char *paths, struct sway_config *config,
+                             struct swaynag_instance *swaynag);
 
 /**
  * Reads the config from the given FILE.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -103,6 +103,7 @@ static const struct cmd_handler handlers[] = {
 static const struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "include", cmd_include },
+	{ "include_one", cmd_include_one },
 	{ "primary_selection", cmd_primary_selection },
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },

--- a/sway/commands/include_one.c
+++ b/sway/commands/include_one.c
@@ -1,14 +1,14 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 
-struct cmd_results *cmd_include(int argc, char **argv) {
+struct cmd_results *cmd_include_one(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "include", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "include_one", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
 
 	// We don't care if the included config(s) fails to load.
-	load_include_configs(argv[0], config, &config->swaynag_config_errors, false);
+	load_include_one_config(argv[0], config, &config->swaynag_config_errors);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/config.c
+++ b/sway/config.c
@@ -549,8 +549,22 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	return success;
 }
 
+static char *extract_filename(const char *path) {
+  char *filename = strrchr(path, '/');
+  if (filename == NULL) {
+    return NULL;
+  }
+  return filename;
+}
+
+static bool same_file(const char *path1, const char *path2) {
+  const char *file1 = extract_filename(path1);
+  const char *file2 = extract_filename(path2);
+  return (strcmp(file1, file2) == 0);
+}
+
 static bool load_include_config(const char *path, const char *parent_dir,
-		struct sway_config *config, struct swaynag_instance *swaynag) {
+		struct sway_config *config, struct swaynag_instance *swaynag, bool flag) {
 	// save parent config
 	const char *parent_config = config->current_config_path;
 
@@ -588,6 +602,14 @@ static bool load_include_config(const char *path, const char *parent_dir,
 			free(real_path);
 			return false;
 		}
+		    // check if function is called from include_one
+		if (flag == true && same_file(real_path, old_path) == true) {
+			sway_log(SWAY_DEBUG,
+				"%s already included once, won't be included again.",
+				real_path);
+			free(real_path);
+			return false;
+		}
 	}
 
 	config->current_config_path = real_path;
@@ -607,7 +629,7 @@ static bool load_include_config(const char *path, const char *parent_dir,
 }
 
 void load_include_configs(const char *path, struct sway_config *config,
-		struct swaynag_instance *swaynag) {
+		struct swaynag_instance *swaynag, bool flag) {
 	char *wd = getcwd(NULL, 0);
 	char *parent_path = strdup(config->current_config_path);
 	const char *parent_dir = dirname(parent_path);
@@ -622,7 +644,7 @@ void load_include_configs(const char *path, struct sway_config *config,
 		char **w = p.we_wordv;
 		size_t i;
 		for (i = 0; i < p.we_wordc; ++i) {
-			load_include_config(w[i], parent_dir, config, swaynag);
+			load_include_config(w[i], parent_dir, config, swaynag, flag);
 		}
 		wordfree(&p);
 	}
@@ -634,6 +656,21 @@ void load_include_configs(const char *path, struct sway_config *config,
 cleanup:
 	free(parent_path);
 	free(wd);
+}
+
+
+void load_include_one_config(const char *paths, struct sway_config *config,
+                             struct swaynag_instance *swaynag) {
+  char *p = strdup(paths);
+  char *path = strtok(p, " ");
+  while (path != NULL) {
+    load_include_configs(path, config, swaynag, true);
+    path = strtok(NULL, " ");
+  }
+  goto cleanup;
+
+cleanup:
+  free(p);
 }
 
 void run_deferred_commands(void) {

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -74,6 +74,7 @@ sway_sources = files(
 	'commands/max_render_time.c',
 	'commands/opacity.c',
 	'commands/include.c',
+	'commands/include_one.c',
 	'commands/input.c',
 	'commands/layout.c',
 	'commands/mode.c',


### PR DESCRIPTION
It would include all the files in the first directory and then from the second directory it would only import the files that weren't import before. So if the first directory contains a file called for example, "70_bar" then such file would be skipped when processing the second directory.

So currently I have only tested it my building the sway using following steps:

```
meson build/
ninja -C build/
```

I will mark it as draft for further testing on the command. 