### PR TITLE
trigger container update after disabling urgent in timer

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1094,6 +1094,7 @@ static void seat_send_unfocus(struct sway_node *node, struct sway_seat *seat) {
 static int handle_urgent_timeout(void *data) {
 	struct sway_view *view = data;
 	view_set_urgent(view, false);
+	container_update_itself_and_parents(view->container);
 	return 0;
 }
 


### PR DESCRIPTION
switching workspace directly to urgent window creates timer which delays reset of urgent state so user is able to notice it. make sure state change is reflected visually as well (border change) by triggering container update

Fixes: #8377

Created PR to get feedback on change proposed in #8377