### PR TITLE
Remove constraint that con->view != NULL to use __focused__ criteria

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -630,8 +630,7 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		if (strcmp(value, "__focused__") == 0) {
 			struct sway_seat *seat = input_manager_current_seat();
 			struct sway_container *focus = seat_get_focused_container(seat);
-			struct sway_view *view = focus ? focus->view : NULL;
-			criteria->con_id = view ? view->container->node.id : 0;
+			criteria->con_id = focus ? focus->node.id : 0;
 		} else {
 			criteria->con_id = strtoul(value, &endptr, 10);
 			if (*endptr != 0) {


### PR DESCRIPTION
To use something like:

`[con_id=__focused__] mark --add --toggle foo`

The container must currently have a view. However, it is possible to focus parent containers that do not have a view. For example, via:

`focus parent`

Since containers without views can be the focused (meaning the container is marked `"focused": true` in the output of: `swaymsg -t get_tree`), it seems reasonable that a view is not required to target a container via `__focused__`.

My motivation for making this change is that I have the following in my sway config:

```
bindsym $mod+i \
	exec \
        'swaymsg -t get_tree                                                            \
           | jq -r ".. | select(.focused?) | .marks[]"                                  \
           | wmenu -f "'$font'" -p "Marks:"                                             \
           | xargs -r -I{} swaymsg "[con_id=__focused__] mark --add --toggle {}"'
```

And if I have a layout like V[Alacritty Alacritty], I was unable to focus the parent and apply a mark to it with the above. With this change, I can.

An obvious workaround that requires no changes to sway would be to pull out the container id when querying with jq and then target the specific container via it's id. I can do that, but I thought this seemed like a reasonable change and it gave me an excuse to dig into sway's code a bit more.