### PR TITLE
commands/destroy_output: Add new command

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -125,6 +125,7 @@ sway_cmd cmd_create_output;
 sway_cmd cmd_default_border;
 sway_cmd cmd_default_floating_border;
 sway_cmd cmd_default_orientation;
+sway_cmd cmd_destroy_output;
 sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -115,6 +115,7 @@ static const struct cmd_handler command_handlers[] = {
 	{ "allow_tearing", cmd_allow_tearing },
 	{ "border", cmd_border },
 	{ "create_output", cmd_create_output },
+	{ "destroy_output", cmd_destroy_output },
 	{ "exit", cmd_exit },
 	{ "floating", cmd_floating },
 	{ "fullscreen", cmd_fullscreen },

--- a/sway/commands/create_output.c
+++ b/sway/commands/create_output.c
@@ -6,6 +6,7 @@
 #include <wlr/backend/x11.h>
 #endif
 #include "sway/commands.h"
+#include "sway/output.h"
 #include "sway/server.h"
 #include "log.h"
 
@@ -30,6 +31,20 @@ static void create_output(struct wlr_backend *backend, void *data) {
 #endif
 }
 
+static bool output_is_destroyable(struct wlr_output *output) {
+	if (wlr_output_is_wl(output)) {
+		return true;
+	} else if (wlr_output_is_headless(output)) {
+		return true;
+	}
+#if WLR_HAS_X11_BACKEND
+	else if (wlr_output_is_x11(output)) {
+		return true;
+	}
+#endif
+	return false;
+}
+
 /**
  * This command is intended for developer use only.
  */
@@ -46,4 +61,33 @@ struct cmd_results *cmd_create_output(int argc, char **argv) {
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results *cmd_destroy_output(int argc, char **argv) {
+	sway_assert(wlr_backend_is_multi(server.backend),
+			"Expected a multi backend");
+
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "destroy_output", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	char *output_name = argv[0];
+
+	struct sway_output *sway_output;
+	wl_list_for_each(sway_output, &root->all_outputs, link) {
+		if (sway_output == root->fallback_output ||
+				strcmp(sway_output->wlr_output->name, output_name) != 0) {
+			continue;
+		}
+
+		if (!output_is_destroyable(sway_output->wlr_output)) {
+			return cmd_results_new(CMD_INVALID,
+				"Can only destroy outputs for Wayland, X11 or headless backends");
+		}
+
+		wlr_output_destroy(sway_output->wlr_output);
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+
+	return cmd_results_new(CMD_INVALID, "No matching output found");
 }


### PR DESCRIPTION
destroy_output does the opposite of create_output, destroying any output by the specified name.

Neither create_output nor destroy_output are currently documented.