### PR TITLE
Make xkb_layout reset xkb_file and vice versa

### DIFF
--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -117,10 +117,13 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 		free(dst->xkb_file);
 		dst->xkb_file = src->xkb_file ? strdup(src->xkb_file) : NULL;
 		dst->xkb_file_is_set = dst->xkb_file != NULL;
+		dst->xkb_layout = NULL;
 	}
 	if (src->xkb_layout) {
 		free(dst->xkb_layout);
 		dst->xkb_layout = strdup(src->xkb_layout);
+		dst->xkb_file = NULL;
+		dst->xkb_file_is_set = false;
 	}
 	if (src->xkb_model) {
 		free(dst->xkb_model);


### PR DESCRIPTION
Users that generally use a custom keyboard layout via xkb_file likely want to reset it to `us` for other devices that pretend to be keyboards like security keys, barcode scanners or shortcut remotes. For example:

    input 10429:2395:UGTABLET_Artist_Pro_16_(Gen2) {
      xkb_layout us
    }
    input type:keyboard {
      xkb_file ~/.config/sway/my_weird_layout.xkb
    }

Such configuration however didn't work because the config merge logic merged both commands together and then the xkb_file took precedence.

Fixes #8329.