### PR TITLE
transaction: Fix size of children container decorations in stacking l…

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -343,7 +343,7 @@ static void arrange_children(enum sway_container_layout layout, list_t *children
 			wlr_scene_node_set_position(&child->scene_tree->node, 0, title_height);
 			wlr_scene_node_reparent(&child->scene_tree->node, content);
 
-			int net_height = height - title_bar_height;
+			int net_height = height - title_height;
 			if (activated && width > 0 && net_height > 0) {
 				arrange_container(child, width, net_height, title_bar_height == 0, 0);
 			} else {


### PR DESCRIPTION
…ayouts

Before this commit stacking containers with more than one child sized the active container's decorations as if there was only one titlebar. Commit a25645a introduced the local variable 'net_height' but incorrectly calculated it for stacking containers. Fixes #8686.