### PR TITLE
transaction: reparent scenes of containers behind fullscreen containers

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -587,13 +587,13 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 			wlr_scene_node_set_enabled(&child->layers.tiling->node, !fs);
 			wlr_scene_node_set_enabled(&child->layers.fullscreen->node, fs);
 
-			arrange_workspace_floating(child);
-
 			wlr_scene_node_set_enabled(&output->layers.shell_background->node, !fs);
 			wlr_scene_node_set_enabled(&output->layers.shell_bottom->node, !fs);
 			wlr_scene_node_set_enabled(&output->layers.fullscreen->node, fs);
 
 			if (fs) {
+				disable_workspace(child);
+
 				wlr_scene_rect_set_size(output->fullscreen_background, width, height);
 
 				arrange_fullscreen(child->layers.fullscreen, fs, child,
@@ -609,6 +609,8 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 					area->width - gaps->left - gaps->right,
 					area->height - gaps->top - gaps->bottom);
 			}
+
+			arrange_workspace_floating(child);
 		} else {
 			wlr_scene_node_set_enabled(&child->layers.tiling->node, false);
 			wlr_scene_node_set_enabled(&child->layers.fullscreen->node, false);
@@ -665,6 +667,13 @@ static void arrange_root(struct sway_root *root) {
 
 			wlr_scene_output_set_position(output->scene_output, output->lx, output->ly);
 
+			// disable all workspaces to get to a known state
+			for (int j = 0; j < output->current.workspaces->length; j++) {
+				struct sway_workspace *workspace = output->current.workspaces->items[j];
+				disable_workspace(workspace);
+			}
+
+			// arrange the active workspace
 			if (ws) {
 				arrange_workspace_floating(ws);
 			}


### PR DESCRIPTION
Currently we do a good job of reparenting the scenes of a container when it moves into a disabled workspace. We need to do this since normally the scenes are reparented in the 'arrange_{children,container}' functions but these don't get called for disabled workspaces. However, the 'arrange_{children,container}' functions also don't get called when there is a fullscreen container hiding them.

This commit makes sure to call 'disable_workspace' on workspaces with a fullscreen container so that when a container is moved into the workspace its scenes will be properly reparented. Also, when there is a fullscreen global container 'disable_workspace' is called for all workspaces since the scenes of a previously fullscreen global container may still be parented in the 'fullscreen_global' layer.
Fixes #8705
Fixes #8659
Fixes #8432