### PR TITLE
Remove duplicate call to arrange_container

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -375,7 +375,6 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_enabled(&child->border.tree->node, true);
 			wlr_scene_node_set_position(&child->scene_tree->node, off, 0);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
-			arrange_container(child, cwidth, height, true, gaps);
 			if (cwidth > 0 && height > 0) {
 				arrange_container(child, cwidth, height, true, gaps);
 				off += cwidth + gaps;


### PR DESCRIPTION
Related to https://github.com/swaywm/sway/pull/8606
One of the calls to `arrange_container` was left outside the if block