### PR TITLE
transaction: Disable workspaces of disabled outputs

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -559,7 +559,7 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 	for (int i = 0; i < output->current.workspaces->length; i++) {
 		struct sway_workspace *child = output->current.workspaces->items[i];
 
-		bool activated = output->current.active_workspace == child;
+		bool activated = output->current.active_workspace == child && output->wlr_output->enabled;
 
 		wlr_scene_node_reparent(&child->layers.tiling->node, output->layers.tiling);
 		wlr_scene_node_reparent(&child->layers.fullscreen->node, output->layers.fullscreen);

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -314,14 +314,6 @@ void arrange_output(struct sway_output *output) {
 	if (config->reloading) {
 		return;
 	}
-	struct wlr_box output_box;
-	wlr_output_layout_get_box(root->output_layout,
-		output->wlr_output, &output_box);
-	output->lx = output_box.x;
-	output->ly = output_box.y;
-	output->width = output_box.width;
-	output->height = output_box.height;
-
 	for (int i = 0; i < output->workspaces->length; ++i) {
 		struct sway_workspace *workspace = output->workspaces->items[i];
 		arrange_workspace(workspace);

--- a/sway/tree/arrange.c
+++ b/sway/tree/arrange.c
@@ -314,6 +314,9 @@ void arrange_output(struct sway_output *output) {
 	if (config->reloading) {
 		return;
 	}
+	if (!output->wlr_output->enabled) {
+		return;
+	}
 	for (int i = 0; i < output->workspaces->length; ++i) {
 		struct sway_workspace *workspace = output->workspaces->items[i];
 		arrange_workspace(workspace);


### PR DESCRIPTION
Instead of attempting to arrange workspaces on a disabled output which may not have a valid geometry, treat workspaces on disabled output as disabled, ensuring that scene nodes are properly disabled and the missing geometry not accidentally relied on.

Fixes: https://github.com/swaywm/sway/issues/8328#issuecomment-2332747218