### PR TITLE
Revert "sway/commands/layout: flatten parent once"

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -134,15 +134,6 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	// Operate on parent container, like i3.
 	if (container) {
 		container = container->pending.parent;
-		// If parent has only a singe child operate on its parent and
-		// flatten once, like i3
-		if (container && container->pending.children->length == 1) {
-			struct sway_container *child = container->pending.children->items[0];
-			struct sway_container *parent = container->pending.parent;
-			container_replace(container, child);
-			container_begin_destroy(container);
-			container = parent;
-		}
 	}
 
 	// We could be working with a container OR a workspace. These are different


### PR DESCRIPTION
This reverts commit f50e307227c8938a57c098edd77098786ea6613a.

The commit broke all mixed layouts, regardless of orientation and rotation. For example:
[window][stacked or tabbed windows]

This was my main workflow stacking method, by having my editor and a lot of terminals off to the side.