### PR TITLE
xdg_shell: don't send configure events to uninitialized surfaces

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -289,6 +289,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		}
 		// XXX: https://github.com/swaywm/sway/issues/2176
 		wlr_xdg_surface_schedule_configure(xdg_surface);
+		wlr_xdg_toplevel_set_wm_capabilities(view->wlr_xdg_toplevel,
+			XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 		// TODO: wlr_xdg_toplevel_set_bounds()
 		return;
 	}
@@ -575,7 +577,4 @@ void handle_xdg_shell_toplevel(struct wl_listener *listener, void *data) {
 	wlr_scene_xdg_surface_create(xdg_shell_view->view.content_tree, xdg_toplevel->base);
 
 	xdg_toplevel->base->data = xdg_shell_view;
-
-	wlr_xdg_toplevel_set_wm_capabilities(xdg_toplevel,
-		XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 }


### PR DESCRIPTION
the surface isn't initialized yet when we first handle it in `handle_xdg_shell_toplevel`, move setting WM capabilities to handle_commit instead.

Fixes warnings from wlroots about a configure being scheduled for uninitialized surface