### PR TITLE
config/output: Use all outputs for config merge

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -210,7 +210,7 @@ static void merge_output_config(struct output_config *dst, struct output_config 
 void store_output_config(struct output_config *oc) {
 	bool merged = false;
 	bool wildcard = strcmp(oc->name, "*") == 0;
-	struct sway_output *output = wildcard ? NULL : output_by_name_or_id(oc->name);
+	struct sway_output *output = wildcard ? NULL : all_output_by_name_or_id(oc->name);
 
 	char id[128];
 	if (output) {


### PR DESCRIPTION
When storing a config, we need to find the output that is being configured to extract its identifier. output_by_name_or_id does not return outputs that are disabled, and using this makes it impossible to merge configurations related to disabled outputs.

Switch to all_outputs_by_name_or_id.

Fixes: https://github.com/swaywm/sway/issues/8141