### PR TITLE
swaybar: prioritize workspace scroll over bindsyms

### DIFF
--- a/include/swaybar/input.h
+++ b/include/swaybar/input.h
@@ -78,6 +78,9 @@ uint32_t event_to_x11_button(uint32_t event);
 
 void free_hotspots(struct wl_list *list);
 
+bool handle_workspace_button(struct swaybar_output *output,
+	uint32_t button, bool released, const char *ws);
+
 void swaybar_seat_free(struct swaybar_seat *seat);
 
 #endif

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -246,6 +246,15 @@ bool handle_workspace_button(struct swaybar_output *output,
 		}
 		ipc_send_workspace_command(output->bar, ws);
 		return true;
+	} else if (button == SWAY_SCROLL_UP || button == SWAY_SCROLL_DOWN ||
+			button == SWAY_SCROLL_LEFT || button == SWAY_SCROLL_RIGHT) {
+		if (released) {
+			return true;
+		}
+
+		workspace_next(output->bar, output,
+				button == SWAY_SCROLL_UP || button == SWAY_SCROLL_LEFT);
+		return true;
 	}
 
 	return false;
@@ -266,6 +275,7 @@ static void process_discrete_scroll(struct swaybar_seat *seat,
 		return;
 	}
 
+	// If no hotspot nor binding handles the event, scroll through workspaces
 	struct swaybar_config *config = seat->bar->config;
 	double amt = wl_fixed_to_double(value);
 	if (amt == 0.0 || !config->workspace_buttons) {

--- a/swaybar/input.c
+++ b/swaybar/input.c
@@ -236,6 +236,21 @@ static void workspace_next(struct swaybar *bar, struct swaybar_output *output,
 	}
 }
 
+bool handle_workspace_button(struct swaybar_output *output,
+	uint32_t button, bool released, const char *ws) {
+	if (button == BTN_LEFT) {
+		if (released) {
+			// Since we handle the pressed event, also handle the released event
+			// to block it from falling through to a binding in the bar
+			return true;
+		}
+		ipc_send_workspace_command(output->bar, ws);
+		return true;
+	}
+
+	return false;
+}
+
 static void process_discrete_scroll(struct swaybar_seat *seat,
 		struct swaybar_output *output, struct swaybar_pointer *pointer,
 		uint32_t axis, wl_fixed_t value) {

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -599,16 +599,8 @@ static uint32_t render_binding_mode_indicator(struct render_context *ctx,
 static enum hotspot_event_handling workspace_hotspot_callback(
 		struct swaybar_output *output, struct swaybar_hotspot *hotspot,
 		double x, double y, uint32_t button, bool released, void *data) {
-	if (button != BTN_LEFT) {
-		return HOTSPOT_PROCESS;
-	}
-	if (released) {
-		// Since we handle the pressed event, also handle the released event
-		// to block it from falling through to a binding in the bar
-		return HOTSPOT_IGNORE;
-	}
-	ipc_send_workspace_command(output->bar, (const char *)data);
-	return HOTSPOT_IGNORE;
+	return handle_workspace_button(output, button, released, (const char *)data)
+		? HOTSPOT_IGNORE : HOTSPOT_PROCESS;
 }
 
 static uint32_t render_workspace_button(struct render_context *ctx,


### PR DESCRIPTION
This adds handling for scroll events (e.g. mouse wheel) to the hotspot callback equivalent to the fallback in `process_discrete_scroll`.
While this may seem redundant (and in many cases, it is), it changes the priority when the user has Button4/Button5 bindsyms on the bar.

Before this commit:
* Scrolling on unused bar space calls the user's bindsyms.
* Scrolling over the workspaces *still* calls the user's bindsyms.

After this commit:
* Scrolling on unused bar space calls the user's bindsyms.
* Scrolling over the workspaces moves to the previous/next workspace.

If the user has no bindsyms for Button4/Button5, there is no change.

# Utility

This shows an example of why this is useful. Here, the user has set up a Button4/Button5 bindsym to change the volume (see: top right corner) when scrolling over the bar.

Before this change, the user could no longer use the mouse wheel to switch workspaces:

![beforeY](https://github.com/user-attachments/assets/6e3dce4f-6901-4e28-b2dd-44f4dd9a4df6)

After this change, the user can (*only* when scrolling over the workspaces):

![afterY](https://github.com/user-attachments/assets/8d24f536-c9e4-423a-ac13-82ae5669289f)

# Discussion

This is consistent with the idea that workspaces are hotspots, and hotspot event handlers take priority over the user's bindsyms, see https://github.com/swaywm/sway/commit/53f9dbd424dc173a85c9f4cd30802259d38b1ef4 ("swaybar: Prioritize hotspot events to bar bindings").

However, note that **this strays further away from i3's behaviour**. On i3, user bindsyms take precedence over workspaces, even for Button1. In fact, it's [explicitly documented as such](https://web.archive.org/web/20240725173949/https://i3wm.org/docs/userguide.html#_mouse_button_commands).