### PR TITLE
ext-session-lock: Do not use commit listener to arrange

### DIFF
--- a/include/sway/lock.h
+++ b/include/sway/lock.h
@@ -1,0 +1,6 @@
+#ifndef _SWAY_LOCK_H
+#define _SWAY_LOCK_H
+
+void arrange_locks(void);
+
+#endif

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -14,6 +14,7 @@
 #include "sway/desktop/transaction.h"
 #include "sway/input/cursor.h"
 #include "sway/layers.h"
+#include "sway/lock.h"
 #include "sway/output.h"
 #include "sway/server.h"
 #include "sway/tree/arrange.h"
@@ -955,6 +956,7 @@ static bool apply_resolved_output_configs(struct matched_output_config *configs,
 	}
 
 	arrange_root();
+	arrange_locks();
 	update_output_manager_config(&server);
 	transaction_commit_dirty();
 


### PR DESCRIPTION
Arranging lock surfaces rely on the sway_output width and height being updated, but these are only updated after the commit has been completed and all commit listeners have executed. This means that the lock surfaces will not be appropriately scaled to match a change in output dimensions, and may reveal what is under the lock background.

Replace the implicit arrange through the output commit listener with an explicit arrange after the output configuration is finalized.

This might have regressed by other transition away from output commit listeners for other arrange tasks, but even then it would have erroneously relied on signalling order.

Note: There is still a one-frame glitch on scale change as we only have the new output layout geometry for arrange *after* the output commits have gone through, as the output layout is feeding off commit listeners itself and cannot be updated in advance.