### PR TITLE
container not in scratchpad: return CMD_FAILURE

### DIFF
--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -121,7 +121,7 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		// we'll return an error. The same is true if the
 		// overridden node is not a container.
 		if (!con || !con->scratchpad) {
-			return cmd_results_new(CMD_INVALID, "Container is not in scratchpad.");
+			return cmd_results_new(CMD_FAILURE, "Container is not in scratchpad.");
 		}
 		scratchpad_toggle_container(con);
 	} else {


### PR DESCRIPTION
Closes #8696.

This was changed to CMD_INVALID in #8615, but for a scenario where there are criteria matched containers both inside and outside scratchpad, the container in scratchpad can no longer be shown via `[<criteria>] scratchpad show`.

Changing it to CMD_FAILURE still leads to an error message and exit code 2, but scratchpad show works again.