### PR TITLE
Assign parent workspace

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -106,6 +106,7 @@ sway_cmd cmd_exec_process;
 
 sway_cmd cmd_allow_tearing;
 sway_cmd cmd_assign;
+sway_cmd cmd_assign_parent_workspace;
 sway_cmd cmd_bar;
 sway_cmd cmd_bindcode;
 sway_cmd cmd_bindgesture;

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -17,6 +17,7 @@ enum criteria_type {
 	CT_ASSIGN_WORKSPACE        = 1 << 2,
 	CT_ASSIGN_WORKSPACE_NUMBER = 1 << 3,
 	CT_NO_FOCUS                = 1 << 4,
+	CT_ASSIGN_PARENT_WORKSPACE = 1 << 5,
 };
 
 enum pattern_type {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -43,6 +43,7 @@ struct cmd_results *checkarg(int argc, const char *name, enum expected_args type
 /* Keep alphabetized */
 static const struct cmd_handler handlers[] = {
 	{ "assign", cmd_assign },
+	{ "assign_parent_workspace", cmd_assign_parent_workspace },
 	{ "bar", cmd_bar },
 	{ "bindcode", cmd_bindcode },
 	{ "bindgesture", cmd_bindgesture },

--- a/sway/commands/assign_parent_workspace.c
+++ b/sway/commands/assign_parent_workspace.c
@@ -1,0 +1,34 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/criteria.h"
+#include "list.h"
+#include "log.h"
+
+struct cmd_results *cmd_assign_parent_workspace(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "assign_parent_workspace", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	char *err_str = NULL;
+	struct criteria *criteria = criteria_parse(argv[0], &err_str);
+	if (!criteria) {
+		error = cmd_results_new(CMD_INVALID, "%s", err_str);
+		free(err_str);
+		return error;
+	}
+
+	criteria->type = CT_ASSIGN_PARENT_WORKSPACE;
+
+	// Check if it already exists
+	if (criteria_already_exists(criteria)) {
+		sway_log(SWAY_DEBUG, "assign_parent_workspace already exists: '%s'", criteria->raw);
+		criteria_destroy(criteria);
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+
+	list_add(config->criteria, criteria);
+	sway_log(SWAY_DEBUG, "assign_parent_workspace: '%s' added", criteria->raw);
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -44,6 +44,7 @@ sway_sources = files(
 
 	'commands/allow_tearing.c',
 	'commands/assign.c',
+	'commands/assign_parent_workspace.c',
 	'commands/bar.c',
 	'commands/bind.c',
 	'commands/border.c',

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -619,15 +619,9 @@ static struct sway_workspace *get_parent_workspace(struct sway_view *view) {
 static struct sway_workspace *select_workspace(struct sway_view *view) {
 	struct sway_seat *seat = input_manager_current_seat();
 
-	// Check if the view has a parent window, and if so, use its workspace
-	struct sway_workspace *parent_ws = get_parent_workspace(view);
-	if (parent_ws) {
-		return parent_ws;
-	}
-
 	// Check if there's any `assign` criteria for the view
 	list_t *criterias = criteria_for_view(view,
-			CT_ASSIGN_WORKSPACE | CT_ASSIGN_WORKSPACE_NUMBER | CT_ASSIGN_OUTPUT);
+			CT_ASSIGN_WORKSPACE | CT_ASSIGN_WORKSPACE_NUMBER | CT_ASSIGN_OUTPUT | CT_ASSIGN_PARENT_WORKSPACE);
 	struct sway_workspace *ws = NULL;
 	for (int i = 0; i < criterias->length; ++i) {
 		struct criteria *criteria = criterias->items[i];
@@ -635,6 +629,12 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 			struct sway_output *output = output_by_name_or_id(criteria->target);
 			if (output) {
 				ws = output_get_active_workspace(output);
+				break;
+			}
+		} else if (criteria->type == CT_ASSIGN_PARENT_WORKSPACE) {
+			// Assign to parent's workspace if parent exists
+			ws = get_parent_workspace(view);
+			if (ws) {
 				break;
 			}
 		} else {


### PR DESCRIPTION
Solves #3234

Added `assign_parent_workspace` directive.
When a window is created, if it matches this directive, and has a parent, and the parent has a workspace, the window will be created in the parent's workspace.

I'm aware that this PR is against 
> For this reason, most new window management feature requests are not accepted, even if accompanied by a patch.

But figured I'd suggest it anyway. I'm happy to close..

## Testing
Done by starting FF on a separate unused profile, hitting openwrt's binary which shows as a download dialog.
That's the best case I could think about.
```
$ cat test-config 
include ~/.config/sway/config
assign_parent_workspace [app_id="firefox"]

$ cat test-ff.sh 
#!/bin/bash
set -e

CURRENT=$(swaymsg -t get_workspaces | jq -r '.[] | select(.focused) | .name')
swaymsg "workspace 4"
firefox -P 'poop' -no-remote 'https://downloads.openwrt.org/releases/24.10.4/targets/apm821xx/nand/openwrt-24.10.4-apm821xx-nand-meraki_mr24-initramfs-kernel.bin' &>/dev/null &
FF_PID=$!
sleep 1

swaymsg "workspace $CURRENT"
sleep 3

FF_WS_ID=$(swaymsg -t get_tree | jq -r ".nodes[].nodes[] | select(.nodes[] | select(.pid == $FF_PID)).name" | head -1)
DIALOG_WS_ID=$(swaymsg -t get_tree | jq -r ".nodes[].nodes[] | select(.floating_nodes[] | select(.pid == $FF_PID)).name" | head -1)
echo "Firefox (PID $FF_PID) workspace: $FF_WS_ID"
echo "Dialog workspace: $DIALOG_WS_ID"

kill $FF_PID

if [ "$FF_WS_ID" = "4" ] && [ "$DIALOG_WS_ID" = "4" ]; then
    exit 0
else
    exit 1
fi
```

In a separate tty, run:
```
meson setup build/ && ninja -C build/ && ./build/sway/sway --config ./test-config
```