### PR TITLE
Fix has_prefix() comparisons with 0

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -398,7 +398,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 	list_t *split = split_string(argv[0], "+");
 	for (int i = 0; i < split->length; ++i) {
 		// Check for group
-		if (has_prefix(split->items[i], "Group") == 0) {
+		if (has_prefix(split->items[i], "Group")) {
 			if (binding->group != XKB_LAYOUT_INVALID) {
 				free_sway_binding(binding);
 				list_free_items_and_destroy(split);

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -23,7 +23,7 @@ struct cmd_results *cmd_mark(int argc, char **argv) {
 	}
 
 	bool add = false, toggle = false;
-	while (argc > 0 && has_prefix(*argv, "--") == 0) {
+	while (argc > 0 && has_prefix(*argv, "--")) {
 		if (strcmp(*argv, "--add") == 0) {
 			add = true;
 		} else if (strcmp(*argv, "--replace") == 0) {


### PR DESCRIPTION
has_prefix() returns a bool, unlike strncmp() which returns an int.

When writing the has_prefix() patch, I said to myself that I really should be careful to remove the integer comparisons, but still managed to miss these.

Fixes: 0c60d1581f7b ("Use has_prefix() instead of strncmp() throughout")
Closes: https://github.com/swaywm/sway/issues/8527