### PR TITLE
Update README.it.md for Italian

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -1,7 +1,7 @@
 # sway
 
 sway è un compositore di [Wayland] compatibile con [i3]. Leggi le [FAQ].
-Unisciti al [canale di IRC] \(#sway su irc.libera.chat).
+Unisciti al [canale IRC] \(#sway su irc.libera.chat).
 
 ## Firma delle versioni
 
@@ -57,7 +57,7 @@ Lancia `sway` da un TTY o da un display manager.
 [i3]: https://i3wm.org/
 [Wayland]: http://wayland.freedesktop.org/
 [FAQ]: https://github.com/swaywm/sway/wiki
-[Canale IRC]: https://web.libera.chat/gamja/?channels=#sway
+[canale IRC]: https://web.libera.chat/gamja/?channels=#sway
 [E88F5E48]: https://keys.openpgp.org/search?q=34FF9526CFEF0E97A340E2E40FDE7BE0E88F5E48
 [GitHub releases]: https://github.com/swaywm/sway/releases
 [Development setup]: https://github.com/swaywm/sway/wiki/Development-Setup


### PR DESCRIPTION
Updated italian readme to follow the recent changes to the English one. I also removed "gestore di accesso" which in theory translates to display manager, but in practice is never used in this context. Other wikis such as [Debian](https://wiki.debian.org/it/DisplayManager) and [Ubuntu](https://wiki.ubuntu-it.org/AmbienteGrafico/DisplayManager) just use the term "Display Manager" as is. Another small thing that I corrected is "canale di IRC" which sounds a bit weird. 