### PR TITLE
config/output: Only error when enabling HDR

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -365,7 +365,7 @@ bool output_supports_hdr(struct wlr_output *output, const char **unsupported_rea
 
 static void set_hdr(struct wlr_output *output, struct wlr_output_state *pending, bool enabled) {
 	const char *unsupported_reason = NULL;
-	if (!output_supports_hdr(output, &unsupported_reason)) {
+	if (enabled && !output_supports_hdr(output, &unsupported_reason)) {
 		sway_log(SWAY_ERROR, "Cannot enable HDR on output %s: %s",
 			output->name, unsupported_reason);
 		enabled = false;


### PR DESCRIPTION
We currently emit errors about HDR support even if HDR is not being requested, which mean errors on every regular modeset when monitors not supporting HDR are connected.

Only emit errors when attempting to enable HDR on such device.