### PR TITLE
desktop/output: Skip repaint if wlr_output is disabled

### DIFF
--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -264,7 +264,7 @@ static int output_repaint_timer_handler(void *data) {
 	struct sway_output *output = data;
 
 	output->wlr_output->frame_pending = false;
-	if (!output->enabled) {
+	if (!output->wlr_output->enabled) {
 		return 0;
 	}
 


### PR DESCRIPTION
When the repaint timer fires, we check if the sway_output is disabled, and if so, skip the output commit after having reset frame_pending.

The sway_output enable flag is only updated if the output is disabled and removed from the layout, not if the power is disabled for e.g. idle. This can lead to situations where a commit is attempted on a disabled output, which will lead to an attempted and failed primary swapchain allocation.

Use the wlr_output.enabled state to check if the output is active.