### PR TITLE
Allow sway to remap key combinations

### DIFF
--- a/config.in
+++ b/config.in
@@ -239,3 +239,27 @@ bar {
 }
 
 include @sysconfdir@/sway/config.d/*
+
+# Basic clipboard operations (non-conflicting)
+remap Super-c C-c
+remap Super-x C-x
+remap Super-z C-z
+remap Super-Shift-z C-Shift-z
+
+remap Super-t C-t          # New tab
+remap Super-n C-n          # New window
+remap Super-o C-o          # Open file
+remap Super-q C-q          # Quit
+
+# Tab navigation
+remap Super-Shift-bracketleft C-Page_Up
+remap Super-Shift-bracketleft C-Page_Down
+
+
+# Terminal-specific 
+remap Super-c C-Shift-c for foot
+remap Super-x C-Shift-x for foot
+
+remap Super-t C-Shift-t for com.mitchellh.ghostty
+remap Super-n C-Shift-n for com.mitchellh.ghostty
+

--- a/config.in
+++ b/config.in
@@ -253,7 +253,7 @@ remap Super-q C-q          # Quit
 
 # Tab navigation
 remap Super-Shift-bracketleft C-Page_Up
-remap Super-Shift-bracketleft C-Page_Down
+remap Super-Shift-bracketright C-Page_Down
 
 
 # Terminal-specific 

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -98,6 +98,16 @@ void container_resize_tiled(struct sway_container *parent, uint32_t axis,
 struct sway_container *container_find_resize_parent(struct sway_container *con,
 		uint32_t edge);
 
+// Keysym to keycode translation (used by bind.c and keyboard.c)
+struct keycode_matches {
+	xkb_keysym_t keysym;
+	xkb_keycode_t keycode;
+	int count;
+};
+
+void find_keycode(struct xkb_keymap *keymap, xkb_keycode_t keycode, void *data);
+struct keycode_matches get_keycode_for_keysym(xkb_keysym_t keysym);
+
 /**
  * Handlers shared by exec and exec_always.
  */

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -168,6 +168,7 @@ sway_cmd cmd_popup_during_fullscreen;
 sway_cmd cmd_primary_selection;
 sway_cmd cmd_reject;
 sway_cmd cmd_reload;
+sway_cmd cmd_remap;
 sway_cmd cmd_rename;
 sway_cmd cmd_resize;
 sway_cmd cmd_scratchpad;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -95,6 +95,17 @@ struct sway_gesture_binding {
 };
 
 /**
+ * A key remap rule for transforming key combinations
+ */
+struct sway_key_remap {
+	uint32_t from_modifiers;
+	xkb_keysym_t from_keysym;
+	uint32_t to_modifiers;
+	xkb_keysym_t to_keysym;
+	char *app_id;
+};
+
+/**
  * Focus on window activation.
  */
 enum sway_fowa {
@@ -498,6 +509,7 @@ struct sway_config {
 	list_t *criteria;
 	list_t *no_focus;
 	list_t *active_bar_modifiers;
+	list_t *key_remaps; 
 	struct sway_mode *current_mode;
 	struct bar_config *current_bar;
 	uint32_t floating_mod;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -81,6 +81,7 @@ static const struct cmd_handler handlers[] = {
 	{ "no_focus", cmd_no_focus },
 	{ "output", cmd_output },
 	{ "popup_during_fullscreen", cmd_popup_during_fullscreen },
+	{ "remap", cmd_remap },
 	{ "seat", cmd_seat },
 	{ "set", cmd_set },
 	{ "show_marks", cmd_show_marks },

--- a/sway/commands/bind.c
+++ b/sway/commands/bind.c
@@ -648,20 +648,10 @@ void seat_execute_command(struct sway_seat *seat, struct sway_binding *binding) 
 }
 
 /**
- * The last found keycode associated with the keysym
- * and the total count of matches.
- */
-struct keycode_matches {
-	xkb_keysym_t keysym;
-	xkb_keycode_t keycode;
-	int count;
-};
-
-/**
  * Iterate through keycodes in the keymap to find ones matching
  * the specified keysym.
  */
-static void find_keycode(struct xkb_keymap *keymap,
+void find_keycode(struct xkb_keymap *keymap,
 		xkb_keycode_t keycode, void *data) {
 	xkb_keysym_t keysym = xkb_state_key_get_one_sym(
 			config->keysym_translation_state, keycode);
@@ -680,7 +670,7 @@ static void find_keycode(struct xkb_keymap *keymap,
 /**
  * Return the keycode for the specified keysym.
  */
-static struct keycode_matches get_keycode_for_keysym(xkb_keysym_t keysym) {
+struct keycode_matches get_keycode_for_keysym(xkb_keysym_t keysym) {
 	struct keycode_matches matches = {
 		.keysym = keysym,
 		.keycode = XKB_KEYCODE_INVALID,

--- a/sway/commands/remap.c
+++ b/sway/commands/remap.c
@@ -1,0 +1,101 @@
+#include <string.h>
+#include <strings.h>
+#include <xkbcommon/xkbcommon.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "sway/input/keyboard.h"
+#include "list.h"
+#include "log.h"
+#include "stringop.h"
+
+// Parse a key combination string like "Super-Shift-c" into modifiers and keysym
+static bool parse_key_combo(const char *combo_str, uint32_t *modifiers, xkb_keysym_t *keysym) {
+	*modifiers = 0;
+	*keysym = XKB_KEY_NoSymbol;
+
+	list_t *split = split_string(combo_str, "-");
+	if (!split || split->length == 0) {
+		list_free_items_and_destroy(split);
+		return false;
+	}
+
+	// Parse all but last component as modifiers
+	for (int i = 0; i < split->length - 1; i++) {
+		char *mod_name = split->items[i];
+		uint32_t mod = get_modifier_mask_by_name(mod_name);
+		if (mod == 0) {
+			// Special case for "C" and "Ctrl" shorthand
+			if (strcasecmp(mod_name, "C") == 0 || strcasecmp(mod_name, "Ctrl") == 0) {
+				mod = WLR_MODIFIER_CTRL;
+			} else {
+				list_free_items_and_destroy(split);
+				return false;
+			}
+		}
+		*modifiers |= mod;
+	}
+
+	// Last component is the key
+	char *key_name = split->items[split->length - 1];
+	*keysym = xkb_keysym_from_name(key_name, XKB_KEYSYM_CASE_INSENSITIVE);
+
+	list_free_items_and_destroy(split);
+
+	if (*keysym == XKB_KEY_NoSymbol) {
+		return false;
+	}
+
+	return true;
+}
+
+// Implements the 'remap' command
+// Syntax: remap <from-combo> <to-combo> [for <app_id>]
+// Example: remap Super-c C-c for firefox
+struct cmd_results *cmd_remap(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "remap", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+
+	const char *from_str = argv[0];
+	const char *to_str = argv[1];
+	const char *app_id = NULL;
+
+	if (argc >= 4 && strcasecmp(argv[2], "for") == 0) {
+		app_id = argv[3];
+	}
+
+	struct sway_key_remap *remap = calloc(1, sizeof(struct sway_key_remap));
+	if (!remap) {
+		return cmd_results_new(CMD_FAILURE, "Unable to allocate key remap");
+	}
+
+	if (!parse_key_combo(from_str, &remap->from_modifiers, &remap->from_keysym)) {
+		free(remap);
+		return cmd_results_new(CMD_FAILURE, "Invalid 'from' key combination: %s", from_str);
+	}
+
+	if (!parse_key_combo(to_str, &remap->to_modifiers, &remap->to_keysym)) {
+		free(remap);
+		return cmd_results_new(CMD_FAILURE, "Invalid 'to' key combination: %s", to_str);
+	}
+
+	if (app_id) {
+		remap->app_id = strdup(app_id);
+		// App-specific remaps go at the front (higher priority)
+		list_insert(config->key_remaps, 0, remap);
+	} else {
+		remap->app_id = NULL;
+		// Global remaps go at the back (lower priority)
+		list_add(config->key_remaps, remap);
+	}
+
+	sway_log(SWAY_DEBUG, "Added key remap: 0x%x+0x%x -> 0x%x+0x%x%s%s",
+		remap->from_modifiers, remap->from_keysym,
+		remap->to_modifiers, remap->to_keysym,
+		app_id ? " for " : "", app_id ? app_id : "");
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}
+
+

--- a/sway/config.c
+++ b/sway/config.c
@@ -100,6 +100,14 @@ static void free_mode(struct sway_mode *mode) {
 	free(mode);
 }
 
+static void free_key_remap(struct sway_key_remap *remap) {
+	if (!remap) {
+		return;
+	}
+	free(remap->app_id);
+	free(remap);
+}
+
 void free_config(struct sway_config *config) {
 	if (!config) {
 		return;
@@ -166,6 +174,12 @@ void free_config(struct sway_config *config) {
 		}
 		list_free(config->criteria);
 	}
+	if (config->key_remaps) {
+		for (int i = 0; i < config->key_remaps->length; i++) {
+			free_key_remap(config->key_remaps->items[i]);
+		}
+		list_free(config->key_remaps);
+	}
 	list_free(config->no_focus);
 	list_free(config->active_bar_modifiers);
 	list_free_items_and_destroy(config->config_chain);
@@ -228,6 +242,7 @@ static void config_defaults(struct sway_config *config) {
 	if (!(config->input_configs = create_list())) goto cleanup;
 
 	if (!(config->cmd_queue = create_list())) goto cleanup;
+	if (!(config->key_remaps = create_list())) goto cleanup;
 
 	if (!(config->current_mode = malloc(sizeof(struct sway_mode))))
 		goto cleanup;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -89,6 +89,7 @@ sway_sources = files(
 	'commands/popup_during_fullscreen.c',
 	'commands/primary_selection.c',
 	'commands/reload.c',
+	'commands/remap.c',
 	'commands/rename.c',
 	'commands/resize.c',
 	'commands/scratchpad.c',


### PR DESCRIPTION
The goal of this PR is adding support for remapping key combinations in a global way, avoiding the need for setting up other applications that normally require full access to a device or sudo. 

Since all the processing already happens on sway, I only introduced a new configuration and we replace the keys for keyboards that belong to a group.

I'm quite new to the sway codebase so please let me know if there's a better way of achieving this or any modifications so that you'd be willing to accept the PR. 

I have tested by starting a nested compositor and trying all the keybinds in either terminals or a text editor, from my testing everything seemed to be working. 