### PR TITLE
input/cursor: fix selection of all contaners when clicking in popup-menu and on the lockscreen

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -102,6 +102,10 @@ struct sway_node *node_at_coords(
 				return NULL;
 			}
 
+			if (scene_descriptor_try_get(current, SWAY_SCENE_DESC_POPUP)) {
+				return NULL;
+			}
+
 #if WLR_HAS_XWAYLAND
 			if (scene_descriptor_try_get(current, SWAY_SCENE_DESC_XWAYLAND_UNMANAGED)) {
 				return NULL;
@@ -131,6 +135,10 @@ struct sway_node *node_at_coords(
 
 	struct sway_workspace *ws = output_get_active_workspace(output);
 	if (!ws) {
+		return NULL;
+	}
+
+	if (server.session_lock.lock) {
 		return NULL;
 	}
 


### PR DESCRIPTION
After mouse-down on an item in the popup-menus (for example, waybar tray-menus) all containers in the current workspace become selected. The same thing happens when clicking in the lockscreen.
I made this patch for myself to fix this behavior. Perhaps there is a better solution to this problem.