### PR TITLE
Reduce modesets and input configuration

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -704,6 +704,8 @@ struct output_config *find_output_config(struct sway_output *output);
 
 void free_output_config(struct output_config *oc);
 
+void request_modeset(void);
+
 bool spawn_swaybg(void);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -94,7 +94,7 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			return res;
 		}
 
-		if (!config->reloading) {
+		if (!config->reading) {
 			input_manager_apply_input_config(ic);
 		}
 	} else {

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -107,17 +107,16 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 
 	store_output_config(output);
 
-	// If reloading, the output configs will be applied after reading the
-	// entire config and before the deferred commands so that an auto generated
-	// workspace name is not given to re-enabled outputs.
-	if (!config->reloading && !config->validating) {
-		apply_stored_output_configs();
-		if (background) {
-			if (!spawn_swaybg()) {
-				return cmd_results_new(CMD_FAILURE,
-					"Failed to apply background configuration");
-			}
-		}
+	if (config->reading) {
+		// When reading the config file, we wait till the end to do a single
+		// modeset and swaybg spawn.
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+	request_modeset();
+
+	if (background && !spawn_swaybg()) {
+		return cmd_results_new(CMD_FAILURE,
+			"Failed to apply background configuration");
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/config.c
+++ b/sway/config.c
@@ -516,7 +516,7 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 	// Only really necessary if not explicitly `font` is set in the config.
 	config_update_font_height();
 
-	if (is_active && !validating) {
+	if (!validating) {
 		input_manager_verify_fallback_seat();
 
 		for (int i = 0; i < config->input_configs->length; i++) {
@@ -533,12 +533,14 @@ bool load_main_config(const char *file, bool is_active, bool validating) {
 		}
 		sway_switch_retrigger_bindings_for_all();
 
-		apply_stored_output_configs();
 		spawn_swaybg();
 
 		config->reloading = false;
-		if (config->swaynag_config_errors.client != NULL) {
-			swaynag_show(&config->swaynag_config_errors);
+		if (is_active) {
+			request_modeset();
+			if (config->swaynag_config_errors.client != NULL) {
+				swaynag_show(&config->swaynag_config_errors);
+			}
 		}
 	}
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -390,17 +390,15 @@ static int timer_modeset_handle(void *data) {
 	return 0;
 }
 
-static void request_modeset(struct sway_server *server) {
-	if (server->delayed_modeset == NULL) {
-		server->delayed_modeset = wl_event_loop_add_timer(server->wl_event_loop,
-			timer_modeset_handle, server);
-		wl_event_source_timer_update(server->delayed_modeset, 10);
+void request_modeset(void) {
+	if (server.delayed_modeset == NULL) {
+		server.delayed_modeset = wl_event_loop_add_timer(server.wl_event_loop,
+			timer_modeset_handle, &server);
+		wl_event_source_timer_update(server.delayed_modeset, 10);
 	}
 }
 
 static void begin_destroy(struct sway_output *output) {
-	struct sway_server *server = output->server;
-
 	if (output->enabled) {
 		output_disable(output);
 	}
@@ -420,7 +418,7 @@ static void begin_destroy(struct sway_output *output) {
 	output->wlr_output->data = NULL;
 	output->wlr_output = NULL;
 
-	request_modeset(server);
+	request_modeset();
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -540,7 +538,7 @@ void handle_new_output(struct wl_listener *listener, void *data) {
 		sway_session_lock_add_output(server->session_lock.lock, output);
 	}
 
-	request_modeset(server);
+	request_modeset();
 }
 
 static struct output_config *output_config_for_config_head(
@@ -646,5 +644,5 @@ void handle_output_power_manager_set_mode(struct wl_listener *listener,
 		break;
 	}
 	store_output_config(oc);
-	request_modeset(output->server);
+	request_modeset();
 }

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -607,6 +607,10 @@ static void output_manager_apply(struct sway_server *server,
 done:
 	if (ok) {
 		wlr_output_configuration_v1_send_succeeded(cfg);
+		if (server->delayed_modeset != NULL) {
+			wl_event_source_remove(server->delayed_modeset);
+			server->delayed_modeset = NULL;
+		}
 	} else {
 		wlr_output_configuration_v1_send_failed(cfg);
 	}


### PR DESCRIPTION
During a fresh sway start, we end up doing a bunch of input and output configuration, as each input command triggers input device configuration, and each output command triggers modeset. In addition, because output manager failed to clear the modeset timer, we could end up with another bogus modeset after output manager apply.

Batch input/output configuration during the initial config load, and skip the initial modeset altogether as we don't have any output devices at this point - those come later, and will trigger modeset on their own.

We still waste up to a few milliseconds per input command on my machine due to config store making some costly checks.