### PR TITLE
input/text_input: stop using listener data

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -42,23 +42,21 @@ static void handle_im_commit(struct wl_listener *listener, void *data) {
 	if (!text_input) {
 		return;
 	}
-	struct wlr_input_method_v2 *context = data;
-	assert(context == relay->input_method);
-	if (context->current.preedit.text) {
+	if (relay->input_method->current.preedit.text) {
 		wlr_text_input_v3_send_preedit_string(text_input->input,
-			context->current.preedit.text,
-			context->current.preedit.cursor_begin,
-			context->current.preedit.cursor_end);
+			relay->input_method->current.preedit.text,
+			relay->input_method->current.preedit.cursor_begin,
+			relay->input_method->current.preedit.cursor_end);
 	}
-	if (context->current.commit_text) {
+	if (relay->input_method->current.commit_text) {
 		wlr_text_input_v3_send_commit_string(text_input->input,
-			context->current.commit_text);
+			relay->input_method->current.commit_text);
 	}
-	if (context->current.delete.before_length
-			|| context->current.delete.after_length) {
+	if (relay->input_method->current.delete.before_length
+			|| relay->input_method->current.delete.after_length) {
 		wlr_text_input_v3_send_delete_surrounding_text(text_input->input,
-			context->current.delete.before_length,
-			context->current.delete.after_length);
+			relay->input_method->current.delete.before_length,
+			relay->input_method->current.delete.after_length);
 	}
 	wlr_text_input_v3_send_done(text_input->input);
 }
@@ -66,7 +64,7 @@ static void handle_im_commit(struct wl_listener *listener, void *data) {
 static void handle_im_keyboard_grab_destroy(struct wl_listener *listener, void *data) {
 	struct sway_input_method_relay *relay = wl_container_of(listener, relay,
 		input_method_keyboard_grab_destroy);
-	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab = data;
+	struct wlr_input_method_keyboard_grab_v2 *keyboard_grab = relay->input_method->keyboard_grab;
 	struct wlr_seat *wlr_seat = keyboard_grab->input_method->seat;
 	wl_list_remove(&relay->input_method_keyboard_grab_destroy.link);
 
@@ -110,8 +108,6 @@ static void text_input_set_pending_focused_surface(
 static void handle_im_destroy(struct wl_listener *listener, void *data) {
 	struct sway_input_method_relay *relay = wl_container_of(listener, relay,
 		input_method_destroy);
-	struct wlr_input_method_v2 *context = data;
-	assert(context == relay->input_method);
 	wl_list_remove(&relay->input_method_commit.link);
 	wl_list_remove(&relay->input_method_grab_keyboard.link);
 	wl_list_remove(&relay->input_method_destroy.link);
@@ -322,8 +318,6 @@ static void handle_pending_focused_surface_destroy(struct wl_listener *listener,
 		void *data) {
 	struct sway_text_input *text_input = wl_container_of(listener, text_input,
 		pending_focused_surface_destroy);
-	struct wlr_surface *surface = data;
-	assert(text_input->pending_focused_surface == surface);
 	text_input->pending_focused_surface = NULL;
 	wl_list_remove(&text_input->pending_focused_surface_destroy.link);
 	wl_list_init(&text_input->pending_focused_surface_destroy.link);


### PR DESCRIPTION
These are now NULL.

Fixes: aaab7f961e0b ("input/text_input: chase wlroots update")  
Closes: https://github.com/swaywm/sway/issues/8864  
References: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5107