### PR TITLE
Fix session lock cursor event

### DIFF
--- a/sway/lock.c
+++ b/sway/lock.c
@@ -335,8 +335,9 @@ void sway_session_lock_add_output(struct sway_session_lock *lock,
 bool sway_session_lock_has_surface(struct sway_session_lock *lock,
 		struct wlr_surface *surface) {
 	struct sway_session_lock_output *lock_output;
+	struct wlr_surface *root_surface = wlr_surface_get_root_surface(surface);
 	wl_list_for_each(lock_output, &lock->outputs, link) {
-		if (lock_output->surface && lock_output->surface->surface == surface) {
+		if (lock_output->surface && lock_output->surface->surface == root_surface) {
 			return true;
 		}
 	}

--- a/sway/lock.c
+++ b/sway/lock.c
@@ -26,6 +26,7 @@ struct sway_session_lock_output {
 	// invalid if surface is NULL
 	struct wl_listener surface_destroy;
 	struct wl_listener surface_map;
+	struct wl_listener surface_commit;
 };
 
 static void focus_surface(struct sway_session_lock *lock,
@@ -64,7 +65,15 @@ static void handle_surface_map(struct wl_listener *listener, void *data) {
 	if (surf->lock->focused == NULL) {
 		focus_surface(surf->lock, surf->surface->surface);
 	}
+}
+
+static void handle_surface_commit(struct wl_listener *listener, void *data) {
+	// We need to rebase cursor after surface_reconfigure, which is called after the commit event.
+	// If we rebase cursor earlier, wlr_scene_node_at won't get the session lock scene node.
 	cursor_rebase_all();
+	struct sway_session_lock_output *surf = wl_container_of(listener, surf, surface_commit);
+	wl_list_remove(&surf->surface_commit.link);
+	wl_list_init(&surf->surface_commit.link);
 }
 
 static void handle_surface_destroy(struct wl_listener *listener, void *data) {
@@ -76,6 +85,7 @@ static void handle_surface_destroy(struct wl_listener *listener, void *data) {
 	output->surface = NULL;
 	wl_list_remove(&output->surface_destroy.link);
 	wl_list_remove(&output->surface_map.link);
+	wl_list_remove(&output->surface_commit.link);
 }
 
 static void lock_output_reconfigure(struct sway_session_lock_output *output) {
@@ -125,6 +135,8 @@ static void handle_new_surface(struct wl_listener *listener, void *data) {
 	wl_signal_add(&lock_surface->events.destroy, &lock_output->surface_destroy);
 	lock_output->surface_map.notify = handle_surface_map;
 	wl_signal_add(&lock_surface->surface->events.map, &lock_output->surface_map);
+	lock_output->surface_commit.notify = handle_surface_commit;
+	wl_signal_add(&lock_surface->surface->events.commit, &lock_output->surface_commit);
 
 	lock_output_reconfigure(lock_output);
 }
@@ -134,6 +146,7 @@ static void sway_session_lock_output_destroy(struct sway_session_lock_output *ou
 		refocus_output(output);
 		wl_list_remove(&output->surface_destroy.link);
 		wl_list_remove(&output->surface_map.link);
+		wl_list_remove(&output->surface_commit.link);
 	}
 
 	wl_list_remove(&output->destroy.link);
@@ -237,6 +250,8 @@ static void handle_unlock(struct wl_listener *listener, void *data) {
 
 	// Views are now visible, so check if we need to activate inhibition again.
 	sway_idle_inhibit_v1_check_active();
+
+	cursor_rebase_all();
 }
 
 static void handle_abandon(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Inspired by https://github.com/swaywm/sway/pull/8343

Fixes https://github.com/swaywm/sway/issues/8342

`cursor_rebase_all` calls `node_at_coords`, and `node_at_coords` only
returns the lock surface after the surface has been committed(not mapped).

Also add the missing `cursor_rebase_all` in handle_unlock.