### PR TITLE
Fix NULL ptr deref in `ipc_describe_workspace`

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -516,8 +516,9 @@ static void ipc_json_describe_workspace(struct sway_workspace *workspace,
 	}
 	json_object_object_add(object, "num", json_object_new_int(num));
 	json_object_object_add(object, "fullscreen_mode", json_object_new_int(1));
-	json_object_object_add(object, "output", workspace->output ?
-			json_object_new_string(workspace->output->wlr_output->name) : NULL);
+	json_object_object_add(object, "output",
+			workspace->output && workspace->output->wlr_output->name ?
+				json_object_new_string(workspace->output->wlr_output->name) : NULL);
 	json_object_object_add(object, "urgent",
 			json_object_new_boolean(workspace->urgent));
 	json_object_object_add(object, "representation", workspace->representation ?


### PR DESCRIPTION
When hot-plugging monitor(s) `ipc_json_describe_workspace` can end up dereferencing a NULL ptr in `wlr_output->name`. Here we simply check that it is set.

While this is probably a race and just checking that it is not NULL before accessing it won't fully solve the race, it should make it substantially more rare.

Mostly addresses #8747