### PR TITLE
config/output: support DRM_FORMAT_ARGB8888

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -783,6 +783,7 @@ static bool search_render_format(struct search_context *ctx, size_t output_idx) 
 		DRM_FORMAT_XRGB2101010,
 		DRM_FORMAT_XBGR2101010,
 		DRM_FORMAT_XRGB8888,
+		DRM_FORMAT_ARGB8888,
 		DRM_FORMAT_INVALID,
 	};
 	if (render_format_is_bgr(wlr_output->render_format)) {


### PR DESCRIPTION
Some display output hardware [1] doesn't support any of the current formats, but works with ARGB8888. Fall back to it if available.

[1] https://github.com/torvalds/linux/blob/196145c606d0f816fd3926483cb1ff87e09c2c0b/drivers/gpu/drm/xlnx/zynqmp_disp.c#L313