### PR TITLE
tearing: fix UAF, remove trailing whitespace

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -578,9 +578,9 @@ static bool finalize_output_config(struct output_config *oc, struct sway_output 
 		wlr_color_transform_unref(output->color_transform);
 		output->color_transform = oc->color_transform;
 	}
-	
+
 	if (oc && oc->allow_tearing >= 0) {
-		sway_log(SWAY_DEBUG, "Set %s allow tearing to %d", 
+		sway_log(SWAY_DEBUG, "Set %s allow tearing to %d",
 			oc->name, oc->allow_tearing);
 		output->allow_tearing = oc->allow_tearing;
 	}

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -292,14 +292,13 @@ static int output_repaint_timer_handler(void *data) {
 			wlr_output_state_set_gamma_lut(&pending, 0, NULL, NULL, NULL);
 		}
 	}
-	
+
 	if (output_can_tear(output)) {
 		pending.tearing_page_flip = true;
-		
+
 		if (!wlr_output_test_state(output->wlr_output, &pending)) {
 			sway_log(SWAY_DEBUG, "Output test failed on '%s', retrying without tearing page-flip",
 				output->wlr_output->name);
-				
 			pending.tearing_page_flip = false;
 		}
 	}

--- a/sway/desktop/tearing.c
+++ b/sway/desktop/tearing.c
@@ -17,7 +17,7 @@ static void handle_tearing_controller_set_hint(struct wl_listener *listener,
 		void *data) {
 	struct sway_tearing_controller *controller =
 		wl_container_of(listener, controller, set_hint);
-	
+
 	struct sway_view *view = view_from_wlr_surface(
 		controller->tearing_control->surface);
 	if (view) {
@@ -25,27 +25,27 @@ static void handle_tearing_controller_set_hint(struct wl_listener *listener,
 	}
 }
 
-static void handle_tearing_controller_destroy(struct wl_listener *listener, 
+static void handle_tearing_controller_destroy(struct wl_listener *listener,
 		void *data) {
-	struct sway_tearing_controller *controller = 
+	struct sway_tearing_controller *controller =
 		wl_container_of(listener, controller, destroy);
 	wl_list_remove(&controller->link);
 	free(controller);
 }
 
-void handle_new_tearing_hint(struct wl_listener *listener, 
+void handle_new_tearing_hint(struct wl_listener *listener,
 		void *data) {
-	struct sway_server *server = 
+	struct sway_server *server =
 		wl_container_of(listener, server, tearing_control_new_object);
 	struct wlr_tearing_control_v1 *tearing_control = data;
-	
-	enum wp_tearing_control_v1_presentation_hint hint = 
+
+	enum wp_tearing_control_v1_presentation_hint hint =
 		wlr_tearing_control_manager_v1_surface_hint_from_surface(
 			server->tearing_control_v1, tearing_control->surface);
 	sway_log(SWAY_DEBUG, "New presentation hint %d received for surface %p",
 		hint, tearing_control->surface);
 
-	struct sway_tearing_controller *controller = 
+	struct sway_tearing_controller *controller =
 		calloc(1, sizeof(struct sway_tearing_controller));
 	if (!controller) {
 		return;

--- a/sway/desktop/tearing.c
+++ b/sway/desktop/tearing.c
@@ -29,6 +29,8 @@ static void handle_tearing_controller_destroy(struct wl_listener *listener,
 		void *data) {
 	struct sway_tearing_controller *controller =
 		wl_container_of(listener, controller, destroy);
+	wl_list_remove(&controller->set_hint.link);
+	wl_list_remove(&controller->destroy.link);
 	wl_list_remove(&controller->link);
 	free(controller);
 }

--- a/sway/server.c
+++ b/sway/server.c
@@ -377,8 +377,8 @@ bool server_init(struct sway_server *server) {
 	server->content_type_manager_v1 =
 		wlr_content_type_manager_v1_create(server->wl_display, 1);
 	wlr_fractional_scale_manager_v1_create(server->wl_display, 1);
-	
-	server->tearing_control_v1 = 
+
+	server->tearing_control_v1 =
 		wlr_tearing_control_manager_v1_create(server->wl_display, 1);
 	server->tearing_control_new_object.notify = handle_new_tearing_hint;
 	wl_signal_add(&server->tearing_control_v1->events.new_object,

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1268,7 +1268,7 @@ bool view_can_tear(struct sway_view *view) {
 	case TEARING_OVERRIDE_TRUE:
 		return true;
 	case TEARING_WINDOW_HINT:
-		return view->tearing_hint == 
+		return view->tearing_hint ==
 			WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;
 	}
 	return false;


### PR DESCRIPTION
Fixes: 9a1c411abd8261c121dcd50dfe54132718768084