### PR TITLE
github: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+- What changed?
+- Why does it matter to users or maintainers?
+
+## Testing
+- [ ] Not run (please justify)
+- [ ] Built locally (`meson setup build && ninja -C build`)
+- [ ] Manual checks (describe)
+- [ ] Added/updated automated tests
+
+## Risks / rollout
+- Any configuration, protocol, or ABI considerations reviewers should note?


### PR DESCRIPTION
## Summary
- Added `.github/pull_request_template.md` to prompt contributors for a concise summary, explicit testing status, and risk/rollout notes.
- Provides a consistent structure for PR descriptions, improving clarity and review efficiency.

## Motivation
- Standardize incoming pull requests and reduce missing context for reviewers.
- Encourage authors to clearly state intent, testing coverage, and potential impact.

## Scope / Safety
- Change is limited to adding a PR template under `.github/`.
- No code or runtime behavior is affected.

## Testing
- Tests not run (per instructions).
