### PR TITLE
input/cursor: remove tool_proximity listener in destroy

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1047,6 +1047,7 @@ void sway_cursor_destroy(struct sway_cursor *cursor) {
 	wl_list_remove(&cursor->touch_frame.link);
 	wl_list_remove(&cursor->tool_axis.link);
 	wl_list_remove(&cursor->tool_tip.link);
+	wl_list_remove(&cursor->tool_proximity.link);
 	wl_list_remove(&cursor->tool_button.link);
 	wl_list_remove(&cursor->request_set_cursor.link);
 


### PR DESCRIPTION
Fixes crash when a transient seat client destroys its seat since https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/8f56f7ca43257cc05c7c4eb57a0f541e05cf9a79