### PR TITLE
sway/server: stop advertising "srgb" color transfer function

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -459,7 +459,6 @@ bool server_init(struct sway_server *server) {
 			WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL,
 		};
 		const enum wp_color_manager_v1_transfer_function transfer_functions[] = {
-			WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB,
 			WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ,
 			WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_LINEAR,
 			WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22,


### PR DESCRIPTION
In anticipation of https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/442

A brutish approach, clients that require or assume `wp_color_manager_v1::transfer_function::srgb` to always be available will die.

On recent mesa and wine, this gives the desired outcome of vulkan `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR` using no color management messages. Closes: #8918

If this causes issues, a safer alternative would be a change in wlroots to quietly reinterpret "srgb" as an alias for "gamma22"