### PR TITLE
sway/tree/container: don't trunc coords in `floating_fix_coordinates`

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -773,11 +773,11 @@ void floating_fix_coordinates(struct sway_container *con, struct wlr_box *old, s
 		// Fall back to centering on the workspace.
 		container_floating_move_to_center(con);
 	} else {
-		int rel_x = con->pending.x - old->x + (con->pending.width / 2);
-		int rel_y = con->pending.y - old->y + (con->pending.height / 2);
+		double rel_x = con->pending.x - old->x + (con->pending.width / 2);
+		double rel_y = con->pending.y - old->y + (con->pending.height / 2);
 
-		con->pending.x = new->x + (double)(rel_x * new->width) / old->width - (con->pending.width / 2);
-		con->pending.y = new->y + (double)(rel_y * new->height) / old->height - (con->pending.height / 2);
+		con->pending.x = new->x + (rel_x * new->width) / old->width - (con->pending.width / 2);
+		con->pending.y = new->y + (rel_y * new->height) / old->height - (con->pending.height / 2);
 
 		sway_log(SWAY_DEBUG, "Transformed container %p to coords (%f, %f)", con, con->pending.x, con->pending.y);
 	}


### PR DESCRIPTION
This can cause issues such as the window not being shown at the exact same coordinates when the old and new wlr_box aren't the same dimensions and the container is being moved back-and-forth between them.

For example, in the case where a floating window gets moved from one output to another but the outputs aren't the same resolution. For e.g. have two displays that aren't the same resolution then:

1. Open a floating window and set it to pos 0,0 on output 2
2. Send it to scratchpad then `scratchpad show` on output 1
3. `scratchpad show` on output 2 again

Observe that the window isn't at 0,0 on output 2 anymore.