### PR TITLE
tree/container: remove output_{enter,leave} listeners in destroy

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -508,6 +508,8 @@ void container_destroy(struct sway_container *con) {
 
 	if (con->view && con->view->container == con) {
 		con->view->container = NULL;
+		wl_list_remove(&con->output_enter.link);
+		wl_list_remove(&con->output_leave.link);
 		wlr_scene_node_destroy(&con->output_handler->node);
 		if (con->view->destroying) {
 			view_destroy(con->view);


### PR DESCRIPTION
https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/0d6cc471e95c1632b234fc9152659d24fe5982f1 added an assert that all signals are clear when destroying a wlr_scene_buffer, which is currently triggering due to sway not removing the output_enter and output_leave listeners on the container before calling wlr_scene_node_destroy on output_handler. Remove the listeners before wlr_scene_node_destroy is called.