### PR TITLE
sway/commands/layout: fix flatten parent once

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -136,12 +136,16 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		container = container->pending.parent;
 		// If parent has only a singe child operate on its parent and
 		// flatten once, like i3
-		if (container && container->pending.children->length == 1 && container->pending.parent && container->pending.parent->pending.children->length == 1) {
-			struct sway_container *child = container->pending.children->items[0];
+		if (container && container->pending.children->length == 1) {
+			// Also check grandparent to avoid restricting layouts
 			struct sway_container *parent = container->pending.parent;
-			container_replace(container, child);
-			container_begin_destroy(container);
-			container = parent;
+			if (parent && parent->pending.children->length == 1) {
+				struct sway_container *child = container->pending.children->items[0];
+				struct sway_container *parent = container->pending.parent;
+				container_replace(container, child);
+				container_begin_destroy(container);
+				container = parent;
+			}
 		}
 	}
 


### PR DESCRIPTION
only flatten if grandparent also has only a single child

this is also the behavior in i3

i missed this check, when i first implemented it