### PR TITLE
config/output: Skip VRR tests when not supported

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -721,21 +721,18 @@ static bool search_adaptive_sync(struct search_context *ctx, size_t output_idx) 
 	struct wlr_backend_output_state *backend_state = &ctx->states[output_idx];
 	struct wlr_output_state *state = &backend_state->base;
 
+	if (!backend_state->output->adaptive_sync_supported) {
+		return search_finish(ctx, output_idx);
+	}
+
 	if (cfg->config && cfg->config->adaptive_sync == 1) {
 		wlr_output_state_set_adaptive_sync_enabled(state, true);
 		if (search_finish(ctx, output_idx)) {
 			return true;
 		}
 	}
-	if (!cfg->config || cfg->config->adaptive_sync != -1) {
-		wlr_output_state_set_adaptive_sync_enabled(state, false);
-		if (search_finish(ctx, output_idx)) {
-			return true;
-		}
-	}
-	// If adaptive sync has not been set, or fallback in case we are on a
-	// backend that cannot disable adaptive sync such as the wayland backend.
-	state->committed &= ~WLR_OUTPUT_STATE_ADAPTIVE_SYNC_ENABLED;
+
+	wlr_output_state_set_adaptive_sync_enabled(state, false);
 	return search_finish(ctx, output_idx);
 }
 


### PR DESCRIPTION
Adaptive sync is a "soft" setting which we degrade of off when not supported. Some outputs types do not support turning it off (Wayland, X11), which makes for an awkward three-way test where we first enable, disable and finally unset the setting.

wlr_output.adaptive_sync_supported tells us whether the output definitely does not support making changes (backend without support, connector without the feature), or whether it might work.

Use this to avoid wasting time on adaptive sync test that can never succeed, and to avoid the Wayland/X11-backend specific unset step.