### PR TITLE
common/pango: Disable glyph position rounding

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -53,6 +53,8 @@ size_t escape_markup_text(const char *src, char *dest) {
 PangoLayout *get_pango_layout(cairo_t *cairo, const PangoFontDescription *desc,
 		const char *text, double scale, bool markup) {
 	PangoLayout *layout = pango_cairo_create_layout(cairo);
+	pango_context_set_round_glyph_positions(pango_layout_get_context(layout), false);
+
 	PangoAttrList *attrs;
 	if (markup) {
 		char *buf;
@@ -104,6 +106,7 @@ void get_text_size(cairo_t *cairo, const PangoFontDescription *desc, int *width,
 void get_text_metrics(const PangoFontDescription *description, int *height, int *baseline) {
 	cairo_t *cairo = cairo_create(NULL);
 	PangoContext *pango = pango_cairo_create_context(cairo);
+	pango_context_set_round_glyph_positions(pango, false);
 	// When passing NULL as a language, pango uses the current locale.
 	PangoFontMetrics *metrics = pango_context_get_metrics(pango, description, NULL);
 


### PR DESCRIPTION
Pango rounds glyph position and widths to nearest integer, which leads to font dimensions jumping around when rendering with a scale, causing text geometry to jump around when changing scale. This is disturbing when text buffers change scale, and also mean that the text geometry calculations in sway_text_node are incorrect.

Disable this rounding to make the geometry stable.