### PR TITLE
desktop/output: Stop repaint loop when not needed

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -247,6 +247,13 @@ static int output_repaint_timer_handler(void *data) {
 		.color_transform = output->color_transform,
 	};
 
+	struct wlr_output *wlr_output = output->wlr_output;
+	struct wlr_scene_output *scene_output = output->scene_output;
+	if (!wlr_output->needs_frame && !output->gamma_lut_changed &&
+			!pixman_region32_not_empty(&scene_output->pending_commit_damage)) {
+		return 0;
+	}
+
 	struct wlr_output_state pending;
 	wlr_output_state_init(&pending);
 	if (!wlr_scene_output_build_state(output->scene_output, &pending, &opts)) {


### PR DESCRIPTION
1e0031781fc9 refactored repaint to accumulate all changes in a single wlr_output_state and commit them at the end of the repaint loop, replacing a call to wlr_scene_output_commit. wlr_scene_output_commit contains an early bail-out when no frame has been requested and no damage has accumulated, which was not replicated as part of this refactor, causing the repaint loop to never pause.

Replicate the logic to stop the repaint loop as needed.

Fixes: 1e0031781fc9 ("desktop/output: unify page-flip codepath")