### PR TITLE
Simplify some input logic

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -84,6 +84,14 @@ struct sway_cursor {
 
 struct sway_node;
 
+struct wlr_scene_node *scene_node_at_coords(
+		double lx, double ly, double *sx, double *sy);
+
+struct wlr_surface *surface_try_from_scene_node(struct wlr_scene_node *node);
+
+struct sway_node *sway_node_try_from_scene_node(struct wlr_scene_node *node,
+		double lx, double ly);
+
 struct sway_node *node_at_coords(
 		double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);
 

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -85,8 +85,7 @@ struct sway_cursor {
 struct sway_node;
 
 struct sway_node *node_at_coords(
-		struct sway_seat *seat, double lx, double ly,
-		struct wlr_surface **surface, double *sx, double *sy);
+		double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);
 
 void sway_cursor_destroy(struct sway_cursor *cursor);
 struct sway_cursor *sway_cursor_create(struct sway_seat *seat);

--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -36,9 +36,6 @@ struct sway_layer_popup {
 
 struct sway_output;
 
-struct wlr_layer_surface_v1 *toplevel_layer_surface_from_surface(
-		struct wlr_surface *surface);
-
 void arrange_layers(struct sway_output *output);
 
 #endif

--- a/include/sway/scene_descriptor.h
+++ b/include/sway/scene_descriptor.h
@@ -32,6 +32,9 @@ enum sway_scene_descriptor_type {
 bool scene_descriptor_assign(struct wlr_scene_node *node,
 	enum sway_scene_descriptor_type type, void *data);
 
+bool scene_descriptor_reassign(struct wlr_scene_node *node,
+	enum sway_scene_descriptor_type type, void *data);
+
 void *scene_descriptor_try_get(struct wlr_scene_node *node,
 	enum sway_scene_descriptor_type type);
 

--- a/include/sway/scene_descriptor.h
+++ b/include/sway/scene_descriptor.h
@@ -10,6 +10,14 @@
 #define _SWAY_SCENE_DESCRIPTOR_H
 #include <wlr/types/wlr_scene.h>
 
+struct sway_view;
+
+// used for SWAY_SCENE_DESC_POPUP
+struct sway_popup_desc {
+	struct wlr_scene_node *relative;
+	struct sway_view *view;
+};
+
 enum sway_scene_descriptor_type {
 	SWAY_SCENE_DESC_BUFFER_TIMER,
 	SWAY_SCENE_DESC_NON_INTERACTIVE,

--- a/include/sway/scene_descriptor.h
+++ b/include/sway/scene_descriptor.h
@@ -38,4 +38,14 @@ void *scene_descriptor_try_get(struct wlr_scene_node *node,
 void scene_descriptor_destroy(struct wlr_scene_node *node,
 	enum sway_scene_descriptor_type type);
 
+/*
+ * Searches the scene node and all its parents for this scene descriptor.
+ *
+ * Note that while searching, SWAY_SCENE_DESC_POPUP types will start tracking
+ * its relative node. With popups, they are part of a seperate layer in the scene
+ * graph, but that's irrelavent to users of this function.
+ */
+void *scene_descriptor_find(struct wlr_scene_node *node,
+	enum sway_scene_descriptor_type type);
+
 #endif

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -11,6 +11,7 @@
 #endif
 #include "sway/input/input-manager.h"
 #include "sway/input/seat.h"
+#include "sway/scene_descriptor.h"
 
 struct sway_container;
 struct sway_xdg_decoration;
@@ -189,11 +190,6 @@ struct sway_xwayland_unmanaged {
 	struct wl_listener override_redirect;
 };
 #endif
-
-struct sway_popup_desc {
-	struct wlr_scene_node *relative;
-	struct sway_view *view;
-};
 
 struct sway_xdg_popup {
 	struct sway_view *view;

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -620,7 +620,7 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 			|| binding->type == BINDING_MOUSECODE) {
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
-		struct sway_node *node = node_at_coords(seat,
+		struct sway_node *node = node_at_coords(
 				seat->cursor->cursor->x, seat->cursor->cursor->y,
 				&surface, &sx, &sy);
 		if (node && node->type == N_CONTAINER) {

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -20,39 +20,6 @@
 #include "sway/tree/arrange.h"
 #include "sway/tree/workspace.h"
 
-struct wlr_layer_surface_v1 *toplevel_layer_surface_from_surface(
-		struct wlr_surface *surface) {
-	struct wlr_layer_surface_v1 *layer;
-	do {
-		if (!surface) {
-			return NULL;
-		}
-		// Topmost layer surface
-		if ((layer = wlr_layer_surface_v1_try_from_wlr_surface(surface))) {
-			return layer;
-		}
-		// Layer subsurface
-		if (wlr_subsurface_try_from_wlr_surface(surface)) {
-			surface = wlr_surface_get_root_surface(surface);
-			continue;
-		}
-
-		// Layer surface popup
-		struct wlr_xdg_surface *xdg_surface = NULL;
-		if ((xdg_surface = wlr_xdg_surface_try_from_wlr_surface(surface)) &&
-				xdg_surface->role == WLR_XDG_SURFACE_ROLE_POPUP && xdg_surface->popup != NULL) {
-			if (!xdg_surface->popup->parent) {
-				return NULL;
-			}
-			surface = wlr_surface_get_root_surface(xdg_surface->popup->parent);
-			continue;
-		}
-
-		// Return early if the surface is not a layer/xdg_popup/sub surface
-		return NULL;
-	} while (true);
-}
-
 static void arrange_surface(struct sway_output *output, const struct wlr_box *full_area,
 		struct wlr_box *usable_area, struct wlr_scene_tree *tree, bool exclusive) {
 	struct wlr_scene_node *node;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -158,20 +158,9 @@ static void send_frame_done_iterator(struct wlr_scene_buffer *buffer,
 		return;
 	}
 
-	struct wlr_scene_node *current = &buffer->node;
-	while (true) {
-		struct sway_view *view = scene_descriptor_try_get(current,
-			SWAY_SCENE_DESC_VIEW);
-		if (view) {
-			view_max_render_time = view->max_render_time;
-			break;
-		}
-
-		if (!current->parent) {
-			break;
-		}
-
-		current = &current->parent->node;
+	struct sway_view *view = scene_descriptor_find(&buffer->node, SWAY_SCENE_DESC_VIEW);
+	if (view) {
+		view_max_render_time = view->max_render_time;
 	}
 
 	int delay = data->msec_until_refresh - output->max_render_time

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -77,14 +77,6 @@ struct sway_node *node_at_coords(
 				SWAY_SCENE_DESC_CONTAINER);
 
 			if (!con) {
-				struct sway_view *view = scene_descriptor_try_get(current,
-					SWAY_SCENE_DESC_VIEW);
-				if (view) {
-					con = view->container;
-				}
-			}
-
-			if (!con) {
 				struct sway_popup_desc *popup =
 					scene_descriptor_try_get(current, SWAY_SCENE_DESC_POPUP);
 				if (popup && popup->view) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -36,8 +36,7 @@
  * Returns the node at the cursor's position. If there is a surface at that
  * location, it is stored in **surface (it may not be a view).
  */
-struct sway_node *node_at_coords(
-		struct sway_seat *seat, double lx, double ly,
+struct sway_node *node_at_coords(double lx, double ly,
 		struct wlr_surface **surface, double *sx, double *sy) {
 	struct wlr_scene_node *scene_node = NULL;
 
@@ -279,8 +278,7 @@ void pointer_motion(struct sway_cursor *cursor, uint32_t time_msec,
 	if (cursor->active_constraint && device->type == WLR_INPUT_DEVICE_POINTER) {
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
-		node_at_coords(cursor->seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+		node_at_coords(cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 		if (cursor->active_constraint->surface != surface) {
 			return;
@@ -539,7 +537,7 @@ static void handle_tablet_tool_position(struct sway_cursor *cursor,
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 	struct sway_seat *seat = cursor->seat;
-	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	node_at_coords(cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	// The logic for whether we should send a tablet event or an emulated pointer
 	// event is tricky. It comes down to:
@@ -629,8 +627,7 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
-	node_at_coords(seat, cursor->cursor->x, cursor->cursor->y,
-		&surface, &sx, &sy);
+	node_at_coords(cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (cursor->simulating_pointer_from_tool_tip &&
 			event->state == WLR_TABLET_TOOL_TIP_UP) {
@@ -714,8 +711,7 @@ static void handle_tool_button(struct wl_listener *listener, void *data) {
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
 
-	node_at_coords(cursor->seat, cursor->cursor->x, cursor->cursor->y,
-		&surface, &sx, &sy);
+	node_at_coords(cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	// TODO: floating resize should support graphics tablet events
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(cursor->seat->wlr_seat);

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -224,7 +224,7 @@ static void handle_tablet_tool_tip(struct sway_seat *seat,
 	struct sway_cursor *cursor = seat->cursor;
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
+	struct sway_node *node = node_at_coords(
 		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (!sway_assert(surface,
@@ -337,8 +337,8 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_coords(
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
@@ -550,8 +550,7 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 
 		struct wlr_surface *surface = NULL;
 		double sx, sy;
-		node_at_coords(seat, seat->cursor->cursor->x, seat->cursor->cursor->y,
-				&surface, &sx, &sy);
+		node_at_coords(seat->cursor->cursor->x, seat->cursor->cursor->y, &surface, &sx, &sy);
 
 		// Focus topmost layer surface
 		struct wlr_layer_surface_v1 *layer = NULL;
@@ -605,8 +604,8 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_coords(
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (config->focus_follows_mouse != FOLLOWS_NO) {
 		check_focus_follows_mouse(seat, e, node);
@@ -634,8 +633,8 @@ static void handle_tablet_tool_motion(struct sway_seat *seat,
 
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_coords(
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (config->focus_follows_mouse != FOLLOWS_NO) {
 		check_focus_follows_mouse(seat, e, node);
@@ -663,7 +662,7 @@ static void handle_touch_down(struct sway_seat *seat,
 	struct wlr_seat *wlr_seat = seat->wlr_seat;
 	struct sway_cursor *cursor = seat->cursor;
 	double sx, sy;
-	node_at_coords(seat, seat->touch_x, seat->touch_y, &surface, &sx, &sy);
+	node_at_coords(seat->touch_x, seat->touch_y, &surface, &sx, &sy);
 
 	if (surface && wlr_surface_accepts_touch(surface, wlr_seat)) {
 		if (seat_is_input_allowed(seat, surface)) {
@@ -715,7 +714,7 @@ static void handle_pointer_axis(struct sway_seat *seat,
 	// Determine what's under the cursor
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
-	struct sway_node *node = node_at_coords(seat,
+	struct sway_node *node = node_at_coords(
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 	struct sway_container *cont = node && node->type == N_CONTAINER ?
 		node->sway_container : NULL;
@@ -1107,8 +1106,8 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 	struct sway_cursor *cursor = seat->cursor;
 	struct wlr_surface *surface = NULL;
 	double sx = 0.0, sy = 0.0;
-	e->previous_node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	e->previous_node = node_at_coords(
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (surface) {
 		if (seat_is_input_allowed(seat, surface)) {

--- a/sway/input/seatop_down.c
+++ b/sway/input/seatop_down.c
@@ -75,7 +75,7 @@ static void handle_touch_down(struct sway_seat *seat,
 	struct seatop_down_event *e = seat->seatop_data;
 	double sx, sy;
 	struct wlr_surface *surface = NULL;
-	struct sway_node *focused_node = node_at_coords(seat, seat->touch_x,
+	struct sway_node *focused_node = node_at_coords(seat->touch_x,
 		seat->touch_y, &surface, &sx, &sy);
 
 	if (!surface || surface != e->surface) { // Must start from the initial surface

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -163,8 +163,8 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 	struct wlr_surface *surface = NULL;
 	double sx, sy;
 	struct sway_cursor *cursor = seat->cursor;
-	struct sway_node *node = node_at_coords(seat,
-			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
+	struct sway_node *node = node_at_coords(
+		cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (!node) {
 		// Eg. hovered over a layer surface such as swaybar

--- a/sway/scene_descriptor.c
+++ b/sway/scene_descriptor.c
@@ -36,6 +36,31 @@ void *scene_descriptor_try_get(struct wlr_scene_node *node,
 	return desc->data;
 }
 
+void *scene_descriptor_find(struct wlr_scene_node *node,
+		enum sway_scene_descriptor_type type) {
+	while (node) {
+		struct scene_descriptor *desc = scene_node_get_descriptor(node, type);
+		if (desc) {
+			return desc->data;
+		}
+
+		struct sway_popup_desc *popup =
+			scene_descriptor_try_get(node, SWAY_SCENE_DESC_POPUP);
+		if (popup) {
+			node = popup->relative;
+			continue;
+		}
+
+		if (!node->parent) {
+			break;
+		}
+
+		node = &node->parent->node;
+	}
+
+	return NULL;
+}
+
 void scene_descriptor_destroy(struct wlr_scene_node *node,
 		enum sway_scene_descriptor_type type) {
 	struct scene_descriptor *desc = scene_node_get_descriptor(node, type);

--- a/sway/scene_descriptor.c
+++ b/sway/scene_descriptor.c
@@ -92,3 +92,14 @@ bool scene_descriptor_assign(struct wlr_scene_node *node,
 	desc->data = data;
 	return true;
 }
+
+bool scene_descriptor_reassign(struct wlr_scene_node *node,
+		enum sway_scene_descriptor_type type, void *data) {
+	struct scene_descriptor *desc = scene_node_get_descriptor(node, type);
+	if (desc) {
+		desc->data = data;
+		return true;
+	}
+
+	return scene_descriptor_assign(node, type, data);
+}

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -556,6 +556,7 @@ void container_destroy(struct sway_container *con) {
 
 	if (con->view && con->view->container == con) {
 		con->view->container = NULL;
+		scene_descriptor_destroy(&con->view->scene_tree->node, SWAY_SCENE_DESC_CONTAINER);
 		wlr_scene_node_destroy(&con->output_handler->node);
 	}
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -750,6 +750,8 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	view->surface = wlr_surface;
 	view_populate_pid(view);
 	view->container = container_create(view);
+	scene_descriptor_assign(&view->scene_tree->node,
+			SWAY_SCENE_DESC_CONTAINER, view->container);
 
 	if (view->ctx == NULL) {
 		struct launcher_ctx *ctx = launcher_ctx_find_pid(view->pid);


### PR DESCRIPTION
Goals:
1. Get rid of `toplevel_layer_surface_from_surface()`. We can just walk the scene to get this info.
2. Introduce a few scene descriptor helpers to reduce code duplication

See individual commits.