### PR TITLE
input_method: Split up update method

### DIFF
--- a/include/sway/input/text_input_popup.h
+++ b/include/sway/input/text_input_popup.h
@@ -15,6 +15,8 @@ struct sway_input_popup {
 
 	struct wl_listener popup_destroy;
 	struct wl_listener popup_surface_commit;
+	struct wl_listener popup_surface_map;
+	struct wl_listener popup_surface_unmap;
 
 	struct wl_listener focused_surface_unmap;
 };

--- a/include/sway/input/text_input_popup.h
+++ b/include/sway/input/text_input_popup.h
@@ -9,6 +9,7 @@ struct sway_input_popup {
 	struct wlr_scene_tree *scene_tree;
 	struct sway_popup_desc desc;
 	struct wlr_input_popup_surface_v2 *popup_surface;
+	struct wlr_output *fixed_output;
 
 	struct wl_list link;
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -612,9 +612,11 @@ void arrange_popups(struct wlr_scene_tree *popups) {
 		struct sway_popup_desc *popup = scene_descriptor_try_get(node,
 			SWAY_SCENE_DESC_POPUP);
 
-		int lx, ly;
-		wlr_scene_node_coords(popup->relative, &lx, &ly);
-		wlr_scene_node_set_position(node, lx, ly);
+		if (popup) {
+			int lx, ly;
+			wlr_scene_node_coords(popup->relative, &lx, &ly);
+			wlr_scene_node_set_position(node, lx, ly);
+		}
 	}
 }
 

--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -448,6 +448,11 @@ static void handle_im_new_popup_surface(struct wl_listener *listener,
 	struct sway_input_method_relay *relay = wl_container_of(listener, relay,
 		input_method_new_popup_surface);
 	struct sway_input_popup *popup = calloc(1, sizeof(*popup));
+	if (!popup) {
+		sway_log(SWAY_ERROR, "Failed to allocate an input method popup");
+		return;
+	}
+
 	popup->relay = relay;
 	popup->popup_surface = data;
 	popup->popup_surface->data = popup;


### PR DESCRIPTION
The update method was a big hammer, it did a lot of things.
- This function would recreate the scene every time the input method client commits a new buffer

Instead, we create the scene when the input method surface maps / unmaps.
When the input method is unfocused, we simply disable the scene node.

Fixes: #8086