### PR TITLE
Improvements to swaynag rendering

### DIFF
--- a/include/swaynag/swaynag.h
+++ b/include/swaynag/swaynag.h
@@ -90,6 +90,7 @@ struct swaynag {
 	struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
 	struct wl_surface *surface;
 
+	bool needs_redraw;
 	uint32_t width;
 	uint32_t height;
 	int32_t scale;

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -235,12 +235,10 @@ static uint32_t render_to_cairo(cairo_t *cairo, struct swaynag *swaynag) {
 	}
 
 	int border = swaynag->type->bar_border_thickness;
-	if (max_height > swaynag->height) {
-		max_height += border;
-	}
+	max_height += border;
 	cairo_set_source_u32(cairo, swaynag->type->border_bottom);
 	cairo_rectangle(cairo, 0,
-			swaynag->height - border,
+			max_height - border,
 			swaynag->width,
 			border);
 	cairo_fill(cairo);

--- a/swaynag/render.c
+++ b/swaynag/render.c
@@ -250,6 +250,7 @@ void render_frame(struct swaynag *swaynag) {
 	if (!swaynag->run_display) {
 		return;
 	}
+	swaynag->needs_redraw = false;
 
 	cairo_surface_t *recorder = cairo_recording_surface_create(
 			CAIRO_CONTENT_COLOR_ALPHA, NULL);


### PR DESCRIPTION
Swaynag did not redraw buffers promptly when the output scale was changed or when scrolling the detail view. The root cause was wl_buffer exhaustion -- trying to commit too many updates before the compositor could respond. Fixing this (commit 3) required eliminating a roundtrip in `render_frame` (commit 2) which required adjusting the way the lower border is drawn (commit 1).

Observable improvements:
* With `swaynag --border-bottom-size 15 -m "Test" `, the bottom border no longer overlaps the message
* An intermediate wl_surface::commit() the detail view is toggled was eliminated, reducing "flicker" as swaynag no longer commits an under- (or over-) sized buffer followed by the correctly sized one.
* Given a long (>10kb) message in  `input.txt` , and running  `swaymsg -d -m 'test' -l < input.txt`: scrolling the detail view with the pointer axis should be less jerky, and there should be fewer "Failed to get buffer. Skipping frame." warning messages.