### PR TITLE
Add mouse_warp to mark option

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -472,6 +472,7 @@ enum mouse_warping_mode {
 	WARP_NO,
 	WARP_OUTPUT,
 	WARP_CONTAINER,
+	WARP_MARK,
 };
 
 enum alignment {
@@ -537,6 +538,7 @@ struct sway_config {
 	// Flags
 	enum focus_follows_mouse_mode focus_follows_mouse;
 	enum mouse_warping_mode mouse_warping;
+	char *mouse_warping_mark_name;
 	enum focus_wrapping_mode focus_wrapping;
 	bool active;
 	bool failed;

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -280,6 +280,11 @@ static struct cmd_results *focus_mode(struct sway_workspace *ws,
 		// to anyway.
 		if (config->mouse_warping == WARP_CONTAINER) {
 			cursor_warp_to_container(seat->cursor, new_focus, true);
+		} else if (config->mouse_warping == WARP_MARK) {
+			bool has_warp_mark = container_has_mark(new_focus, config->mouse_warping_mark_name);
+			if (has_warp_mark) {
+				cursor_warp_to_container(seat->cursor, new_focus, true);
+			}
 		} else {
 			seat_consider_warp_to_focus(seat);
 		}

--- a/sway/commands/mouse_warping.c
+++ b/sway/commands/mouse_warping.c
@@ -4,7 +4,7 @@
 
 struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "mouse_warping", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "mouse_warping", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	} else if (strcasecmp(argv[0], "container") == 0) {
 		config->mouse_warping = WARP_CONTAINER;
@@ -12,9 +12,15 @@ struct cmd_results *cmd_mouse_warping(int argc, char **argv) {
 		config->mouse_warping = WARP_OUTPUT;
 	} else if (strcasecmp(argv[0], "none") == 0) {
 		config->mouse_warping = WARP_NO;
+	} else if (strcasecmp(argv[0], "mark") == 0) {
+		config->mouse_warping = WARP_MARK;
+		if (argc < 2) {
+			return cmd_results_new(CMD_FAILURE, "Expected an mark name as a second argument");
+		}
+		config->mouse_warping_mark_name = argv[1];
 	} else {
 		return cmd_results_new(CMD_FAILURE,
-				"Expected 'mouse_warping output|container|none'");
+				"Expected 'mouse_warping output|container|mark|none'");
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }


### PR DESCRIPTION
This allows to better support certain pop-ups which require focus or they close (like certain password managers). The popup can be marked and only that window will get mouse_warped.

For example:
```
for_window [title="Enpass Assistant"] {
    move position mouse
    inhibit_idle visible
    urgent enable
    mark --add mouse_me
}

mouse_warping mark mouse_me
```