### PR TITLE
fix: sway crashes if switch to another workspace with surface when IME popup is shown

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -454,6 +454,7 @@ static void handle_im_popup_surface_unmap(struct wl_listener *listener, void *da
 	struct sway_input_popup *popup =
 		wl_container_of(listener, popup, popup_surface_unmap);
 
+	scene_descriptor_destroy(&popup->scene_tree->node, SWAY_SCENE_DESC_POPUP);
 	// relative should already be freed as it should be a child of the just unmapped scene
 	popup->desc.relative = NULL;
 

--- a/sway/scene_descriptor.c
+++ b/sway/scene_descriptor.c
@@ -39,6 +39,9 @@ void *scene_descriptor_try_get(struct wlr_scene_node *node,
 void scene_descriptor_destroy(struct wlr_scene_node *node,
 		enum sway_scene_descriptor_type type) {
 	struct scene_descriptor *desc = scene_node_get_descriptor(node, type);
+	if (!desc) {
+		return;
+	}
 	descriptor_destroy(desc);
 }
 


### PR DESCRIPTION
resolve: https://github.com/swaywm/sway/issues/8375

in pr https://github.com/swaywm/sway/pull/8196, when im_popup_surface is unmapped, author set the popup->relative to NULL, butt popup is still in popup groups, where assert the relative is not NULL, this cause the panic