### PR TITLE
build: drop xwayland option

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -38,8 +38,13 @@ tasks:
       cd sway
       ninja -C build
   - build-no-xwayland: |
-      cd sway
+      cd wlroots
       meson configure build -Dxwayland=disabled
+      ninja -C build
+      sudo ninja -C build install
+
+      cd ../sway
+      meson configure build --clearcache
       ninja -C build
   - build-static: |
       cd sway

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -36,7 +36,7 @@ struct criteria {
 	struct pattern *app_id;
 	struct pattern *con_mark;
 	uint32_t con_id; // internal ID
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct pattern *class;
 	uint32_t id; // X11 window ID
 	struct pattern *instance;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -5,7 +5,7 @@
 #include "config.h"
 #include "list.h"
 #include "sway/desktop/idle_inhibit_v1.h"
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include "sway/xwayland.h"
 #endif
 
@@ -59,7 +59,7 @@ struct sway_server {
 
 	struct wlr_tablet_manager_v2 *tablet_v2;
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct sway_xwayland xwayland;
 	struct wl_listener xwayland_surface;
 	struct wl_listener xwayland_ready;
@@ -165,7 +165,7 @@ void sway_session_lock_add_output(struct sway_session_lock *lock,
 bool sway_session_lock_has_surface(struct sway_session_lock *lock,
 	struct wlr_surface *surface);
 void handle_xdg_shell_toplevel(struct wl_listener *listener, void *data);
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 void handle_xwayland_surface(struct wl_listener *listener, void *data);
 #endif
 void handle_server_decoration(struct wl_listener *listener, void *data);

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -2,12 +2,12 @@
 #define _SWAY_ROOT_H
 #include <wayland-server-core.h>
 #include <wayland-util.h>
+#include <wlr/config.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/render/wlr_texture.h>
 #include "sway/tree/container.h"
 #include "sway/tree/node.h"
-#include "config.h"
 #include "list.h"
 
 extern struct sway_root *root;
@@ -47,7 +47,7 @@ struct sway_root {
 		struct wlr_scene_tree *shell_top;
 		struct wlr_scene_tree *fullscreen;
 		struct wlr_scene_tree *fullscreen_global;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		struct wlr_scene_tree *unmanaged;
 #endif
 		struct wlr_scene_tree *shell_overlay;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -1,10 +1,11 @@
 #ifndef _SWAY_VIEW_H
 #define _SWAY_VIEW_H
 #include <wayland-server-core.h>
+#include <wlr/config.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_scene.h>
 #include "sway/config.h"
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
 #include "sway/input/input-manager.h"
@@ -15,7 +16,7 @@ struct sway_xdg_decoration;
 
 enum sway_view_type {
 	SWAY_VIEW_XDG_SHELL,
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	SWAY_VIEW_XWAYLAND,
 #endif
 };
@@ -27,7 +28,7 @@ enum sway_view_prop {
 	VIEW_PROP_INSTANCE,
 	VIEW_PROP_WINDOW_TYPE,
 	VIEW_PROP_WINDOW_ROLE,
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	VIEW_PROP_X11_WINDOW_ID,
 	VIEW_PROP_X11_PARENT_ID,
 #endif
@@ -98,7 +99,7 @@ struct sway_view {
 
 	union {
 		struct wlr_xdg_toplevel *wlr_xdg_toplevel;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		struct wlr_xwayland_surface *wlr_xwayland_surface;
 #endif
 	};
@@ -127,7 +128,7 @@ struct sway_xdg_shell_view {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 };
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 struct sway_xwayland_view {
 	struct sway_view view;
 
@@ -293,7 +294,7 @@ void view_center_and_clip_surface(struct sway_view *view);
 
 struct sway_view *view_from_wlr_xdg_surface(
 	struct wlr_xdg_surface *xdg_surface);
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 struct sway_view *view_from_wlr_xwayland_surface(
 	struct wlr_xwayland_surface *xsurface);
 #endif

--- a/meson.build
+++ b/meson.build
@@ -57,10 +57,6 @@ foreach name, _ : wlroots_features
 	wlroots_features += { name: have }
 endforeach
 
-if get_option('xwayland').enabled() and not wlroots_features['xwayland']
-	error('Cannot enable Xwayland in sway: wlroots has been built without Xwayland support')
-endif
-
 null_dep = dependency('', required: false)
 
 jsonc = dependency('json-c', version: '>=0.13')
@@ -77,15 +73,13 @@ gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 pixman = dependency('pixman-1')
 libevdev = dependency('libevdev')
 libinput = wlroots_features['libinput_backend'] ? dependency('libinput', version: '>=1.21.0') : null_dep
-xcb = dependency('xcb', required: get_option('xwayland'))
+xcb = wlroots_features['xwayland'] ? dependency('xcb') : null_dep
 drm = dependency('libdrm')
 libudev = wlroots_features['libinput_backend'] ? dependency('libudev') : null_dep
 math = cc.find_library('m')
 rt = cc.find_library('rt')
-xcb_icccm = dependency('xcb-icccm', required: get_option('xwayland'))
+xcb_icccm = wlroots_features['xwayland'] ? dependency('xcb-icccm') : null_dep
 threads = dependency('threads') # for pthread_setschedparam
-
-have_xwayland = xcb.found() and xcb_icccm.found() and wlroots_features['xwayland']
 
 if get_option('sd-bus-provider') == 'auto'
 	if not get_option('tray').disabled()
@@ -110,7 +104,6 @@ have_tray = (not get_option('tray').disabled()) and tray_deps_found
 
 conf_data = configuration_data()
 
-conf_data.set10('HAVE_XWAYLAND', have_xwayland)
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
 conf_data.set10('HAVE_LIBSYSTEMD', sdbus.found() and sdbus.name() == 'libsystemd')
 conf_data.set10('HAVE_LIBELOGIND', sdbus.found() and sdbus.name() == 'libelogind')
@@ -271,7 +264,6 @@ endif
 subdir('completions')
 
 summary({
-	'xwayland': have_xwayland,
 	'gdk-pixbuf': gdk_pixbuf.found(),
 	'tray': have_tray,
 	'man-pages': scdoc.found(),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,6 @@ option('bash-completions', type: 'boolean', value: true, description: 'Install b
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions.')
 option('swaybar', type: 'boolean', value: true, description: 'Enable support for swaybar')
 option('swaynag', type: 'boolean', value: true, description: 'Enable support for swaynag')
-option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('tray', type: 'feature', value: 'auto', description: 'Enable support for swaybar tray')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybar tray')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')

--- a/sway/commands/swap.c
+++ b/sway/commands/swap.c
@@ -18,7 +18,7 @@ static bool test_con_id(struct sway_container *container, void *data) {
 	return container->node.id == *con_id;
 }
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 static bool test_id(struct sway_container *container, void *data) {
 	xcb_window_t *wid = data;
 	return (container->view && container->view->type == SWAY_VIEW_XWAYLAND
@@ -53,7 +53,7 @@ struct cmd_results *cmd_swap(int argc, char **argv) {
 
 	char *value = join_args(argv + 3, argc - 3);
 	if (strcasecmp(argv[2], "id") == 0) {
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		xcb_window_t id = strtol(value, NULL, 0);
 		other = root_find_container(test_id, &id);
 #endif

--- a/sway/commands/xwayland.c
+++ b/sway/commands/xwayland.c
@@ -10,7 +10,7 @@ struct cmd_results *cmd_xwayland(int argc, char **argv) {
 		return error;
 	}
 
-#ifdef HAVE_XWAYLAND
+#ifdef WLR_HAS_XWAYLAND
 	enum xwayland_mode xwayland;
 	if (strcmp(argv[0], "force") == 0) {
 		xwayland = XWAYLAND_MODE_IMMEDIATE;

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -22,7 +22,7 @@ bool criteria_is_empty(struct criteria *criteria) {
 		&& !criteria->app_id
 		&& !criteria->con_mark
 		&& !criteria->con_id
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		&& !criteria->class
 		&& !criteria->id
 		&& !criteria->instance
@@ -90,7 +90,7 @@ void criteria_destroy(struct criteria *criteria) {
 	pattern_destroy(criteria->title);
 	pattern_destroy(criteria->shell);
 	pattern_destroy(criteria->app_id);
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	pattern_destroy(criteria->class);
 	pattern_destroy(criteria->instance);
 	pattern_destroy(criteria->window_role);
@@ -110,7 +110,7 @@ static int regex_cmp(const char *item, const pcre2_code *regex) {
 	return result;
 }
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 static bool view_has_window_type(struct sway_view *view, enum atom_name name) {
 	if (view->type != SWAY_VIEW_XWAYLAND) {
 		return false;
@@ -251,7 +251,7 @@ static bool criteria_matches_view(struct criteria *criteria,
 		return false;
 	}
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (criteria->id) { // X11 window ID
 		uint32_t x11_window_id = view_get_x11_window_id(view);
 		if (!x11_window_id || x11_window_id != criteria->id) {
@@ -428,7 +428,7 @@ list_t *criteria_get_containers(struct criteria *criteria) {
 	return matches;
 }
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 static enum atom_name parse_window_type(const char *type) {
 	if (strcasecmp(type, "normal") == 0) {
 		return NET_WM_WINDOW_TYPE_NORMAL;
@@ -461,7 +461,7 @@ enum criteria_token {
 	T_CON_ID,
 	T_CON_MARK,
 	T_FLOATING,
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	T_CLASS,
 	T_ID,
 	T_INSTANCE,
@@ -487,7 +487,7 @@ static enum criteria_token token_from_name(char *name) {
 		return T_CON_ID;
 	} else if (strcmp(name, "con_mark") == 0) {
 		return T_CON_MARK;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	} else if (strcmp(name, "class") == 0) {
 		return T_CLASS;
 	} else if (strcmp(name, "id") == 0) {
@@ -566,7 +566,7 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 	case T_CON_MARK:
 		pattern_create(&criteria->con_mark, value);
 		break;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case T_CLASS:
 		pattern_create(&criteria->class, value);
 		break;
@@ -674,7 +674,7 @@ struct criteria *criteria_parse(char *raw, char **error_arg) {
 	++head;
 
 	struct criteria *criteria = calloc(1, sizeof(struct criteria));
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	criteria->window_type = ATOM_LAST; // default value
 #endif
 	char *name = NULL, *value = NULL;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -761,7 +761,7 @@ static bool should_configure(struct sway_node *node,
 	}
 	struct sway_container_state *cstate = &node->sway_container->current;
 	struct sway_container_state *istate = &instruction->container_state;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	// Xwayland views are position-aware and need to be reconfigured
 	// when their position changes.
 	if (node->sway_container->view->type == SWAY_VIEW_XWAYLAND) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -107,7 +107,7 @@ struct sway_node *node_at_coords(
 				return NULL;
 			}
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 			if (scene_descriptor_try_get(current, SWAY_SCENE_DESC_XWAYLAND_UNMANAGED)) {
 				return NULL;
 			}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -190,7 +190,7 @@ static void seat_send_focus(struct sway_node *node, struct sway_seat *seat) {
 		node->sway_container->view : NULL;
 
 	if (view && seat_is_input_allowed(seat, view->surface)) {
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		if (view->type == SWAY_VIEW_XWAYLAND) {
 			struct wlr_xwayland *xwayland = server.xwayland.wlr_xwayland;
 			wlr_xwayland_set_seat(xwayland, seat->wlr_seat);
@@ -1002,7 +1002,7 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 			setenv("XCURSOR_THEME", cursor_theme, 1);
 		}
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 		if (server.xwayland.wlr_xwayland && (!server.xwayland.xcursor_manager ||
 				!xcursor_manager_is_named(server.xwayland.xcursor_manager,
 					cursor_theme) ||

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -15,7 +15,7 @@
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
 #include "log.h"
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include "sway/xwayland.h"
 #endif
 
@@ -234,7 +234,7 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 		node->sway_container : NULL;
 
 	struct wlr_layer_surface_v1 *layer;
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct wlr_xwayland_surface *xsurface;
 #endif
 	if ((layer = wlr_layer_surface_v1_try_from_wlr_surface(surface)) &&
@@ -268,7 +268,7 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 		seat_set_focus_container(seat, cont);
 		seatop_begin_down(seat, node->sway_container, sx, sy);
 	}
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	// Handle tapping on an xwayland unmanaged view
 	else if ((xsurface = wlr_xwayland_surface_try_from_wlr_surface(surface)) &&
 			xsurface->override_redirect &&
@@ -514,7 +514,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 		return;
 	}
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	// Handle clicking on xwayland unmanaged view
 	struct wlr_xwayland_surface *xsurface;
 	if (surface &&

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -154,7 +154,7 @@ static json_object *ipc_json_output_mode_description(
 	return mode_object;
 }
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 static const char *ipc_json_xwindow_type_description(struct sway_view *view) {
 	struct wlr_xwayland_surface *surface = view->wlr_xwayland_surface;
 	struct sway_xwayland *xwayland = &server.xwayland;
@@ -633,7 +633,7 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 			json_object_new_string(ipc_json_content_type_description(content_type)));
 	}
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (c->view->type == SWAY_VIEW_XWAYLAND) {
 		json_object_object_add(object, "window",
 				json_object_new_int(view_get_x11_window_id(c->view)));

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -231,7 +231,7 @@ sway_deps = [
 	xcb_icccm,
 ]
 
-if have_xwayland
+if wlroots_features['xwayland']
 	sway_sources += 'desktop/xwayland.c'
 endif
 

--- a/sway/server.c
+++ b/sway/server.c
@@ -56,7 +56,7 @@
 #include "sway/input/cursor.h"
 #include "sway/tree/root.h"
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include <wlr/xwayland/shell.h>
 #include "sway/xwayland.h"
 #endif
@@ -118,7 +118,7 @@ static bool is_privileged(const struct wl_global *global) {
 
 static bool filter_global(const struct wl_client *client,
 		const struct wl_global *global, void *data) {
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct wlr_xwayland *xwayland = server.xwayland.wlr_xwayland;
 	if (xwayland && global == xwayland->shell_v1->global) {
 		return xwayland->server != NULL && client == xwayland->server->client;
@@ -437,7 +437,7 @@ bool server_init(struct sway_server *server) {
 
 void server_fini(struct sway_server *server) {
 	// TODO: free sway-specific resources
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	wlr_xwayland_destroy(server->xwayland.wlr_xwayland);
 #endif
 	wl_display_destroy_clients(server->wl_display);
@@ -447,7 +447,7 @@ void server_fini(struct sway_server *server) {
 }
 
 bool server_start(struct sway_server *server) {
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	if (config->xwayland != XWAYLAND_MODE_DISABLED) {
 		sway_log(SWAY_DEBUG, "Initializing Xwayland (lazy=%d)",
 				config->xwayland == XWAYLAND_MODE_LAZY);

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -53,7 +53,7 @@ struct sway_root *root_create(struct wl_display *wl_display) {
 	root->layers.shell_top = alloc_scene_tree(root->layer_tree, &failed);
 	root->layers.fullscreen = alloc_scene_tree(root->layer_tree, &failed);
 	root->layers.fullscreen_global = alloc_scene_tree(root->layer_tree, &failed);
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	root->layers.unmanaged = alloc_scene_tree(root->layer_tree, &failed);
 #endif
 	root->layers.shell_overlay = alloc_scene_tree(root->layer_tree, &failed);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <wayland-server-core.h>
+#include <wlr/config.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
@@ -9,8 +10,7 @@
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
-#include "config.h"
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
 #include "list.h"
@@ -126,7 +126,7 @@ const char *view_get_instance(struct sway_view *view) {
 	}
 	return NULL;
 }
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 uint32_t view_get_x11_window_id(struct sway_view *view) {
 	if (view->impl->get_int_prop) {
 		return view->impl->get_int_prop(view, VIEW_PROP_X11_WINDOW_ID);
@@ -159,7 +159,7 @@ const char *view_get_shell(struct sway_view *view) {
 	switch(view->type) {
 	case SWAY_VIEW_XDG_SHELL:
 		return "xdg_shell";
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case SWAY_VIEW_XWAYLAND:
 		return "xwayland";
 #endif
@@ -499,7 +499,7 @@ void view_execute_criteria(struct sway_view *view) {
 static void view_populate_pid(struct sway_view *view) {
 	pid_t pid;
 	switch (view->type) {
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	case SWAY_VIEW_XWAYLAND:;
 		struct wlr_xwayland_surface *surf =
 			wlr_xwayland_surface_try_from_wlr_surface(view->surface);
@@ -838,7 +838,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 
 	bool set_focus = should_focus(view);
 
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct wlr_xwayland_surface *xsurface;
 	if ((xsurface = wlr_xwayland_surface_try_from_wlr_surface(wlr_surface))) {
 		set_focus &= wlr_xwayland_icccm_input_model(xsurface) !=
@@ -954,7 +954,7 @@ struct sway_view *view_from_wlr_surface(struct wlr_surface *wlr_surface) {
 	if ((xdg_surface = wlr_xdg_surface_try_from_wlr_surface(wlr_surface))) {
 		return view_from_wlr_xdg_surface(xdg_surface);
 	}
-#if HAVE_XWAYLAND
+#if WLR_HAS_XWAYLAND
 	struct wlr_xwayland_surface *xsurface;
 	if ((xsurface = wlr_xwayland_surface_try_from_wlr_surface(wlr_surface))) {
 		return view_from_wlr_xwayland_surface(xsurface);


### PR DESCRIPTION
Instead of having a build-time option to enable/disable xwayland support, just use the wlroots build config: enable xwayland in Sway if it was enabled when building wlroots. I don't see any use-case for disabling xwayland in Sway when enabled in wlroots: Sway doesn't pull in any additional dependency (just pulls in dependencies that wlroots already needs). We have a config command to disable xwayland at runtime anyways.

This makes it so xwayland behaves the same way as other features such as libinput backend and session support. This also reduces the build matrix (less combinations of build options).

I think we originally introduced the xwayland option when we didn't have a good way to figure out the wlroots build config from the Sway build system.