### PR TITLE
idle_inhibit: Session lock and unmapped surface fixes

### DIFF
--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -126,9 +126,9 @@ bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 			return wlr_surface->mapped;
 		}
 
-		// If there is no view associated with the inhibitor, assume visible
+		// If there is no view associated with the inhibitor, assume invisible
 		struct sway_view *view = view_from_wlr_surface(wlr_surface);
-		return !view || !view->container || view_is_visible(view);
+		return view && view->container && view_is_visible(view);
 	case INHIBIT_IDLE_FOCUS:;
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -119,8 +119,15 @@ bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 
 	switch (inhibitor->mode) {
 	case INHIBIT_IDLE_APPLICATION:;
+		struct wlr_surface *wlr_surface = inhibitor->wlr_inhibitor->surface;
+		if (wlr_layer_surface_v1_try_from_wlr_surface(wlr_surface)) {
+			// Layer surfaces can be occluded but are always on screen after
+			// they have been mapped.
+			return wlr_surface->mapped;
+		}
+
 		// If there is no view associated with the inhibitor, assume visible
-		struct sway_view *view = view_from_wlr_surface(inhibitor->wlr_inhibitor->surface);
+		struct sway_view *view = view_from_wlr_surface(wlr_surface);
 		return !view || !view->container || view_is_visible(view);
 	case INHIBIT_IDLE_FOCUS:;
 		struct sway_seat *seat = NULL;

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -120,10 +120,13 @@ bool sway_idle_inhibit_v1_is_active(struct sway_idle_inhibitor_v1 *inhibitor) {
 	switch (inhibitor->mode) {
 	case INHIBIT_IDLE_APPLICATION:;
 		struct wlr_surface *wlr_surface = inhibitor->wlr_inhibitor->surface;
-		if (wlr_layer_surface_v1_try_from_wlr_surface(wlr_surface)) {
+		struct wlr_layer_surface_v1 *layer_surface =
+				wlr_layer_surface_v1_try_from_wlr_surface(wlr_surface);
+		if (layer_surface) {
 			// Layer surfaces can be occluded but are always on screen after
 			// they have been mapped.
-			return wlr_surface->mapped;
+			return layer_surface->output && layer_surface->output->enabled &&
+					wlr_surface->mapped;
 		}
 
 		// If there is no view associated with the inhibitor, assume invisible

--- a/sway/lock.c
+++ b/sway/lock.c
@@ -239,6 +239,9 @@ static void handle_unlock(struct wl_listener *listener, void *data) {
 		struct sway_output *output = root->outputs->items[i];
 		arrange_layers(output);
 	}
+
+	// Views are now visible, so check if we need to activate inhibition again.
+	sway_idle_inhibit_v1_check_active();
 }
 
 static void handle_abandon(struct wl_listener *listener, void *data) {
@@ -302,6 +305,10 @@ static void handle_session_lock(struct wl_listener *listener, void *data) {
 
 	wlr_session_lock_v1_send_locked(lock);
 	server.session_lock.lock = sway_lock;
+
+	// The lock screen covers everything, so check if any active inhibition got
+	// deactivated due to lost visibility.
+	sway_idle_inhibit_v1_check_active();
 }
 
 static void handle_session_lock_destroy(struct wl_listener *listener, void *data) {

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -190,6 +190,10 @@ uint32_t view_configure(struct sway_view *view, double lx, double ly, int width,
 }
 
 bool view_inhibit_idle(struct sway_view *view) {
+	if (server.session_lock.lock) {
+		return false;
+	}
+
 	struct sway_idle_inhibitor_v1 *user_inhibitor =
 		sway_idle_inhibit_v1_user_inhibitor_for_view(view);
 


### PR DESCRIPTION
We were not correctly handling idle inhibitor visibility in case of session locks, nor in case of unmapped surfaces.

This tries to fix both. Not yet tested.