### PR TITLE
build: use fs.relative_to() instead of hand-rolled logic

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '1.10-dev',
 	license: 'MIT',
-	meson_version: '>=0.60.0',
+	meson_version: '>=1.3',
 	default_options: [
 		'c_std=c11',
 		'warning_level=2',
@@ -172,31 +172,10 @@ if git.found()
 endif
 add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
 
-# Compute the relative path used by compiler invocations.
-source_root = meson.current_source_dir().split('/')
-build_root = meson.global_build_root().split('/')
-relative_dir_parts = []
-i = 0
-in_prefix = true
-foreach p : build_root
-	if i >= source_root.length() or not in_prefix or p != source_root[i]
-		in_prefix = false
-		relative_dir_parts += '..'
-	endif
-	i += 1
-endforeach
-i = 0
-in_prefix = true
-foreach p : source_root
-	if i >= build_root.length() or not in_prefix or build_root[i] != p
-		in_prefix = false
-		relative_dir_parts += p
-	endif
-	i += 1
-endforeach
-relative_dir = join_paths(relative_dir_parts) + '/'
+fs = import('fs')
 
 # Strip relative path prefixes from the code if possible, otherwise hide them.
+relative_dir = fs.relative_to(meson.current_source_dir(), meson.global_build_root()) + '/'
 if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
 	add_project_arguments(
 		'-fmacro-prefix-map=@0@='.format(relative_dir),


### PR DESCRIPTION
Meson has introduced a relative_to() function [1] in its fs module since version 1.3.

[1]: https://mesonbuild.com/Fs-module.html#relative_to

Same as https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4724