### PR TITLE
Add null-safety check for virtual keyboard keymaps

### DIFF
--- a/sway/commands/input/xkb_switch_layout.c
+++ b/sway/commands/input/xkb_switch_layout.c
@@ -95,10 +95,18 @@ struct cmd_results *input_cmd_xkb_switch_layout(int argc, char **argv) {
 			continue;
 		}
 
+		struct wlr_keyboard *keyboard =
+			wlr_keyboard_from_input_device(dev->wlr_device);
+		if (keyboard->keymap == NULL && dev->is_virtual) {
+			// The `sway_keyboard_set_layout` function is by default skipped
+			// when configuring virtual keyboards.
+			continue;
+		}
+
 		struct xkb_switch_layout_action *action =
 			&actions[actions_len++];
+		action->keyboard = keyboard;
 
-		action->keyboard = wlr_keyboard_from_input_device(dev->wlr_device);
 		if (relative) {
 			action->layout = get_layout_relative(action->keyboard, relative);
 		} else {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1133,7 +1133,9 @@ json_object *ipc_json_describe_input(struct sway_input_device *device) {
 		json_object *layouts_arr = json_object_new_array();
 		json_object_object_add(object, "xkb_layout_names", layouts_arr);
 
-		xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
+		xkb_layout_index_t num_layouts =
+			keymap ? xkb_keymap_num_layouts(keymap) : 0;
+		// Virtual keyboards might have null keymap
 		xkb_layout_index_t layout_idx;
 		for (layout_idx = 0; layout_idx < num_layouts; layout_idx++) {
 			const char *layout = xkb_keymap_layout_get_name(keymap, layout_idx);


### PR DESCRIPTION
Even though there are already many issues / prs trying to address this problem, including #6484, #6873, #6990, I still get segfaults due to null keymap pointer.

Hence, I would simply suggest to add a check before we call `xkb_keymap_num_layouts`.