### PR TITLE
Fix opacity command not updating contents sometimes

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -91,6 +91,9 @@ struct sway_output *output_from_wlr_output(struct wlr_output *output);
 struct sway_output *output_get_in_direction(struct sway_output *reference,
 		enum wlr_direction direction);
 
+void output_configure_scene(struct sway_output *output,
+	struct wlr_scene_node *node, float opacity);
+
 void output_add_workspace(struct sway_output *output,
 		struct sway_workspace *workspace);
 

--- a/sway/commands/opacity.c
+++ b/sway/commands/opacity.c
@@ -2,7 +2,8 @@
 #include <stdlib.h>
 #include <strings.h>
 #include "sway/commands.h"
-#include "sway/tree/view.h"
+#include "sway/tree/container.h"
+#include "sway/output.h"
 #include "log.h"
 
 struct cmd_results *cmd_opacity(int argc, char **argv) {
@@ -37,6 +38,7 @@ struct cmd_results *cmd_opacity(int argc, char **argv) {
 	}
 
 	con->alpha = val;
+	output_configure_scene(NULL, &con->scene_tree->node, 1);
 	container_update(con);
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -229,7 +229,9 @@ void output_configure_scene(struct sway_output *output,
 		// hack: don't call the scene setter because that will damage all outputs
 		// We don't want to damage outputs that aren't our current output that
 		// we're configuring
-		buffer->filter_mode = get_scale_filter(output, buffer);
+		if (output) {
+			buffer->filter_mode = get_scale_filter(output, buffer);
+		}
 
 		wlr_scene_buffer_set_opacity(buffer, opacity);
 	} else if (node->type == WLR_SCENE_NODE_TREE) {

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -202,7 +202,7 @@ static enum wlr_scale_filter_mode get_scale_filter(struct sway_output *output,
 	}
 }
 
-static void output_configure_scene(struct sway_output *output,
+void output_configure_scene(struct sway_output *output,
 		struct wlr_scene_node *node, float opacity) {
 	if (!node->enabled) {
 		return;


### PR DESCRIPTION
```
Calling container_update() wasn't enough: If there is no visible window
decorations (title bar, borders) container_update would basically no-op
and the scene wouldn't repaint with the update alpha. By also calling
output_configure_scene() we force a call to
wlr_scene_buffer_set_opacity() thus ensuring we update the scene.
```

Closes: #8580