### PR TITLE
Add support for BT2020 primaries

### DIFF
--- a/sway/commands/output/color_profile.c
+++ b/sway/commands/output/color_profile.c
@@ -90,7 +90,7 @@ struct cmd_results *output_cmd_color_profile(int argc, char **argv) {
 		free(icc_path);
 
 		struct wlr_color_transform *tmp =
-			wlr_color_transform_init_linear_to_icc(data, size);
+			wlr_color_transform_init_linear_to_icc(WLR_COLOR_NAMED_PRIMARIES_SRGB, data, size);
 		if (!tmp) {
 			free(data);
 			return cmd_results_new(CMD_FAILURE,

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -563,6 +563,7 @@ static bool finalize_output_config(struct output_config *oc, struct sway_output 
 	if (output->color_transform == NULL && oc && oc->render_bit_depth == RENDER_BIT_DEPTH_10 &&
 			(wlr_output->supported_primaries & WLR_COLOR_NAMED_PRIMARIES_BT2020) &&
 			server.renderer->features.output_color_transform) {
+		sway_log(SWAY_INFO, "ENABLING HDR ON %s", wlr_output->name);
 		output->color_transform = wlr_color_transform_init_srgb(WLR_COLOR_NAMED_PRIMARIES_BT2020);
 	}
 


### PR DESCRIPTION
References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4976

This is very basic and just enables BT2020 when 10-bit render depth is enabled and the output supports BT2020.