### PR TITLE
Fix output repositioning in global fullscreen

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -652,6 +652,8 @@ static void arrange_root(struct sway_root *root) {
 			struct sway_output *output = root->outputs->items[i];
 			struct sway_workspace *ws = output->current.active_workspace;
 
+			wlr_scene_output_set_position(output->scene_output, output->lx, output->ly);
+
 			if (ws) {
 				arrange_workspace_floating(ws);
 			}


### PR DESCRIPTION
As of Sway 1.10, output positions no longer seem to be correctly applied when repositioning outputs in global fullscreen. For example, if I run a program in global fullscreen in a dual-monitor setup and then want to mirror the monitors by setting both monitor positions to 0 0 (using "swaymsg output ... pos 0 0"on both monitors, not using the sway config file!), I get a blank picture on one of the monitors. In Sway 1.9, the screens are mirrored as expected.

I had a look at the code and found the line

wlr_scene_output_set_position(output->scene_output, output->lx, output->ly);

in arrange_root in sway/desktop/transaction.c. At the moment, it looks like wlr_scene_output_set_position is only called when global fullscreen is not enabled. I modified the code so that wlr_scene_output_set_position is also called when in global fullscreen. That seemed to do the trick. Repositioning outputs in global fullscreen now behave as expected (as was previously the case in Sway 1.9).

I know almost nothing about wlroots or Wayland, so I have no idea if this is a good solution or if there was a reason for not calling wlr_scene_output_set_position when in global fullscreen mode.