### PR TITLE
commit dirty transactions upon window attribute changes

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -354,6 +354,7 @@ static void handle_set_title(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_view->view;
 	view_update_title(view, false);
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_set_app_id(struct wl_listener *listener, void *data) {
@@ -362,6 +363,7 @@ static void handle_set_app_id(struct wl_listener *listener, void *data) {
 	struct sway_view *view = &xdg_shell_view->view;
 	view_update_app_id(view);
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_new_popup(struct wl_listener *listener, void *data) {
@@ -594,4 +596,5 @@ void xdg_toplevel_tag_manager_v1_handle_set_tag(struct wl_listener *listener, vo
 	free(xdg_shell_view->tag);
 	xdg_shell_view->tag = strdup(event->tag);
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }

--- a/sway/desktop/xwayland.c
+++ b/sway/desktop/xwayland.c
@@ -689,6 +689,7 @@ static void handle_set_title(struct wl_listener *listener, void *data) {
 	}
 	view_update_title(view, false);
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_set_class(struct wl_listener *listener, void *data) {
@@ -700,6 +701,7 @@ static void handle_set_class(struct wl_listener *listener, void *data) {
 		return;
 	}
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_set_role(struct wl_listener *listener, void *data) {
@@ -711,6 +713,7 @@ static void handle_set_role(struct wl_listener *listener, void *data) {
 		return;
 	}
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_set_startup_id(struct wl_listener *listener, void *data) {
@@ -747,6 +750,7 @@ static void handle_set_window_type(struct wl_listener *listener, void *data) {
 		return;
 	}
 	view_execute_criteria(view);
+	transaction_commit_dirty();
 }
 
 static void handle_set_hints(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
Attempts to fix https://github.com/swaywm/sway/issues/6137

This PR adds dirty transaction commits at the end of each `handle_set_*` call which didn't previously call it. This makes it so that if a window changes its title, for example, that will trigger `for_window` listeners properly.

Previously, `view_execute_criteria` may have been called (and as such, the change *staged*), but it would not be commited until some other event triggered the dirty commit. The user clicking any part of the window or changing the focused window would end up committing the transaction, but not **until** then.

---

### Motivating example: Bitwarden extension in Firefox

With this change, with the following rule: `for_window [title="Bitwarden Password Manager"] floating enable`

When opening the bitwarden extension in another window under firefox, it starts with a title of `null`. Then very quickly changes it to `... Bitwarden Password Manager ... `. Previously, this would not trigger the floating enable until some other committing action happened. Now, it does. This causes it to open briefly as a normal window, then flash to a floating window. This behavior is not quite perfect, but it follows the semantics of what is happening _correctly_.