### PR TITLE
server: Use wlr_renderer_get_texture_formats

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -240,13 +240,12 @@ bool server_init(struct sway_server *server) {
 
 	wlr_renderer_init_wl_shm(server->renderer, server->wl_display);
 
-	if (wlr_renderer_get_dmabuf_texture_formats(server->renderer) != NULL) {
+	if (wlr_renderer_get_texture_formats(server->renderer, WLR_BUFFER_CAP_DMABUF) != NULL) {
 		server->linux_dmabuf_v1 = wlr_linux_dmabuf_v1_create_with_renderer(
 			server->wl_display, 4, server->renderer);
-	}
-	if (wlr_renderer_get_dmabuf_texture_formats(server->renderer) != NULL &&
-			debug.legacy_wl_drm) {
-		wlr_drm_create(server->wl_display, server->renderer);
+		if (debug.legacy_wl_drm) {
+			wlr_drm_create(server->wl_display, server->renderer);
+		}
 	}
 
 	server->allocator = wlr_allocator_autocreate(server->backend,


### PR DESCRIPTION
wlr_renderer_get_{dmabuf|shm}_texture_formats have been replaced by a unified wlr_renderer_get_texture_formats interface using buffer caps.

References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4644