### PR TITLE
desktop/layer_shell: provide fractional scale on creation

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_scene.h>
@@ -431,6 +432,12 @@ void handle_layer_shell_surface(struct wl_listener *listener, void *data) {
 	}
 
 	surface->output = output;
+
+	// now that the surface's output is known, we can advertise its scale
+	wlr_fractional_scale_v1_notify_scale(surface->layer_surface->surface,
+		layer_surface->output->scale);
+	wlr_surface_set_preferred_buffer_scale(surface->layer_surface->surface,
+		ceil(layer_surface->output->scale));
 
 	surface->surface_commit.notify = handle_surface_commit;
 	wl_signal_add(&layer_surface->surface->events.commit,


### PR DESCRIPTION
Since layer shell surfaces are assigned an output on creation, before being mapped, it is possible to provide them with an output scale immediately. This commit does this.

I do not know the scene graph code very well, so it's possible this is the wrong place to add the `wlr_fractional_scale_v1_notify_scale()` call. (The other point I was considering was in `wlr_scene_layer_surface_v1_create()`, the first wlroots function that could know about the output which the client (or Sway, if no output specified) picked, but I don't know if it is possible to get an output scale within that function.)

This can be tested with the most recent (git) version of swaybg, which supports wp-fractional-scale-v1. With non-integral output scales, like 1.5, swaybg should only render a single buffer, and the WAYLAND_DEBUG log should look like the following, with a wp_fractional_scale_v1.preferred_scale event being sent after the first commit.
```
[ 861865.534] {Default Queue}  -> wp_fractional_scale_manager_v1#9.get_fractional_scale(new id wp_fractional_scale_v1#12, wl_surface#3)
[ 861865.543] {Default Queue}  -> wp_viewporter#7.get_viewport(new id wp_viewport#13, wl_surface#3)
[ 861865.550] {Default Queue}  -> zwlr_layer_shell_v1#6.get_layer_surface(new id zwlr_layer_surface_v1#14, wl_surface#3, wl_output#10, 0, "wallpaper")
[ 861865.558] {Default Queue}  -> zwlr_layer_surface_v1#14.set_size(0, 0)
[ 861865.566] {Default Queue}  -> zwlr_layer_surface_v1#14.set_anchor(15)
[ 861865.570] {Default Queue}  -> zwlr_layer_surface_v1#14.set_exclusive_zone(-1)
[ 861865.577] {Default Queue}  -> wl_surface#3.commit()
[ 861865.812] {Display Queue} wl_display#1.delete_id(11)
[ 861865.829] {Default Queue} wp_fractional_scale_v1#12.preferred_scale(180)
[ 861865.837] {Default Queue} zwlr_layer_surface_v1#14.configure(204, 852, 920)
[ 861865.844] {Default Queue}  -> zwlr_layer_surface_v1#14.ack_configure(204)
[ 862959.390] {Default Queue}  -> wl_shm#4.create_pool(new id wl_shm_pool#11, fd 5, 7054560)
```