### PR TITLE
man: Document bar mode toggle command

### DIFF
--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -143,6 +143,12 @@ runtime.
 
 	This setting also applies to the current binding mode indicator.
 
+The following commands may only be used at runtime.
+
+*mode* toggle [<bar_id>]
+	Toggles the current mode between _hide_ and _dock_. Any other mode
+	is treated as _hide_.
+
 ## TRAY
 
 Swaybar provides a system tray where third-party applications may place icons.


### PR DESCRIPTION
Functionality for switching swaybar's current mode between hidden and docked currently exists, but is absent from the relevant manpage. The described behavior is referenced from [mode.c](https://github.com/swaywm/sway/blob/d093c2e3583e785cb308bec74c08a61e8808faf6/sway/commands/bar/mode.c#L10-L15).

Closes #7646