### PR TITLE
Use wmenu-run for menu

### DIFF
--- a/config.in
+++ b/config.in
@@ -18,7 +18,7 @@ set $term foot
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.
-set $menu dmenu_path | wmenu | xargs swaymsg exec --
+set $menu wmenu-run
 
 ### Output configuration
 #


### PR DESCRIPTION
The recent [wmenu 0.1.8 release](https://git.sr.ht/~adnano/wmenu/refs/0.1.8) has included a new executable, `wmenu-run`, which is similar in behavior to `dmenu_run` however it does not cache, and is an executable which shares code with the `wmenu` binary.

`wmenu-run` launches the program with the xdg activation token (`XDG_ACTIVATION_TOKEN`) set.