### PR TITLE
input/mouse: add accel_profile custom

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -263,6 +263,7 @@ sway_cmd input_cmd_map_to_region;
 sway_cmd input_cmd_middle_emulation;
 sway_cmd input_cmd_natural_scroll;
 sway_cmd input_cmd_pointer_accel;
+sway_cmd input_cmd_pointer_accel_custom;
 sway_cmd input_cmd_rotation_angle;
 sway_cmd input_cmd_scroll_factor;
 sway_cmd input_cmd_repeat_delay;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -139,6 +139,12 @@ struct input_config_tool {
 	enum sway_tablet_tool_mode mode;
 };
 
+struct accel_custom {
+	double step;
+	size_t npoints;
+	double points[64]; /* LIBINPUT_ACCEL_NPOINTS_MAX */
+};
+
 /**
  * options for input devices
  */
@@ -158,6 +164,7 @@ struct input_config {
 	int middle_emulation;
 	int natural_scroll;
 	float pointer_accel;
+	struct accel_custom pointer_accel_custom;
 	float rotation_angle;
 	float scroll_factor;
 	int repeat_delay;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -24,6 +24,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "middle_emulation", input_cmd_middle_emulation },
 	{ "natural_scroll", input_cmd_natural_scroll },
 	{ "pointer_accel", input_cmd_pointer_accel },
+	{ "pointer_accel_custom", input_cmd_pointer_accel_custom },
 	{ "repeat_delay", input_cmd_repeat_delay },
 	{ "repeat_rate", input_cmd_repeat_rate },
 	{ "rotation_angle", input_cmd_rotation_angle },

--- a/sway/commands/input/accel_profile.c
+++ b/sway/commands/input/accel_profile.c
@@ -18,9 +18,17 @@ struct cmd_results *input_cmd_accel_profile(int argc, char **argv) {
 		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE;
 	} else if (strcasecmp(argv[0], "flat") == 0) {
 		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT;
+	} else if (strcasecmp(argv[0], "custom") == 0) {
+#if HAVE_LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM
+		ic->accel_profile = LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM;
+#else
+		return cmd_results_new(CMD_INVALID,
+				"Config 'accel_profile custom' not supported (requires libinput >= 1.23.0).");
+#endif
 	} else {
 		return cmd_results_new(CMD_INVALID,
-				"Expected 'accel_profile <adaptive|flat>'");
+				"Expected 'accel_profile <adaptive|flat|custom>'"
+		);
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);

--- a/sway/commands/input/pointer_accel.c
+++ b/sway/commands/input/pointer_accel.c
@@ -27,3 +27,36 @@ struct cmd_results *input_cmd_pointer_accel(int argc, char **argv) {
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }
+
+#if HAVE_LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
+#define ACCEL_CUSTOM_MAX (1 + ARRAY_SIZE(((struct input_config *)0)->pointer_accel_custom.points))
+struct cmd_results *input_cmd_pointer_accel_custom(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "pointer_accel_custom", EXPECTED_AT_LEAST, 3))) {
+		return error;
+	}
+	if ((error = checkarg(argc, "pointer_accel_custom", EXPECTED_AT_MOST, ACCEL_CUSTOM_MAX))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	for(int i=0; i<argc; ++i) {
+		double dbl = parse_float(argv[i]);
+		if (isnan(dbl) || dbl < 0.0) {
+			return cmd_results_new(CMD_INVALID,
+				"Invalid pointer_accel_custom value; expected non-negative double.");
+		}
+		if (i == 0) {
+			ic->pointer_accel_custom.step = dbl;
+		} else {
+			ic->pointer_accel_custom.points[i-1] = dbl;
+		}
+	}
+	ic->pointer_accel_custom.npoints = argc - 1;
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+#endif

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -170,6 +170,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 		memcpy(dst->calibration_matrix.matrix, src->calibration_matrix.matrix,
 			sizeof(src->calibration_matrix.matrix));
 	}
+	if (src->pointer_accel_custom.npoints) {
+		memcpy(&dst->pointer_accel_custom, &src->pointer_accel_custom, sizeof(src->pointer_accel_custom));
+	}
 	for (int i = 0; i < src->tools->length; i++) {
 		struct input_config_tool *src_tool = src->tools->items[i];
 		for (int j = 0; j < dst->tools->length; j++) {

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -134,7 +134,7 @@ The following commands may only be used in the configuration file.
 
 ## LIBINPUT CONFIGURATION
 
-*input* <identifier> accel_profile adaptive|flat
+*input* <identifier> accel_profile adaptive|flat|custom
 	Sets the pointer acceleration profile for the specified input device.
 
 *input* <identifier> calibration_matrix <6 space-separated floating point values>
@@ -186,6 +186,14 @@ The following commands may only be used in the configuration file.
 
 *input* <identifier> pointer_accel [<-1|1>]
 	Changes the pointer acceleration for the specified input device.
+
+*input* <identifier> pointer_accel_custom <step> <point0 point1 ... pointN>
+	Specifies custom mouse pointer acceleration curve that is used when
+	accel_profile is set to _custom_. Values are floating point numbers. The
+	behaviour of the custom acceleration profile is defined by libinput and
+	described in libinput *doc/user/pointer-acceleration.rst*. For example,
+	'pointer_accel_custom 1.0 0.0 1.0' means step=1.0 and points=[0.0 1.0], which
+	is equivalent to the 'flat' profile. Requires libinput >= 1.23.0.
 
 *input* <identifier> rotation_angle <angle>
 	Sets the rotation angle of the device to the given clockwise angle in

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1201,7 +1201,8 @@ following properties will be included for devices that support them:
 :  The pointer-acceleration in use
 |- accel_profile
 :  string
-:  The acceleration profile in use. It can be _none_, _flat_, or _adaptive_
+:  The acceleration profile in use. It can be _none_, _flat_, _adaptive_, or
+   _custom_
 |- natural_scroll
 :  string
 :  Whether natural scrolling is enabled. It can be _enabled_ or _disabled_


### PR DESCRIPTION
Support libinput LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM to define a custom mouse pointer acceleration curve. Implements #8488.

Custom acceleration curve is documented in libinput https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#the-custom-acceleration-profile.

Some thoughts:

Custom acceleration is also supported for scrolling, but this commit only implements pointer motion (LIBINPUT_ACCEL_TYPE_MOTION).

We can't detect if values changed because libinput does not provide a way to read back values set by libinput_config_accel_set_points/libinput_device_config_accel_apply. Sway seems to want to know if it changed to trigger a notification (ipc_event_input).

I stuffed the "step" and "points" values into one config option. Maybe it's better to have two like libinput.conf AccelStepMotion/AccelPointsMotion.