### PR TITLE
Stop using wlr_scene_buffer_send_frame_done()

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1242,7 +1242,11 @@ bool view_can_tear(struct sway_view *view) {
 static void send_frame_done_iterator(struct wlr_scene_buffer *scene_buffer,
 		int x, int y, void *data) {
 	struct timespec *when = data;
-	wl_signal_emit_mutable(&scene_buffer->events.frame_done, when);
+	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(scene_buffer);
+	if (scene_surface == NULL) {
+		return;
+	}
+	wlr_scene_surface_send_frame_done(scene_surface, when);
 }
 
 void view_send_frame_done(struct sway_view *view) {


### PR DESCRIPTION
That function now takes the output as input. We don't always have the output at hand, so use the function operating on a wlr_scene_surface instead.

Taken from https://github.com/swaywm/sway/pull/8737 to fix accidental breakage from merging https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5078. That PR is still draft and has an open TODO, so let's merge this single commit first. Not needed if the other PR is merged.