### PR TITLE
commands/move: Focus inactive view when no parent is found

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -601,7 +601,9 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 			focus = seat_get_focus_inactive(seat, &old_parent->node);
 		}
 		if (!focus && old_ws) {
-			focus = seat_get_focus_inactive(seat, &old_ws->node);
+			struct sway_container *container =
+				seat_get_focus_inactive_view(seat, &old_ws->node);
+			focus = &container->node;
 		}
 	}
 	seat_set_focus(seat, focus);


### PR DESCRIPTION
There are some cases where the inactive view is the null container that wraps tabbed and stacking layouts. The following demonstrates how this results in some unexpected behavior:

1. On an empty workspace, spawn three windows.
2. Convert the layout to stacking with `layout stacking`.
3. Toggle one of the windows as floating with `toggle floating`.
4. With the floating window still selected, move it to another workspace with `move container to workspace`.

We'd expect just one window to be selected instead of all remaining windows in the workspace. We can fix this by selecting the inactive view instead.