### PR TITLE
desktop/output: Fix check if config should be stored

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -619,7 +619,7 @@ static void output_manager_apply(struct sway_server *server,
 		if (!test_only && ok) {
 			struct wlr_output_configuration_head_v1 *config_head;
 			wl_list_for_each(config_head, &config->heads, link) {
-				if (config_head->state.output == sway_output->wlr_output) {
+				if (config_head->state.output == cfg->output->wlr_output) {
 					store_config = true;
 					break;
 				}


### PR DESCRIPTION
We want to check if a config_head existed for the current matched_output_config, so we should check cfg->output. sway_output is a temporary variable from a previous wl_list_for_each, and does not contain anything useful to us.

Fixes: https://github.com/swaywm/sway/issues/8128