### PR TITLE
Allow configuring unfocused tab title

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -116,6 +116,7 @@ sway_cmd cmd_client_focused;
 sway_cmd cmd_client_focused_inactive;
 sway_cmd cmd_client_focused_tab_title;
 sway_cmd cmd_client_unfocused;
+sway_cmd cmd_client_unfocused_tab_title;
 sway_cmd cmd_client_urgent;
 sway_cmd cmd_client_placeholder;
 sway_cmd cmd_client_background;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -571,12 +571,14 @@ struct sway_config {
 		struct border_colors focused_inactive;
 		struct border_colors focused_tab_title;
 		struct border_colors unfocused;
+		struct border_colors unfocused_tab_title;
 		struct border_colors urgent;
 		struct border_colors placeholder;
 		float background[4];
 	} border_colors;
 
 	bool has_focused_tab_title;
+	bool has_unfocused_tab_title;
 
 	// floating view
 	int32_t floating_maximum_width;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -54,6 +54,7 @@ static const struct cmd_handler handlers[] = {
 	{ "client.focused_tab_title", cmd_client_focused_tab_title },
 	{ "client.placeholder", cmd_client_noop },
 	{ "client.unfocused", cmd_client_unfocused },
+	{ "client.unfocused_tab_title", cmd_client_unfocused_tab_title },
 	{ "client.urgent", cmd_client_urgent },
 	{ "default_border", cmd_default_border },
 	{ "default_floating_border", cmd_default_floating_border },

--- a/sway/commands/client.c
+++ b/sway/commands/client.c
@@ -90,3 +90,13 @@ struct cmd_results *cmd_client_focused_tab_title(int argc, char **argv) {
 	}
 	return result;
 }
+
+struct cmd_results *cmd_client_unfocused_tab_title(int argc, char **argv) {
+	struct cmd_results *result =  handle_command(argc, argv,
+			"client.unfocused_tab_title",
+			&config->border_colors.unfocused_tab_title, "#2e9ef4ff");
+	if (result && result->status == CMD_SUCCESS) {
+		config->has_unfocused_tab_title = true;
+	}
+	return result;
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -308,6 +308,7 @@ static void config_defaults(struct sway_config *config) {
 	config->hide_lone_tab = false;
 
 	config->has_focused_tab_title = false;
+	config->has_unfocused_tab_title = false;
 
 	// border colors
 	color_to_rgba(config->border_colors.focused.border, 0x4C7899FF);

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -579,6 +579,11 @@ runtime.
 	*client.unfocused*
 		A view that does not have focus.
 
+	*client.unfocused_tab_title*
+		Title of a tab or stack container that does not have focus. Defaults to
+		unfocused if not specified and does not use the indicator and child_border
+		colors.
+
 	*client.urgent*
 		A view with an urgency hint. *Note*: Native Wayland windows do not
 		support urgency. Urgency only works for Xwayland windows.
@@ -640,6 +645,12 @@ The default colors are:
 :  #888888
 :  #292d2e
 :  #222222
+|  *unfocused_tab_title*
+:  #333333
+:  #222222
+:  #888888
+:  n/a
+:  n/a
 |  *urgent*
 :  #2f343a
 :  #900000

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -175,6 +175,14 @@ static bool container_has_focused_child(struct sway_container *con) {
 	return container_find_child(con, container_is_focused, NULL);
 }
 
+static bool container_is_container(struct sway_container *con, void *data) {
+	return true;  // intentional tautology
+}
+
+static bool container_has_child(struct sway_container *con) {
+	return container_find_child(con, container_is_container, NULL);
+}
+
 static bool container_is_current_parent_focused(struct sway_container *con) {
 	if (con->current.parent) {
 		struct sway_container *parent = con->current.parent;
@@ -211,6 +219,8 @@ static struct border_colors *container_get_current_colors(
 		colors = &config->border_colors.focused_tab_title;
 	} else if (con == active_child) {
 		colors = &config->border_colors.focused_inactive;
+	} else if (config->has_unfocused_tab_title && container_has_child(con)) {
+		colors = &config->border_colors.unfocused_tab_title;
 	} else {
 		colors = &config->border_colors.unfocused;
 	}


### PR DESCRIPTION
Hi sway devs:

This pull request allows configuration of the unfocused tab/stack container title (shortened to tab-title henceforth) independent from the generic unfocused tab-title. The resultant configuration option is called `client.unfocused_tab_title`.

A driving motivation for this is the quick visual distinction of an (unfocused) view and an (unfocused) container. 

The implementation closely mirrors that of the existing option of the _focused_ tab-title `client.focused_tab_title`. The documentation update is made in a separate, second commit.

Thanks for looking over this!