### PR TITLE
tree/view: check for null workspace output

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -307,7 +307,7 @@ void view_autoconfigure(struct sway_view *view) {
 	}
 	struct sway_output *output = ws ? ws->output : NULL;
 
-	if (con->pending.fullscreen_mode == FULLSCREEN_WORKSPACE) {
+	if (output && con->pending.fullscreen_mode == FULLSCREEN_WORKSPACE) {
 		con->pending.content_x = output->lx;
 		con->pending.content_y = output->ly;
 		con->pending.content_width = output->width;


### PR DESCRIPTION
Fixes crash observed roughly half the time with the `for_window` rule: `"move output current ; workspace back_and_forth ; workspace back_and_forth"`.

Resolves #8950