### PR TITLE
xdg-shell: fix reported WM capabilities (backport)

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -290,7 +290,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		// XXX: https://github.com/swaywm/sway/issues/2176
 		wlr_xdg_surface_schedule_configure(xdg_surface);
 		wlr_xdg_toplevel_set_wm_capabilities(view->wlr_xdg_toplevel,
-			XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
+			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 		// TODO: wlr_xdg_toplevel_set_bounds()
 		return;
 	}


### PR DESCRIPTION
Previously it was reporting `window_menu` and `maximize` instead of `fullscreen` because `wlr_xdg_toplevel_set_wm_capabilities` expects a bitmask (`WLR_XDG_TOPLEVEL_WM_CAPABILITIES_*`), and `XDG_TOPLEVEL_WM_CAPABILITIES_*` are supposed to be used as values in `wl_array`, so the values are different:
`XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN = 3`
`WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN = 4`

(cherry picked from commit c5456be7506adece2cdf922ed6d919db597944ab)