### PR TITLE
Re-init renderer for all outputs on lost context

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -205,8 +205,8 @@ static void handle_renderer_lost(struct wl_listener *listener, void *data) {
 
 	wlr_compositor_set_renderer(server->compositor, renderer);
 
-	for (int i = 0; i < root->outputs->length; ++i) {
-		struct sway_output *output = root->outputs->items[i];
+	struct sway_output *output;
+	wl_list_for_each(output, &root->all_outputs, link) {
 		wlr_output_init_render(output->wlr_output,
 			server->allocator, server->renderer);
 	}


### PR DESCRIPTION
sway_root.outputs only include enabled outputs. We also need to re-init the renderer for any disabled outputs, so use sway_root.all_outputs instead.

Resolves the following heap-use-after-free accessing the render formats when a disabled output is modeset after a GPU reset has occurred.

ASan report:
```
=================================================================
==707==ERROR: AddressSanitizer: heap-use-after-free on address 0x522000004930 at pc 0x653f2bb4266c bp 0x7fff72e64220 sp 0x7fff72e64210
READ of size 8 at 0x522000004930 thread T0
    #0 0x653f2bb4266b in wlr_renderer_get_render_formats ../subprojects/wlroots/render/wlr_renderer.c:68
    #1 0x653f2bb4266b in output_pick_format ../subprojects/wlroots/types/output/render.c:159
    #2 0x653f2bb8c4df in manager_output_prepare ../subprojects/wlroots/types/wlr_output_swapchain_manager.c:120
    #3 0x653f2bb8c4df in manager_test ../subprojects/wlroots/types/wlr_output_swapchain_manager.c:175
    #4 0x653f2bb97f69 in wlr_output_swapchain_manager_prepare ../subprojects/wlroots/types/wlr_output_swapchain_manager.c:209
    #5 0x653f2ba56e92 in apply_resolved_output_configs ../sway/config/output.c:918
    #6 0x653f2ba56e92 in apply_output_configs ../sway/config/output.c:1073
    #7 0x653f2b9ed797 in apply_stored_output_configs ../sway/config/output.c:1083
    #8 0x653f2b9ed797 in timer_modeset_handle ../sway/desktop/output.c:392
    #9 0x71db3f956767 in wl_event_loop_dispatch (/usr/lib/libwayland-server.so.0+0xa767) (BuildId: 311edb5eab25bd4a3e6a155319a885cd5bd4a769)
    #10 0x71db3f9590e6 in wl_display_run (/usr/lib/libwayland-server.so.0+0xd0e6) (BuildId: 311edb5eab25bd4a3e6a155319a885cd5bd4a769)
    #11 0x653f2b9c0f5a in server_run ../sway/server.c:504
    #12 0x653f2b9c0f5a in main ../sway/main.c:373
    #13 0x71db3f52718d  (/usr/lib/libc.so.6+0x2618d) (BuildId: ab045bdf48666f852983430db2f0db52ca883ee0)
    #14 0x71db3f527249 in __libc_start_main (/usr/lib/libc.so.6+0x26249) (BuildId: ab045bdf48666f852983430db2f0db52ca883ee0)
    #15 0x653f2b9c2904 in _start (sway+0xe1904) (BuildId: 3aa77d0075c4143455c49cd4f62a13301ce6950f)
0x522000004930 is located 48 bytes inside of 5040-byte region [0x522000004900,0x522000005cb0)
freed by thread T0 here:
    #0 0x71db40143baa in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x71db3f95466d in wl_signal_emit_mutable (/usr/lib/libwayland-server.so.0+0x866d) (BuildId: 311edb5eab25bd4a3e6a155319a885cd5bd4a769)
    #2 0x7fff72e6294f  ([stack]+0x1d94f)
previously allocated by thread T0 here:
    #0 0x71db4014533a in calloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x653f2bada746 in vulkan_renderer_create_for_device ../subprojects/wlroots/render/vulkan/renderer.c:2596
    #2 0x653f2bada746 in wlr_vk_renderer_create_with_drm_fd ../subprojects/wlroots/render/vulkan/renderer.c:2689
    #3 0x653f2bada746 in renderer_autocreate ../subprojects/wlroots/render/wlr_renderer.c:249
    #4 0x653f2bbfe29d in wlr_renderer_autocreate ../subprojects/wlroots/render/wlr_renderer.c:290
    #5 0x653f2bbfe29d in server_init.constprop.0 ../sway/server.c:234
    #6 0x653f2b9bf792 in main ../sway/main.c:334
    #7 0x71db3f52718d  (/usr/lib/libc.so.6+0x2618d) (BuildId: ab045bdf48666f852983430db2f0db52ca883ee0)
SUMMARY: AddressSanitizer: heap-use-after-free ../subprojects/wlroots/render/wlr_renderer.c:68 in wlr_renderer_get_render_formats
Shadow bytes around the buggy address:
  0x522000004680: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
  0x522000004700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x522000004780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x522000004800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x522000004880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x522000004900: fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd
  0x522000004980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x522000004a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x522000004a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x522000004b00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x522000004b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==707==ABORTING
```