### PR TITLE
transaction: fix floating fullscreen containers

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -596,6 +596,7 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 
 				wlr_scene_rect_set_size(output->fullscreen_background, width, height);
 
+				arrange_workspace_floating(child);
 				arrange_fullscreen(child->layers.fullscreen, fs, child,
 					width, height);
 			} else {
@@ -608,9 +609,8 @@ static void arrange_output(struct sway_output *output, int width, int height) {
 				arrange_workspace_tiling(child,
 					area->width - gaps->left - gaps->right,
 					area->height - gaps->top - gaps->bottom);
+				arrange_workspace_floating(child);
 			}
-
-			arrange_workspace_floating(child);
 		} else {
 			wlr_scene_node_set_enabled(&child->layers.tiling->node, false);
 			wlr_scene_node_set_enabled(&child->layers.fullscreen->node, false);


### PR DESCRIPTION
8fecf3a introduced a regression where fullscreening a child of a floating container would result in a black screen. This is because the order of 'arrange_fullscreen' and 'arrange_worksplace_floating' was swapped causing the fullscreen container's scene to get reparented after it was parented in the fullscreen layer.

Fixes #8729