### PR TITLE
Include wlroots checkout helper for bisecting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,3 +243,29 @@ error_session:
 	return NULL;
 }
 ```
+
+## Bisecting
+
+When bisecting, it is often necessary to build older commits with their
+contemporary version of wlroots:
+
+```python
+#!/usr/bin/env python3
+#
+# Check out the wlroots commit that was the current master at the time that the current
+# sway HEAD was committed. Requires pygit2. E.g.: apk add py3-pygit2
+
+import pygit2
+
+sway = pygit2.Repository(".")
+head = sway.revparse_single("HEAD")
+sway_time = head.commit_time
+
+wlroots = pygit2.Repository("subprojects/wlroots")
+master = wlroots.revparse_single("master")
+for commit in wlroots.walk(master.id, pygit2.enums.SortMode.TIME):
+    if commit.commit_time < sway_time:
+        break
+
+wlroots.checkout_tree(commit)
+```


### PR DESCRIPTION
I find this useful when bisecting, since the latest wlroots usually won't work on older sway commits.

Hopefully it can help others too.