### PR TITLE
config/input: Implement libinput clickfinger_button_map option support.

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -249,6 +249,7 @@ sway_cmd input_cmd_seat;
 sway_cmd input_cmd_accel_profile;
 sway_cmd input_cmd_calibration_matrix;
 sway_cmd input_cmd_click_method;
+sway_cmd input_cmd_clickfinger_button_map;
 sway_cmd input_cmd_drag;
 sway_cmd input_cmd_drag_lock;
 sway_cmd input_cmd_dwt;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -149,6 +149,7 @@ struct input_config {
 	int accel_profile;
 	struct calibration_matrix calibration_matrix;
 	int click_method;
+	int clickfinger_button_map;
 	int drag;
 	int drag_lock;
 	int dwt;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -11,6 +11,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "accel_profile", input_cmd_accel_profile },
 	{ "calibration_matrix", input_cmd_calibration_matrix },
 	{ "click_method", input_cmd_click_method },
+	{ "clickfinger_button_map", input_cmd_clickfinger_button_map },
 	{ "drag", input_cmd_drag },
 	{ "drag_lock", input_cmd_drag_lock },
 	{ "dwt", input_cmd_dwt },

--- a/sway/commands/input/clickfinger_button_map.c
+++ b/sway/commands/input/clickfinger_button_map.c
@@ -1,0 +1,27 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+
+struct cmd_results *input_cmd_clickfinger_button_map(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "clickfinger_button_map", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	if (strcasecmp(argv[0], "lrm") == 0) {
+		ic->clickfinger_button_map = LIBINPUT_CONFIG_CLICKFINGER_MAP_LRM;
+	} else if (strcasecmp(argv[0], "lmr") == 0) {
+		ic->clickfinger_button_map = LIBINPUT_CONFIG_CLICKFINGER_MAP_LMR;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+			"Expected 'clickfinger_button_map <lrm|lmr>'");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -28,6 +28,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->dwtp = INT_MIN;
 	input->send_events = INT_MIN;
 	input->click_method = INT_MIN;
+	input->clickfinger_button_map = INT_MIN;
 	input->middle_emulation = INT_MIN;
 	input->natural_scroll = INT_MIN;
 	input->accel_profile = INT_MIN;
@@ -54,6 +55,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->click_method != INT_MIN) {
 		dst->click_method = src->click_method;
+	}
+	if (src->clickfinger_button_map != INT_MIN) {
+		dst->clickfinger_button_map = src->clickfinger_button_map;
 	}
 	if (src->drag != INT_MIN) {
 		dst->drag = src->drag;

--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -132,6 +132,16 @@ static bool set_click_method(struct libinput_device *device,
 	return true;
 }
 
+static bool set_clickfinger_button_map(struct libinput_device *device,
+		enum libinput_config_clickfinger_button_map map) {
+	if (libinput_device_config_click_get_clickfinger_button_map(device) == map) {
+		return false;
+	}
+	sway_log(SWAY_DEBUG, "clickfinger_set_button_map(%d)", map);
+	log_status(libinput_device_config_click_set_clickfinger_button_map(device, map));
+	return true;
+}
+
 static bool set_middle_emulation(struct libinput_device *dev,
 		enum libinput_config_middle_emulation_state mid) {
 	if (!libinput_device_config_middle_emulation_is_available(dev) ||
@@ -281,6 +291,9 @@ bool sway_input_configure_libinput_device(struct sway_input_device *input_device
 	if (ic->click_method != INT_MIN) {
 		changed |= set_click_method(device, ic->click_method);
 	}
+	if (ic->clickfinger_button_map != INT_MIN) {
+		changed |= set_clickfinger_button_map(device, ic->clickfinger_button_map);
+	}
 	if (ic->middle_emulation != INT_MIN) {
 		changed |= set_middle_emulation(device, ic->middle_emulation);
 	}
@@ -356,6 +369,8 @@ void sway_input_reset_libinput_device(struct sway_input_device *input_device) {
 		libinput_device_config_left_handed_get_default(device));
 	changed |= set_click_method(device,
 		libinput_device_config_click_get_default_method(device));
+	changed |= set_clickfinger_button_map(device,
+		libinput_device_config_click_get_default_clickfinger_button_map(device));
 	changed |= set_middle_emulation(device,
 		libinput_device_config_middle_emulation_get_default_enabled(device));
 	changed |= set_scroll_method(device,

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -992,6 +992,18 @@ static json_object *describe_libinput_device(struct libinput_device *device) {
 		}
 		json_object_object_add(object, "click_method",
 				json_object_new_string(click_method));
+
+		const char *button_map = "unknown";
+		switch (libinput_device_config_click_get_clickfinger_button_map(device)) {
+		case LIBINPUT_CONFIG_CLICKFINGER_MAP_LRM:
+			button_map = "lrm";
+			break;
+		case LIBINPUT_CONFIG_CLICKFINGER_MAP_LMR:
+			button_map = "lmr";
+			break;
+		}
+		json_object_object_add(object, "clickfinger_button_map",
+				json_object_new_string(button_map));
 	}
 
 	if (libinput_device_config_middle_emulation_is_available(device)) {
@@ -1109,9 +1121,9 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 		struct xkb_keymap *keymap = keyboard->keymap;
 		struct xkb_state *state = keyboard->xkb_state;
 
-		json_object_object_add(object, "repeat_delay", 
+		json_object_object_add(object, "repeat_delay",
 			json_object_new_int(keyboard->repeat_info.delay));
-		json_object_object_add(object, "repeat_rate", 
+		json_object_object_add(object, "repeat_rate",
 			json_object_new_int(keyboard->repeat_info.rate));
 
 		json_object *layouts_arr = json_object_new_array();

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -154,6 +154,7 @@ sway_sources = files(
 	'commands/input/accel_profile.c',
 	'commands/input/calibration_matrix.c',
 	'commands/input/click_method.c',
+	'commands/input/clickfinger_button_map.c',
 	'commands/input/drag.c',
 	'commands/input/drag_lock.c',
 	'commands/input/dwt.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -143,6 +143,12 @@ The following commands may only be used in the configuration file.
 *input* <identifier> click_method none|button_areas|clickfinger
 	Changes the click method for the specified device.
 
+*input* <identifier> clickfinger_button_map lrm|lmr
+	Specifies which button mapping to use for clickfinger. _lrm_ treats 1 finger as
+	left click, 2 fingers as right click, and 3 fingers as middle click. _lmr_
+	treats 1 finger as left click, 2 fingers as middle click, and 3 fingers as
+	right click.
+
 *input* <identifier> drag enabled|disabled
 	Enables or disables tap-and-drag for specified input device.
 

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1168,7 +1168,7 @@ following properties will be included for devices that support them:
 :  Whether tap to click is enabled. It can be _enabled_ or _disabled_
 |- tap_button_map
 :  string
-:  The finger to button mapping in use. It can be _lmr_ or _lrm_
+:  The finger to button mapping in use for tapping. It can be _lmr_ or _lrm_
 |- tap_drag
 :  string
 :  Whether tap-and-drag is enabled. It can be _enabled_ or _disabled_
@@ -1190,6 +1190,9 @@ following properties will be included for devices that support them:
 |- click_method
 :  string
 :  The click method in use. It can be _none_, _button_areas_, or _clickfinger_
+|- click_button_map
+:  string
+:  The finger to button mapping in use for clickfinger. It can be _lmr_ or _lrm_
 |- middle_emulation
 :  string
 :  Whether middle emulation is enabled. It can be _enabled_ or _disabled_


### PR DESCRIPTION
Opening this as a draft since it depends on an unreleased libinput feature.

I recently closed [libinput issue #909](https://gitlab.freedesktop.org/libinput/libinput/-/issues/909) by [implementing](https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/988) a "clickfinger_button_map" option (mirrors "tap_button_map", but for clickmethod "clickfinger").

This implements support for setting such option in Sway. However, this would bump the required libinput version to 1.26, and the dependency comes through wlroots, which supports 1.14 and up. So maybe this code should be conditionally enabled depending on the libinput version during build, and I'm not sure if there is any project policy about this.