### PR TITLE
Update Norwegian README to make it more in line with the English one, as well as improving grammar

### DIFF
--- a/README.no.md
+++ b/README.no.md
@@ -47,7 +47,7 @@ Kjør følgende kommandoer:
 Hvis du allerede bruker i3 kan du bare kopiere din i3-konfigurasjon til
 `~/.config/sway/config`. Ellers skal du kopiere eksempelkonfigurasjonsfilen til
 `~/.config/sway/config`. Eksempelfilen er normalt plasert i `/etc/sway/config`.
-Kjør `man 5 sway` for å få oplysninger om konfigurasjonen.
+Kjør `man 5 sway` for å få opplysninger om konfigurasjonen.
 
 ## Kjøring
 


### PR DESCRIPTION
This PR does these 3 things, split into 3 commits:

* Mark display managers as supported in the Norwegian README, to reflect https://github.com/swaywm/sway/pull/8861
* Update the Norwegian translation to account for some other changes (see the message in https://github.com/swaywm/sway/commit/0bdf4f4312c6c5d63f67fba40c8601668ae4d3a8 for details)
* Improve the Norwegian translation's grammar. A common error in Norwegian text is to take words which should be written as one (for example "systempakker", meaning "system packages") and write them as two ("system pakker"), so I fixed some instances of that. I also did some other changes which make the text read more natural to me.

Feel free to take or leave individual commits from this PR.