### PR TITLE
text_input: Ignore enable requests from unfocused windows

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -264,6 +264,10 @@ static void handle_text_input_commit(struct wl_listener *listener,
 		void *data) {
 	struct sway_text_input *text_input = wl_container_of(listener, text_input,
 		text_input_commit);
+	if (text_input->input->focused_surface == NULL) {
+		sway_log(SWAY_DEBUG, "Unfocused text input tried to commit an update");
+		return;
+	}
 	if (!text_input->input->current_enabled) {
 		sway_log(SWAY_INFO, "Inactive text input tried to commit an update");
 		return;

--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -248,6 +248,10 @@ static void relay_send_im_state(struct sway_input_method_relay *relay,
 static void handle_text_input_enable(struct wl_listener *listener, void *data) {
 	struct sway_text_input *text_input = wl_container_of(listener, text_input,
 		text_input_enable);
+	if (text_input->input->focused_surface == NULL) {
+		sway_log(SWAY_DEBUG, "Enabling text input, but no longer focused");
+		return;
+	}
 	if (text_input->relay->input_method == NULL) {
 		sway_log(SWAY_INFO, "Enabling text input when input method is gone");
 		return;


### PR DESCRIPTION
Unfocused windows shouldn't be allowed to activate the IM.

This fixes an issue with swaymsg invocations that contain several
commands which result in multiple swift focus changes. An application
briefly gets text input focus, sends an enable request, then sway
processes it and activates the IM only after the commands are all
finished and focus is on something else which did not send an enable
request.

The second commit also prevents unfocused applications from changing content_type/surrounding_text/text_change_cause.