### PR TITLE
sway/config/output.c: fix null deref on output config

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -448,7 +448,7 @@ static void queue_output_config(struct output_config *oc,
 #endif
 	}
 	if (wlr_output->transform != tr) {
-		sway_log(SWAY_DEBUG, "Set %s transform to %d", oc->name, tr);
+		sway_log(SWAY_DEBUG, "Set %s transform to %d", wlr_output->name, tr);
 		wlr_output_state_set_transform(pending, tr);
 	}
 


### PR DESCRIPTION
If there's no config for the output, oc is null, but some screens might have a default rotation, causing the log call to dereference a null pointer.