### PR TITLE
Set color transform when calling wlr_scene_output_build_state()

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -927,6 +927,7 @@ bool apply_output_configs(struct matched_output_config *configs,
 		struct wlr_scene_output_state_options opts = {
 			.swapchain = wlr_output_swapchain_manager_get_swapchain(
 				&swapchain_mgr, backend_state->output),
+			.color_transform = cfg->output->color_transform,
 		};
 		struct wlr_scene_output *scene_output = cfg->output->scene_output;
 		struct wlr_output_state *state = &backend_state->base;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -243,10 +243,14 @@ static int output_repaint_timer_handler(void *data) {
 
 	output_configure_scene(output, &root->root_scene->tree.node, 1.0f);
 
+	struct wlr_scene_output_state_options opts = {
+		.color_transform = output->color_transform,
+	};
+
 	if (output->gamma_lut_changed) {
 		struct wlr_output_state pending;
 		wlr_output_state_init(&pending);
-		if (!wlr_scene_output_build_state(output->scene_output, &pending, NULL)) {
+		if (!wlr_scene_output_build_state(output->scene_output, &pending, &opts)) {
 			return 0;
 		}
 
@@ -269,9 +273,6 @@ static int output_repaint_timer_handler(void *data) {
 		return 0;
 	}
 
-	struct wlr_scene_output_state_options opts = {
-		.color_transform = output->color_transform,
-	};
 	wlr_scene_output_commit(output->scene_output, &opts);
 	return 0;
 }


### PR DESCRIPTION
We were only passing the color transform when calling wlr_scene_output_commit(). However when modesetting or pushing a new gamma LUT we render via wlr_scene_output_build_state(). Pass the color transform there as well.

cc @mstoeckl 