### PR TITLE
input/seatop_default: handle continuous scroll events

### DIFF
--- a/include/sway/input/cursor.h
+++ b/include/sway/input/cursor.h
@@ -8,6 +8,7 @@
 #include "sway/input/seat.h"
 #include "config.h"
 
+#define SWAY_CONTINUOUS_SCROLL_TIMEOUT 1000
 #define SWAY_CURSOR_PRESSED_BUTTONS_CAP 32
 
 #define SWAY_SCROLL_UP KEY_MAX + 1

--- a/include/sway/input/seat.h
+++ b/include/sway/input/seat.h
@@ -80,9 +80,15 @@ struct sway_drag {
 	struct wl_listener destroy;
 };
 
+struct sway_scroll_axis {
+	double value;
+	uint32_t time_msec;
+};
+
 struct sway_seat {
 	struct wlr_seat *wlr_seat;
 	struct sway_cursor *cursor;
+	struct sway_scroll_axis axis[2];
 
 	// Seat scene tree structure
 	// - scene_tree


### PR DESCRIPTION
The implementation is similar to how swaybar handles these events, except that swaybar does it in a pointer frame event handler.

Fixes #8014