### PR TITLE
tree/view: save new wlr_scene_buffer fields

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1206,6 +1206,10 @@ static void view_save_buffer_iterator(struct wlr_scene_buffer *buffer,
 	wlr_scene_buffer_set_dest_size(sbuf,
 		buffer->dst_width, buffer->dst_height);
 	wlr_scene_buffer_set_opaque_region(sbuf, &buffer->opaque_region);
+	wlr_scene_buffer_set_opacity(sbuf, buffer->opacity);
+	wlr_scene_buffer_set_filter_mode(sbuf, buffer->filter_mode);
+	wlr_scene_buffer_set_transfer_function(sbuf, buffer->transfer_function);
+	wlr_scene_buffer_set_primaries(sbuf, buffer->primaries);
 	wlr_scene_buffer_set_source_box(sbuf, &buffer->src_box);
 	wlr_scene_node_set_position(&sbuf->node, sx, sy);
 	wlr_scene_buffer_set_transform(sbuf, buffer->transform);


### PR DESCRIPTION
Visble flicker can occur during transactions, if these are not copied to the 'saved' scene