### PR TITLE
tree/view: send event unconditionally in view_send_frame_done()

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1253,7 +1253,7 @@ static void send_frame_done_iterator(struct wlr_scene_buffer *scene_buffer,
 	if (scene_surface == NULL) {
 		return;
 	}
-	wlr_scene_surface_send_frame_done(scene_surface, when);
+	wlr_surface_send_frame_done(scene_surface->surface, when);
 }
 
 void view_send_frame_done(struct sway_view *view) {


### PR DESCRIPTION
Previously, we were using wl_signal_emit_mutable() directly instead of wlr_scene_buffer_send_frame_done(). This bypassed any visibility checks, which matters before a surface is mapped.

Fixes flickering with an invalid size when launching new programs.

Fixes: eb8acfd7b1cd ("Stop using wlr_scene_buffer_send_frame_done()")