### PR TITLE
release.sh: read meson-rewrite output from stdout

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eu
 
 prev=$(git describe --tags --abbrev=0)
-next=$(meson rewrite kwargs info project / 2>&1 >/dev/null | jq -r '.kwargs["project#/"].version')
+next=$(meson rewrite kwargs info project / | jq -r '.kwargs["project#/"].version')
 
 case "$next" in
 *-dev)


### PR DESCRIPTION
Since version 1.6, Meson now uses stdout:
https://github.com/mesonbuild/meson/commit/3f4957c713f70d708f066fff119088040bb1d287