### PR TITLE
desktop/xwayland: don't restack when marking window as inactive

### DIFF
--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -289,7 +289,9 @@ static void set_activated(struct sway_view *view, bool activated) {
 	}
 
 	wlr_xwayland_surface_activate(surface, activated);
-	wlr_xwayland_surface_restack(surface, NULL, XCB_STACK_MODE_ABOVE);
+	if (activated) {
+		wlr_xwayland_surface_restack(surface, NULL, XCB_STACK_MODE_ABOVE);
+	}
 }
 
 static void set_tiled(struct sway_view *view, bool tiled) {


### PR DESCRIPTION
daaec72ac01f ("desktop/xwayland: restack surface upon activation") has updated Sway for wlroots commit bfc69decdd04 ("xwm: do not restack surfaces on activation"). However, it unconditionally restacks the window above all other windows even if marking the window as inactive.

Closes: https://github.com/swaywm/sway/issues/7974