### PR TITLE
config/output: Do not set adaptive_sync if not supported

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -491,7 +491,7 @@ static void queue_output_config(struct output_config *oc,
 		wlr_output_state_set_scale(pending, scale);
 	}
 
-	if (oc && oc->adaptive_sync != -1) {
+	if (oc && oc->adaptive_sync != -1 && wlr_output->adaptive_sync_supported) {
 		sway_log(SWAY_DEBUG, "Set %s adaptive sync to %d", wlr_output->name,
 			oc->adaptive_sync);
 		wlr_output_state_set_adaptive_sync_enabled(pending, oc->adaptive_sync == 1);


### PR DESCRIPTION
After 4e38f93f367d ("config/output: Skip VRR tests when not supported"), the configuration search no longer touches VRR state for outputs that are known to not support it. This also means that it will not remove VRR if already set, which could cause output configuration to fail.

Ensure that VRR state is never set for outputs that do not support it by adding the same test for support to queue_output_config.

Fixes: 4e38f93f367d ("config/output: Skip VRR tests when not supported")
Fixes: https://github.com/swaywm/sway/issues/8296