### PR TITLE
Use SIG_IGN for SIGCHLD instead of our own handler

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -163,6 +163,7 @@ bool server_start(struct sway_server *server);
 void server_run(struct sway_server *server);
 
 void restore_nofile_limit(void);
+void restore_signals(void);
 
 void handle_new_output(struct wl_listener *listener, void *data);
 

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -52,11 +52,8 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	pid_t child = fork();
 	if (child == 0) {
 		restore_nofile_limit();
+		restore_signals();
 		setsid();
-		sigset_t set;
-		sigemptyset(&set);
-		sigprocmask(SIG_SETMASK, &set, NULL);
-		signal(SIGPIPE, SIG_DFL);
 
 		if (ctx) {
 			const char *token = launcher_ctx_get_token_name(ctx);

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -213,13 +213,8 @@ static void invoke_swaybar(struct bar_config *bar) {
 		sway_log(SWAY_ERROR, "Failed to create fork for swaybar");
 		return;
 	} else if (pid == 0) {
-		// Remove the SIGUSR1 handler that wlroots adds for xwayland
-		sigset_t set;
-		sigemptyset(&set);
-		sigprocmask(SIG_SETMASK, &set, NULL);
-		signal(SIGPIPE, SIG_DFL);
-
 		restore_nofile_limit();
+		restore_signals();
 		if (!sway_set_cloexec(sockets[1], false)) {
 			_exit(EXIT_FAILURE);
 		}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1061,6 +1061,7 @@ static bool _spawn_swaybg(char **command) {
 		return false;
 	} else if (pid == 0) {
 		restore_nofile_limit();
+		restore_signals();
 		if (!sway_set_cloexec(sockets[1], false)) {
 			_exit(EXIT_FAILURE);
 		}


### PR DESCRIPTION
The behavior of handlers registered with signal(3p) is not well-defined  for signals delivered more than once, as laid out in the man page.

We should replace our use of signal with sigaction, but for SIGCHLD specifically we can also just skip the signals altogether by setting the handler to SIG_IGN which causes child reaping to not be required.

Fixes: https://github.com/swaywm/sway/pull/8567

We should still replace our other `signal` calls with `sigaction`, but only SIGCHLD is expected to be seen by sway more than once, and why let us get interrupted by sporadic signals if we can help it? Resetting the handler in 3 places before exec isn't too bad.