### PR TITLE
sway/ipc-json: add foreign_toplevel_identifier to IPC_GET_TREE output

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -6,6 +6,7 @@
 #include <wlr/config.h>
 #include <wlr/types/wlr_content_type_v1.h>
 #include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>
 #include <xkbcommon/xkbcommon.h>
 #include "config.h"
 #include "log.h"
@@ -576,6 +577,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	const char *app_id = view_get_app_id(c->view);
 	json_object_object_add(object, "app_id",
 			app_id ? json_object_new_string(app_id) : NULL);
+
+	json_object_object_add(object, "foreign_toplevel_identifier",
+		c->view->ext_foreign_toplevel ?
+			json_object_new_string(c->view->ext_foreign_toplevel->identifier) : NULL);
 
 	bool visible = view_is_visible(c->view);
 	json_object_object_add(object, "visible", json_object_new_boolean(visible));

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -389,6 +389,9 @@ node and will have the following properties:
 |- pid
 :  integer
 :  (Only views) The PID of the application that owns the view
+|- foreign_toplevel_identifier
+:  string
+:  (Only views) The ext-foreign-toplevel-list-v1 toplevel identifier of this node.
 |- visible
 :  boolean
 :  (Only views) Whether the node is visible

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -330,6 +330,7 @@ static void pretty_print_tree(json_object *obj, int indent) {
 		const char *instance = json_object_get_string(json_object_object_get(window_props_obj, "instance"));
 		const char *class = json_object_get_string(json_object_object_get(window_props_obj, "class"));
 		int x11_id = json_object_get_int(json_object_object_get(obj, "window"));
+		const char *foreign_toplevel_id = json_object_get_string(json_object_object_get(obj, "foreign_toplevel_identifier"));
 		const char *sandbox_engine = json_object_get_string(json_object_object_get(obj, "sandbox_engine"));
 		const char *sandbox_app_id = json_object_get_string(json_object_object_get(obj, "sandbox_app_id"));
 		const char *sandbox_instance_id = json_object_get_string(json_object_object_get(obj, "sandbox_instance_id"));
@@ -346,6 +347,9 @@ static void pretty_print_tree(json_object *obj, int indent) {
 		}
 		if (x11_id != 0) {
 			printf(", X11 window: 0x%X", x11_id);
+		}
+		if (foreign_toplevel_id != NULL) {
+			printf(", foreign_toplevel_id: \"%s\"", foreign_toplevel_id);
 		}
 		if (sandbox_engine != NULL) {
 			printf(", sandbox_engine: \"%s\"", sandbox_engine);


### PR DESCRIPTION
Adds the [ext-foreign-toplevel-list-v1](https://wayland.app/protocols/ext-foreign-toplevel-list-v1) toplevel identifier of a node to the output of the GET_TREE ipc command.

This is useful to be able to connect information from Sway IPC with information from standard Wayland protocols, for example for visual selection of windows with tools like `slurp`.

This PR fixes issue #8291.