### PR TITLE
xdg-shell: dont overwrite for_window scratchpad geometry

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -321,7 +321,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		// containers, we resize the container to match. For tiling containers,
 		// we only recenter the surface.
 		memcpy(&view->geometry, new_geo, sizeof(struct wlr_box));
-		if (container_is_floating(view->container)) {
+		bool pending_configures = xdg_surface->current.configure_serial < xdg_surface->scheduled_serial;
+		if (container_is_floating(view->container) && !view->container->node.instruction && !pending_configures) {
 			view_update_size(view);
 			// Only set the toplevel size the current container actually has a size.
 			if (view->container->current.width) {

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -321,7 +321,8 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		// containers, we resize the container to match. For tiling containers,
 		// we only recenter the surface.
 		memcpy(&view->geometry, new_geo, sizeof(struct wlr_box));
-		if (container_is_floating(view->container)) {
+		bool pending_configures = xdg_surface->current.configure_serial != xdg_surface->scheduled_serial;
+		if (container_is_floating(view->container) && !view->container->node.instruction && !pending_configures) {
 			view_update_size(view);
 			// Only set the toplevel size the current container actually has a size.
 			if (view->container->current.width) {


### PR DESCRIPTION
fixes #8493, fixes #8018, fixes #8711, fixes #8749, fixes #9127