### PR TITLE
New swaymsg message type: get_cursor that returns cursor position

### DIFF
--- a/completions/fish/swaymsg.fish
+++ b/completions/fish/swaymsg.fish
@@ -21,5 +21,6 @@ complete -c swaymsg -s t -l type -fra 'get_binding_modes' --description "Gets a 
 complete -c swaymsg -s t -l type -fra 'get_binding_state' --description "Get JSON-encoded info about the current binding state."
 complete -c swaymsg -s t -l type -fra 'get_config' --description "Gets a JSON-encoded copy of the current configuration."
 complete -c swaymsg -s t -l type -fra 'get_seats' --description "Gets a JSON-encoded list of all seats, its properties and all assigned devices."
+complete -c swaymsg -s t -l type -fra 'get_cursor' --description "Get JSON-encoded information about the current cursor position and the node under it."
 complete -c swaymsg -s t -l type -fra 'send_tick' --description "Sends a tick event to all subscribed clients."
 complete -c swaymsg -s t -l type -fra 'subscribe' --description "Subscribe to a list of event types."

--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -25,6 +25,7 @@ types=(
 'get_binding_modes'
 'get_binding_state'
 'get_config'
+'get_cursor'
 'send_tick'
 'subscribe'
 )

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -22,6 +22,7 @@ enum ipc_command_type {
 	// sway-specific command types
 	IPC_GET_INPUTS = 100,
 	IPC_GET_SEATS = 101,
+	IPC_GET_CURSOR = 102,
 
 	// Events sent from sway to clients. Events have the highest bits set.
 	IPC_EVENT_WORKSPACE = ((1<<31) | 0),

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -84,6 +84,9 @@ supported. *For all replies, any properties not listed are subject to removal.*
 |- 101
 :  GET_SEATS
 :  Get the list of seats
+|- 102
+:  GET_CURSOR
+:  Get the current cursor position and information about the element under it
 
 ## 0. RUN_COMMAND
 
@@ -1456,6 +1459,71 @@ one seat. Each object has the following properties:
 		]
 	}
 ]
+```
+
+## 102. GET_CURSOR
+
+*MESSAGE*++
+Retrieve the current cursor position and information about the element under it
+
+*REPLY*++
+An object containing the following properties:
+
+[- *PROPERTY*
+:- *DATA TYPE*
+:- *DESCRIPTION*
+|- x
+:  integer
+:[ The x coordinate of the cursor (absolute screen coordinates)
+|- y
+:  integer
+:  The y coordinate of the cursor (absolute screen coordinates)
+|- surface_x
+:  integer
+:  The x coordinate of the cursor relative to the surface under it (only available when over a container)
+|- surface_y
+:  integer
+:  The y coordinate of the cursor relative to the surface under it (only available when over a container)
+|- node_type
+:  string
+:  The type of the node under the cursor (e.g., "con", "workspace", "output")
+|- window_title
+:  string
+:  The title of the window under the cursor (if applicable)
+|- app_id
+:  string
+:  The application ID of the window under the cursor (if applicable)
+|- workspace_name
+:  string
+:  The name of the workspace under the cursor (if applicable)
+|- pid
+:  integer
+:  The process ID of the application under the cursor (if applicable)
+
+
+*Example Reply (cursor over container):*
+```
+{
+	"x": 1024,
+	"y": 768,
+	"surface_x": 24,
+	"surface_y": 48,
+	"node_type": "con",
+	"window_title": "Terminal",
+	"app_id": "termite",
+	"workspace_name": "1",
+	"pid": 25370
+}
+```
+
+*Example Reply (cursor over workspace):*
+```
+{
+	"x": 1024,
+	"y": 768,
+	"node_type": "workspace",
+	"workspace_name": "1"
+}
 ```
 
 # EVENTS

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -1,4 +1,3 @@
-
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -377,6 +376,46 @@ static void pretty_print_tree(json_object *obj, int indent) {
 	}
 }
 
+static void pretty_print_cursor(json_object *c) {
+	json_object *x, *y, *surface_x, *surface_y, *node_type, *window_title, *app_id, *workspace_name, *pid;
+	json_object_object_get_ex(c, "x", &x);
+	json_object_object_get_ex(c, "y", &y);
+	json_object_object_get_ex(c, "surface_x", &surface_x);
+	json_object_object_get_ex(c, "surface_y", &surface_y);
+	json_object_object_get_ex(c, "node_type", &node_type);
+	json_object_object_get_ex(c, "window_title", &window_title);
+	json_object_object_get_ex(c, "app_id", &app_id);
+	json_object_object_get_ex(c, "workspace_name", &workspace_name);
+	json_object_object_get_ex(c, "pid", &pid);
+
+	printf("Cursor position: %d, %d", 
+		json_object_get_int(x), json_object_get_int(y));
+	
+	if (surface_x && surface_y) {
+		printf(" (relative: %d, %d)", 
+			json_object_get_int(surface_x), json_object_get_int(surface_y));
+	}
+	printf("\n");
+
+	if (node_type) {
+		printf("Under cursor: %s", json_object_get_string(node_type));
+		
+		if (workspace_name) {
+			printf(" \"%s\"", json_object_get_string(workspace_name));
+		}
+		if (window_title) {
+			printf(" - %s", json_object_get_string(window_title));
+		}
+		if (app_id) {
+			printf(" (%s)", json_object_get_string(app_id));
+		}
+		if (pid) {
+			printf(" [PID: %d]", json_object_get_int(pid));
+		}
+		printf("\n");
+	}
+}
+
 static void pretty_print(int type, json_object *resp) {
 	switch (type) {
 	case IPC_SEND_TICK:
@@ -389,6 +428,9 @@ static void pretty_print(int type, json_object *resp) {
 		return;
 	case IPC_GET_TREE:
 		pretty_print_tree(resp, 0);
+		return;
+	case IPC_GET_CURSOR:
+		pretty_print_cursor(resp);
 		return;
 	case IPC_COMMAND:
 	case IPC_GET_WORKSPACES:
@@ -518,6 +560,8 @@ int main(int argc, char **argv) {
 		type = IPC_GET_WORKSPACES;
 	} else if (strcasecmp(cmdtype, "get_seats") == 0) {
 		type = IPC_GET_SEATS;
+	} else if (strcasecmp(cmdtype, "get_cursor") == 0) {
+		type = IPC_GET_CURSOR;
 	} else if (strcasecmp(cmdtype, "get_inputs") == 0) {
 		type = IPC_GET_INPUTS;
 	} else if (strcasecmp(cmdtype, "get_outputs") == 0) {

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -82,6 +82,9 @@ _swaymsg_ [options...] [message]
 	Gets a list of all seats,
 	its properties and all assigned devices.
 
+*get\_cursor*
+	Gets the current cursor position and information about the element under it.
+
 *get\_marks*
 	Get a JSON-encoded list of marks.
 


### PR DESCRIPTION
Add an IPC command to Sway that allows swaymsg to request information about the cursor:

*Cursor over container:*
```json
{
	"x": 1024,
	"y": 768,
	"surface_x": 24,
	"surface_y": 48,
	"node_type": "con",
	"window_title": "Terminal",
	"app_id": "termite",
	"workspace_name": "1",
	"pid": 25370
}
```

*Cursor over workspace:*
```json
{
	"x": 1024,
	"y": 768,
	"node_type": "workspace",
	"workspace_name": "1"
}
```