### PR TITLE
move: fix broken titlebar when moving child to new workspace

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -222,6 +222,7 @@ static void container_move_to_workspace(struct sway_container *container,
 		container_detach(container);
 		if (workspace_is_empty(workspace) && container->pending.children) {
 			workspace_unwrap_children(workspace, container);
+			container_reap_empty(container);
 		} else {
 			container->pending.width = container->pending.height = 0;
 			container->width_fraction = container->height_fraction = 0;


### PR DESCRIPTION
Before this commit, when moving a non-leaf child of a tabbed or stacking container to a new workspace, the child would be detached from the parent container and the grandchildren would be sent to the new workspace but the child itself wouldn't be destroyed causing the titlebar to still be rendered as part of the parent container. Fixes #8648.