### PR TITLE
Drop sway_output.events.disable

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -9,7 +9,6 @@ struct sway_layer_surface {
 	struct wl_listener map;
 	struct wl_listener unmap;
 	struct wl_listener surface_commit;
-	struct wl_listener output_destroy;
 	struct wl_listener node_destroy;
 	struct wl_listener new_popup;
 
@@ -19,6 +18,8 @@ struct sway_layer_surface {
 	struct sway_popup_desc desc;
 
 	struct sway_output *output;
+	struct wl_list link; // sway_output.layer_surfaces
+
 	struct wlr_scene_layer_surface_v1 *scene;
 	struct wlr_scene_tree *tree;
 	struct wlr_layer_surface_v1 *layer_surface;
@@ -40,5 +41,7 @@ struct wlr_layer_surface_v1 *toplevel_layer_surface_from_surface(
 		struct wlr_surface *surface);
 
 void arrange_layers(struct sway_output *output);
+
+void destroy_layers(struct sway_output *output);
 
 #endif

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -52,6 +52,7 @@ struct sway_output {
 
 	bool enabled;
 	list_t *workspaces;
+	struct wl_list layer_surfaces; // sway_layer_surface.link
 
 	struct sway_output_state current;
 
@@ -60,10 +61,6 @@ struct sway_output {
 	struct wl_listener present;
 	struct wl_listener frame;
 	struct wl_listener request_state;
-
-	struct {
-		struct wl_signal disable;
-	} events;
 
 	struct wlr_color_transform *color_transform;
 


### PR DESCRIPTION
In general wl_signal isn't well-suited for Sway: Sway doesn't need any modularity, and signals make it trickier to track down exactly what happens down the stack.

Replace Sway's output disable signal with a simple list tracking for the only user.