### PR TITLE
sway/commands: Handle incorrect resize unit

### DIFF
--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -457,7 +457,7 @@ static struct cmd_results *cmd_resize_set(int argc, char **argv) {
 		if (argc > num_consumed_args) {
 			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
-		if (width.unit == MOVEMENT_UNIT_INVALID) {
+		if (height.unit == MOVEMENT_UNIT_INVALID) {
 			return cmd_results_new(CMD_INVALID, "%s", usage);
 		}
 	}


### PR DESCRIPTION
problem: an invalid usage of the command `resize set` will cause sway to crash because it doesn't check for an invalid height.

solution:
1. validate height along with width
2. collect all the resize returns into a var in order to log potential errors before returning, so the user has more context as to why the resize config did not work.

fixes #8619