### PR TITLE
Drop server.h include from input/input-manager.h

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -7,6 +7,10 @@
 #include "list.h"
 #include "tree/view.h"
 
+#if WLR_HAS_XWAYLAND
+#include "sway/xwayland.h"
+#endif
+
 enum criteria_type {
 	CT_COMMAND                 = 1 << 0,
 	CT_ASSIGN_OUTPUT           = 1 << 1,

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -5,9 +5,10 @@
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_transient_seat_v1.h>
-#include "sway/server.h"
 #include "sway/config.h"
 #include "list.h"
+
+struct sway_server;
 
 struct sway_input_device {
 	char *identifier;

--- a/sway/commands/input/events.c
+++ b/sway/commands/input/events.c
@@ -5,6 +5,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "sway/server.h"
 #include "log.h"
 
 #if WLR_HAS_LIBINPUT_BACKEND

--- a/sway/commands/input/xkb_switch_layout.c
+++ b/sway/commands/input/xkb_switch_layout.c
@@ -3,6 +3,7 @@
 #include "sway/config.h"
 #include "sway/commands.h"
 #include "sway/input/input-manager.h"
+#include "sway/server.h"
 #include "log.h"
 
 struct xkb_switch_layout_action {

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -11,6 +11,7 @@
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"

--- a/sway/commands/seat/cursor.c
+++ b/sway/commands/seat/cursor.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_pointer.h>
 #include "sway/commands.h"
 #include "sway/input/cursor.h"
+#include "sway/server.h"
 
 static struct cmd_results *press_or_release(struct sway_cursor *cursor,
 		char *action, char *button_str);

--- a/sway/commands/seat/pointer_constraint.c
+++ b/sway/commands/seat/pointer_constraint.c
@@ -4,6 +4,7 @@
 #include "sway/config.h"
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
+#include "sway/server.h"
 
 enum operation {
 	OP_ENABLE,

--- a/sway/commands/seat/shortcuts_inhibitor.c
+++ b/sway/commands/seat/shortcuts_inhibitor.c
@@ -2,6 +2,7 @@
 #include "sway/commands.h"
 #include "sway/input/seat.h"
 #include "sway/input/input-manager.h"
+#include "sway/server.h"
 #include "util.h"
 
 static struct cmd_results *handle_action(struct seat_config *sc,

--- a/sway/commands/shortcuts_inhibitor.c
+++ b/sway/commands/shortcuts_inhibitor.c
@@ -3,6 +3,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/input/seat.h"
+#include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -23,6 +23,7 @@
 #include "sway/config.h"
 #include "sway/criteria.h"
 #include "sway/desktop/transaction.h"
+#include "sway/server.h"
 #include "sway/swaynag.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/root.h"

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -12,6 +12,7 @@
 #include "sway/config.h"
 #include "sway/input/keyboard.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "config.h"
 #include "list.h"
 #include "log.h"

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -3,6 +3,7 @@
 #include <float.h>
 #include "sway/config.h"
 #include "sway/input/keyboard.h"
+#include "sway/server.h"
 #include "log.h"
 
 struct input_config *new_input_config(const char* identifier) {

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -13,6 +13,7 @@
 #include "sway/config.h"
 #include "sway/input/cursor.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "sway/tree/root.h"
 #include "log.h"
 #include "util.h"

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -7,6 +7,7 @@
 #include "sway/criteria.h"
 #include "sway/tree/container.h"
 #include "sway/config.h"
+#include "sway/server.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -4,6 +4,7 @@
 #include "sway/input/seat.h"
 #include "sway/output.h"
 #include "sway/desktop/launcher.h"
+#include "sway/server.h"
 #include "sway/tree/node.h"
 #include "sway/tree/container.h"
 #include "sway/tree/workspace.h"

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -10,6 +10,7 @@
 #include "sway/input/cursor.h"
 #include "sway/input/input-manager.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/node.h"
 #include "sway/tree/view.h"

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -25,6 +25,7 @@
 #include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/scene_descriptor.h"
+#include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -13,6 +13,7 @@
 #include "sway/input/seat.h"
 #include "sway/input/cursor.h"
 #include "sway/ipc-server.h"
+#include "sway/server.h"
 #include "log.h"
 
 #if WLR_HAS_SESSION

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -11,6 +11,7 @@
 #include "sway/input/tablet.h"
 #include "sway/layers.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "sway/scene_descriptor.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"

--- a/sway/input/switch.c
+++ b/sway/input/switch.c
@@ -1,5 +1,6 @@
 #include "sway/config.h"
 #include "sway/input/switch.h"
+#include "sway/server.h"
 #include "log.h"
 
 struct sway_switch *sway_switch_create(struct sway_seat *seat,

--- a/sway/input/tablet.c
+++ b/sway/input/tablet.c
@@ -7,6 +7,7 @@
 #include "sway/input/cursor.h"
 #include "sway/input/seat.h"
 #include "sway/input/tablet.h"
+#include "sway/server.h"
 
 #if WLR_HAS_LIBINPUT_BACKEND
 #include <wlr/backend/libinput.h>

--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -9,6 +9,8 @@
 #include "sway/input/text_input.h"
 #include "sway/input/text_input_popup.h"
 #include "sway/layers.h"
+#include "sway/server.h"
+
 static void input_popup_update(struct sway_input_popup *popup);
 
 static struct sway_text_input *relay_get_focusable_text_input(

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -11,6 +11,7 @@
 #include "log.h"
 #include "sway/config.h"
 #include "sway/ipc-json.h"
+#include "sway/server.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -10,6 +10,7 @@
 #include "sway/input/seat.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
+#include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/node.h"


### PR DESCRIPTION
The only reason it's included there is for a declaration of struct sway_server, but we can just forward-declare it.

This avoids rebuilding almost all of Sway when touching server.h. All other server.h includes are from source files, not headers.