### PR TITLE
Use pthread_atfork() to restore signals and NOFILE limit

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -164,9 +164,6 @@ void server_fini(struct sway_server *server);
 bool server_start(struct sway_server *server);
 void server_run(struct sway_server *server);
 
-void restore_nofile_limit(void);
-void restore_signals(void);
-
 void handle_new_output(struct wl_listener *listener, void *data);
 
 void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ libudev = wlroots_features['libinput_backend'] ? dependency('libudev') : null_de
 math = cc.find_library('m')
 rt = cc.find_library('rt')
 xcb_icccm = wlroots_features['xwayland'] ? dependency('xcb-icccm') : null_dep
-threads = dependency('threads') # for pthread_setschedparam
+threads = dependency('threads') # for pthread_setschedparam and pthread_atfork
 
 if get_option('sd-bus-provider') == 'auto'
 	if not get_option('tray').disabled()

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -51,8 +51,6 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	// Fork process
 	pid_t child = fork();
 	if (child == 0) {
-		restore_nofile_limit();
-		restore_signals();
 		setsid();
 
 		if (ctx) {

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -213,8 +213,6 @@ static void invoke_swaybar(struct bar_config *bar) {
 		sway_log(SWAY_ERROR, "Failed to create fork for swaybar");
 		return;
 	} else if (pid == 0) {
-		restore_nofile_limit();
-		restore_signals();
 		if (!sway_set_cloexec(sockets[1], false)) {
 			_exit(EXIT_FAILURE);
 		}

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1060,8 +1060,6 @@ static bool _spawn_swaybg(char **command) {
 		sway_log_errno(SWAY_ERROR, "fork failed");
 		return false;
 	} else if (pid == 0) {
-		restore_nofile_limit();
-		restore_signals();
 		if (!sway_set_cloexec(sockets[1], false)) {
 			_exit(EXIT_FAILURE);
 		}

--- a/sway/swaynag.c
+++ b/sway/swaynag.c
@@ -63,7 +63,6 @@ bool swaynag_spawn(const char *swaynag_command,
 		sway_log(SWAY_ERROR, "Failed to create fork for swaynag");
 		goto failed;
 	} else if (pid == 0) {
-		restore_nofile_limit();
 		if (!sway_set_cloexec(sockets[1], false)) {
 			_exit(EXIT_FAILURE);
 		}
@@ -148,4 +147,3 @@ void swaynag_show(struct swaynag_instance *swaynag) {
 		close(swaynag->fd[1]);
 	}
 }
-


### PR DESCRIPTION
This ensures these functions are always called (even when a library such as wlroots or libc perform the fork) and removes the need to manually call them.