### PR TITLE
man: fix incorrect smart_borders documentation

### DIFF
--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -785,10 +785,11 @@ The default colors are:
 	Kills (closes) the currently focused container and all of its children.
 
 *smart_borders* on|no_gaps|off
-	If smart_borders are _on_, borders will only be enabled if the workspace
-	has more than one visible child. If smart_borders is set to _no_gaps_,
-	borders will only be enabled if the workspace has more than one visible
-	child and gaps equal to zero.
+	If smart_borders are _on_, borders will only be enabled if the workspace has
+	more than one visible child. If smart_borders is set to _no_gaps_, borders
+	will only be enabled if the workspace has more than one visible child or the
+	workspace does not fill the output. The workspace does not fill the output
+	when the sum of inner and outer gaps is positive for any of its sides.
 
 *smart_gaps* on|off|toggle|inverse_outer
 	If smart_gaps are _on_ gaps will only be enabled if a workspace has more


### PR DESCRIPTION
Currently, the documentation for smart_borders claims that when smart_borders is set to 'no_gaps', borders will only be enabled when the workspace has more than one visible child and gaps are equal to zero. However, the real behavior of 'no_gaps' is that borders are enabled when:
- The workspace has more than one visible child.

or,
- There are non-zero gaps between any of the workspace's edges and the corresponding edge of the output.

This commit adjusts the wording of the smart_borders documentation to reflect the true behavior of the option.