### PR TITLE
commands/include: handle many files in single line

### DIFF
--- a/sway/commands/include.c
+++ b/sway/commands/include.c
@@ -3,12 +3,12 @@
 
 struct cmd_results *cmd_include(int argc, char **argv) {
 	struct cmd_results *error = NULL;
-	if ((error = checkarg(argc, "include", EXPECTED_EQUAL_TO, 1))) {
+	if ((error = checkarg(argc, "include", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-
+	char *files = join_args(argv, argc);
 	// We don't care if the included config(s) fails to load.
-	load_include_configs(argv[0], config, &config->swaynag_config_errors);
+	load_include_configs(files, config, &config->swaynag_config_errors);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -66,8 +66,8 @@ The following commands may only be used in the configuration file.
 *default_orientation* horizontal|vertical|auto
 	Sets the default container layout for tiled containers.
 
-*include* <path>
-	Includes another file from _path_. _path_ can be either a full path or a
+*include* <paths...>
+	Include files from _paths_. _paths_ can include either a full path or a
 	path relative to the parent config, and expands shell syntax (see
 	*wordexp*(3) for details). The same include file can only be included once;
 	subsequent attempts will be ignored.


### PR DESCRIPTION
i3 supports including multiple files in a single line, whereas sway limits to single file per line.