### PR TITLE
desktop/output: Clear repaint timer earlier in destroy

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -440,6 +440,9 @@ static void begin_destroy(struct sway_output *output) {
 	output->wlr_output->data = NULL;
 	output->wlr_output = NULL;
 
+	wl_event_source_remove(output->repaint_timer);
+	output->repaint_timer = NULL;
+
 	request_modeset();
 }
 

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -273,7 +273,6 @@ void output_destroy(struct sway_output *output) {
 	destroy_scene_layers(output);
 	list_free(output->workspaces);
 	list_free(output->current.workspaces);
-	wl_event_source_remove(output->repaint_timer);
 	wlr_color_transform_unref(output->color_transform);
 	free(output);
 }


### PR DESCRIPTION
The teardown of a sway_output is split in two: begin_destroy and output_destroy. The former clears some state such as NULL'ing the reference to wlr_output, while the latter frees the struct and its remaining resources.

If an output is destroyed while a repaint timer is pending, future frame callbacks will no longer occur as the listener is torn down in begin_destroy, but the repaint timer is not torn down and may still fire until output_destroy is hit. As begin_destroy cleared the reference to wlr_output, this leads to a NULL-pointer dereference.

Tear down the repaint timer in begin_destroy as there is no need for it.

Fixes: fdc4318ac66d ("desktop/output: Clear frame_pending even output is disabled")