### PR TITLE
Drop wl_drm again

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -151,7 +151,6 @@ struct sway_debug {
 	bool noatomic;         // Ignore atomic layout updates
 	bool txn_timings;      // Log verbose messages about transactions
 	bool txn_wait;         // Always wait for the timeout before applying
-	bool legacy_wl_drm;    // Enable the legacy wl_drm interface
 };
 
 extern struct sway_debug debug;

--- a/sway/main.c
+++ b/sway/main.c
@@ -181,8 +181,6 @@ void enable_debug_flag(const char *flag) {
 		debug.txn_timings = true;
 	} else if (has_prefix(flag, "txn-timeout=")) {
 		server.txn_timeout_ms = atoi(&flag[strlen("txn-timeout=")]);
-	} else if (strcmp(flag, "legacy-wl-drm") == 0) {
-		debug.legacy_wl_drm = true;
 	} else {
 		sway_log(SWAY_ERROR, "Unknown debug flag: %s", flag);
 	}

--- a/sway/server.c
+++ b/sway/server.c
@@ -16,7 +16,6 @@
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_ext_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
@@ -265,9 +264,6 @@ bool server_init(struct sway_server *server) {
 	if (wlr_renderer_get_texture_formats(server->renderer, WLR_BUFFER_CAP_DMABUF) != NULL) {
 		server->linux_dmabuf_v1 = wlr_linux_dmabuf_v1_create_with_renderer(
 			server->wl_display, 4, server->renderer);
-		if (debug.legacy_wl_drm) {
-			wlr_drm_create(server->wl_display, server->renderer);
-		}
 	}
 	if (wlr_renderer_get_drm_fd(server->renderer) >= 0 &&
 			server->renderer->features.timeline &&


### PR DESCRIPTION
In [1] we re-introduced a debug flag to enable wl_drm. Time has passed and Xwayland + VA-API + amdvlk now all support linux-dmabuf-v1.

[1]: https://github.com/swaywm/sway/pull/7916