### PR TITLE
Separate adjacent borders in swaybar

### DIFF
--- a/include/swaybar/tray/item.h
+++ b/include/swaybar/tray/item.h
@@ -53,6 +53,6 @@ struct swaybar_sni {
 struct swaybar_sni *create_sni(char *id, struct swaybar_tray *tray);
 void destroy_sni(struct swaybar_sni *sni);
 uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
-		struct swaybar_sni *sni);
+		uint32_t height, struct swaybar_sni *sni);
 
 #endif

--- a/include/swaybar/tray/tray.h
+++ b/include/swaybar/tray/tray.h
@@ -37,6 +37,7 @@ struct swaybar_tray {
 struct swaybar_tray *create_tray(struct swaybar *bar);
 void destroy_tray(struct swaybar_tray *tray);
 void tray_in(int fd, short mask, void *data);
-uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x);
+uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output,
+		double *x, uint32_t height);
 
 #endif

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -458,10 +458,10 @@ static void reload_sni(struct swaybar_sni *sni, char *icon_theme,
 }
 
 uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
-		struct swaybar_sni *sni) {
-	uint32_t height = output->height * output->scale;
+		uint32_t height, struct swaybar_sni *sni) {
+	uint32_t scaled_height = height * output->scale;
 	int padding = output->bar->config->tray_padding;
-	int target_size = height - 2*padding;
+	int target_size = scaled_height - 2*padding;
 	if (target_size != sni->target_size && sni_ready(sni)) {
 		// check if another icon should be loaded
 		if (target_size < sni->min_size || target_size > sni->max_size) {
@@ -508,7 +508,7 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 
 	int size = descaled_icon_size + 2 * descaled_padding;
 	*x -= size;
-	int icon_y = floor((output->height - size) / 2.0);
+	int icon_y = floor((height - size) / 2.0);
 
 	cairo_operator_t op = cairo_get_operator(cairo);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_OVER);
@@ -532,11 +532,11 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 	hotspot->x = *x;
 	hotspot->y = 0;
 	hotspot->width = size;
-	hotspot->height = output->height;
+	hotspot->height = height;
 	hotspot->callback = icon_hotspot_callback;
 	hotspot->destroy = free;
 	hotspot->data = strdup(sni->watcher_id);
 	wl_list_insert(&output->hotspots, &hotspot->link);
 
-	return output->height;
+	return height;
 }

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -116,7 +116,8 @@ static int cmp_output(const void *item, const void *cmp_to) {
 	return strcmp(item, output->name);
 }
 
-uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
+uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output,
+		double *x, uint32_t height) {
 	struct swaybar_config *config = output->bar->config;
 	if (config->tray_outputs) {
 		if (list_seq_find(config->tray_outputs, cmp_output, output) == -1) {
@@ -124,14 +125,14 @@ uint32_t render_tray(cairo_t *cairo, struct swaybar_output *output, double *x) {
 		}
 	} // else display on all
 
-	if ((int)(output->height * output->scale) <= 2 * config->tray_padding) {
+	if ((int)(height * output->scale) <= 2 * config->tray_padding) {
 		return (2 * config->tray_padding + 1) / output->scale;
 	}
 
 	uint32_t max_height = 0;
 	struct swaybar_tray *tray = output->bar->tray;
 	for (int i = 0; i < tray->items->length; ++i) {
-		uint32_t h = render_sni(cairo, output, x, tray->items->items[i]);
+		uint32_t h = render_sni(cairo, output, x, height, tray->items->items[i]);
 		if (h > max_height) {
 			max_height = h;
 		}


### PR DESCRIPTION
Unlike `i3bar`, `swaybar` does not render the workspace/mode separator.

IMO stuck together borders are kind of ugly, especially in the default configuration, and even more so when the bar is on top.

For a long time I could ignore this by enabling thicker borders for all windows and effectively disabling workspace borders, but recently I made my configuration look more like the default with smart borders turned on, and now this issue is harder to ignore.

Before:
![before](https://github.com/user-attachments/assets/c6bb488f-6512-4780-8236-e66d36242137)

After:
![after](https://github.com/user-attachments/assets/54a34acc-f8dd-4b50-b659-352e1dd47b21)