### PR TITLE
output: More redundant reconfigures

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -633,10 +633,6 @@ static void output_manager_apply(struct sway_server *server,
 		wlr_output_configuration_v1_send_failed(config);
 	}
 	wlr_output_configuration_v1_destroy(config);
-
-	if (!test_only) {
-		update_output_manager_config(server);
-	}
 }
 
 void handle_output_manager_apply(struct wl_listener *listener, void *data) {

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -180,8 +180,6 @@ void output_enable(struct sway_output *output) {
 		ws->layout = output_get_default_layout(output);
 	}
 
-	input_manager_configure_xcursor();
-
 	wl_signal_emit_mutable(&root->events.new_node, &output->node);
 }
 


### PR DESCRIPTION
Two more places where we did too much stuff on output changes - these are covered by `apply_output_configs`.