### PR TITLE
commands/scratchpad: don't hide scratchpad if no pending workspace

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -214,9 +214,7 @@ void root_scratchpad_hide(struct sway_container *con) {
 	struct sway_node *focus = seat_get_focus_inactive(seat, &root->node);
 	struct sway_workspace *ws = con->pending.workspace;
 
-	if (con->pending.fullscreen_mode == FULLSCREEN_GLOBAL && !con->pending.workspace) {
-		// If the container was made fullscreen global while in the scratchpad,
-		// it should be shown until fullscreen has been disabled
+	if (!con->pending.workspace) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/swaywm/sway/issues/8909