### PR TITLE
container: Skip % char if it doesn't match a view property

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -714,6 +714,10 @@ size_t parse_title_format(struct sway_container *container, char *buffer) {
 			} else if (strncmp(next, "%shell", 6) == 0) {
 				len += append_prop(buffer, view_get_shell(container->view));
 				format += 6;
+			} else {
+				lenient_strcat(buffer, "%");
+				++format;
+				++len;
 			}
 		} else {
 			lenient_strcat(buffer, "%");


### PR DESCRIPTION
The else condition was missed here and we would never skip the % char if it didn't end up matching with any property. Since we fail to skip we would re-evaluate the % in an infinite loop never achieving any forward-progress.

Fixes: https://github.com/swaywm/sway/issues/8333