### PR TITLE
sway/server: Implement wayland socket handover

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -164,7 +164,7 @@ extern bool unsupported_gpu_detected;
 
 void sway_terminate(int exit_code);
 
-bool server_init(struct sway_server *server);
+bool server_init(struct sway_server *server, const char * socket_name, int socket_fd);
 void server_fini(struct sway_server *server);
 bool server_start(struct sway_server *server);
 void server_run(struct sway_server *server);

--- a/sway/main.c
+++ b/sway/main.c
@@ -208,6 +208,8 @@ static const struct option long_options[] = {
 	{"verbose", no_argument, NULL, 'V'},
 	{"get-socketpath", no_argument, NULL, 'p'},
 	{"unsupported-gpu", no_argument, NULL, 'u'},
+	{"socket", required_argument, NULL, 's'},
+	{"wayland-fd", required_argument, NULL, 'S'},
 	{0, 0, 0, 0}
 };
 
@@ -221,12 +223,16 @@ static const char usage[] =
 	"  -v, --version          Show the version number and quit.\n"
 	"  -V, --verbose          Enables more verbose logging.\n"
 	"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
+	"      --socket <name>    Sets the Wayland socket name (for Wayland socket handover)\n"
+	"      --wayland-fd <fd>  Sets the Wayland socket fd (for Wayland socket handover)\n"
 	"\n";
 
 int main(int argc, char **argv) {
 	bool verbose = false, debug = false, validate = false, allow_unsupported_gpu = false;
 
 	char *config_path = NULL;
+	char *socket_name = NULL;
+	int socket_fd = -1;
 
 	int c;
 	while (1) {
@@ -271,6 +277,13 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "sway socket not detected.\n");
 				exit(EXIT_FAILURE);
 			}
+			break;
+		case 's': // --socket
+			free(socket_name);
+			socket_name = strdup(optarg);
+			break;
+		case 'S': // --wayland-fd
+			socket_fd = atoi(optarg);
 			break;
 		default:
 			fprintf(stderr, "%s", usage);
@@ -337,7 +350,7 @@ int main(int argc, char **argv) {
 
 	sway_log(SWAY_INFO, "Starting sway version " SWAY_VERSION);
 
-	if (!server_init(&server)) {
+	if (!server_init(&server, socket_name, socket_fd)) {
 		return 1;
 	}
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <getopt.h>
 #include <pango/pangocairo.h>
 #include <pthread.h>
@@ -303,6 +304,14 @@ int main(int argc, char **argv) {
 	// we let the flag override the environment variable
 	if (!allow_unsupported_gpu && unsupported_gpu_env) {
 		allow_unsupported_gpu = parse_boolean(unsupported_gpu_env, false);
+	}
+
+	// Fail if only one of --socket and --wayland-fd are given.
+	if ((socket_name == NULL) ^ (socket_fd == -1)) {
+		fprintf(stderr,
+				"Both --socket and --wayland-fd are required for Wayland "
+				"socket handover, but only one was provided. Aborting.\n");
+		exit(EXIT_FAILURE);
 	}
 
 	// As the 'callback' function for wlr_log is equivalent to that for

--- a/sway/sway.1.scd
+++ b/sway/sway.1.scd
@@ -31,6 +31,12 @@ sway - An i3-compatible Wayland compositor
 *--get-socketpath*
 	Gets the IPC socket path and prints it, then exits.
 
+*--socket NAME*
+	Sets the Wayland socket name (for Wayland socket handover)
+
+*--wayland-fd FD*
+	Sets the Wayland socket file descriptor (for Wayland socket handover)
+
 # DESCRIPTION
 
 sway was created to fill the need of an i3-like window manager for Wayland. The


### PR DESCRIPTION
This PR implements the compositor side of the Wayland socket handover protocol as described in the [KDE Wiki][KDE Wiki]. The CLI options are chosen so that they are compatible with Kwin (and Hyprland):

Sway now accepts the CLI options `--socket NAME` and `--wayland-fd FD`, which pass the name of the Wayland display socket and the Wayland display socket fd number respectively. If given, Sway will use these instead of finding a free Wayland display socket name and creating it.

This allows for Sway to be used with a helper tool that automatically restarts the compositor on crashes, and allowing clients to reconnect after the compositor restart and survive the crash. The reconnecting clients look like new clients to Sway and perform all the same steps as a fresh Wayland client would. No additional handling is required on the side of Sway.

The helper tool finds and creates the Wayland socket and launches Sway with the new CLI options, restarting it when it exits with a non-zero exit code. Two such helper tools currently exist as far as I know:

- [`kwin_wayland_wrapper`](https://invent.kde.org/plasma/kwin/-/blob/master/src/helpers/wayland_wrapper/kwin_wrapper.cpp?ref_type=heads) (only for KDE)
- [`wl-restart`](https://github.com/ferdi265/wl-restart) (developed by me)

[KDE Wiki]: https://invent.kde.org/plasma/kwin/-/wikis/Restarting