### PR TITLE
exec: export matched container id if present

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -28,13 +28,22 @@ struct cmd_results *cmd_exec_validate(int argc, char **argv) {
 struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	char *cmd = NULL;
+	bool no_matched_container_id = false;
 	bool no_startup_id = false;
-	if (strcmp(argv[0], "--no-startup-id") == 0) {
-		no_startup_id = true;
-		--argc; ++argv;
-		if ((error = checkarg(argc, argv[-1], EXPECTED_AT_LEAST, 1))) {
-			return error;
+	int argv_counter = -1;
+	while (argc > 0 && has_prefix(*argv, "--")) {
+		if (strcmp(argv[0], "--no-matched-container-id") == 0) {
+			no_matched_container_id = true;
+		} else if (strcmp(argv[0], "--no-startup-id") == 0) {
+			no_startup_id = true;
+		} else {
+			return cmd_results_new(CMD_INVALID, "Unrecognized argument '%s'", *argv);
 		}
+		--argc; ++argv; --argv_counter;
+	}
+
+	if ((error = checkarg(argc, argv[argv_counter], EXPECTED_AT_LEAST, 1))) {
+		return error;
 	}
 
 	if (argc == 1 && (argv[0][0] == '\'' || argv[0][0] == '"')) {
@@ -60,6 +69,28 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 				setenv("DESKTOP_STARTUP_ID", token, 1);
 			}
 		}
+
+		if (no_matched_container_id || config->handler_context.node == NULL) {
+			goto no_con_id_export;
+		}
+		size_t con_id = config->handler_context.node->id;
+		int con_id_len = snprintf(NULL, 0, "%zu", con_id);
+		if (con_id_len < 0) {
+			sway_log(SWAY_ERROR, "Unable to determine buffer length for SWAY_EXEC_CON_ID");
+			goto no_con_id_export;
+		}
+		// accommodate \0
+		con_id_len++;
+		char* con_id_str = malloc(con_id_len);
+		if (!con_id_str) {
+			sway_log(SWAY_ERROR, "Unable to allocate buffer for SWAY_EXEC_CON_ID");
+			goto no_con_id_export;
+		}
+		snprintf(con_id_str, con_id_len, "%zu", con_id);
+		setenv("SWAY_EXEC_CON_ID", con_id_str, 1);
+		setenv("I3_WINDOW_ID", con_id_str, 1);
+		free(con_id_str);
+no_con_id_export:
 
 		execlp("sh", "sh", "-c", cmd, (void*)NULL);
 		sway_log_errno(SWAY_ERROR, "execve failed");

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -708,10 +708,14 @@ The default colors are:
 	windows that are spawned in floating mode, not windows that become floating
 	afterwards.
 
-*exec* <shell command>
-	Executes _shell command_ with sh.
+*exec* [--matched-container-id] [--no-startup-id] <shell command>
+	Executes _shell command_ with sh. It exports the matched container id to env
+	variables I3_WINDOW_ID and SWAY_EXEC_CON_ID in case of a criteria match or
+	the focused node otherwise, unless the _--no-matched-container-id_ option
+	is set.  The _--no_startup_id_ option prevents exporting of
+	DESKTOP_STARTUP_ID.
 
-*exec_always* <shell command>
+*exec_always* [--matched-container-id] [--no-startup-id] <shell command>
 	Like *exec*, but the shell command will be executed _again_ after *reload*.
 
 *floating_maximum_size* <width> x <height>

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -708,12 +708,12 @@ The default colors are:
 	windows that are spawned in floating mode, not windows that become floating
 	afterwards.
 
-*exec* [--matched-container-id] [--no-startup-id] <shell command>
-	Executes _shell command_ with sh. It exports the matched container id to env
-	variables I3_WINDOW_ID and SWAY_EXEC_CON_ID in case of a criteria match or
-	the focused node otherwise, unless the _--no-matched-container-id_ option
-	is set.  The _--no_startup_id_ option prevents exporting of
-	DESKTOP_STARTUP_ID.
+*exec* [--matched-ids] [--no-startup-id] <shell command>
+	Executes _shell command_ with sh. With _--matched-ids_, It exports the
+	matched container id to env variable SWAY_EXEC_CON_ID and, if available,
+	X11 window id to env variable I3_WINDOW_ID in case of a criteria match or
+	the focused node otherwise. The _--no_startup_id_ option prevents exporting
+	of DESKTOP_STARTUP_ID.
 
 *exec_always* [--matched-container-id] [--no-startup-id] <shell command>
 	Like *exec*, but the shell command will be executed _again_ after *reload*.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -704,12 +704,12 @@ The default colors are:
 	windows that are spawned in floating mode, not windows that become floating
 	afterwards.
 
-*exec* [--matched-container-id] [--no-startup-id] <shell command>
-	Executes _shell command_ with sh. It exports the matched container id to env
-	variables I3_WINDOW_ID and SWAY_EXEC_CON_ID in case of a criteria match or
-	the focused node otherwise, unless the _--no-matched-container-id_ option
-	is set.  The _--no_startup_id_ option prevents exporting of
-	DESKTOP_STARTUP_ID.
+*exec* [--matched-ids] [--no-startup-id] <shell command>
+	Executes _shell command_ with sh. With _--matched-ids_, It exports the
+	matched container id to env variable SWAY_EXEC_CON_ID and, if available,
+	X11 window id to env variable I3_WINDOW_ID in case of a criteria match or
+	the focused node otherwise. The _--no_startup_id_ option prevents exporting
+	of DESKTOP_STARTUP_ID.
 
 *exec_always* [--matched-container-id] [--no-startup-id] <shell command>
 	Like *exec*, but the shell command will be executed _again_ after *reload*.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -704,10 +704,14 @@ The default colors are:
 	windows that are spawned in floating mode, not windows that become floating
 	afterwards.
 
-*exec* <shell command>
-	Executes _shell command_ with sh.
+*exec* [--matched-container-id] [--no-startup-id] <shell command>
+	Executes _shell command_ with sh. It exports the matched container id to env
+	variables I3_WINDOW_ID and SWAY_EXEC_CON_ID in case of a criteria match or
+	the focused node otherwise, unless the _--no-matched-container-id_ option
+	is set.  The _--no_startup_id_ option prevents exporting of
+	DESKTOP_STARTUP_ID.
 
-*exec_always* <shell command>
+*exec_always* [--matched-container-id] [--no-startup-id] <shell command>
 	Like *exec*, but the shell command will be executed _again_ after *reload*.
 
 *floating_maximum_size* <width> x <height>


### PR DESCRIPTION
Closes: #9038 

Provides matched container id to each command execution via handler_context, if `--no-matched-container-id` is not set with exec
or exec_always. If there is no matched node, the handler_context has the focused node. The idea is that this can simplify scripting.

- Relates to [PR 6160 at i3](https://github.com/i3/i3/pull/6160). The i3 PR does not have `--no-matched-container-id`. After a while I decided for it because it felt better. [thought process](https://github.com/swaywm/sway/pull/8671#issuecomment-2820857830) (This was initially --matched-container-id, but after I3 added the PR, I decided to revert the logic)
- I decided against a function and for inline placement for no particular reason.
  - Since I made it inline though, `goto` seemed like a cleaner choice than guards or nesting more ifs
- I looked at `mark.c` for inspiration for multi argument handling. This could potentially do with redundancy reduction now, but that may be valid for even more command files. I did not feel comfortable addressing these things with this simple PR.
- I may accidentally have fixed a bug while doing this in line 35 (old). The below is what I observe _before patch_ for using `--no-startup-id` and then triggering an error due to no further args -- I believe this should say "exec" or "exec_always", not "--no-startup-id".
```
> swaymsg -- exec --no-startup-id
Error: Invalid --no-startup-id command (expected at least 1 argument, got 0)
```
- this is now 
```
Error: Invalid exec command (expected at least 1 argument, got 0)
```
and
```
Error: Invalid exec_always command (expected at least 1 argument, got 0)
```
for the tests below.

I'm using this change in my regular sway session.

Tested with (edited back to --matched-ids):

```
#!/bin/sh

i=1

echo "20 tests"
echo

for exec_variant in "exec" "exec_always" ; do
    for command_parameter in 'env | grep "\(DESKTOP_STARTUP_ID\|SWAY_EXEC_CON_ID\|I3_WINDOW_ID\)"' '' ; do
        for mode in 0 1 2 3 7; do
            HAVE_NODS=
            HAVE_CONID=
            # 1 = DESKTOP_STARTUP_ID in front, 4 = DESKTOP_STARTUP_ID in the back
            if [ $(($mode & 0x1)) -eq $((0x1)) -o $(($mode & 0x4)) -eq $((0x4)) ];then
                HAVE_NODS=1
            fi

            if [ $(($mode & 0x2)) -eq $((0x2)) ];then
                HAVE_CONID=1
            fi

            if [ -n "$command_parameter" ];then
                swaymsg -- exec "echo \"test ${i}: mode: ${mode}, exec_variant: ${exec_variant}, command_parameter: ${command_parameter:+set}\n---\nexpect: DESKTOP_STARTUP_ID ${HAVE_NODS:+not }set, SWAY_EXEC_CON_ID ${HAVE_CONID:-not set}${HAVE_CONID:+set}\""
            else
                swaymsg -- exec "echo \"test ${i}: mode=${mode}, exec_variant=${exec_variant}, command_parameter ${command_parameter:+set}\n---\nexpect: error message in terminal\""
            fi

            sleep .5
            swaymsg -- exec "echo \"actual command: ${exec_variant}${HAVE_NODS:+ --no-startup-id}${HAVE_CONID:+ --matched-ids}${command_parameter:+ }$command_parameter\""
            sleep .5
            swaymsg -- ${exec_variant}${HAVE_NODS:+ --no-startup-id}${HAVE_CONID:+ --matched-ids}${command_parameter:+ }$command_parameter
            sleep .5
            swaymsg -- exec 'echo "---"'
            i=$((i+1))
            read -p "press key to continue..." x
        done
    done
done
```

My demo use case:
```
[title="Picture-in-Picture"] floating enable, sticky enable, mark --add _newstickychange, mark --add _newnotitle, resize set 20ppt 20ppt, exec swayhelper move_window_to_corner 3 --title Picture-in-Picture
```

can now become

```
[title="Picture-in-Picture"] floating enable, sticky enable, mark --add _newstickychange, mark --add _newnotitle, resize set 20ppt 20ppt, exec --matched-ids swayhelper move_window_to_corner 3
```

While the former would even likely work without any matching in my swayhelper, just working on focused node, it is not guaranteed if this was matching several windows, in that case I have to duplicate the criteria as shown above. The latter is not shorter depending on the actual criteria, but has less redundancy.

