### PR TITLE
Expose sandbox properties via IPC JSON, criteria, title format

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -53,6 +53,9 @@ struct criteria {
 	char urgent; // 'l' for latest or 'o' for oldest
 	struct pattern *workspace;
 	pid_t pid;
+	struct pattern *sandbox_engine;
+	struct pattern *sandbox_app_id;
+	struct pattern *sandbox_instance_id;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -221,6 +221,12 @@ const char *view_get_window_role(struct sway_view *view);
 
 uint32_t view_get_window_type(struct sway_view *view);
 
+const char *view_get_sandbox_engine(struct sway_view *view);
+
+const char *view_get_sandbox_app_id(struct sway_view *view);
+
+const char *view_get_sandbox_instance_id(struct sway_view *view);
+
 const char *view_get_shell(struct sway_view *view);
 
 void view_get_constraints(struct sway_view *view, double *min_width,

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -34,7 +34,10 @@ bool criteria_is_empty(struct criteria *criteria) {
 		&& !criteria->tiling
 		&& !criteria->urgent
 		&& !criteria->workspace
-		&& !criteria->pid;
+		&& !criteria->pid
+		&& !criteria->sandbox_engine
+		&& !criteria->sandbox_app_id
+		&& !criteria->sandbox_instance_id;
 }
 
 // The error pointer is used for parsing functions, and saves having to pass it
@@ -98,6 +101,9 @@ void criteria_destroy(struct criteria *criteria) {
 #endif
 	pattern_destroy(criteria->con_mark);
 	pattern_destroy(criteria->workspace);
+	pattern_destroy(criteria->sandbox_engine);
+	pattern_destroy(criteria->sandbox_app_id);
+	pattern_destroy(criteria->sandbox_instance_id);
 	free(criteria->target);
 	free(criteria->cmdlist);
 	free(criteria->raw);
@@ -242,6 +248,66 @@ static bool criteria_matches_view(struct criteria *criteria,
 			break;
 		case PATTERN_PCRE2:
 			if (regex_cmp(app_id, criteria->app_id->regex) < 0) {
+				return false;
+			}
+			break;
+		}
+	}
+
+	if (criteria->sandbox_engine) {
+		const char *sandbox_engine = view_get_sandbox_engine(view);
+		if (!sandbox_engine) {
+			return false;
+		}
+
+		switch (criteria->sandbox_engine->match_type) {
+		case PATTERN_FOCUSED:
+			if (focused && lenient_strcmp(sandbox_engine, view_get_sandbox_engine(focused))) {
+				return false;
+			}
+			break;
+		case PATTERN_PCRE2:
+			if (regex_cmp(sandbox_engine, criteria->sandbox_engine->regex) < 0) {
+				return false;
+			}
+			break;
+		}
+	}
+
+	if (criteria->sandbox_app_id) {
+		const char *sandbox_app_id = view_get_sandbox_app_id(view);
+		if (!sandbox_app_id) {
+			return false;
+		}
+
+		switch (criteria->sandbox_app_id->match_type) {
+		case PATTERN_FOCUSED:
+			if (focused && lenient_strcmp(sandbox_app_id, view_get_sandbox_app_id(focused))) {
+				return false;
+			}
+			break;
+		case PATTERN_PCRE2:
+			if (regex_cmp(sandbox_app_id, criteria->sandbox_app_id->regex) < 0) {
+				return false;
+			}
+			break;
+		}
+	}
+
+	if (criteria->sandbox_instance_id) {
+		const char *sandbox_instance_id = view_get_sandbox_instance_id(view);
+		if (!sandbox_instance_id) {
+			return false;
+		}
+
+		switch (criteria->sandbox_instance_id->match_type) {
+		case PATTERN_FOCUSED:
+			if (focused && lenient_strcmp(sandbox_instance_id, view_get_sandbox_instance_id(focused))) {
+				return false;
+			}
+			break;
+		case PATTERN_PCRE2:
+			if (regex_cmp(sandbox_instance_id, criteria->sandbox_instance_id->regex) < 0) {
 				return false;
 			}
 			break;
@@ -475,6 +541,9 @@ enum criteria_token {
 	T_URGENT,
 	T_WORKSPACE,
 	T_PID,
+	T_SANDBOX_ENGINE,
+	T_SANDBOX_APP_ID,
+	T_SANDBOX_INSTANCE_ID,
 
 	T_INVALID,
 };
@@ -514,6 +583,12 @@ static enum criteria_token token_from_name(char *name) {
 		return T_FLOATING;
 	} else if (strcmp(name, "pid") == 0) {
 		return T_PID;
+	} else if (strcmp(name, "sandbox_engine") == 0) {
+		return T_SANDBOX_ENGINE;
+	} else if (strcmp(name, "sandbox_app_id") == 0) {
+		return T_SANDBOX_APP_ID;
+	} else if (strcmp(name, "sandbox_instance_id") == 0) {
+		return T_SANDBOX_INSTANCE_ID;
 	}
 	return T_INVALID;
 }
@@ -616,6 +691,15 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		if (*endptr != 0) {
 			error = strdup("The value for 'pid' should be numeric");
 		}
+		break;
+	case T_SANDBOX_ENGINE:
+		pattern_create(&criteria->sandbox_engine, value);
+		break;
+	case T_SANDBOX_APP_ID:
+		pattern_create(&criteria->sandbox_app_id, value);
+		break;
+	case T_SANDBOX_INSTANCE_ID:
+		pattern_create(&criteria->sandbox_instance_id, value);
 		break;
 	case T_INVALID:
 		break;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -602,6 +602,18 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "inhibit_idle",
 		json_object_new_boolean(view_inhibit_idle(c->view)));
 
+	const char *sandbox_engine = view_get_sandbox_engine(c->view);
+	json_object_object_add(object, "sandbox_engine",
+			sandbox_engine ? json_object_new_string(sandbox_engine) : NULL);
+
+	const char *sandbox_app_id = view_get_sandbox_app_id(c->view);
+	json_object_object_add(object, "sandbox_app_id",
+			sandbox_app_id ? json_object_new_string(sandbox_app_id) : NULL);
+
+	const char *sandbox_instance_id = view_get_sandbox_instance_id(c->view);
+	json_object_object_add(object, "sandbox_instance_id",
+			sandbox_instance_id ? json_object_new_string(sandbox_instance_id) : NULL);
+
 	json_object *idle_inhibitors = json_object_new_object();
 
 	struct sway_idle_inhibitor_v1 *user_inhibitor =

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -403,6 +403,16 @@ node and will have the following properties:
 :  (Only views) An object containing the state of the _application_ and _user_ idle inhibitors.
     _application_ can be _enabled_ or _none_.
     _user_ can be _focus_, _fullscreen_, _open_, _visible_ or _none_.
+|- sandbox_engine
+:  string
+:  (Only views) The associated sandbox engine (or _null_)
+|- sandbox_app_id
+:  string
+:  (Only views) The app ID provided by the associated sandbox engine (or _null_)
+|- sandbox_instance_id
+:  string
+:  (Only views) The instance ID provided by the associated sandbox engine (or
+   _null_)
 |- window
 :  integer
 :  (Only xwayland views) The X11 window ID for the xwayland view

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -372,12 +372,29 @@ set|plus|minus|toggle <amount>
 *title_format* <format>
 	Sets the format of window titles. The following placeholders may be used:
 
-		%title - The title supplied by the window ++
-		%app_id - The wayland app ID (applicable to wayland windows only) ++
-		%class - The X11 classname (applicable to xwayland windows only) ++
-		%instance - The X11 instance (applicable to xwayland windows only) ++
-		%shell - The protocol the window is using (typically xwayland or
-			xdg_shell)
+	*%title*
+		The title supplied by the window
+
+	*%app_id*
+		The wayland app ID (applicable to wayland windows only)
+
+	*%class*
+		The X11 classname (applicable to xwayland windows only)
+
+	*%instance*
+		The X11 instance (applicable to xwayland windows only)
+
+	*%shell*
+		The protocol the window is using (typically xwayland or xdg_shell)
+
+	*%sandbox_engine*
+		The associated sandbox engine
+
+	*%sandbox_app_id*
+		The app ID provided by the associated sandbox engine
+
+	*%sandbox_instance_id*
+		The instance ID provided by the associated sandbox engine
 
 	This command is typically used with *for_window* criteria. For example:
 

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -1058,6 +1058,22 @@ The following attributes may be matched with:
 	expression. If the value is \_\_focused\_\_, then all the views on the
 	currently focused workspace matches.
 
+*sandbox_engine*
+	Compare against the associated sandbox engine. Can be a regular expression.
+	If the value is \_\_focused\_\_, then the sandbox engine must be the same as
+	that of the currently focused window.
+
+*sandbox_app_id*
+	Compare against the app ID provided by the associated sandbox engine. Can be
+	a regular expression. If the value is \_\_focused\_\_, then the sandbox app
+	ID must be the same as that of the currently focused window.
+
+*sandbox_instance_id*
+	Compare against the instance ID provided by the associated sandbox engine.
+	Can be a regular expression. If the value is \_\_focused\_\_, then the
+	sandbox instance ID must be the same as that of the currently focused
+	window.
+
 # SEE ALSO
 
 *sway*(1) *sway-input*(5) *sway-output*(5) *sway-bar*(5) *sway-ipc*(7)

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -716,6 +716,15 @@ size_t parse_title_format(struct sway_container *container, char *buffer) {
 			} else if (has_prefix(next, "%shell")) {
 				len += append_prop(buffer, view_get_shell(container->view));
 				format += strlen("%shell");
+			} else if (has_prefix(next, "%sandbox_engine")) {
+				len += append_prop(buffer, view_get_sandbox_engine(container->view));
+				format += strlen("%sandbox_engine");
+			} else if (has_prefix(next, "%sandbox_app_id")) {
+				len += append_prop(buffer, view_get_sandbox_app_id(container->view));
+				format += strlen("%sandbox_app_id");
+			} else if (has_prefix(next, "%sandbox_instance_id")) {
+				len += append_prop(buffer, view_get_sandbox_instance_id(container->view));
+				format += strlen("%sandbox_instance_id");
 			} else {
 				lenient_strcat(buffer, "%");
 				++format;

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_security_context_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
@@ -152,6 +153,34 @@ uint32_t view_get_window_type(struct sway_view *view) {
 		return view->impl->get_int_prop(view, VIEW_PROP_WINDOW_TYPE);
 	}
 	return 0;
+}
+
+static const struct wlr_security_context_v1_state *security_context_from_view(
+		struct sway_view *view) {
+	const struct wl_client *client =
+		wl_resource_get_client(view->surface->resource);
+	const struct wlr_security_context_v1_state *security_context =
+		wlr_security_context_manager_v1_lookup_client(
+				server.security_context_manager_v1, client);
+	return security_context;
+}
+
+const char *view_get_sandbox_engine(struct sway_view *view) {
+	const struct wlr_security_context_v1_state *security_context =
+		security_context_from_view(view);
+	return security_context ? security_context->sandbox_engine : NULL;
+}
+
+const char *view_get_sandbox_app_id(struct sway_view *view) {
+	const struct wlr_security_context_v1_state *security_context =
+		security_context_from_view(view);
+	return security_context ? security_context->app_id : NULL;
+}
+
+const char *view_get_sandbox_instance_id(struct sway_view *view) {
+	const struct wlr_security_context_v1_state *security_context =
+		security_context_from_view(view);
+	return security_context ? security_context->instance_id : NULL;
 }
 
 const char *view_get_shell(struct sway_view *view) {

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -330,6 +330,9 @@ static void pretty_print_tree(json_object *obj, int indent) {
 		const char *instance = json_object_get_string(json_object_object_get(window_props_obj, "instance"));
 		const char *class = json_object_get_string(json_object_object_get(window_props_obj, "class"));
 		int x11_id = json_object_get_int(json_object_object_get(obj, "window"));
+		const char *sandbox_engine = json_object_get_string(json_object_object_get(obj, "sandbox_engine"));
+		const char *sandbox_app_id = json_object_get_string(json_object_object_get(obj, "sandbox_app_id"));
+		const char *sandbox_instance_id = json_object_get_string(json_object_object_get(obj, "sandbox_instance_id"));
 
 		printf(" (%s, pid: %d", shell, pid);
 		if (app_id != NULL) {
@@ -343,6 +346,15 @@ static void pretty_print_tree(json_object *obj, int indent) {
 		}
 		if (x11_id != 0) {
 			printf(", X11 window: 0x%X", x11_id);
+		}
+		if (sandbox_engine != NULL) {
+			printf(", sandbox_engine: \"%s\"", sandbox_engine);
+		}
+		if (sandbox_app_id != NULL) {
+			printf(", sandbox_app_id: \"%s\"", sandbox_app_id);
+		}
+		if (sandbox_instance_id != NULL) {
+			printf(", sandbox_instance_id: \"%s\"", sandbox_instance_id);
 		}
 		printf(")");
 	}


### PR DESCRIPTION
Rebase and update of https://github.com/swaywm/sway/pull/7187.

Add sandbox properties to IPC JSON, criteria, and title format:
- `sandbox_engine`
- `sandbox_app_id`
- `sandbox_instance_id`

These properties may be set by sandbox engines (e.g. `flatpak`) via the security context protocol: https://wayland.app/protocols/security-context-v1.

### Example Usage

Prepend sandbox properties to window title when sandbox engine is set:
```
for_window [sandbox_engine="."] title_format "[%sandbox_engine/%sandbox_app_id/%sandbox_instance_id] %title"
```

### Testing

Launch an app via `flatpak`:
```
flatpak run org.gnome.clocks
```

Observe JSON layout tree via `swaymsg -r -t get_tree`:
```
"name": "Clocks",
"pid": 14309,
"app_id": "org.gnome.clocks",
...
"sandbox_engine": "org.flatpak",
"sandbox_app_id": "org.gnome.clocks",
"sandbox_instance_id": "2307446143",
```

Observe pretty layout tree via `swaymsg -p -t get_tree`:
```
#1: root "root"
  #2147483647: output "__i3"
    #2147483646: workspace "__i3_scratch"
  #3: output "WL-1"
    #4: workspace "1"
      #5: con "Clocks" (xdg_shell, pid: 14309, app_id: "org.gnome.clocks", sandbox_engine: "org.flatpak", sandbox_app_id: "org.gnome.clocks", sandbox_instance_id: "2307446143")
```

Observe window title when configured as shown above:
```
[org.flatpak/org.gnome.clocks/2307446143] Clocks
```