### PR TITLE
swaynag: fix null dereference on scale change

### DIFF
--- a/swaynag/swaynag.c
+++ b/swaynag/swaynag.c
@@ -324,7 +324,9 @@ static void output_scale(void *data, struct wl_output *output,
 	swaynag_output->scale = factor;
 	if (swaynag_output->swaynag->output == swaynag_output) {
 		swaynag_output->swaynag->scale = swaynag_output->scale;
-		update_all_cursors(swaynag_output->swaynag);
+		if (!swaynag_output->swaynag->cursor_shape_manager) {
+			update_all_cursors(swaynag_output->swaynag);
+		}
 		render_frame(swaynag_output->swaynag);
 	}
 }


### PR DESCRIPTION
To reproduce the null dereference, run `swaynag` under recent sway or some other compositor supporting cursor-shape-v1, and then change the output scale.

Example:
```
swaymsg output '*' scale 1
swaynag -d -m "Test" &
sleep 1
swaymsg output '*' scale 2
```

Instead of crashing, the error `[swaynag/swaynag.c:161] Failed to get default cursor from theme` is also possible if your cursor theme does not have images for 2x scale; clearing the XCURSOR_THEME environment variable may help.

(The example sometimes produces  `Failed to get buffer. Skipping frame.` warnings for me and produces mis-sized buffers, but that is a separate issue.)