### PR TITLE
layer_shell: cleanup new_popup listener when destroying node

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -256,6 +256,7 @@ static void handle_node_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&layer->unmap.link);
 	wl_list_remove(&layer->surface_commit.link);
 	wl_list_remove(&layer->node_destroy.link);
+	wl_list_remove(&layer->new_popup.link);
 	wl_list_remove(&layer->output_destroy.link);
 
 	layer->layer_surface->data = NULL;


### PR DESCRIPTION
Found via https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4918