### PR TITLE
sway/commands: Use sigaction instead of signal

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -8,9 +8,6 @@
 #include "sway/config.h"
 #include "sway/server.h"
 #include "sway/desktop/launcher.h"
-#include "sway/tree/container.h"
-#include "sway/tree/root.h"
-#include "sway/tree/workspace.h"
 #include "log.h"
 #include "stringop.h"
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -330,9 +330,14 @@ int main(int argc, char **argv) {
 	increase_nofile_limit();
 
 	// handle SIGTERM signals
-	signal(SIGTERM, sig_handler);
-	signal(SIGINT, sig_handler);
-	signal(SIGCHLD, sigchld_handler);
+	struct sigaction sa;
+	sa.sa_handler = sigchld_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+	sigaction(SIGCHLD, &sa, NULL);
+	sa.sa_handler = sig_handler;
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGINT, &sa, NULL);
 
 	// prevent ipc from crashing sway
 	signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
man signal(2) says to use sigaction rather than signal.
```man
WARNING: the behavior of signal() varies across UNIX versions, and has
also varied historically across different versions of Linux.  Avoid its
use: use sigaction(2) instead.  See Portability below.
```
I put a breakpoint on main.c:sigchld_handler and noticed that it would only get hit for the first process to send SIGCHLD. Using `signal`, subsequent processes do not trigger sigchld_handler, causing them to become zombies. With these changes, sigchld_handler is called per each `exec`ed process.

Fixes #8602