### PR TITLE
output: Minimize interaction with output after destroy

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -96,7 +96,7 @@ void workspace_output_add_priority(struct sway_workspace *workspace,
 		struct sway_output *output);
 
 struct sway_output *workspace_output_get_highest_available(
-		struct sway_workspace *ws, struct sway_output *exclude);
+		struct sway_workspace *ws);
 
 void workspace_detect_urgent(struct sway_workspace *workspace);
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -422,13 +422,6 @@ void force_modeset(void) {
 }
 
 static void begin_destroy(struct sway_output *output) {
-	if (output->enabled) {
-		output_disable(output);
-	}
-
-	output_begin_destroy(output);
-
-	wl_list_remove(&output->link);
 
 	wl_list_remove(&output->layout_destroy.link);
 	wl_list_remove(&output->destroy.link);
@@ -436,8 +429,17 @@ static void begin_destroy(struct sway_output *output) {
 	wl_list_remove(&output->frame.link);
 	wl_list_remove(&output->request_state.link);
 
+	// Remove the scene_output first to ensure that the scene does not emit
+	// events for this output.
 	wlr_scene_output_destroy(output->scene_output);
 	output->scene_output = NULL;
+
+	if (output->enabled) {
+		output_disable(output);
+	}
+	output_begin_destroy(output);
+	wl_list_remove(&output->link);
+
 	output->wlr_output->data = NULL;
 	output->wlr_output = NULL;
 

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -37,7 +37,7 @@ static void restore_workspaces(struct sway_output *output) {
 		for (int j = 0; j < other->workspaces->length; j++) {
 			struct sway_workspace *ws = other->workspaces->items[j];
 			struct sway_output *highest =
-				workspace_output_get_highest_available(ws, NULL);
+				workspace_output_get_highest_available(ws);
 			if (highest == output) {
 				workspace_detach(ws);
 				output_add_workspace(output, ws);
@@ -215,7 +215,7 @@ static void output_evacuate(struct sway_output *output) {
 		workspace_detach(workspace);
 
 		struct sway_output *new_output =
-			workspace_output_get_highest_available(workspace, output);
+			workspace_output_get_highest_available(workspace);
 		if (!new_output) {
 			new_output = fallback_output;
 		}

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -205,11 +205,8 @@ static void output_evacuate(struct sway_output *output) {
 		return;
 	}
 	struct sway_output *fallback_output = NULL;
-	if (root->outputs->length > 1) {
+	if (root->outputs->length > 0) {
 		fallback_output = root->outputs->items[0];
-		if (fallback_output == output) {
-			fallback_output = root->outputs->items[1];
-		}
 	}
 
 	while (output->workspaces->length) {
@@ -289,11 +286,13 @@ void output_disable(struct sway_output *output) {
 	sway_log(SWAY_DEBUG, "Disabling output '%s'", output->wlr_output->name);
 	wl_signal_emit_mutable(&output->events.disable, output);
 
-	output_evacuate(output);
-
+	// Remove the output now to avoid interacting with it during e.g.,
+	// transactions, as the output might be physically removed with the scene
+	// output destroyed.
 	list_del(root->outputs, index);
-
 	output->enabled = false;
+
+	output_evacuate(output);
 }
 
 void output_begin_destroy(struct sway_output *output) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -659,13 +659,9 @@ void workspace_output_add_priority(struct sway_workspace *workspace,
 }
 
 struct sway_output *workspace_output_get_highest_available(
-		struct sway_workspace *ws, struct sway_output *exclude) {
+		struct sway_workspace *ws) {
 	for (int i = 0; i < ws->output_priority->length; i++) {
 		const char *name = ws->output_priority->items[i];
-		if (exclude && output_match_name_or_id(exclude, name)) {
-			continue;
-		}
-
 		struct sway_output *output = output_by_name_or_id(name);
 		if (output) {
 			return output;


### PR DESCRIPTION
When an output is destroyed, we go through the process of disabling it. This includes evacuating all content away from the output, which can lead to various modifications to the scene. With the scene_output still present, this can lead to things like output_enter events being emitted for the output currently being destroyed.

Ensure that the scene output is destroyed first and that the output is immediately considered disabled.

References: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3974