### PR TITLE
layer-shell: reclaim space from unmapped layer surfaces

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -269,12 +269,8 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 		wl_container_of(listener, surface, surface_commit);
 
 	struct wlr_layer_surface_v1 *layer_surface = surface->layer_surface;
-	if (!layer_surface->initialized) {
-		return;
-	}
-
 	uint32_t committed = layer_surface->current.committed;
-	if (committed & WLR_LAYER_SURFACE_V1_STATE_LAYER) {
+	if (layer_surface->initialized && committed & WLR_LAYER_SURFACE_V1_STATE_LAYER) {
 		enum zwlr_layer_shell_v1_layer layer_type = layer_surface->current.layer;
 		struct wlr_scene_tree *output_layer = sway_layer_get_scene(
 			surface->output, layer_type);


### PR DESCRIPTION
wlroots resets 'initialized' when a layer surface is unmapped and sway doesn't rearrange the layer surfaces in response to a commit of a surface where 'initialized' is false. This results in space not getting reclaimed from a recently unmapped layer surface until some other action causes 'arrange_layers' to get called. This commit makes sure all layer surfaces get rearranged when a layer surface is unmapped.