### PR TITLE
Remove mouse button event name validation

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -1237,12 +1237,6 @@ uint32_t get_mouse_bindcode(const char *name, char **error) {
 		*error = strdup("Button event code out of range.");
 		return 0;
 	}
-	const char *event = libevdev_event_code_get_name(EV_KEY, code);
-	if (!event || !has_prefix(event, "BTN_")) {
-		*error = format_str("Event code %d (%s) is not a button",
-			code, event ? event : "(null)");
-		return 0;
-	}
 	return code;
 }
 


### PR DESCRIPTION
Some MMO mouse devices feature a large number of additional buttons.  The Mad Catz MMO TE for example has 20 total mouse buttons, generating event codes from 272-292.  Some of these event codes (279-288) have undefined event names.  When using 'bindcode' to attempt to bind these events to actions, Sway currently attempts to validate that the corresponding event has a name beginning with 'BTN_'.  This change removes that validation check.

I'm not certain this is the right way to solve this problem for these mouse devices, but I've confirmed that this change allows buttons with undefined event names to be bound with 'bindcode' and I can't see anything else that might be affected by this change.