### PR TITLE
config/output: Use INT_MAX as x/y unset value

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -67,7 +67,7 @@ struct output_config *new_output_config(const char *name) {
 	oc->refresh_rate = -1;
 	oc->custom_mode = -1;
 	oc->drm_mode.type = -1;
-	oc->x = oc->y = -1;
+	oc->x = oc->y = INT_MAX;
 	oc->scale = -1;
 	oc->scale_filter = SCALE_FILTER_DEFAULT;
 	oc->transform = -1;
@@ -93,11 +93,11 @@ static void supersede_output_config(struct output_config *dst, struct output_con
 	if (src->height != -1) {
 		dst->height = -1;
 	}
-	if (src->x != -1) {
-		dst->x = -1;
+	if (src->x != INT_MAX) {
+		dst->x = INT_MAX;
 	}
-	if (src->y != -1) {
-		dst->y = -1;
+	if (src->y != INT_MAX) {
+		dst->y = INT_MAX;
 	}
 	if (src->scale != -1) {
 		dst->scale = -1;
@@ -157,10 +157,10 @@ static void merge_output_config(struct output_config *dst, struct output_config 
 	if (src->height != -1) {
 		dst->height = src->height;
 	}
-	if (src->x != -1) {
+	if (src->x != INT_MAX) {
 		dst->x = src->x;
 	}
-	if (src->y != -1) {
+	if (src->y != INT_MAX) {
 		dst->y = src->y;
 	}
 	if (src->scale != -1) {
@@ -527,7 +527,7 @@ static bool finalize_output_config(struct output_config *oc, struct sway_output 
 	}
 
 	// Find position for it
-	if (oc && (oc->x != -1 || oc->y != -1)) {
+	if (oc && oc->x != INT_MAX && oc->y != INT_MAX) {
 		sway_log(SWAY_DEBUG, "Set %s position to %d, %d", oc->name, oc->x, oc->y);
 		wlr_output_layout_add(root->output_layout, wlr_output, oc->x, oc->y);
 	} else {


### PR DESCRIPTION
We oftne use -1 to indicate unset values. In case of output (x, y), we would consider the fields set if they are not both -1. This means that (0, -1) and (-1, 0) are valid coordinates, but (-1, -1) is not.

We support negative output positioning, so we cannot use -1 to mean unset. Zero is also not an option as that would disallow reverting a set position back to (0, 0).

INT_MAX is an unreasonable output position, so use it to indicate unset values, and only use the value when both are set.