### PR TITLE
Fix cursor events on screen lock/unlock

### DIFF
--- a/sway/lock.c
+++ b/sway/lock.c
@@ -59,12 +59,17 @@ static void refocus_output(struct sway_session_lock_output *output) {
 	}
 }
 
-static void handle_surface_map(struct wl_listener *listener, void *data) {
+static void update_focus(void *data) {
+	struct wl_listener *listener = data;
 	struct sway_session_lock_output *surf = wl_container_of(listener, surf, surface_map);
 	if (surf->lock->focused == NULL) {
 		focus_surface(surf->lock, surf->surface->surface);
 	}
 	cursor_rebase_all();
+}
+
+static void handle_surface_map(struct wl_listener *listener, void *data) {
+	wl_event_loop_add_idle(server.wl_event_loop, update_focus, listener);
 }
 
 static void handle_surface_destroy(struct wl_listener *listener, void *data) {
@@ -234,6 +239,7 @@ static void handle_unlock(struct wl_listener *listener, void *data) {
 		struct sway_output *output = root->outputs->items[i];
 		arrange_layers(output);
 	}
+	cursor_rebase_all();
 }
 
 static void handle_abandon(struct wl_listener *listener, void *data) {

--- a/sway/lock.c
+++ b/sway/lock.c
@@ -331,11 +331,31 @@ void sway_session_lock_add_output(struct sway_session_lock *lock,
 	}
 }
 
+struct is_lock_surface_data {
+	struct wlr_surface *surface;
+	bool is_lock_surface;
+};
+
+static void is_lock_surface(struct wlr_surface *surface, int sx, int sy, void *data) {
+	struct is_lock_surface_data *is_lock_surface_data = data;
+	if (is_lock_surface_data->surface == surface) {
+		is_lock_surface_data->is_lock_surface = true;
+	}
+}
+
 bool sway_session_lock_has_surface(struct sway_session_lock *lock,
 		struct wlr_surface *surface) {
 	struct sway_session_lock_output *lock_output;
 	wl_list_for_each(lock_output, &lock->outputs, link) {
-		if (lock_output->surface && lock_output->surface->surface == surface) {
+		if (!lock_output->surface) {
+			continue;
+		}
+		struct is_lock_surface_data data = {
+			.surface = surface,
+			.is_lock_surface = false,
+		};
+		wlr_surface_for_each_surface(lock_output->surface->surface, is_lock_surface, &data);
+		if (data.is_lock_surface) {
 			return true;
 		}
 	}


### PR DESCRIPTION
After the scene graph refactor, node_at_coords no longer return the lock surface after the screen is locked, thereby cursor_rebase_all in handle_surface_map won't work.

This commit make node_at_coords return lock surface when locked.

I also found that the cursor would disappear after screen is unlocked, thereby adding a cursor_rebase_all in handle_unlock.