### PR TITLE
Increase default max buffer size to 1 MiB to prevent client crashes

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -222,6 +222,7 @@ bool server_init(struct sway_server *server) {
 	server->wl_event_loop = wl_display_get_event_loop(server->wl_display);
 
 	wl_display_set_global_filter(server->wl_display, filter_global, NULL);
+	wl_display_set_default_max_buffer_size(server->wl_display, 1024 * 1024);
 
 	root = root_create(server->wl_display);
 


### PR DESCRIPTION
This change increases the default max buffer size to 1 MiB, preventing clients from crashing when they require more than the default 4096 bytes of buffer.

#### Background
When an application’s GUI thread is blocked, the Wayland protocol may require larger buffers to handle input events. If the buffer size is insufficient, it can result in client crashes.

For example, Firefox has recently started crashing occasionally with the following crash report:

    MozCrashReason: () Error reading events from display: Connection reset by peer


When this happens, the following appears in the Sway logs:

    00:13:36.485 [INFO] [wlr] [wayland] Data too big for buffer (4092 + 20 > 4096).
    00:13:37.336 [INFO] [wlr] [wayland] error in client communication (pid 3029)

This issue has been observed in Firefox ([Bug 1890074](https://bugzilla.mozilla.org/show_bug.cgi?id=1890074)) and is similar to issues reported in KDE ([Bug 392376](https://bugs.kde.org/show_bug.cgi?id=392376)).

After increasing the buffer size to 1 MiB, like other compositors have done, no further crashes have been observed.

#### Relevant context
- Wayland introduced `wl_display_set_default_max_buffer_size` to address this problem ([Wayland MR 188](https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/188)).
- KDE addressed a similar issue in KWin ([KWin MR 5984](https://invent.kde.org/plasma/kwin/-/merge_requests/5984)).


#### Other relevant issues
- [Wayland: Blocked clients that received too many events get destroyed even though the Wayland connection is not broken](https://gitlab.freedesktop.org/wayland/wayland/-/issues/159)
- [Wayland: Does our code suck or is there something we're not seeing? (Lutris, high DPI mouse)](https://gitlab.freedesktop.org/wayland/wayland/-/issues/443)
- [KDE: Wayland native apps close often when the computer is slower due to high i/o ](https://bugs.kde.org/show_bug.cgi?id=484495)
- [Qt: Application terminates when mouse is moved over busy (blocked) GUI](https://bugreports.qt.io/browse/QTBUG-66997)

This fix ensures Sway can handle cases where the default buffer size is insufficient, improving stability for affected applications like Firefox. Increasing the buffer size to 1 MiB has proven effective in preventing crashes, aligning Sway with similar fixes in other Wayland compositors.