### PR TITLE
Switch default config to wmenu-run

### DIFF
--- a/config.in
+++ b/config.in
@@ -16,9 +16,7 @@ set $right l
 # Your preferred terminal emulator
 set $term foot
 # Your preferred application launcher
-# Note: pass the final command to swaymsg so that the resulting window can be opened
-# on the original workspace that the command was run on.
-set $menu dmenu_path | wmenu | xargs swaymsg exec --
+set $menu wmenu-run
 
 ### Output configuration
 #


### PR DESCRIPTION
This removes the last dependency bit on dmenu. No need for "swaymsg exec" anymore: wmenu-run handles the xdg-activation shenanigans.