### PR TITLE
docs: use "window" instead of "view" throughout.

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -138,7 +138,7 @@ has the following properties:
 :  Whether the workspace is currently focused by the default seat (_seat0_)
 |- urgent
 :  boolean
-:  Whether a view on the workspace has the urgent flag set
+:  Whether a window on the workspace has the urgent flag set
 |- rect
 :  object
 :  The bounds of the workspace. It consists of _x_, _y_, _width_, and _height_
@@ -374,7 +374,7 @@ node and will have the following properties:
    that can be used as an aid in submitting reproduction steps for bug reports
 |- fullscreen_mode
 :  integer
-:  (Only containers and views) The fullscreen mode of the node. 0 means none, 1 means
+:  (Only containers and windows) The fullscreen mode of the node. 0 means none, 1 means
    full workspace, and 2 means global fullscreen
 |- floating
 :  string
@@ -384,45 +384,45 @@ node and will have the following properties:
 :  Whether the window is in the scratchpad. Can be either "none" or "fresh"
 |- app_id
 :  string
-:  (Only views) For an xdg-shell view, the name of the application, if set.
+:  (Only windows) For an xdg-shell window, the name of the application, if set.
    Otherwise, _null_
 |- pid
 :  integer
-:  (Only views) The PID of the application that owns the view
+:  (Only windows) The PID of the application that owns the window
 |- foreign_toplevel_identifier
 :  string
-:  (Only views) The ext-foreign-toplevel-list-v1 toplevel identifier of this node.
+:  (Only windows) The ext-foreign-toplevel-list-v1 toplevel identifier of this node.
 |- visible
 :  boolean
-:  (Only views) Whether the node is visible
+:  (Only windows) Whether the node is visible
 |- shell
 :  string
-:  (Only views) The shell of the view, such as _xdg\_shell_ or _xwayland_
+:  (Only windows) The shell of the window, such as _xdg\_shell_ or _xwayland_
 |- inhibit_idle
 :  boolean
-:  (Only views) Whether the view is inhibiting the idle state
+:  (Only windows) Whether the window is inhibiting the idle state
 |- idle_inhibitors
 :  object
-:  (Only views) An object containing the state of the _application_ and _user_ idle inhibitors.
+:  (Only windows) An object containing the state of the _application_ and _user_ idle inhibitors.
     _application_ can be _enabled_ or _none_.
     _user_ can be _focus_, _fullscreen_, _open_, _visible_ or _none_.
 |- sandbox_engine
 :  string
-:  (Only views) The associated sandbox engine (or _null_)
+:  (Only windows) The associated sandbox engine (or _null_)
 |- sandbox_app_id
 :  string
-:  (Only views) The app ID provided by the associated sandbox engine (or _null_)
+:  (Only windows) The app ID provided by the associated sandbox engine (or _null_)
 |- sandbox_instance_id
 :  string
-:  (Only views) The instance ID provided by the associated sandbox engine (or
+:  (Only windows) The instance ID provided by the associated sandbox engine (or
    _null_)
 |- window
 :  integer
-:  (Only xwayland views) The X11 window ID for the xwayland view
+:  (Only xwayland windows) The X11 window ID for the xwayland window
 |- window_properties
 :  object
-:  (Only xwayland views) An object containing the _title_, _class_, _instance_,
-   _window\_role_, _window\_type_, and _transient\_for_ for the view
+:  (Only xwayland windows) An object containing the _title_, _class_, _instance_,
+   _window\_role_, _window\_type_, and _transient\_for_ for the window
 
 
 *Example Reply:*
@@ -927,13 +927,13 @@ containing the _#RRGGBBAA_ representation of the color:
    that are not visible
 |- urgent_workspace_text
 :  The color to use for the text of the workspace buttons for workspaces that
-   contain an urgent view
+   contain an urgent window
 |- urgent_workspace_bg
 :  The color to use for the background of the workspace buttons for workspaces
-   that contain an urgent view
+   that contain an urgent window
 |- urgent_workspace_border
 :  The color to use for the border of the workspace buttons for workspaces that
-   contain an urgent view
+   contain an urgent window
 |- binding_mode_text
 :  The color to use for the text of the binding mode indicator
 |- binding_mode_bg
@@ -1480,7 +1480,7 @@ available:
 :  Sent whenever the binding mode changes
 |- 0x80000003
 :  window
-:  Sent whenever an event involving a view occurs such as being reparented,
+:  Sent whenever an event involving a window occurs such as being reparented,
    focused, or closed
 |- 0x80000004
 :  barconfig_update
@@ -1536,8 +1536,8 @@ The following change types are currently available:
 |- rename
 :  The workspace was renamed
 |- urgent
-:  A view on the workspace has had their urgency hint set or all urgency hints
-   for views on the workspace have been cleared
+:  A window on the workspace has had their urgency hint set or all urgency hints
+   for windows on the workspace have been cleared
 |- reload
 :  The configuration file has been reloaded
 
@@ -1635,7 +1635,7 @@ with the following properties:
 
 ## 0x80000003. WINDOW
 
-Sent whenever a change involving a view occurs. The event consists of a single
+Sent whenever a change involving a window occurs. The event consists of a single
 object with the following properties:
 
 [- *PROPERTY*
@@ -1646,30 +1646,30 @@ object with the following properties:
 :[ The type of change that occurred. See below for more information
 |- container
 :  object
-:  An object representing the view effected
+:  An object representing the window effected
 
 
 The following change types are currently available:
 [- *TYPE*
 :- *DESCRIPTION*
 |- new
-:[ The view was created
+:[ The window was created
 |- close
-:  The view was closed
+:  The window was closed
 |- focus
-:  The view was focused
+:  The window was focused
 |- title
-:  The view's title has changed
+:  The window's title has changed
 |- fullscreen_mode
-:  The view's fullscreen mode has changed
+:  The window's fullscreen mode has changed
 |- move
-:  The view has been reparented in the tree
+:  The window has been reparented in the tree
 |- floating
-:  The view has become floating or is no longer floating
+:  The window has become floating or is no longer floating
 |- urgent
-:  The view's urgency hint has changed status
+:  The window's urgency hint has changed status
 |- mark
-:  A mark has been added or removed from the view
+:  A mark has been added or removed from the window
 
 
 *Example Event:*

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -117,7 +117,7 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 	Exit sway and end your Wayland session.
 
 *floating* enable|disable|toggle
-	Make focused view floating, non-floating, or the opposite of what it is now.
+	Make focused window floating, non-floating, or the opposite of what it is now.
 
 <criteria> *focus*
 	Moves focus to the container that matches the specified criteria.
@@ -152,9 +152,9 @@ They are expected to be used with *bindsym* or at runtime through *swaymsg*(1).
 	Moves focus between the floating and tiled layers.
 
 *fullscreen* [enable|disable|toggle] [global]
-	Makes focused view fullscreen, non-fullscreen, or the opposite of what it
+	Makes focused window fullscreen, non-fullscreen, or the opposite of what it
 	is now. If no argument is given, it does the same as _toggle_. If _global_
-	is specified, the view will be fullscreen across all outputs.
+	is specified, the window will be fullscreen across all outputs.
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left all|current
 set|plus|minus|toggle <amount>
@@ -164,16 +164,16 @@ set|plus|minus|toggle <amount>
 	_vertical_.
 
 *inhibit_idle* focus|fullscreen|open|none|visible
-	Set/unset an idle inhibitor for the view. _focus_ will inhibit idle when
-	the view is focused by any seat. _fullscreen_ will inhibit idle when the
+	Set/unset an idle inhibitor for the window. _focus_ will inhibit idle when
+	the window is focused by any seat. _fullscreen_ will inhibit idle when the
 	view is fullscreen (or a descendant of a fullscreen container) and is
-	visible. _open_ will inhibit idle until the view is closed (or the
-	inhibitor is unset/changed). _visible_ will inhibit idle when the view is
+	visible. _open_ will inhibit idle until the window is closed (or the
+	inhibitor is unset/changed). _visible_ will inhibit idle when the window is
 	visible on any output. _none_ will remove any existing idle inhibitor for
-	the view.
+	the window.
 
 	This can also be used with criteria to set an idle inhibitor for any
-	existing view or with _for_window_ to set idle inhibitors for future views.
+	existing window or with _for_window_ to set idle inhibitors for future windows.
 
 *layout* default|splith|splitv|stacking|tabbed
 	Sets the layout mode of the focused container.
@@ -331,12 +331,12 @@ set|plus|minus|toggle <amount>
 
 *shortcuts_inhibitor* enable|disable
 	Enables or disables the ability of clients to inhibit keyboard
-	shortcuts for a view. This is primarily useful for virtualization and
-	remote desktop software. It affects either the currently focused view
-	or a set of views selected by criteria. Subcommand _disable_
-	additionally deactivates any active inhibitors for the given view(s).
+	shortcuts for a window. This is primarily useful for virtualization and
+	remote desktop software. It affects either the currently focused window
+	or a set of windows selected by criteria. Subcommand _disable_
+	additionally deactivates any active inhibitors for the given window(s).
 	Criteria are particularly useful with the *for_window* command to
-	configure a class of views differently from the per-seat defaults
+	configure a class of windows differently from the per-seat defaults
 	established by the *seat* subcommand of the same name. See
 	*sway-input*(5) for more ways to affect inhibitors.
 
@@ -364,7 +364,7 @@ set|plus|minus|toggle <amount>
 	Swaps the position, geometry, and fullscreen status of two containers. The
 	first container can be selected either by criteria or focus. The second
 	container can be selected by _id_, _con_id_, or _mark_. _id_ can only be
-	used with xwayland views. If the first container has focus, it will retain
+	used with xwayland windows. If the first container has focus, it will retain
 	focus unless it is moved to a different workspace or the second container
 	becomes fullscreen on the same workspace as the first container. In either
 	of those cases, the second container will gain focus.
@@ -409,14 +409,14 @@ The following commands may be used either in the configuration file or at
 runtime.
 
 *assign* <criteria> [→] [workspace] [number] <workspace>
-	Assigns views matching _criteria_ (see *CRITERIA* for details) to
+	Assigns windows matching _criteria_ (see *CRITERIA* for details) to
 	_workspace_. The → (U+2192) is optional and cosmetic. This command is
 	equivalent to:
 
 		for_window <criteria> move container to workspace <workspace>
 
 *assign* <criteria> [→] output left|right|up|down|<name>
-	Assigns views matching _criteria_ (see *CRITERIA* for details) to the
+	Assigns windows matching _criteria_ (see *CRITERIA* for details) to the
 	specified output. The → (U+2192) is optional and cosmetic. This command is
 	equivalent to:
 
@@ -599,10 +599,10 @@ runtime.
 		The window that has focus.
 
 	*client.focused_inactive*
-		The most recently focused view within a container which is not focused.
+		The most recently focused window within a container which is not focused.
 
 	*client.focused_tab_title*
-		A view that has focused descendant container.
+		A window that has focused descendant container.
 		Tab or stack container title that is the parent of the focused container
 		but is not directly focused. Defaults to focused_inactive if not
 		specified and does not use the indicator and child_border colors.
@@ -611,10 +611,10 @@ runtime.
 		Ignored (present for i3 compatibility).
 
 	*client.unfocused*
-		A view that does not have focus.
+		A window that does not have focus.
 
 	*client.urgent*
-		A view with an urgency hint. *Note*: Native Wayland windows do not
+		A window with an urgency hint. *Note*: Native Wayland windows do not
 		support urgency. Urgency only works for Xwayland windows.
 
 	The meaning of each color is:
@@ -629,12 +629,12 @@ runtime.
 		The text color of the title bar.
 
 	_indicator_
-		The color used to indicate where a new view will open. In a tiled
-		container, this would paint the right border of the current view if a
-		new view would be opened to the right.
+		The color used to indicate where a new window will open. In a tiled
+		container, this would paint the right border of the current window if a
+		new window would be opened to the right.
 
 	_child_border_
-		The border around the view itself.
+		The border around the window itself.
 
 The default colors are:
 
@@ -772,7 +772,7 @@ The default colors are:
 
 *gaps* inner|outer|horizontal|vertical|top|right|bottom|left <amount>
 	Sets default _amount_ pixels of _inner_ or _outer_ gap, where the inner
-	affects spacing around each view and outer affects the spacing around each
+	affects spacing around each window and outer affects the spacing around each
 	workspace. Outer gaps are in addition to inner gaps. To reduce or remove
 	outer gaps, outer gaps can be set to a negative value. _outer_ gaps can
 	also be specified per side with _top_, _right_, _bottom_, and _left_ or
@@ -844,9 +844,9 @@ The default colors are:
 	A list of output names may be obtained via *swaymsg -t get_outputs*.
 
 *popup_during_fullscreen* smart|ignore|leave_fullscreen
-	Determines what to do when a fullscreen view opens a dialog.
+	Determines what to do when a fullscreen window opens a dialog.
 	If _smart_ (the default), the dialog will be displayed. If _ignore_, the
-	dialog will not be rendered. If _leave_fullscreen_, the view will exit
+	dialog will not be rendered. If _leave_fullscreen_, the window will exit
 	fullscreen mode and the dialog will be rendered.
 
 *primary_selection* enabled|disabled
@@ -976,14 +976,14 @@ A criteria is a string in the form of, for example:
 ```
 
 The string contains one or more (space separated) attribute/value pairs. They
-are used by some commands to choose which views to execute actions on. All
+are used by some commands to choose which windows to execute actions on. All
 attributes must match for the criteria to match. Criteria is retained across
 commands separated by a *,*, but will be reset (and allow for new criteria, if
 desired) for commands separated by a *;*.
 
 Criteria may be used with either the *for_window* or *assign* commands to
-specify operations to perform on new views. A criteria may also be used to
-perform specific commands (ones that normally act upon one window) on all views
+specify operations to perform on new windows. A criteria may also be used to
+perform specific commands (ones that normally act upon one window) on all windows
 that match that criteria. For example:
 
 Focus on a window with the mark "IRC":
@@ -1071,8 +1071,8 @@ The following attributes may be matched with:
 	applications and requires XWayland.
 
 *workspace*
-	Compare against the workspace name for this view. Can be a regular
-	expression. If the value is \_\_focused\_\_, then all the views on the
+	Compare against the workspace name for this window. Can be a regular
+	expression. If the value is \_\_focused\_\_, then all the windows on the
 	currently focused workspace matches.
 
 *sandbox_engine*


### PR DESCRIPTION
"view" is an internal term, while the commonly understood
user-facing term is "window"

Ref: #7323
