### PR TITLE
sway: implement selinux based filtering for globals

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 pixman = dependency('pixman-1')
 libevdev = dependency('libevdev')
 libinput = wlroots_features['libinput_backend'] ? dependency('libinput', version: '>=1.26.0') : null_dep
+libselinux = dependency('libselinux', required: get_option('selinux'))
 xcb = wlroots_features['xwayland'] ? dependency('xcb') : null_dep
 drm = dependency('libdrm')
 libudev = wlroots_features['libinput_backend'] ? dependency('libudev') : null_dep
@@ -110,6 +111,7 @@ conf_data.set10('HAVE_LIBSYSTEMD', sdbus.found() and sdbus.name() == 'libsystemd
 conf_data.set10('HAVE_LIBELOGIND', sdbus.found() and sdbus.name() == 'libelogind')
 conf_data.set10('HAVE_BASU', sdbus.found() and sdbus.name() == 'basu')
 conf_data.set10('HAVE_TRAY', have_tray)
+conf_data.set10('HAVE_SELINUX', libselinux.found())
 foreach sym : ['LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM', 'LIBINPUT_CONFIG_DRAG_LOCK_ENABLED_STICKY']
 	conf_data.set10('HAVE_' + sym, cc.has_header_symbol('libinput.h', sym, dependencies: libinput))
 endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('tray', type: 'feature', value: 'auto', description: 'Enable support for 
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats in swaybar tray')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('sd-bus-provider', type: 'combo', choices: ['auto', 'libsystemd', 'libelogind', 'basu'], value: 'auto', description: 'Provider of the sd-bus library')
+option('selinux', type: 'boolean', value: false, description: 'Enable support for SELinux access control')

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -224,6 +224,7 @@ sway_deps = [
 	jsonc,
 	libevdev,
 	libinput,
+	libselinux,
 	libudev,
 	math,
 	pango,

--- a/sway/server.c
+++ b/sway/server.c
@@ -1,7 +1,12 @@
+#ifdef __linux__
+#define _DEFAULT_SOURCE
+#endif
+
 #include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/headless.h>
@@ -72,6 +77,10 @@
 #include <wlr/types/wlr_drm_lease_v1.h>
 #endif
 
+#if HAVE_SELINUX
+#include <selinux/selinux.h>
+#endif
+
 #define SWAY_XDG_SHELL_VERSION 5
 #define SWAY_LAYER_SHELL_VERSION 4
 #define SWAY_FOREIGN_TOPLEVEL_LIST_VERSION 1
@@ -92,6 +101,163 @@ static void handle_drm_lease_request(struct wl_listener *listener, void *data) {
 	}
 }
 #endif
+
+#if HAVE_SELINUX
+static const char *get_selinux_protocol(const struct wl_global *global) {
+#if WLR_HAS_DRM_BACKEND
+	if (server.drm_lease_manager != NULL) {
+		struct wlr_drm_lease_device_v1 *drm_lease_dev;
+		wl_list_for_each(drm_lease_dev, &server.drm_lease_manager->devices, link) {
+			if (drm_lease_dev->global == global) {
+				return "drm_lease";
+			}
+		}
+	}
+#endif
+
+	if (global == server.output_manager_v1->global) {
+		return "output_manager";
+	}
+	if (global == server.output_power_manager_v1->global) {
+		return "output_power_manager";
+	}
+	if (global == server.input_method->global) {
+		return "input_method";
+	}
+	if (global == server.foreign_toplevel_list->global) {
+		return "foreign_toplevel_list";
+	}
+	if (global == server.foreign_toplevel_manager->global) {
+		return "foreign_toplevel_manager";
+	}
+	if (global == server.wlr_data_control_manager_v1->global) {
+		return "data_control_manager";
+	}
+	if (global == server.ext_data_control_manager_v1->global) {
+		return "data_control_manager";
+	}
+	if (global == server.screencopy_manager_v1->global) {
+		return "screencopy_manager";
+	}
+	if (global == server.ext_image_copy_capture_manager_v1->global) {
+		return "image_copy_capture_manager";
+	}
+	if (global == server.export_dmabuf_manager_v1->global) {
+		return "export_dmabuf_manager";
+	}
+	if (global == server.security_context_manager_v1->global) {
+		return "security_context_manager";
+	}
+	if (global == server.gamma_control_manager_v1->global) {
+		return "gamma_control_manager";
+	}
+	if (global == server.layer_shell->global) {
+		return "layer_shell";
+	}
+	if (global == server.session_lock.manager->global) {
+		return "session_lock_manager";
+	}
+	if (global == server.input->keyboard_shortcuts_inhibit->global) {
+		return "keyboard_shortcuts_inhibit";
+	}
+	if (global == server.input->virtual_keyboard->global) {
+		return "virtual_keyboard";
+	}
+	if (global == server.input->virtual_pointer->global) {
+		return "virtual_pointer";
+	}
+	if (global == server.input->transient_seat_manager->global) {
+		return "transient_seat_manager";
+	}
+	if (global == server.xdg_output_manager_v1->global) {
+		return "xdg_output_manager";
+	}
+
+	return NULL;
+}
+#endif
+
+static bool check_access_selinux(const struct wl_global *global,
+			const struct wl_client *client) {
+#if HAVE_SELINUX
+	if (is_selinux_enabled() == 0) {
+		// SELinux not running
+		return true;
+	}
+
+	const char *protocol = get_selinux_protocol(global);
+	if (protocol == NULL) {
+		return true; // Not a privileged protocol, access granted
+	}
+
+	char *client_context = NULL;
+	socklen_t len = NAME_MAX;
+	int r;
+
+	const int sockfd = wl_client_get_fd((struct wl_client *)client);
+
+	do {
+		char *new_context = realloc(client_context, len);
+		if (new_context == NULL) {
+			free(client_context);
+			return false;
+		}
+		client_context = new_context;
+
+		r = getsockopt(sockfd, SOL_SOCKET, SO_PEERSEC, client_context, &len);
+		if (r < 0 && errno != ERANGE) {
+			free(client_context);
+			return false;
+		}
+	} while (r < 0 && errno == ERANGE);
+
+	if (client_context == NULL) {
+		return true; // Getting NULL back for SO_PEERSEC means that an LSM
+		             // that provides security contexts is not running.
+	}
+
+	r = security_getenforce();
+	// If we can't determine if SELinux is enforcing or not, proceed as if enforcing.
+	const bool enforcing = !r;
+
+	char *compositor_context = NULL;
+	if (getcon_raw(&compositor_context) < 0) {
+		_sway_log(SWAY_ERROR, "[selinux] getcon_raw() failed: %s", strerror(errno));
+		free(client_context);
+		// We can't get our own context. Only allow the access if not in enforcing mode.
+		return !enforcing;
+	}
+	if (compositor_context == NULL) {
+		_sway_log(SWAY_ERROR, "[selinux] getcon_raw() returned NULL");
+		free(client_context);
+		// We can't get our own context. Only allow the access if not in enforcing mode.
+		return !enforcing;
+	}
+
+	static const char *const tclass = "wayland";
+	errno = 0;
+	r = selinux_check_access(client_context, compositor_context, tclass, protocol, NULL);
+	_sway_log(SWAY_DEBUG, "[selinux] access check scon=%s tcon=%s tclass=%s perm=%s",
+	         client_context, compositor_context, tclass, protocol);
+	if (r < 0) {
+		// EINVAL for contexts unknown to policy.
+		if (errno != EACCES || errno != EINVAL) {
+			_sway_log(SWAY_INFO, "[selinux] access check failed: %s", strerror(errno));
+			free(client_context);
+			free(compositor_context);
+			// selinux_check_access failed. Only allow the access if not in enforcing mode.
+			return !enforcing;
+		}
+		_sway_log(SWAY_INFO, "[selinux] access check denied: %s", strerror(errno));
+	}
+	free(client_context);
+	free(compositor_context);
+
+	return enforcing ? (r == 0) : true;
+#else
+	return true;
+#endif
+}
 
 static bool is_privileged(const struct wl_global *global) {
 #if WLR_HAS_DRM_BACKEND
@@ -135,6 +301,10 @@ static bool filter_global(const struct wl_client *client,
 		return xwayland->server != NULL && client == xwayland->server->client;
 	}
 #endif
+
+	if (!check_access_selinux(global, client)) {
+		return false;
+	}
 
 	// Restrict usage of privileged protocols to unsandboxed clients
 	// TODO: add a way for users to configure an allow-list


### PR DESCRIPTION
I understand that the issue on this was previously turned down because you understandably don't want to have to maintain SELinux code, but I think it may be worth a second look:

1. The only SELinux specific pieces of this code are the calls to `selinux_check_access ()`, `getcon_raw ()`, `security_getenforce ()`, and `selinux_set_callback ()`. These are also all stable APIs that have not changed in years; for example, the last change to `selinux_check_access ()` was 11 years ago at the time of writing, and even calls made previously would still succeed due a typedef. Upstream (libselinux) also promises ABI stability.
2. SO_PEERSEC (the other piece of logic here) is not actually SELinux specific, meaning this code could be trivially changed/be updated to work with various other LSMs also in active use, for example AppArmor and SMACK.
 
If it's of any reassurance, outside of some personal emergency, I'm available to respond to any bugs fairly quickly. I'm happy to be pinged on any issues created that even involve builds with the SELinux build option if desired. I've run this on my own personal systems for over 6 months now.

I do understand if you still wish to turn it down, however this would be great to have upstream; it would allow a compelling case to work on improving the Wayland security model in reference policy as well.
 
Best Regards,
Rahul

Sidenote: `get_selinux_protocol ()` is a bit ugly, but I'm not sure if there's a nicer way to write this; `->name` and trim doesn't seem to work as `struct wl_global` is opaque :/ - suggestions appreciated.