### PR TITLE
transaction: ensure border scene is enabled for floating containers

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -534,6 +534,7 @@ static void arrange_workspace_floating(struct sway_workspace *ws) {
 		wlr_scene_node_set_position(&floater->scene_tree->node,
 			floater->current.x, floater->current.y);
 		wlr_scene_node_set_enabled(&floater->scene_tree->node, true);
+		wlr_scene_node_set_enabled(&floater->border.tree->node, true);
 
 		arrange_container(floater, floater->current.width, floater->current.height,
 			true, ws->gaps_inner);


### PR DESCRIPTION
When a container that was previously an inactive child of a tabbed or stacking layout becomes floating, it's border scene tree remains disabled. This results in only the titlebar being rendered for the container. This commit ensures the border scene tree is enabled when arranging floating containers.
Fixes #8721