### PR TITLE
Add an option to keep cursor active when using `seat * hide_cursor`.

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -207,6 +207,12 @@ enum seat_config_hide_cursor_when_typing {
 	HIDE_WHEN_TYPING_DISABLE,
 };
 
+enum seat_config_hide_cursor_but_keep_active {
+	HIDE_CURSOR_BUT_KEEP_ACTIVE_DEFAULT, // the default is currently disabled
+	HIDE_CURSOR_BUT_KEEP_ACTIVE_ENABLE,
+	HIDE_CURSOR_BUT_KEEP_ACTIVE_DISABLE,
+};
+
 enum seat_config_allow_constrain {
 	CONSTRAIN_DEFAULT, // the default is currently enabled
 	CONSTRAIN_ENABLE,
@@ -243,6 +249,7 @@ struct seat_config {
 	list_t *attachments; // list of seat_attachment configs
 	int hide_cursor_timeout;
 	enum seat_config_hide_cursor_when_typing hide_cursor_when_typing;
+	enum seat_config_hide_cursor_but_keep_active hide_cursor_but_keep_active;
 	enum seat_config_allow_constrain allow_constrain;
 	enum seat_config_shortcuts_inhibit shortcuts_inhibit;
 	enum seat_keyboard_grouping keyboard_grouping;

--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -74,10 +74,6 @@ struct sway_cursor {
 
 	struct wl_event_source *hide_source;
 	bool hidden;
-	// This field is just a cache of the field in seat_config in order to avoid
-	// costly seat_config lookups on every keypress. HIDE_WHEN_TYPING_DEFAULT
-	// indicates that there is no cached value.
-	enum seat_config_hide_cursor_when_typing hide_when_typing;
 
 	size_t pressed_button_count;
 };

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -83,6 +83,7 @@ struct sway_drag {
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct sway_cursor *cursor;
+	struct seat_config *config;
 
 	// Seat scene tree structure
 	// - scene_tree
@@ -242,10 +243,6 @@ void seat_for_each_node(struct sway_seat *seat,
 		void (*f)(struct sway_node *node, void *data), void *data);
 
 void seat_apply_config(struct sway_seat *seat, struct seat_config *seat_config);
-
-struct seat_config *seat_get_config(struct sway_seat *seat);
-
-struct seat_config *seat_get_config_by_name(const char *name);
 
 void seat_idle_notify_activity(struct sway_seat *seat,
 		enum sway_input_idle_source source);

--- a/sway/commands/seat/hide_cursor.c
+++ b/sway/commands/seat/hide_cursor.c
@@ -31,12 +31,16 @@ struct cmd_results *seat_cmd_hide_cursor(int argc, char **argv) {
 		}
 		seat_config->hide_cursor_timeout = timeout;
 	} else {
-		if (strcmp(argv[0], "when-typing") != 0) {
+		if (strcmp(argv[0], "when-typing") == 0) {
+    		seat_config->hide_cursor_when_typing = parse_boolean(argv[1], true) ?
+    		    HIDE_WHEN_TYPING_ENABLE : HIDE_WHEN_TYPING_DISABLE;
+    	} else if (strcmp(argv[0], "but-keep-active") == 0) {
+    		seat_config->hide_cursor_but_keep_active = parse_boolean(argv[1], true) ?
+    			HIDE_CURSOR_BUT_KEEP_ACTIVE_ENABLE : HIDE_CURSOR_BUT_KEEP_ACTIVE_DISABLE;
+		} else {
 			return cmd_results_new(CMD_INVALID,
-				"Expected 'hide_cursor <timeout>|when-typing [enable|disable]'");
+				"Expected 'hide_cursor <timeout>|when-typing|but-keep-active [enable|disable]'");
 		}
-		seat_config->hide_cursor_when_typing = parse_boolean(argv[1], true) ?
-			HIDE_WHEN_TYPING_ENABLE : HIDE_WHEN_TYPING_DISABLE;
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/seat/hide_cursor.c
+++ b/sway/commands/seat/hide_cursor.c
@@ -37,12 +37,6 @@ struct cmd_results *seat_cmd_hide_cursor(int argc, char **argv) {
 		}
 		seat_config->hide_cursor_when_typing = parse_boolean(argv[1], true) ?
 			HIDE_WHEN_TYPING_ENABLE : HIDE_WHEN_TYPING_DISABLE;
-
-		// Invalidate all the caches for this config
-		struct sway_seat *seat = NULL;
-		wl_list_for_each(seat, &server.input->seats, link) {
-			seat->cursor->hide_when_typing = HIDE_WHEN_TYPING_DEFAULT;
-		}
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/config/seat.c
+++ b/sway/config/seat.c
@@ -29,6 +29,7 @@ struct seat_config *new_seat_config(const char* name) {
 	}
 	seat->hide_cursor_timeout = -1;
 	seat->hide_cursor_when_typing = HIDE_WHEN_TYPING_DEFAULT;
+	seat->hide_cursor_but_keep_active = HIDE_CURSOR_BUT_KEEP_ACTIVE_DEFAULT;
 	seat->allow_constrain = CONSTRAIN_DEFAULT;
 	seat->shortcuts_inhibit = SHORTCUTS_INHIBIT_DEFAULT;
 	seat->keyboard_grouping = KEYBOARD_GROUP_DEFAULT;
@@ -152,6 +153,10 @@ void merge_seat_config(struct seat_config *dest, struct seat_config *source) {
 
 	if (source->hide_cursor_when_typing != HIDE_WHEN_TYPING_DEFAULT) {
 		dest->hide_cursor_when_typing = source->hide_cursor_when_typing;
+	}
+
+	if (source->hide_cursor_but_keep_active != HIDE_CURSOR_BUT_KEEP_ACTIVE_DEFAULT) {
+		dest->hide_cursor_but_keep_active = source->hide_cursor_but_keep_active;
 	}
 
 	if (source->allow_constrain != CONSTRAIN_DEFAULT) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -183,7 +183,10 @@ void cursor_update_image(struct sway_cursor *cursor,
 static void cursor_hide(struct sway_cursor *cursor) {
 	wlr_cursor_unset_image(cursor->cursor);
 	cursor->hidden = true;
-	wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
+	if (cursor->seat->config->hide_cursor_but_keep_active
+	    != HIDE_CURSOR_BUT_KEEP_ACTIVE_ENABLE) {
+	    wlr_seat_pointer_notify_clear_focus(cursor->seat->wlr_seat);
+	}
 }
 
 static int hide_notify(void *data) {

--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -198,10 +198,8 @@ int cursor_get_timeout(struct sway_cursor *cursor) {
 		return 0;
 	}
 
-	struct seat_config *sc = seat_get_config(cursor->seat);
-	if (!sc) {
-		sc = seat_get_config_by_name("*");
-	}
+	struct seat_config *sc = cursor->seat->config;
+
 	int timeout = sc ? sc->hide_cursor_timeout : 0;
 	if (timeout < 0) {
 		timeout = 0;
@@ -214,23 +212,7 @@ void cursor_notify_key_press(struct sway_cursor *cursor) {
 		return;
 	}
 
-	if (cursor->hide_when_typing == HIDE_WHEN_TYPING_DEFAULT) {
-		// No cached value, need to lookup in the seat_config
-		const struct seat_config *seat_config = seat_get_config(cursor->seat);
-		if (!seat_config) {
-			seat_config = seat_get_config_by_name("*");
-			if (!seat_config) {
-				return;
-			}
-		}
-		cursor->hide_when_typing = seat_config->hide_cursor_when_typing;
-		// The default is currently disabled
-		if (cursor->hide_when_typing == HIDE_WHEN_TYPING_DEFAULT) {
-			cursor->hide_when_typing = HIDE_WHEN_TYPING_DISABLE;
-		}
-	}
-
-	if (cursor->hide_when_typing == HIDE_WHEN_TYPING_ENABLE) {
+	if (cursor->seat->config->hide_cursor_when_typing == HIDE_WHEN_TYPING_ENABLE) {
 		cursor_hide(cursor);
 	}
 }
@@ -1339,10 +1321,7 @@ void handle_pointer_constraint(struct wl_listener *listener, void *data) {
 
 void sway_cursor_constrain(struct sway_cursor *cursor,
 		struct wlr_pointer_constraint_v1 *constraint) {
-	struct seat_config *config = seat_get_config(cursor->seat);
-	if (!config) {
-		config = seat_get_config_by_name("*");
-	}
+	struct seat_config *config = cursor->seat->config;
 
 	if (!config || config->allow_constrain == CONSTRAIN_DISABLE) {
 		return;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -632,7 +632,7 @@ void input_manager_apply_seat_config(struct seat_config *seat_config) {
 	if (strcmp(seat_config->name, "*") == 0) {
 		struct sway_seat *seat = NULL;
 		wl_list_for_each(seat, &server.input->seats, link) {
-			// Only apply the wildcard config directly if there is no seatz
+			// Only apply the wildcard config directly if there is no seat
 			// specific config
 			struct seat_config *sc = seat->config;
 			if (!sc) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -831,10 +831,7 @@ static void sway_keyboard_group_remove_invalid(struct sway_keyboard *keyboard) {
 	}
 
 	struct sway_seat *seat = keyboard->seat_device->sway_seat;
-	struct seat_config *sc = seat_get_config(seat);
-	if (!sc) {
-		sc = seat_get_config_by_name("*");
-	}
+	struct seat_config *sc = seat->config;
 
 	switch (sc ? sc->keyboard_grouping : KEYBOARD_GROUP_DEFAULT) {
 	case KEYBOARD_GROUP_NONE:
@@ -854,15 +851,11 @@ static void sway_keyboard_group_remove_invalid(struct sway_keyboard *keyboard) {
 static void sway_keyboard_group_add(struct sway_keyboard *keyboard) {
 	struct sway_input_device *device = keyboard->seat_device->input_device;
 	struct sway_seat *seat = keyboard->seat_device->sway_seat;
-	struct seat_config *sc = seat_get_config(seat);
+	struct seat_config *sc = seat->config;
 
 	if (device->is_virtual) {
 		// Virtual devices should not be grouped
 		return;
-	}
-
-	if (!sc) {
-		sc = seat_get_config_by_name("*");
 	}
 
 	if (sc && sc->keyboard_grouping == KEYBOARD_GROUP_NONE) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -984,13 +984,9 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 	unsigned cursor_size = 24;
 	const char *cursor_theme = NULL;
 
-	const struct seat_config *seat_config = seat_get_config(seat);
-	if (!seat_config) {
-		seat_config = seat_get_config_by_name("*");
-	}
-	if (seat_config) {
-		cursor_size = seat_config->xcursor_theme.size;
-		cursor_theme = seat_config->xcursor_theme.name;
+	if (seat->config) {
+		cursor_size = seat->config->xcursor_theme.size;
+		cursor_theme = seat->config->xcursor_theme.name;
 	}
 
 	if (seat == input_manager_get_default_seat()) {
@@ -1493,38 +1489,13 @@ void seat_apply_config(struct sway_seat *seat,
 		return;
 	}
 
-	seat->idle_inhibit_sources = seat_config->idle_inhibit_sources;
-	seat->idle_wake_sources = seat_config->idle_wake_sources;
+	seat->config = seat_config;
 
 	wl_list_for_each(seat_device, &seat->devices, link) {
 		seat_configure_device(seat, seat_device->input_device);
 		cursor_handle_activity_from_device(seat->cursor,
 			seat_device->input_device->wlr_device);
 	}
-}
-
-struct seat_config *seat_get_config(struct sway_seat *seat) {
-	struct seat_config *seat_config = NULL;
-	for (int i = 0; i < config->seat_configs->length; ++i ) {
-		seat_config = config->seat_configs->items[i];
-		if (strcmp(seat->wlr_seat->name, seat_config->name) == 0) {
-			return seat_config;
-		}
-	}
-
-	return NULL;
-}
-
-struct seat_config *seat_get_config_by_name(const char *name) {
-	struct seat_config *seat_config = NULL;
-	for (int i = 0; i < config->seat_configs->length; ++i ) {
-		seat_config = config->seat_configs->items[i];
-		if (strcmp(name, seat_config->name) == 0) {
-			return seat_config;
-		}
-	}
-
-	return NULL;
 }
 
 void seat_pointer_notify_button(struct sway_seat *seat, uint32_t time_msec,

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1490,6 +1490,8 @@ void seat_apply_config(struct sway_seat *seat,
 	}
 
 	seat->config = seat_config;
+	seat->idle_inhibit_sources = seat_config->idle_inhibit_sources;
+	seat->idle_wake_sources = seat_config->idle_wake_sources;
 
 	wl_list_for_each(seat_device, &seat->devices, link) {
 		seat_configure_device(seat, seat_device->input_device);

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -258,7 +258,7 @@ correct seat.
 	Set this seat as the fallback seat. A fallback seat will attach any device
 	not explicitly attached to another seat (similar to a "default" seat).
 
-*seat* <name> hide_cursor <timeout>|when-typing [enable|disable]
+*seat* <name> hide_cursor <timeout>|when-typing|but-keep-active [enable|disable]
 	Hides the cursor image after the specified event occurred.
 
 	If _timeout_ is specified, then the cursor will be hidden after _timeout_
@@ -272,6 +272,9 @@ correct seat.
 	Be aware that this setting can interfere with input handling in games and
 	certain types of software (Gimp, Blender etc) that rely on simultaneous
 	input from mouse and keyboard.
+
+	If _but-keep-active_ is enabled, then the cursor will remain active when
+	hidden. This solves the issues with _when-typing_ as mentioned above.
 
 *seat* <name> idle_inhibit <sources...>
 	Sets the set of input event sources which can prevent the seat from


### PR DESCRIPTION
*Note: Requires swaywm/sway/pull/8269 to be merged first*

There's been a long-standing issue in Sway about hide_cursor's behavior, here are people complaining about it:
* https://github.com/swaywm/sway/issues/6297
* https://github.com/swaywm/sway/issues/7853
* https://github.com/swaywm/sway/issues/7383
* https://github.com/swaywm/sway/issues/7382
...and more people on Reddit:
* https://www.reddit.com/r/swaywm/comments/10kevqd/avoid_using_the_option_hide_cursor_whentyping_by
* https://www.reddit.com/r/swaywm/comments/n7m5d2/a_script_to_disable_hide_cursor_whentyping_when

Its broken behavior is even mentioned in the manpages!
* swaywm/sway/pull/7435

KDE Plasma has also recently added a cursor hide timeout to their compositor, and does not deactivate the pointer while hidden.