### PR TITLE
config: Force modeset before running deferred configs

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -705,6 +705,7 @@ struct output_config *find_output_config(struct sway_output *output);
 void free_output_config(struct output_config *oc);
 
 void request_modeset(void);
+void force_modeset(void);
 
 bool spawn_swaybg(void);
 

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -706,6 +706,7 @@ void free_output_config(struct output_config *oc);
 
 void request_modeset(void);
 void force_modeset(void);
+bool modeset_is_pending(void);
 
 bool spawn_swaybg(void);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -408,6 +408,10 @@ void request_modeset(void) {
 	}
 }
 
+bool modeset_is_pending(void) {
+	return server.delayed_modeset != NULL;
+}
+
 void force_modeset(void) {
 	if (server.delayed_modeset != NULL) {
 		wl_event_source_remove(server.delayed_modeset);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -408,6 +408,14 @@ void request_modeset(void) {
 	}
 }
 
+void force_modeset(void) {
+	if (server.delayed_modeset != NULL) {
+		wl_event_source_remove(server.delayed_modeset);
+		server.delayed_modeset = NULL;
+	}
+	apply_stored_output_configs();
+}
+
 static void begin_destroy(struct sway_output *output) {
 	if (output->enabled) {
 		output_disable(output);
@@ -493,12 +501,8 @@ static void handle_request_state(struct wl_listener *listener, void *data) {
 	// We do not expect or support any other changes here
 	assert(committed == 0);
 	store_output_config(oc);
-	apply_stored_output_configs();
 
-	if (server.delayed_modeset != NULL) {
-		wl_event_source_remove(server.delayed_modeset);
-		server.delayed_modeset = NULL;
-	}
+	force_modeset();
 }
 
 static unsigned int last_headless_num = 0;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -648,6 +648,12 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 		}
 
 		list_t *res_list = execute_command(buf, NULL, NULL);
+		if (modeset_is_pending()) {
+			// IPC expects commands to have taken immediate effect, so we need
+			// to force a modeset after output commands. We do a single modeset
+			// here to avoid modesetting for every output command in sequence.
+			force_modeset();
+		}
 		transaction_commit_dirty();
 		char *json = cmd_results_to_json(res_list);
 		int length = strlen(json);

--- a/sway/main.c
+++ b/sway/main.c
@@ -361,6 +361,7 @@ int main(int argc, char **argv) {
 	}
 
 	config->active = true;
+	force_modeset();
 	load_swaybars();
 	run_deferred_commands();
 	run_deferred_bindings();


### PR DESCRIPTION
Some commands require outputs to be enabled. These commands are deferred to allow outputs to be discovered, but the delayed modeset might only run some time later.

Force a modeset to occur before running deferred commands.

Fixes: https://github.com/swaywm/sway/issues/8433