### PR TITLE
stringop: fix has_prefix() arg order in config parsing

### DIFF
--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -367,7 +367,7 @@ static struct cmd_results *cmd_bindsym_or_bindcode(int argc, char **argv,
 			}
 		} else if (strcmp("--exclude-titlebar", argv[0]) == 0) {
 			exclude_titlebar = true;
-		} else if (has_prefix("--input-device=", argv[0])) {
+		} else if (has_prefix(argv[0], "--input-device=")) {
 			free(binding->input);
 			binding->input = strdup(argv[0] + strlen("--input-device="));
 			strip_quotes(binding->input);

--- a/sway/commands/gesture.c
+++ b/sway/commands/gesture.c
@@ -121,7 +121,7 @@ static struct cmd_results *cmd_bind_or_unbind_gesture(int argc, char **argv, boo
 			binding->flags |= BINDING_EXACT;
 		} else if (strcmp("--no-warn", argv[0]) == 0) {
 			warn = false;
-		} else if (has_prefix("--input-device=", argv[0])) {
+		} else if (has_prefix(argv[0], "--input-device=")) {
 			free(binding->input);
 			binding->input = strdup(argv[0] + strlen("--input-device="));
 		} else {

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -46,7 +46,7 @@ void ipc_send_workspace_command(struct swaybar *bar, const char *ws) {
 
 char *parse_font(const char *font) {
 	char *new_font = NULL;
-	if (has_prefix("pango:", font)) {
+	if (has_prefix(font, "pango:")) {
 		font += strlen("pango:");
 	}
 	new_font = strdup(font);


### PR DESCRIPTION
`has_prefix()` signature is `bool has_prefix(const char *str, const char *prefix)`. The prefix is expected to be given 2nd, not first.
This breaks in places where order was swapped around when moving from `strncmp` to `has_prefix` (added in 0c60d1581f7b12ae472c786b7dfe27a1c6ec9a47)

My following config was broken:
```
    bindcode --no-repeat --input-device=$logitech_g604 {
        # + / - buttons
        191 focus output right
        192 focus output left
        # G-shift + left click
        193 move workspace to left, focus output right, focus output left
        # G-shift + middle button
        194 exec pamixer --toggle-mute, $volume_notification -i "$([ $(pamixer --get-mute) == "true" ] && echo "audio-volume-muted-symbolic" || echo "audio-volume-high-symbolic")"
        # G-shift + right click
        195 move workspace to right, focus output right, focus output left
        # G-Shift + wheel up
        196 exec pamixer --increase 5, $volume_notification -i audio-volume-high-symbolic
        # G-Shift + wheel down
        197 exec pamixer --decrease 5, $volume_notification -i audio-volume-low-symbolic
        # G-shift + wheel left
        198 exec playerctl previous, $media_notification -i media-skip-backward-symbolic "Previous"
        # G-shift + wheel right
        199 exec playerctl next, $media_notification -i media-skip-forward-symbolic "Next"
        # G-shift + G6
        200 exec playerctl play-pause, $media_notification -i media-playback-start-symbolic "Play-pause"
    }
```
A swaynag warning banner would be displayed with multiple times the following:
> "Overwriting binding'--intput-device=1133:16517:Logitech_G604' for device '*' ...

### Testing done

* Compiled sway with commit and ran with sampled config: no more error banner.
* Searched for all instances of `has_prefix` to see if all calls looked alright. I may have missed some!
  > ![2025-03-20-195940_screenshot](https://github.com/user-attachments/assets/e9a870f5-6cf5-4375-b495-420d3433a182)
