### PR TITLE
server: fix socket path memory leak

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -27,7 +27,7 @@ struct sway_session_lock {
 struct sway_server {
 	struct wl_display *wl_display;
 	struct wl_event_loop *wl_event_loop;
-	const char *socket;
+	char *socket;
 
 	struct wlr_backend *backend;
 	struct wlr_session *session;

--- a/sway/server.c
+++ b/sway/server.c
@@ -502,6 +502,7 @@ void server_fini(struct sway_server *server) {
 	wlr_backend_destroy(server->backend);
 	wl_display_destroy(server->wl_display);
 	list_free(server->dirty_nodes);
+	free(server->socket);
 }
 
 bool server_start(struct sway_server *server) {


### PR DESCRIPTION
The socket path allocated with strdup() in server_init() was not being freed in server_fini().
Remove const qualifier and add proper cleanup.