### PR TITLE
config/output: Fix interaction with output management

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -297,14 +297,6 @@ struct output_config {
 };
 
 /**
- * An output config pre-matched to an output
- */
-struct matched_output_config {
-	struct sway_output *output;
-	struct output_config *config;
-};
-
-/**
  * Stores size of gaps for each side
  */
 struct side_gaps {
@@ -693,13 +685,7 @@ const char *sway_output_scale_filter_to_string(enum scale_filter_mode scale_filt
 
 struct output_config *new_output_config(const char *name);
 
-bool apply_output_configs(struct matched_output_config *configs,
-		size_t configs_len, bool test_only, bool degrade_to_off);
-
 bool apply_all_output_configs(bool test_only, bool degrade_to_off);
-
-void sort_output_configs_by_priority(struct matched_output_config *configs,
-		size_t configs_len);
 
 /**
  * store_output_config stores a new output config. An output may be matched by

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -710,6 +710,14 @@ void sort_output_configs_by_priority(struct matched_output_config *configs,
  */
 void store_output_config(struct output_config *oc);
 
+/**
+ * Store a temporary output config that will not be merged for testing
+ * purposes. This must be removed again after test, before any calls to
+ * store_output_config that could result in merge with the temporary config.
+ */
+void store_temp_output_config(struct output_config *oc);
+void remove_temp_output_config(struct output_config *oc);
+
 struct output_config *find_output_config(struct sway_output *output);
 
 void free_output_config(struct output_config *oc);

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -696,7 +696,7 @@ struct output_config *new_output_config(const char *name);
 bool apply_output_configs(struct matched_output_config *configs,
 		size_t configs_len, bool test_only, bool degrade_to_off);
 
-void apply_all_output_configs(void);
+bool apply_all_output_configs(bool test_only, bool degrade_to_off);
 
 void sort_output_configs_by_priority(struct matched_output_config *configs,
 		size_t configs_len);

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -111,7 +111,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 	// entire config and before the deferred commands so that an auto generated
 	// workspace name is not given to re-enabled outputs.
 	if (!config->reloading && !config->validating) {
-		apply_all_output_configs();
+		apply_all_output_configs(false, true);
 		if (background) {
 			if (!spawn_swaybg()) {
 				return cmd_results_new(CMD_FAILURE,

--- a/sway/config.c
+++ b/sway/config.c
@@ -533,7 +533,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		}
 		sway_switch_retrigger_bindings_for_all();
 
-		apply_all_output_configs();
+		apply_all_output_configs(false, true);
 		spawn_swaybg();
 
 		config->reloading = false;

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -997,11 +997,11 @@ out:
 	return ok;
 }
 
-void apply_all_output_configs(void) {
+bool apply_all_output_configs(bool test_only, bool degrade_to_off) {
 	size_t configs_len = wl_list_length(&root->all_outputs);
 	struct matched_output_config *configs = calloc(configs_len, sizeof(*configs));
 	if (!configs) {
-		return;
+		return false;
 	}
 
 	int config_idx = 0;
@@ -1018,12 +1018,13 @@ void apply_all_output_configs(void) {
 	}
 
 	sort_output_configs_by_priority(configs, configs_len);
-	apply_output_configs(configs, configs_len, false, true);
+	bool ok = apply_output_configs(configs, configs_len, test_only, degrade_to_off);
 	for (size_t idx = 0; idx < configs_len; idx++) {
 		struct matched_output_config *cfg = &configs[idx];
 		free_output_config(cfg->config);
 	}
 	free(configs);
+	return ok;
 }
 
 void free_output_config(struct output_config *oc) {

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -666,6 +666,11 @@ static bool config_has_manual_mode(struct output_config *oc) {
 	return false;
 }
 
+struct matched_output_config {
+	struct sway_output *output;
+	struct output_config *config;
+};
+
 struct search_context {
 	struct wlr_output_swapchain_manager *swapchain_mgr;
 	struct wlr_backend_output_state *states;
@@ -884,12 +889,12 @@ static int compare_matched_output_config_priority(const void *a, const void *b) 
 	return 0;
 }
 
-void sort_output_configs_by_priority(struct matched_output_config *configs,
+static void sort_output_configs_by_priority(struct matched_output_config *configs,
 		size_t configs_len) {
 	qsort(configs, configs_len, sizeof(*configs), compare_matched_output_config_priority);
 }
 
-bool apply_output_configs(struct matched_output_config *configs,
+static bool apply_output_configs(struct matched_output_config *configs,
 		size_t configs_len, bool test_only, bool degrade_to_off) {
 	struct wlr_backend_output_state *states = calloc(configs_len, sizeof(*states));
 	if (!states) {

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -218,6 +218,19 @@ static void merge_output_config(struct output_config *dst, struct output_config 
 	}
 }
 
+void remove_temp_output_config(struct output_config *oc) {
+	size_t idx = list_find(config->output_configs, oc);
+	if (idx) {
+		list_del(config->output_configs, idx);
+	}
+}
+
+void store_temp_output_config(struct output_config *oc) {
+	// Add it directly so the config can be removed later
+	list_add(config->output_configs, oc);
+	return;
+}
+
 void store_output_config(struct output_config *oc) {
 	bool merged = false;
 	bool wildcard = strcmp(oc->name, "*") == 0;

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -386,7 +386,7 @@ static int timer_modeset_handle(void *data) {
 	wl_event_source_remove(server->delayed_modeset);
 	server->delayed_modeset = NULL;
 
-	apply_all_output_configs();
+	apply_all_output_configs(false, true);
 	return 0;
 }
 


### PR DESCRIPTION
Configuration applied by output management had an unfortunate interaction with configuration already present. Only a configuration based on the new config_head would be applied, rather than the result of merging this configuration with what was stored.

If the output manager provided a config_head that lead to `enable = 1`, this would disregard that the output had `power = 0` and light up an output that should have remained off. When committing any other changes later, the power state is sorted out, disabling the output again.

Rather than try to sort out merging at the call-site, we take a different approach: Just store the config temporarily while testing in a way that we can easily remove afterwards.

To reproduce the issue on master:
1. `WLR_WL_OUTPUTS=2 sway`
2. `swaymsg WL-2 power off`
3. `wlr-randr --output WL-2 --on` - Output turns on
4. `swaymsg WL-2 scale 2` - Output turns back off as stored config takes effect