### PR TITLE
ipc-json, swaymsg: indicate when adaptive sync is unsupported

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -318,6 +318,12 @@ static void ipc_json_describe_wlr_output(struct wlr_output *wlr_output, json_obj
 		json_object_array_add(modes_array, mode_object);
 	}
 	json_object_object_add(object, "modes", modes_array);
+
+	json_object *features_object = json_object_new_object();
+	json_object_object_add(features_object, "adaptive_sync",
+		json_object_new_boolean(wlr_output->adaptive_sync_supported ||
+			wlr_output->adaptive_sync_status ==  WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
+	json_object_object_add(object, "features", features_object);
 }
 
 static void ipc_json_describe_output(struct sway_output *output,

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -210,6 +210,9 @@ static void pretty_print_output(json_object *o) {
 	json_object_object_get_ex(current_mode, "width", &width);
 	json_object_object_get_ex(current_mode, "height", &height);
 	json_object_object_get_ex(current_mode, "refresh", &refresh);
+	json_object *features, *features_adaptive_sync;
+	json_object_object_get_ex(o, "features", &features);
+	json_object_object_get_ex(features, "adaptive_sync", &features_adaptive_sync);
 
 	if (json_object_get_boolean(non_desktop)) {
 		printf(
@@ -252,7 +255,9 @@ static void pretty_print_output(json_object *o) {
 		printf(max_render_time_int == 0 ? "off\n" : "%d ms\n", max_render_time_int);
 
 		printf("  Adaptive sync: %s\n",
-			json_object_get_string(adaptive_sync_status));
+			json_object_get_boolean(features_adaptive_sync) ?
+				json_object_get_string(adaptive_sync_status) :
+				"unsupported");
 
 		printf("  Allow tearing: %s\n",
 			json_object_get_boolean(allow_tearing) ? "yes" : "no");


### PR DESCRIPTION
A new "features" object is added to the output description. We'll add more entries in the future, e.g. HDR.