### PR TITLE
ipc: standardize pretty print with raw print

### DIFF
--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -99,7 +99,7 @@ static const char *pretty_type_name(const char *name) {
 		const char *b;
 	} type_names[] = {
 		{ "keyboard", "Keyboard" },
-		{ "pointer", "Mouse" },
+		{ "pointer", "Pointer" },
 		{ "touchpad", "Touchpad" },
 		{ "tablet_pad", "Tablet pad" },
 		{ "tablet_tool", "Tablet tool" },


### PR DESCRIPTION
`swaymsg -t get_inputs --raw` calls it a pointer but `--pretty` calls it a Mouse. Previous commit 6737b90cb that set this to pointer probably forgo to update the pretty one.

closes #8584