### PR TITLE
command for defining default floating height / width

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -129,6 +129,8 @@ sway_cmd cmd_exec;
 sway_cmd cmd_exec_always;
 sway_cmd cmd_exit;
 sway_cmd cmd_floating;
+sway_cmd cmd_floating_default_height;
+sway_cmd cmd_floating_default_width;
 sway_cmd cmd_floating_maximum_size;
 sway_cmd cmd_floating_minimum_size;
 sway_cmd cmd_floating_modifier;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -582,6 +582,9 @@ struct sway_config {
 	int32_t floating_minimum_width;
 	int32_t floating_minimum_height;
 
+	float floating_default_height;
+	float floating_default_width;
+
 	// The keysym to keycode translation
 	struct xkb_state *keysym_translation_state;
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -59,6 +59,8 @@ static const struct cmd_handler handlers[] = {
 	{ "default_floating_border", cmd_default_floating_border },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },
+	{ "floating_default_height", cmd_floating_default_height },
+	{ "floating_default_width", cmd_floating_default_width },
 	{ "floating_maximum_size", cmd_floating_maximum_size },
 	{ "floating_minimum_size", cmd_floating_minimum_size },
 	{ "floating_modifier", cmd_floating_modifier },

--- a/sway/commands/floating_default_size.c
+++ b/sway/commands/floating_default_size.c
@@ -1,0 +1,43 @@
+#include "sway/commands.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+struct cmd_results *cmd_floating_default_width(int argc, char **argv) {
+    struct cmd_results *error;
+    if ((error =
+             checkarg(argc, "floating_default_width", EXPECTED_EQUAL_TO, 1))) {
+        return error;
+    }
+
+    char *err;
+    float width = strtof(argv[0], &err);
+    if (*err) {
+        return cmd_results_new(CMD_INVALID,
+                               "Expected 'floating_default_width <width>'");
+    }
+
+    config->floating_default_width = width;
+
+    return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+struct cmd_results *cmd_floating_default_height(int argc, char **argv) {
+    struct cmd_results *error;
+    if ((error =
+             checkarg(argc, "floating_default_height", EXPECTED_EQUAL_TO, 1))) {
+        return error;
+    }
+
+    char *err;
+    float height = strtof(argv[0], &err);
+    if (*err) {
+        return cmd_results_new(CMD_INVALID,
+                               "Expected 'floating_default_height <height>'");
+    }
+
+    config->floating_default_height = height;
+
+    return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -268,6 +268,9 @@ static void config_defaults(struct sway_config *config) {
 	config->floating_minimum_width = 75;
 	config->floating_minimum_height = 50;
 
+	config->floating_default_height = 0.75;
+	config->floating_default_width = 0.5;
+
 	// Flags
 	config->focus_follows_mouse = FOLLOWS_YES;
 	config->mouse_warping = WARP_OUTPUT;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -57,6 +57,7 @@ sway_sources = files(
 	'commands/exec_always.c',
 	'commands/floating.c',
 	'commands/floating_minmax_size.c',
+	'commands/floating_default_size.c',
 	'commands/floating_modifier.c',
 	'commands/focus.c',
 	'commands/focus_follows_mouse.c',

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -711,6 +711,14 @@ The default colors are:
 *floating_minimum_size* <width> x <height>
 	Specifies the minimum size of floating windows. The default is 75 x 50.
 
+*floating_default_height* <height>
+	Specifies the default size of floating windows as fraction of maximal
+	available height
+
+*floating_default_width* <width>
+	Specifies the default size of floating windows as fraction of maximal
+	available width
+
 *floating_modifier* <modifier> [normal|inverse]
 	When the _modifier_ key is held down, you may hold left click to move
 	windows, and right click to resize them. Setting _modifier_ to _none_

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -953,8 +953,8 @@ void container_floating_set_default_size(struct sway_container *con) {
 	struct wlr_box box;
 	workspace_get_box(con->pending.workspace, &box);
 
-	double width = fmax(min_width, fmin(box.width * 0.5, max_width));
-	double height = fmax(min_height, fmin(box.height * 0.75, max_height));
+	double width = fmax(min_width, fmin(box.width * config->floating_default_width, max_width));
+	double height = fmax(min_height, fmin(box.height * config->floating_default_height, max_height));
 	if (!con->view) {
 		con->pending.width = width;
 		con->pending.height = height;


### PR DESCRIPTION
This patch adds a command for defining the default floating height or width as fraction of the respective maximum.

This would be nice for setting the default scratchpad size #6294 