### PR TITLE
output: Log output information when connected

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -680,7 +680,7 @@ struct seat_config *store_seat_config(struct seat_config *seat);
 int output_name_cmp(const void *item, const void *data);
 
 void output_get_identifier(char *identifier, size_t len,
-	struct sway_output *output);
+	struct wlr_output *output);
 
 const char *sway_output_scale_filter_to_string(enum scale_filter_mode scale_filter);
 

--- a/sway/commands/output.c
+++ b/sway/commands/output.c
@@ -65,7 +65,7 @@ struct cmd_results *cmd_output(int argc, char **argv) {
 			output = new_output_config(sway_output->wlr_output->name);
 		} else {
 			char identifier[128];
-			output_get_identifier(identifier, 128, sway_output);
+			output_get_identifier(identifier, 128, sway_output->wlr_output);
 			output = new_output_config(identifier);
 		}
 	} else {

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -29,8 +29,7 @@
 #endif
 
 void output_get_identifier(char *identifier, size_t len,
-		struct sway_output *output) {
-	struct wlr_output *wlr_output = output->wlr_output;
+		struct wlr_output *wlr_output) {
 	snprintf(identifier, len, "%s %s %s",
 		wlr_output->make ? wlr_output->make : "Unknown",
 		wlr_output->model ? wlr_output->model : "Unknown",
@@ -238,7 +237,7 @@ void store_output_config(struct output_config *oc) {
 
 	char id[128];
 	if (output) {
-		output_get_identifier(id, sizeof(id), output);
+		output_get_identifier(id, sizeof(id), output->wlr_output);
 	}
 
 	for (int i = 0; i < config->output_configs->length; i++) {
@@ -586,7 +585,7 @@ static struct output_config *find_output_config_from_list(
 	}
 
 	char id[128];
-	output_get_identifier(id, sizeof(id), sway_output);
+	output_get_identifier(id, sizeof(id), sway_output->wlr_output);
 
 	// We take a new config and merge on top, in order, the wildcard config,
 	// output config by name, and output config by identifier to form the final

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -47,7 +47,7 @@ bool output_match_name_or_id(struct sway_output *output,
 	}
 
 	char identifier[128];
-	output_get_identifier(identifier, sizeof(identifier), output);
+	output_get_identifier(identifier, sizeof(identifier), output->wlr_output);
 	return strcasecmp(identifier, name_or_id) == 0
 		|| strcasecmp(output->wlr_output->name, name_or_id) == 0;
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -615,7 +615,7 @@ static int find_output(const void *id1, const void *id2) {
 static int workspace_output_get_priority(struct sway_workspace *ws,
 		struct sway_output *output) {
 	char identifier[128];
-	output_get_identifier(identifier, sizeof(identifier), output);
+	output_get_identifier(identifier, sizeof(identifier), output->wlr_output);
 	int index_id = list_seq_find(ws->output_priority, find_output, identifier);
 	int index_name = list_seq_find(ws->output_priority, find_output,
 			output->wlr_output->name);
@@ -632,7 +632,7 @@ void workspace_output_raise_priority(struct sway_workspace *ws,
 	int new_index = workspace_output_get_priority(ws, output);
 	if (new_index < 0) {
 		char identifier[128];
-		output_get_identifier(identifier, sizeof(identifier), output);
+		output_get_identifier(identifier, sizeof(identifier), output->wlr_output);
 		list_insert(ws->output_priority, old_index, strdup(identifier));
 	} else if (new_index > old_index) {
 		char *name = ws->output_priority->items[new_index];
@@ -645,7 +645,7 @@ void workspace_output_add_priority(struct sway_workspace *workspace,
 		struct sway_output *output) {
 	if (workspace_output_get_priority(workspace, output) < 0) {
 		char identifier[128];
-		output_get_identifier(identifier, sizeof(identifier), output);
+		output_get_identifier(identifier, sizeof(identifier), output->wlr_output);
 		list_add(workspace->output_priority, strdup(identifier));
 	}
 }


### PR DESCRIPTION
The only logging we currently provide about outputs is debug logging
from wlroots about available modes, tested output states and errors
applying it.

Be more informative by logging some output details at INFO level when
they pop up, including optional features like HDR and adaptive sync.
This makes such output details more obvious from a quick glance, both
for users and in case logs are shared for support.