### PR TITLE
Raise scratchpad container in floating

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -199,6 +199,8 @@ void root_scratchpad_show(struct sway_container *con) {
 	if (old_ws) {
 		workspace_consider_destroy(old_ws);
 	}
+
+	container_raise_floating(con);
 }
 
 static void disable_fullscreen(struct sway_container *con, void *data) {


### PR DESCRIPTION
When a scratchpad container is shown, it may appear underneath other floating containers, making it difficult for users to access it. This can lead to a frustrating user experience, as the scratchpad container is intended to be easily accessible.