### PR TITLE
layer_shell: destroy layer_surface on assigned output destruction

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -221,7 +221,7 @@ static void handle_output_destroy(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, layer, output_destroy);
 
 	layer->output = NULL;
-	wlr_scene_node_destroy(&layer->scene->tree->node);
+	wlr_layer_surface_v1_destroy(layer->layer_surface);
 }
 
 static void handle_node_destroy(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
According to the spec, the closed event should be sent when the surface is no longer shown, because the output may have been destroyed or the user may have asked for it to be removed. In such cases, the clients should destroy the resource.

This fixes mako not being able to show notifications if the assigned output was destroyed while a notificataion was still visible