### PR TITLE
Fix includes with relative paths

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -549,28 +549,12 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	return success;
 }
 
-static bool load_include_config(const char *path, const char *parent_dir,
-		struct sway_config *config, struct swaynag_instance *swaynag) {
+static bool load_include_config(const char *path, struct sway_config *config,
+		struct swaynag_instance *swaynag) {
 	// save parent config
 	const char *parent_config = config->current_config_path;
 
-	char *full_path;
-	int len = strlen(path);
-	if (len >= 1 && path[0] != '/') {
-		len = len + strlen(parent_dir) + 2;
-		full_path = malloc(len * sizeof(char));
-		if (!full_path) {
-			sway_log(SWAY_ERROR,
-				"Unable to allocate full path to included config");
-			return false;
-		}
-		snprintf(full_path, len, "%s/%s", parent_dir, path);
-	} else {
-		full_path = strdup(path);
-	}
-
-	char *real_path = realpath(full_path, NULL);
-	free(full_path);
+	char *real_path = realpath(path, NULL);
 
 	if (real_path == NULL) {
 		sway_log(SWAY_DEBUG, "%s not found.", path);
@@ -622,7 +606,7 @@ void load_include_configs(const char *path, struct sway_config *config,
 		char **w = p.we_wordv;
 		size_t i;
 		for (i = 0; i < p.we_wordc; ++i) {
-			load_include_config(w[i], parent_dir, config, swaynag);
+			load_include_config(w[i], config, swaynag);
 		}
 		wordfree(&p);
 	}


### PR DESCRIPTION
The function `load_include_configs` already changes the directory to the one containing the parent config. Therefore, `load_include_config` trying to assemble the "full" path leads to repetition of path segments, making the `realpath` call fail with ENOENT.

Just calling `realpath` on the path itself from the directory with the parent configuration is sufficient, so there is no point in passing `parent_dir` to `load_include_config`.

## What was broken

When running sway with a relative path to confiig, like `sway -c tmp/sway-configs/root`, if that config includes other file with `include other`, the file that gets included is in fact `tmp/sway-configs/tmp/sway-configs/other` relative to where sway was ran from. (Without such directory structure the include fails.)

---

(oops, I forgor to write this part in the original version)

Alternatives: It would be possible to not change the directory in `load_include_configs`, but even then the actual path resolution might require a different approach I think (I am thinking about `openat`, but I haven't thought it through enough).