### PR TITLE
build: set wrap_mode=nodownload in default options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
 		'c_std=c11',
 		'warning_level=2',
 		'werror=true',
+		'wrap_mode=nodownload',
 	],
 )
 


### PR DESCRIPTION
This can be surprising (e.g. in CI, this can download source code instead of using system libraries) and users can easily turn it back on if desired.