### PR TITLE
Reduce output configurations and rearranges

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -57,7 +57,6 @@ struct sway_output {
 
 	struct wl_listener layout_destroy;
 	struct wl_listener destroy;
-	struct wl_listener commit;
 	struct wl_listener present;
 	struct wl_listener frame;
 	struct wl_listener request_state;
@@ -145,5 +144,7 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 	void *data);
 
 struct sway_output_non_desktop *output_non_desktop_create(struct wlr_output *wlr_output);
+
+void update_output_manager_config(struct sway_server *server);
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -134,8 +134,6 @@ enum sway_container_layout output_get_default_layout(
 
 enum wlr_direction opposite_direction(enum wlr_direction d);
 
-void handle_output_layout_change(struct wl_listener *listener, void *data);
-
 void handle_output_manager_apply(struct wl_listener *listener, void *data);
 
 void handle_output_manager_test(struct wl_listener *listener, void *data);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -45,7 +45,6 @@ struct sway_server {
 	struct sway_input_manager *input;
 
 	struct wl_listener new_output;
-	struct wl_listener output_layout_change;
 	struct wl_listener renderer_lost;
 
 	struct wlr_idle_notifier_v1 *idle_notifier_v1;

--- a/include/sway/tree/root.h
+++ b/include/sway/tree/root.h
@@ -16,8 +16,6 @@ struct sway_root {
 	struct sway_node node;
 	struct wlr_output_layout *output_layout;
 
-	struct wl_listener output_layout_change;
-
 	// scene node layout:
 	// - root
 	// 	- staging

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -11,9 +11,12 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_swapchain_manager.h>
 #include "sway/config.h"
+#include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
+#include "sway/layers.h"
 #include "sway/output.h"
 #include "sway/server.h"
+#include "sway/tree/arrange.h"
 #include "sway/tree/root.h"
 #include "log.h"
 #include "util.h"
@@ -963,7 +966,12 @@ bool apply_output_configs(struct matched_output_config *configs,
 		sway_log(SWAY_DEBUG, "Finalizing config for %s",
 			cfg->output->wlr_output->name);
 		finalize_output_config(cfg->config, cfg->output);
+		arrange_layers(cfg->output);
 	}
+
+	arrange_root();
+	update_output_manager_config(&server);
+	transaction_commit_dirty();
 
 out:
 	wlr_output_swapchain_manager_finish(&swapchain_mgr);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -356,7 +356,7 @@ static void handle_frame(struct wl_listener *listener, void *user_data) {
 	wlr_scene_output_for_each_buffer(output->scene_output, send_frame_done_iterator, &data);
 }
 
-static void update_output_manager_config(struct sway_server *server) {
+void update_output_manager_config(struct sway_server *server) {
 	struct wlr_output_configuration_v1 *config =
 		wlr_output_configuration_v1_create();
 
@@ -387,9 +387,6 @@ static int timer_modeset_handle(void *data) {
 	server->delayed_modeset = NULL;
 
 	apply_all_output_configs();
-	transaction_commit_dirty();
-	update_output_manager_config(server);
-
 	return 0;
 }
 
@@ -414,7 +411,6 @@ static void begin_destroy(struct sway_output *output) {
 
 	wl_list_remove(&output->layout_destroy.link);
 	wl_list_remove(&output->destroy.link);
-	wl_list_remove(&output->commit.link);
 	wl_list_remove(&output->present.link);
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->request_state.link);
@@ -437,26 +433,6 @@ static void handle_layout_destroy(struct wl_listener *listener, void *data) {
 	begin_destroy(output);
 }
 
-static void handle_commit(struct wl_listener *listener, void *data) {
-	struct sway_output *output = wl_container_of(listener, output, commit);
-	struct wlr_output_event_commit *event = data;
-
-	if (!output->enabled) {
-		return;
-	}
-
-	if (event->state->committed & (
-			WLR_OUTPUT_STATE_MODE |
-			WLR_OUTPUT_STATE_TRANSFORM |
-			WLR_OUTPUT_STATE_SCALE)) {
-		arrange_layers(output);
-		arrange_output(output);
-		transaction_commit_dirty();
-
-		update_output_manager_config(output->server);
-	}
-}
-
 static void handle_present(struct wl_listener *listener, void *data) {
 	struct sway_output *output = wl_container_of(listener, output, present);
 	struct wlr_output_event_present *output_event = data;
@@ -473,7 +449,20 @@ static void handle_request_state(struct wl_listener *listener, void *data) {
 	struct sway_output *output =
 		wl_container_of(listener, output, request_state);
 	const struct wlr_output_event_request_state *event = data;
+
+	uint32_t committed = event->state->committed;
 	wlr_output_commit_state(output->wlr_output, event->state);
+
+	if (committed & (
+			WLR_OUTPUT_STATE_MODE |
+			WLR_OUTPUT_STATE_TRANSFORM |
+			WLR_OUTPUT_STATE_SCALE)) {
+		arrange_layers(output);
+		arrange_output(output);
+		transaction_commit_dirty();
+
+		update_output_manager_config(output->server);
+	}
 }
 
 static unsigned int last_headless_num = 0;
@@ -537,8 +526,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	output->layout_destroy.notify = handle_layout_destroy;
 	wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 	output->destroy.notify = handle_destroy;
-	wl_signal_add(&wlr_output->events.commit, &output->commit);
-	output->commit.notify = handle_commit;
 	wl_signal_add(&wlr_output->events.present, &output->present);
 	output->present.notify = handle_present;
 	wl_signal_add(&wlr_output->events.frame, &output->frame);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -543,13 +543,6 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 	request_modeset(server);
 }
 
-void handle_output_layout_change(struct wl_listener *listener,
-		void *data) {
-	struct sway_server *server =
-		wl_container_of(listener, server, output_layout_change);
-	update_output_manager_config(server);
-}
-
 static struct output_config *output_config_for_config_head(
 		struct wlr_output_configuration_head_v1 *config_head,
 		struct sway_output *output) {

--- a/sway/server.c
+++ b/sway/server.c
@@ -277,9 +277,6 @@ bool server_init(struct sway_server *server) {
 
 	server->new_output.notify = handle_new_output;
 	wl_signal_add(&server->backend->events.new_output, &server->new_output);
-	server->output_layout_change.notify = handle_output_layout_change;
-	wl_signal_add(&root->output_layout->events.change,
-		&server->output_layout_change);
 
 	server->xdg_output_manager_v1 =
 		wlr_xdg_output_manager_v1_create(server->wl_display, root->output_layout);

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -183,9 +183,6 @@ void output_enable(struct sway_output *output) {
 	input_manager_configure_xcursor();
 
 	wl_signal_emit_mutable(&root->events.new_node, &output->node);
-
-	arrange_layers(output);
-	arrange_root();
 }
 
 static void evacuate_sticky(struct sway_workspace *old_ws,
@@ -300,13 +297,6 @@ void output_disable(struct sway_output *output) {
 	list_del(root->outputs, index);
 
 	output->enabled = false;
-
-	arrange_root();
-
-	// Reconfigure all devices, since devices with map_to_output directives for
-	// an output that goes offline should stop sending events as long as the
-	// output remains offline.
-	input_manager_configure_all_input_mappings();
 }
 
 void output_begin_destroy(struct sway_output *output) {

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -19,12 +19,6 @@
 
 struct sway_root *root;
 
-static void output_layout_handle_change(struct wl_listener *listener,
-		void *data) {
-	arrange_root();
-	transaction_commit_dirty();
-}
-
 struct sway_root *root_create(struct wl_display *wl_display) {
 	struct sway_root *root = calloc(1, sizeof(struct sway_root));
 	if (!root) {
@@ -81,14 +75,10 @@ struct sway_root *root_create(struct wl_display *wl_display) {
 	root->non_desktop_outputs = create_list();
 	root->scratchpad = create_list();
 
-	root->output_layout_change.notify = output_layout_handle_change;
-	wl_signal_add(&root->output_layout->events.change,
-		&root->output_layout_change);
 	return root;
 }
 
 void root_destroy(struct sway_root *root) {
-	wl_list_remove(&root->output_layout_change.link);
 	list_free(root->scratchpad);
 	list_free(root->non_desktop_outputs);
 	list_free(root->outputs);


### PR DESCRIPTION
Whenever output configurations occurred we would end up re-arranging everything a gajillion times due to several components and listeners all responding to the change by calling `arrange_*`.

We now have a central location where changes occur from - by relying on that we can get down to a single `arrange_layers` per output and a shared `arrange_root` + output manager update... In most cases, as arrange_layers still calls arrange_output/arrange_popups on its own for now.