### PR TITLE
fix crash when setting urgency on an hidden scratchpad container

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1185,7 +1185,7 @@ void view_set_urgent(struct sway_view *view, bool enable) {
 
 	ipc_event_window(view->container, "urgent");
 
-	if (!container_is_scratchpad_hidden(view->container)) {
+	if (!container_is_scratchpad_hidden_or_child(view->container)) {
 		workspace_detect_urgent(view->container->pending.workspace);
 	}
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -708,6 +708,11 @@ void workspace_for_each_container(struct sway_workspace *ws,
 struct sway_container *workspace_find_container(struct sway_workspace *ws,
 		bool (*test)(struct sway_container *con, void *data), void *data) {
 	struct sway_container *result = NULL;
+    if (ws == NULL){
+        sway_log(SWAY_ERROR, "Cannot find container with no workspace.");
+        return NULL;
+    }
+
 	// Tiling
 	for (int i = 0; i < ws->tiling->length; ++i) {
 		struct sway_container *child = ws->tiling->items[i];


### PR DESCRIPTION
To reproduce:

1. Open a new (terminal) window
2. Execute: `sleep 5 && notify-send crash "this is how you crash"`
3. Send the container to the scratchpad before the 5 seconds sleep is finished
4. `sway` will crash as soon as the notification is sent.

The reason for this is that `container_is_scratchpad_hidden` returns false and `workspace_detect_urgent` is run, calling `workspace_find_container` with a `NULL` workspace, causing it to crash because of a null pointer dereference: https://github.com/swaywm/sway/blob/master/sway/tree/workspace.c#L695-L696