### PR TITLE
Drop wlr_matrix.h include from sway/desktop/output.c

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -10,7 +10,6 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_alpha_modifier_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
-#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_output_power_management_v1.h>


### PR DESCRIPTION
wlr_matrix is now private API.

Fixes #8549