### PR TITLE
sway/commands/move.c: arrange new workspace

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -510,6 +510,7 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 				}
 			}
 			ws = workspace_create(NULL, ws_name);
+			arrange_workspace(ws);
 		}
 		free(ws_name);
 		struct sway_container *dst = seat_get_focus_inactive_tiling(seat, ws);


### PR DESCRIPTION
When moving a container to a new workspace, the workspace's dimension are left unset. Usually this doesn't matter, but when moving a floating container to a new workspace on a different output, this leads to the position of the container being calculated with 0, so the container ends up halfway offscreen on the leftmost topmost monitor.