### PR TITLE
desktop/transaction: clamp vertical border length to 0

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -424,13 +424,14 @@ static void arrange_container(struct sway_container *con,
 		int border_bottom = con->current.border_bottom ? border_width : 0;
 		int border_left = con->current.border_left ? border_width : 0;
 		int border_right = con->current.border_right ? border_width : 0;
+		int vert_border_height = MAX(0, height - border_top - border_bottom);
 
 		wlr_scene_rect_set_size(con->border.top, width, border_top);
 		wlr_scene_rect_set_size(con->border.bottom, width, border_bottom);
 		wlr_scene_rect_set_size(con->border.left,
-			border_left, height - border_top - border_bottom);
+			border_left, vert_border_height);
 		wlr_scene_rect_set_size(con->border.right,
-			border_right, height - border_top - border_bottom);
+			border_right, vert_border_height);
 
 		wlr_scene_node_set_position(&con->border.top->node, 0, 0);
 		wlr_scene_node_set_position(&con->border.bottom->node,


### PR DESCRIPTION
Fixes #8120. More changes might be required within IPC to prevent other issues.