### PR TITLE
Improve example of input section in default config

### DIFF
--- a/config.in
+++ b/config.in
@@ -46,14 +46,18 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 #
 # Example configuration:
 #
-#   input "2:14:SynPS/2_Synaptics_TouchPad" {
+#   input type:touchpad {
 #       dwt enabled
 #       tap enabled
 #       natural_scroll enabled
 #       middle_emulation enabled
 #   }
 #
-# You can get the names of your inputs by running: swaymsg -t get_inputs
+#   input type:keyboard {
+#       xkb_layout "eu"
+#   }
+#
+# You can also configure each device individually.
 # Read `man 5 sway-input` for more information about this section.
 
 ### Key bindings


### PR DESCRIPTION
I assisted someone in getting their tap to click working.
The default example left them confused as it did not seem to work.
The issue was, that the device name in the example did not work for their laptop.

Instead of using a device name, i suggest to use the input type in the example.
This should work on most devices.