### PR TITLE
build: switch to explicit 'meson setup' syntax

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -29,12 +29,12 @@ sources:
 tasks:
   - wlroots: |
       cd wlroots
-      meson --prefix=/usr build -Dexamples=false
+      meson setup --prefix=/usr build -Dexamples=false
       ninja -C build
       sudo ninja -C build install
   - setup: |
       cd sway
-      meson build --fatal-meson-warnings -Dauto_features=enabled -Dtray=disabled
+      meson setup build --fatal-meson-warnings -Dauto_features=enabled -Dtray=disabled
   - build: |
       cd sway
       ninja -C build
@@ -52,5 +52,5 @@ tasks:
       mkdir subprojects
       ln -s ../../wlroots subprojects/wlroots
       rm -rf build
-      meson build --fatal-meson-warnings --default-library=static --force-fallback-for=wlroots
+      meson setup build --fatal-meson-warnings --default-library=static --force-fallback-for=wlroots
       ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -26,12 +26,12 @@ sources:
 tasks:
   - wlroots: |
       cd wlroots
-      meson --prefix=/usr build -Dexamples=false
+      meson setup --prefix=/usr build -Dexamples=false
       ninja -C build
       sudo ninja -C build install
   - setup: |
       cd sway
-      meson build --fatal-meson-warnings -Dauto_features=enabled -Dsd-bus-provider=libsystemd
+      meson setup build --fatal-meson-warnings -Dauto_features=enabled -Dsd-bus-provider=libsystemd
   - build: |
       cd sway
       ninja -C build

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -39,7 +39,7 @@ tasks:
     cd subprojects
     ln -s ../../wlroots wlroots
     cd ..
-    meson build --fatal-meson-warnings -Dtray=enabled -Dsd-bus-provider=basu
+    meson setup build --fatal-meson-warnings -Dtray=enabled -Dsd-bus-provider=basu
 - build: |
     cd sway
     ninja -C build

--- a/README.ar.md
+++ b/README.ar.md
@@ -37,7 +37,7 @@ _\* Compile-time dep_
 
 نفذ هذه الأوامر:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.az.md
+++ b/README.az.md
@@ -38,7 +38,7 @@ _\* Kompilyasiya asılılıqları_
 
 Bu əmrləri icra edin:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.cs.md
+++ b/README.cs.md
@@ -39,7 +39,7 @@ _\* Závislost pouze pro kompilaci_
 
 Spusťte tyto příkazy:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.de.md
+++ b/README.de.md
@@ -31,7 +31,7 @@ _\*Werden nur für das Kompilieren benötigt_
 
 Führe die folgenden Befehle aus:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.dk.md
+++ b/README.dk.md
@@ -41,7 +41,7 @@ _\*Kompileringsafhængighed_
 
 Kør følgende kommandoer:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.es.md
+++ b/README.es.md
@@ -40,7 +40,7 @@ _\*Compile-time dep_
 
 Desde su consola, ejecute las órdenes:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -47,7 +47,7 @@ _\* Requis uniquement pour la compilation_
 
 Exécutez ces commandes :
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.ge.md
+++ b/README.ge.md
@@ -35,7 +35,7 @@ _\* Compile-time dep_
 
 გაუშვით ეს ბრძანებები:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.gr.md
+++ b/README.gr.md
@@ -40,7 +40,7 @@ _\*Compile-time dep_
 
 Τρέξτε αυτά τα commands:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -44,7 +44,7 @@ _\* Compilation के समय आवश्यक_
 
 ये commands चलाएं:
 
-	meson build/
+	meson setup build/
 	ninja -C build/
 	sudo ninja -C build/ install
 

--- a/README.hu.md
+++ b/README.hu.md
@@ -40,7 +40,7 @@ _\*Fordításidejű függőség_
 
 Futtasd ezeket a parancsokat:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.ir.md
+++ b/README.ir.md
@@ -41,7 +41,7 @@ _\*نیازمندی‌های زمان کامپایل برنامه_
 
 این فرمان‌ها را اجرا کنید:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.it.md
+++ b/README.it.md
@@ -38,7 +38,7 @@ _\* Dipendenza necessaria per la compilazione_
 
 Esegui questi comandi:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,7 @@ _\*コンパイル時の依存_
 
 次のコマンドを実行してください:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,7 +39,7 @@ _\*컴파일 떄 필요_
 
 다음 명령을 실행하세요:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _\* Compile-time dep_
 
 Run these commands:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -40,7 +40,7 @@ _\* Compileerafhankelijkheden_
 
 Voer deze opdrachten uit:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.no.md
+++ b/README.no.md
@@ -38,7 +38,7 @@ _\* Kompileringsavhengigheter_
 
 Kjør følgende kommandoer:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -40,7 +40,7 @@ _\*zależności kompilacji_
 
 Wykonaj następujące polecenia:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -42,7 +42,7 @@ _\*Dependência de tempo de compilação_
 
 Execute esses comandos:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.ro.md
+++ b/README.ro.md
@@ -38,7 +38,7 @@ Dependențe pentru instalare:
 Rulați aceste comenzi:
 
 ```
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -41,7 +41,7 @@ _\*Зависимости для сборки_
 
 Выполните эти команды:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.sr.md
+++ b/README.sr.md
@@ -38,7 +38,7 @@ _\* Потребно само за компајлирање_
 
 Покрените следеће команде:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -35,7 +35,7 @@ _\* Krav för kompilering_
 
 Kör dessa kommandon:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -38,7 +38,7 @@ _\*Derleme-anı bağımlılıkları_
 
 Şu komutları çalıştırın:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -51,7 +51,7 @@ _\*Лише для компіляції_
 
 Виконайте ці команди:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ _\*编译时依赖_
 
 运行如下命令:
 
-    meson build/
+    meson setup build/
     ninja -C build/
     sudo ninja -C build/ install
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -40,7 +40,7 @@ _\*編譯時相依_
 
 執行這些指令:
 
-    meson build
+    meson setup build
     ninja -C build
     sudo ninja -C build install
 


### PR DESCRIPTION
Fixes: 
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```