### PR TITLE
Fix regression that added visible waterline

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -312,9 +312,9 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_position(&child->scene_tree->node, 0, title_bar_height);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
 
-			height -= title_bar_height;
-			if (activated && width > 0 && height > 0) {
-				arrange_container(child, width, height, title_bar_height == 0, 0);
+			int net_height = height - title_bar_height;
+			if (activated && width > 0 && net_height > 0) {
+				arrange_container(child, width, net_height, title_bar_height == 0, 0);
 			} else {
 				disable_container(child);
 			}
@@ -341,9 +341,9 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_position(&child->scene_tree->node, 0, title_height);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
 
-			height -= title_bar_height;
-			if (activated && width > 0 && height > 0) {
-				arrange_container(child, width, height, title_bar_height == 0, 0);
+			int net_height = height - title_bar_height;
+			if (activated && width > 0 && net_height > 0) {
+				arrange_container(child, width, net_height, title_bar_height == 0, 0);
 			} else {
 				disable_container(child);
 			}


### PR DESCRIPTION
Commit c2d6aff added a bounds check on `height - title_bar_height`, repurposing the local variable `height` in an attempt to DRY out the expression.

In https://github.com/swaywm/sway/issues/8625#issuecomment-2748546723, @lbatalha noted that the variable gets re-assigned inside the loop body, so its result would leak across loop iterations. This effect compounds and causes the artifact reported in issue #8625, where each child except the first in a tabbed container would acquire a visible waterline.

This PR introduced a second variable and reset it in each loop iteration to get rid of the waterline.

## Steps to reproduce and test

### Tabbed containers

Open Sway and create three tabbed children in the root container.  
Check for visible waterlines in child windows (except the first child):

![image](https://github.com/user-attachments/assets/359f589c-3fab-4a79-9349-a8a8d9368ac7)

### Stacking containers

Notably, I couldn’t reproduce the effect in stacking containers, even though those should have the regression, too, but I don’t fully understand why it doesn’t occur there. I have added the same fix there for consistency (and just in case).
