### PR TITLE
Fix an issue with `hide_cursor` and container focus

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -1111,7 +1111,7 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 			cursor->cursor->x, cursor->cursor->y, &surface, &sx, &sy);
 
 	if (surface) {
-		if (seat_is_input_allowed(seat, surface)) {
+		if (seat_is_input_allowed(seat, surface) && !cursor->hidden) {
 			wlr_seat_pointer_notify_enter(seat->wlr_seat, surface, sx, sy);
 			wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
 		}


### PR DESCRIPTION
This small patch fixes an issue with how `hide_cursor` feature interacts with keyboard control and `wl_pointer.{enter,leave}` Wayland events. It seems to fix #6245.

When the cursor is hidden over a container which regains focus without mouse warping (for example with keyboard bindings for `focus` and `workspace` commands when `mouse_warping` is set to `output`), the Wayland event `wl_pointer.enter` is sent despite the cursor remaining hidden (and it is not reverted with `wl_pointer.leave`). This is noticeable and somewhat bothersome in particular when using a web browser primarily with a keyboard — when the browser regains focus and a web site is scrolled with a keyboard, some hyperlinks become unexpectedly underlined (sometimes causing popups to appear, as on Wikipedia) because of the invisible cursor hovering above them, and getting rid of this behavior (for as long as the browser remains constantly focused) requires moving the cursor only to hide it again and send the `wl_pointer.leave` event.

This bug can be observed more precisely with [wev](https://git.sr.ht/~sircmpwn/wev), for example with these steps:

1. Start sway with default configuration with additional line `seat * hide_cursor 1000`.
2. Run `wev -f wl_pointer:enter -f wl_pointer:leave`.
3. Move the cursor over the wev window and wait for it to hide — this should show `enter` and `leave` events in wev output.
4. Using only keyboard, switch to another workspace and then return to the one with wev — this should show an erroneous `enter` event in wev output.
5. Move the cursor without leaving the wev window and wait for it to hide — this should only show `leave` event in wev output.

The fix appears to be a simple check for `cursor->hidden` in `handle_rebase` (it works for `hide_cursor when-typing` as well), but honestly I haven't overanalyzed this input system and can't say for sure if this is the best solution.