### PR TITLE
desktop/output: Modeset on session activation

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -46,6 +46,7 @@ struct sway_server {
 
 	struct wl_listener new_output;
 	struct wl_listener renderer_lost;
+	struct wl_listener session_active;
 
 	struct wlr_idle_notifier_v1 *idle_notifier_v1;
 	struct sway_idle_inhibit_manager_v1 idle_inhibit_manager_v1;
@@ -162,6 +163,7 @@ void server_run(struct sway_server *server);
 
 void restore_nofile_limit(void);
 
+void handle_session_active(struct wl_listener *listener, void *data);
 void handle_new_output(struct wl_listener *listener, void *data);
 
 void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -473,6 +473,16 @@ static void handle_request_state(struct wl_listener *listener, void *data) {
 	}
 }
 
+void handle_session_active(struct wl_listener *listener, void *data) {
+	if (server.session->active) {
+		apply_stored_output_configs();
+		if (server.delayed_modeset != NULL) {
+			wl_event_source_remove(server.delayed_modeset);
+			server.delayed_modeset = NULL;
+		}
+	}
+}
+
 static unsigned int last_headless_num = 0;
 
 void handle_new_output(struct wl_listener *listener, void *data) {

--- a/sway/server.c
+++ b/sway/server.c
@@ -6,6 +6,7 @@
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/multi.h>
+#include <wlr/backend/session.h>
 #include <wlr/config.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
@@ -277,6 +278,9 @@ bool server_init(struct sway_server *server) {
 		wlr_gamma_control_manager_v1_create(server->wl_display);
 	wlr_scene_set_gamma_control_manager_v1(root->root_scene,
 		server->gamma_control_manager_v1);
+
+	server->session_active.notify = handle_session_active;
+	wl_signal_add(&server->session->events.active, &server->session_active);
 
 	server->new_output.notify = handle_new_output;
 	wl_signal_add(&server->backend->events.new_output, &server->new_output);


### PR DESCRIPTION
We need to modeset when our session is activated as the output state might have deviated from what we previously had active.

Depends on: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4878