### PR TITLE
Fix crashes on exit caused by wlroots listener checks

### DIFF
--- a/include/sway/desktop/idle_inhibit_v1.h
+++ b/include/sway/desktop/idle_inhibit_v1.h
@@ -13,6 +13,7 @@ enum sway_idle_inhibit_mode {
 struct sway_idle_inhibit_manager_v1 {
 	struct wlr_idle_inhibit_manager_v1 *wlr_manager;
 	struct wl_listener new_idle_inhibitor_v1;
+	struct wl_listener manager_destroy;
 	struct wl_list inhibitors;
 };
 

--- a/include/sway/input/input-manager.h
+++ b/include/sway/input/input-manager.h
@@ -39,6 +39,8 @@ struct sway_input_manager {
 
 struct sway_input_manager *input_manager_create(struct sway_server *server);
 
+void input_manager_finish(struct sway_input_manager *input);
+
 bool input_manager_has_focus(struct sway_node *node);
 
 void input_manager_set_focus(struct sway_node *node);

--- a/include/sway/input/text_input.h
+++ b/include/sway/input/text_input.h
@@ -25,8 +25,10 @@ struct sway_input_method_relay {
 	struct wlr_input_method_v2 *input_method; // doesn't have to be present
 
 	struct wl_listener text_input_new;
+	struct wl_listener text_input_manager_destroy;
 
 	struct wl_listener input_method_new;
+	struct wl_listener input_method_manager_destroy;
 	struct wl_listener input_method_commit;
 	struct wl_listener input_method_new_popup_surface;
 	struct wl_listener input_method_grab_keyboard;

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -46,6 +46,7 @@ struct sway_server {
 
 	struct wl_listener new_output;
 	struct wl_listener renderer_lost;
+	struct wl_event_source *recreating_renderer;
 
 	struct wlr_idle_notifier_v1 *idle_notifier_v1;
 	struct sway_idle_inhibit_manager_v1 idle_inhibit_manager_v1;

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -95,6 +95,7 @@ struct sway_container {
 
 	struct wl_listener output_enter;
 	struct wl_listener output_leave;
+	struct wl_listener output_handler_destroy;
 
 	struct sway_container_state current;
 	struct sway_container_state pending;

--- a/sway/desktop/idle_inhibit_v1.c
+++ b/sway/desktop/idle_inhibit_v1.c
@@ -45,6 +45,14 @@ void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data) {
 	sway_idle_inhibit_v1_check_active();
 }
 
+void handle_manager_destroy(struct wl_listener *listener, void *data) {
+	struct sway_idle_inhibit_manager_v1 *manager =
+		wl_container_of(listener, manager, manager_destroy);
+
+	wl_list_remove(&manager->manager_destroy.link);
+	wl_list_remove(&manager->new_idle_inhibitor_v1.link);
+}
+
 void sway_idle_inhibit_v1_user_inhibitor_register(struct sway_view *view,
 		enum sway_idle_inhibit_mode mode) {
 	struct sway_idle_inhibit_manager_v1 *manager = &server.idle_inhibit_manager_v1;
@@ -177,6 +185,9 @@ bool sway_idle_inhibit_manager_v1_init(void) {
 	wl_signal_add(&manager->wlr_manager->events.new_inhibitor,
 		&manager->new_idle_inhibitor_v1);
 	manager->new_idle_inhibitor_v1.notify = handle_idle_inhibitor_v1;
+	wl_signal_add(&manager->wlr_manager->events.destroy,
+		&manager->manager_destroy);
+	manager->manager_destroy.notify = handle_manager_destroy;
 	wl_list_init(&manager->inhibitors);
 
 	return true;

--- a/sway/input/input-manager.c
+++ b/sway/input/input-manager.c
@@ -493,6 +493,14 @@ struct sway_input_manager *input_manager_create(struct sway_server *server) {
 	return input;
 }
 
+void input_manager_finish(struct sway_input_manager *input) {
+	wl_list_remove(&input->new_input.link);
+	wl_list_remove(&input->virtual_keyboard_new.link);
+	wl_list_remove(&input->virtual_pointer_new.link);
+	wl_list_remove(&input->keyboard_shortcuts_inhibit_new_inhibitor.link);
+	wl_list_remove(&input->transient_seat_create.link);
+}
+
 bool input_manager_has_focus(struct sway_node *node) {
 	struct sway_seat *seat = NULL;
 	wl_list_for_each(seat, &server.input->seats, link) {

--- a/sway/server.c
+++ b/sway/server.c
@@ -460,8 +460,29 @@ bool server_init(struct sway_server *server) {
 }
 
 void server_fini(struct sway_server *server) {
+	// remove listeners
+	wl_list_remove(&server->renderer_lost.link);
+	wl_list_remove(&server->new_output.link);
+	wl_list_remove(&server->layer_shell_surface.link);
+	wl_list_remove(&server->xdg_shell_toplevel.link);
+	wl_list_remove(&server->server_decoration.link);
+	wl_list_remove(&server->xdg_decoration.link);
+	wl_list_remove(&server->pointer_constraint.link);
+	wl_list_remove(&server->output_manager_apply.link);
+	wl_list_remove(&server->output_manager_test.link);
+	wl_list_remove(&server->output_power_manager_set_mode.link);
+#if WLR_HAS_DRM_BACKEND
+	wl_list_remove(&server->drm_lease_request.link);
+#endif
+	wl_list_remove(&server->tearing_control_new_object.link);
+	wl_list_remove(&server->xdg_activation_v1_request_activate.link);
+	wl_list_remove(&server->xdg_activation_v1_new_token.link);
+	wl_list_remove(&server->request_set_cursor_shape.link);
+
 	// TODO: free sway-specific resources
 #if WLR_HAS_XWAYLAND
+	wl_list_remove(&server->xwayland_surface.link);
+	wl_list_remove(&server->xwayland_ready.link);
 	wlr_xwayland_destroy(server->xwayland.wlr_xwayland);
 #endif
 	wl_display_destroy_clients(server->wl_display);

--- a/sway/server.c
+++ b/sway/server.c
@@ -478,6 +478,7 @@ void server_fini(struct sway_server *server) {
 	wl_list_remove(&server->xdg_activation_v1_request_activate.link);
 	wl_list_remove(&server->xdg_activation_v1_new_token.link);
 	wl_list_remove(&server->request_set_cursor_shape.link);
+	input_manager_finish(server->input);
 
 	// TODO: free sway-specific resources
 #if WLR_HAS_XWAYLAND


### PR DESCRIPTION
This PR fixes sway crashing on exit due to event listeners not being removed from wlroots objects on exit.

Listeners fixed:

- server: all objects created during `server_init()`, reworked `handle_renderer_lost()` to use an idle callback 
- input/input-manager: `wlr_backend.new_input`, `wlr_virtual_keyboard`, `wlr_virtual_pointer`, `wlr_keyboard_shortcuts_inhibit`, `wlr_transient_seat_manager`
- desktop/idle-inhibit: `wlr_idle_inhibit_manager`
- input/text-input: `wlr_text_input_manager` and `wlr_input_method_manager`
- tree/container:  `wlr_scene_buffer.output_enter` and `wlr_scene_buffer.output_leave`

If I haven't missed any, this fixes removing listeners at exit for all wlroots objects with listeners that sway uses. Other wlroots objects not touched in this PR already have some form of listener remove logic. I haven't individually tested those, but they do not lead to crashes on my system.