### PR TITLE
Drop wlr-data-control-unstable-v1

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -105,7 +105,6 @@ struct sway_server {
 	struct wlr_ext_foreign_toplevel_list_v1 *foreign_toplevel_list;
 	struct wlr_foreign_toplevel_manager_v1 *foreign_toplevel_manager;
 	struct wlr_content_type_manager_v1 *content_type_manager_v1;
-	struct wlr_data_control_manager_v1 *wlr_data_control_manager_v1;
 	struct wlr_ext_data_control_manager_v1 *ext_data_control_manager_v1;
 	struct wlr_screencopy_manager_v1 *screencopy_manager_v1;
 	struct wlr_ext_image_copy_capture_manager_v1 *ext_image_copy_capture_manager_v1;

--- a/sway/server.c
+++ b/sway/server.c
@@ -14,7 +14,6 @@
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_content_type_v1.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
-#include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_ext_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
@@ -110,7 +109,6 @@ static bool is_privileged(const struct wl_global *global) {
 		global == server.input_method->global ||
 		global == server.foreign_toplevel_list->global ||
 		global == server.foreign_toplevel_manager->global ||
-		global == server.wlr_data_control_manager_v1->global ||
 		global == server.ext_data_control_manager_v1->global ||
 		global == server.screencopy_manager_v1->global ||
 		global == server.ext_image_copy_capture_manager_v1->global ||
@@ -403,7 +401,6 @@ bool server_init(struct sway_server *server) {
 	server->screencopy_manager_v1 = wlr_screencopy_manager_v1_create(server->wl_display);
 	server->ext_image_copy_capture_manager_v1 = wlr_ext_image_copy_capture_manager_v1_create(server->wl_display, 1);
 	wlr_ext_output_image_capture_source_manager_v1_create(server->wl_display, 1);
-	server->wlr_data_control_manager_v1 = wlr_data_control_manager_v1_create(server->wl_display);
 	server->ext_data_control_manager_v1 = wlr_ext_data_control_manager_v1_create(server->wl_display, 1);
 	server->security_context_manager_v1 = wlr_security_context_manager_v1_create(server->wl_display);
 	wlr_viewporter_create(server->wl_display);


### PR DESCRIPTION
This protocol has been superseded by ext-data-control-v1.