### PR TITLE
RFC: add ability for clients to be shown over the lock screen

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -13,6 +13,7 @@ struct sway_layer_surface {
 	struct wl_listener node_destroy;
 	struct wl_listener new_popup;
 
+	bool show_over_lockscreen;
 	bool mapped;
 
 	struct wlr_scene_tree *popups;

--- a/include/sway/lockscreen-overlay.h
+++ b/include/sway/lockscreen-overlay.h
@@ -1,0 +1,4 @@
+#include <wayland-server-core.h>
+
+struct sway_lockscreen_overlay;
+struct sway_lockscreen_overlay *sway_lockscreen_overlay_create(struct wl_display *display);

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -97,6 +97,8 @@ struct sway_server {
 		struct wl_listener manager_destroy;
 	} session_lock;
 
+	struct sway_lockscreen_overlay *lockscreen_overlay;
+
 	struct wlr_output_power_manager_v1 *output_power_manager_v1;
 	struct wl_listener output_power_manager_set_mode;
 	struct wlr_input_method_manager_v2 *input_method;

--- a/protocols/kde-lockscreen-overlay-v1.xml
+++ b/protocols/kde-lockscreen-overlay-v1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="kde_lockscreen_overlay_v1">
+  <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2022 Aleix Pol Gonzalez <aleixpol@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.1-or-later
+  ]]></copyright>
+
+  <interface name="kde_lockscreen_overlay_v1" version="1">
+    <description summary="Allow surfaces over the lockscreen">
+        Allows a client to request a surface to be visible when the system is locked.
+
+        This is meant to be used for specific high urgency cases like phone calls or alarms.
+
+        Warning! The protocol described in this file is a desktop environment
+        implementation detail. Regular clients must not use this protocol.
+        Backward incompatible changes may be added without bumping the major
+        version of the extension.
+      </description>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="the client provided an invalid surface state"/>
+    </enum>
+
+    <request name="allow">
+      <description summary="Tell about which surface could be raised above the lockscreen">
+          Informs the compositor that the surface could be shown when the screen is locked. This request should be called while the surface is unmapped.
+        </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the kde_lockscreen_overlay_v1">
+          This won't affect the surface previously marked with the allow request.
+        </description>
+    </request>
+  </interface>
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -18,6 +18,7 @@ protocols = [
 	'wlr-layer-shell-unstable-v1.xml',
 	'idle.xml',
 	'wlr-output-power-management-unstable-v1.xml',
+	'kde-lockscreen-overlay-v1.xml',
 ]
 
 wl_protos_src = []

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -623,13 +623,22 @@ void arrange_popups(struct wlr_scene_tree *popups) {
 
 static void arrange_root(struct sway_root *root) {
 	struct sway_container *fs = root->fullscreen_global;
+	bool locked = server.session_lock.lock;
 
 	wlr_scene_node_set_enabled(&root->layers.shell_background->node, !fs);
 	wlr_scene_node_set_enabled(&root->layers.shell_bottom->node, !fs);
-	wlr_scene_node_set_enabled(&root->layers.tiling->node, !fs);
-	wlr_scene_node_set_enabled(&root->layers.floating->node, !fs);
+	wlr_scene_node_set_enabled(&root->layers.tiling->node, !fs && !locked);
+	wlr_scene_node_set_enabled(&root->layers.floating->node, !fs && !locked);
 	wlr_scene_node_set_enabled(&root->layers.shell_top->node, !fs);
-	wlr_scene_node_set_enabled(&root->layers.fullscreen->node, !fs);
+	wlr_scene_node_set_enabled(&root->layers.fullscreen->node, !fs && !locked);
+	wlr_scene_node_set_enabled(&root->layers.fullscreen_global->node, !locked);
+#if WLR_HAS_XWAYLAND
+	wlr_scene_node_set_enabled(&root->layers.unmanaged->node, !locked);
+#endif
+
+	if (server.session_lock.lock) {
+		sway_log(SWAY_INFO, "arranging locked layout");
+	}
 
 	// hide all contents in the scratchpad
 	for (int i = 0; i < root->scratchpad->length; i++) {

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1068,7 +1068,20 @@ void seat_configure_xcursor(struct sway_seat *seat) {
 bool seat_is_input_allowed(struct sway_seat *seat,
 		struct wlr_surface *surface) {
 	if (server.session_lock.lock) {
-		return sway_session_lock_has_surface(server.session_lock.lock, surface);
+		if (sway_session_lock_has_surface(server.session_lock.lock, surface)) {
+			return true;
+		}
+
+		struct wlr_layer_surface_v1 *layer_surface =
+			wlr_layer_surface_v1_try_from_wlr_surface(surface);
+		struct sway_layer_surface *layer =
+			layer_surface ? layer_surface->data : NULL;
+
+		if (layer && layer->show_over_lockscreen) {
+			return true;
+		}
+
+		return false;
 	}
 	return true;
 }

--- a/sway/lockscreen-overlay.c
+++ b/sway/lockscreen-overlay.c
@@ -1,0 +1,87 @@
+#include "sway/lockscreen-overlay.h"
+#include "sway/desktop/transaction.h"
+#include "sway/layers.h"
+
+#include "kde-lockscreen-overlay-v1-protocol.h"
+#include "log.h"
+#include "sway/tree/arrange.h"
+
+#include <stdlib.h>
+#include <wayland-server-core.h>
+
+#include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
+
+struct sway_lockscreen_overlay {
+};
+
+static void kde_lockscreen_overlay_allow(struct wl_client *client,
+		struct wl_resource *resource, struct wl_resource *surface) {
+	sway_log(SWAY_ERROR, "at %s:%d", __func__, __LINE__);
+
+	struct wlr_surface *overlay_surface = wlr_surface_from_resource(surface);
+	// TODO: send a protocol error for each of these checks?
+	if (!overlay_surface) {
+		sway_log(SWAY_ERROR, "No overlay surface found");
+		return;
+	}
+
+	struct wlr_layer_surface_v1 *wlr_layer_surface =
+		wlr_layer_surface_v1_try_from_wlr_surface(overlay_surface);
+	if (!wlr_layer_surface) {
+		sway_log(SWAY_ERROR, "no wlr_layer surface found");
+		return;
+	}
+
+	struct sway_layer_surface *layer_surface = wlr_layer_surface->data;
+	if (!layer_surface) {
+		sway_log(SWAY_ERROR, "no sway_layer surface found");
+		return;
+	}
+
+	layer_surface->show_over_lockscreen = true;
+
+	arrange_layers(layer_surface->output);
+	arrange_root();
+	transaction_commit_dirty();
+}
+
+static void kde_lockscreen_overlay_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct kde_lockscreen_overlay_v1_interface impl = {
+	.allow = kde_lockscreen_overlay_allow,
+	.destroy = kde_lockscreen_overlay_destroy,
+};
+
+static void lockscreen_overlay_bind(
+	struct wl_client *client,
+	void *data,
+	uint32_t version,
+	uint32_t id
+) {
+	struct sway_lockscreen_overlay *overlay = data;
+
+	struct wl_resource *resource = wl_resource_create(client,
+		&kde_lockscreen_overlay_v1_interface, version, id);
+	if (!resource) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+
+	wl_resource_set_implementation(resource, &impl, overlay, NULL);
+}
+
+struct sway_lockscreen_overlay *sway_lockscreen_overlay_create(struct wl_display *display) {
+	struct sway_lockscreen_overlay *overlay = calloc(1, sizeof(*overlay));
+
+	wl_global_create(
+		display,
+		&kde_lockscreen_overlay_v1_interface, 1,
+		overlay, lockscreen_overlay_bind
+	);
+
+	return overlay;
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -6,6 +6,7 @@ sway_sources = files(
 	'ipc-json.c',
 	'ipc-server.c',
 	'lock.c',
+	'lockscreen-overlay.c',
 	'main.c',
 	'realtime.c',
 	'scene_descriptor.c',

--- a/sway/server.c
+++ b/sway/server.c
@@ -57,6 +57,7 @@
 #include "sway/server.h"
 #include "sway/input/cursor.h"
 #include "sway/tree/root.h"
+#include "sway/lockscreen-overlay.h"
 
 #if WLR_HAS_XWAYLAND
 #include <wlr/xwayland/shell.h>
@@ -352,6 +353,8 @@ bool server_init(struct sway_server *server) {
 		wlr_ext_foreign_toplevel_list_v1_create(server->wl_display, SWAY_FOREIGN_TOPLEVEL_LIST_VERSION);
 	server->foreign_toplevel_manager =
 		wlr_foreign_toplevel_manager_v1_create(server->wl_display);
+	server->lockscreen_overlay =
+		sway_lockscreen_overlay_create(server->wl_display);
 
 	sway_session_lock_init();
 

--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -50,10 +50,10 @@ struct sway_root *root_create(struct wl_display *wl_display) {
 #if WLR_HAS_XWAYLAND
 	root->layers.unmanaged = alloc_scene_tree(root->layer_tree, &failed);
 #endif
+	root->layers.session_lock = alloc_scene_tree(root->layer_tree, &failed);
 	root->layers.shell_overlay = alloc_scene_tree(root->layer_tree, &failed);
 	root->layers.popup = alloc_scene_tree(root->layer_tree, &failed);
 	root->layers.seat = alloc_scene_tree(root->layer_tree, &failed);
-	root->layers.session_lock = alloc_scene_tree(root->layer_tree, &failed);
 
 	if (!failed && !scene_descriptor_assign(&root->layers.seat->node,
 			SWAY_SCENE_DESC_NON_INTERACTIVE, (void *)1)) {


### PR DESCRIPTION
**WARNING:** this implementation proof-of-concept quality, I expect there are bugs. I
haven't done a cleanup pass to find them yet.

My goal with opening this pr now is to find out if the architecture is agreeable, so I can determine if I want to commit more time to this project.

This can be tested with [this wvkbd fork](https://git.sr.ht/~aren/wvkbd/tree/lockscreen-overlay). When wvkbd is running and the screen is locked, wvkbd should stay visible. And if wvkbd is run after locking the screen, swyalock should resize to make space for wvkbd and wvkbd
should be shown.

# Motivation

The only way to use a lock screen on devices with no keyboard currently is if the lock screen implements an on-screen-keyboard. I'm not aware of any that do this.

The idea of adding this protocol is to allow applications (such as an on-screen-keybaord) to request they be shown over the lock screen so they could be used unmodified with swaylock.

Secondarily, on mobile phones it may be desirable to make and receive phone calls without unlocking the device (with user configuration). Being able to keep this logic out of the lock screen would be nice. This is a major factor blocking sxmo from getting a lock screen by default.

# Known Issues / TODO

- [ ] Is a protocol like this an acceptable way to implement this? If not I'd like to throw this away before putting more work in.
- [ ] Develop a robust way to control what is shown on the lock screen. I think this could be done by attaching a "allowed over lock" variable to each node in the scene tree, which defaults to false, and hide any node that doesn't have it set when entering the lock state.
  - [ ] This is wrong currently, the application I'm using to test has a popup layer which doesn't opt-in, but is being displayed anyway.
- [ ] Write a new protocol for this. kde's protocol is good enough for a prototype, but this is not a compatible implementation.
- [ ] Move protocol glue code from `sway/lockscreen-overlay.c` into wlroots. I'm not sure how much should move yet, I need to study the structure of sway/wlroots more.
- [ ] Should this be a privileged protocol? I need to do some more reading on this.
- [ ] Ensure the layout is computed at the right time. Layer shell surfaces resizing now require the lock screen to resize too. I think I've done this, but I'm not confident.
