### PR TITLE
Removed destination-is-ancestor check from container_move_to_container to match i3 behaviour

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -240,7 +240,6 @@ static void container_move_to_workspace(struct sway_container *container,
 static void container_move_to_container(struct sway_container *container,
 		struct sway_container *destination) {
 	if (container == destination
-			|| container_has_ancestor(container, destination)
 			|| container_has_ancestor(destination, container)) {
 		return;
 	}


### PR DESCRIPTION
Closes #6818

This extracts the specific part of #6835 that addresses the issue. I'm doing this since the original PR was closed over 2 years ago after the author got informal approval for this part of the change but pushback on other parts (not included here).

> It removes this line
> https://github.com/swaywm/sway/blob/f707f583e17cb5e8323ceb4bfd951ad0465b7d10/sway/commands/move.c#L235
> In order to match the behaviour of i3's move functionality, which can be found [here](https://github.com/i3/i3/blob/c822eff1bfdeac30baf92b14a09d1c81a0193997/src/move.c#L72-L79), posted below:
> ```c
>     /* We compare the focus order of the children of the lowest common ancestor. If con or
>      * its ancestor is before target's ancestor then con should be placed before the target
>      * in the focus stack. */
>     Con *lca = lowest_common_ancestor(con, parent);
>     if (lca == con) {
>         ELOG(\"Container is being inserted into one of its descendants.\
> \");
>         return;
>     }
> ```
> Basically, sway is checking on move that a destination is neither a descendant of the container to be moved, *and* that the container to be moved is not a descendant of the destination, whereas i3 only (rightly, I think) checks that the destination is not a descendant, as such a lot of valid moves in i3 simply don't work in sway and this fixes that.

