### PR TITLE
swaybar: Fix 100% cpu usage if dbus dies.

### DIFF
--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -508,7 +508,7 @@ void bar_run(struct swaybar *bar) {
 	}
 #if HAVE_TRAY
 	if (bar->tray) {
-		loop_add_fd(bar->eventloop, bar->tray->fd, POLLIN, tray_in, bar->tray->bus);
+		loop_add_fd(bar->eventloop, bar->tray->fd, POLLIN, tray_in, bar);
 	}
 #endif
 	while (bar->running) {

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -518,8 +518,7 @@ static bool handle_barconfig_update(struct swaybar *bar, const char *payload,
 #if HAVE_TRAY
 	if (oldcfg->tray_hidden && !newcfg->tray_hidden) {
 		bar->tray = create_tray(bar);
-		loop_add_fd(bar->eventloop, bar->tray->fd, POLLIN, tray_in,
-				bar->tray->bus);
+		loop_add_fd(bar->eventloop, bar->tray->fd, POLLIN, tray_in, bar);
 	} else if (bar->tray && newcfg->tray_hidden) {
 		loop_remove_fd(bar->eventloop, bar->tray->fd);
 		destroy_tray(bar->tray);


### PR DESCRIPTION
Currently, swaybar does not gracefully die if it detects that the dbus connection was lost. Although it's not recommended to restart dbus without restarting the compositor, it can very easily happen. In the case it does, compositor's tray should not consume 100% cpu until it has to be force killed.