### PR TITLE
[RFC/DRAFT] Support xdg-toplevel-drag-v1

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -123,6 +123,8 @@ struct sway_server {
 
 	struct wl_listener request_set_cursor_shape;
 
+	struct wlr_xdg_toplevel_drag_manager_v1 *xdg_toplevel_drag_manager;
+
 	struct wlr_tearing_control_manager_v1 *tearing_control_v1;
 	struct wl_listener tearing_control_new_object;
 	struct wl_list tearing_controllers; // sway_tearing_controller::link

--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -234,6 +234,12 @@ void container_floating_translate(struct sway_container *con,
 		double x_amount, double y_amount);
 
 /**
+ * Update scene graph position immediately for a floating container.
+ * Used during drag operations for smoother visual feedback.
+ */
+void container_floating_update_scene_position(struct sway_container *con);
+
+/**
  * Choose an output for the floating container's new position.
  */
 struct sway_output *container_floating_find_output(struct sway_container *con);

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -2,10 +2,13 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_xdg_toplevel_drag_v1.h>
 #include <wlr/types/wlr_xdg_toplevel_tag_v1.h>
 #include <wlr/util/edges.h>
 #include "log.h"
+#include "sway/server.h"
 #include "sway/decoration.h"
 #include "sway/scene_descriptor.h"
 #include "sway/desktop/transaction.h"
@@ -228,6 +231,13 @@ static void set_resizing(struct sway_view *view, bool resizing) {
 static bool wants_floating(struct sway_view *view) {
 	struct wlr_xdg_toplevel *toplevel = view->wlr_xdg_toplevel;
 	struct wlr_xdg_toplevel_state *state = &toplevel->current;
+
+	// Check if this toplevel is attached to a toplevel drag
+	if (wlr_xdg_toplevel_drag_v1_from_wlr_xdg_toplevel(
+			server.xdg_toplevel_drag_manager, toplevel) != NULL) {
+		return true;
+	}
+
 	return (state->min_width != 0 && state->min_height != 0
 		&& (state->min_width == state->max_width
 		|| state->min_height == state->max_height))

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -522,6 +522,8 @@ static void drag_handle_destroy(struct wl_listener *listener, void *data) {
 	drag->wlr_drag->data = NULL;
 	wl_list_remove(&drag->destroy.link);
 	if (drag->toplevel_drag != NULL) {
+		// Mark drag as ended so client can safely destroy xdg_toplevel_drag
+		wlr_xdg_toplevel_drag_v1_finish(drag->toplevel_drag);
 		wl_list_remove(&drag->motion.link);
 		// Clean up our surface tracking listener if active
 		if (drag->toplevel_surface != NULL) {
@@ -582,6 +584,7 @@ static void handle_start_drag(struct wl_listener *listener, void *data) {
 		drag->toplevel_drag = wlr_xdg_toplevel_drag_v1_from_wlr_data_source(
 			server.xdg_toplevel_drag_manager, wlr_drag->source);
 		if (drag->toplevel_drag != NULL) {
+			wlr_xdg_toplevel_drag_v1_start(drag->toplevel_drag);
 			drag->motion.notify = toplevel_drag_handle_motion;
 			wl_signal_add(&wlr_drag->events.motion, &drag->motion);
 			// Initialize surface tracking (will be set on first identification)

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -467,8 +467,8 @@ static void toplevel_drag_handle_motion(struct wl_listener *listener, void *data
 	}
 
 	if (!container_is_floating(view->container)) {
-		// During tearout phase (not yet floating), don't skip hit-testing.
-		return;
+		// Tiled container being torn out - float it at cursor position
+		container_set_floating(view->container, true);
 	}
 
 	struct wlr_surface *surface = view->surface;

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -437,11 +437,6 @@ static void toplevel_drag_handle_motion(struct wl_listener *listener, void *data
 	struct wlr_xdg_toplevel_drag_v1 *toplevel_drag = drag->toplevel_drag;
 	struct sway_seat *seat = drag->seat;
 
-	if (toplevel_drag == NULL) {
-		seat->toplevel_drag_container = NULL;
-		return;
-	}
-
 	// If we have a tracked surface being dragged, move its container.
 	// We track the surface ourselves rather than trusting wlroots' toplevel
 	// pointer, which may not be NULLed promptly during destruction.

--- a/sway/server.c
+++ b/sway/server.c
@@ -51,6 +51,7 @@
 #include <wlr/types/wlr_xdg_foreign_v1.h>
 #include <wlr/types/wlr_xdg_foreign_v2.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
+#include <wlr/types/wlr_xdg_toplevel_drag_v1.h>
 #include <wlr/types/wlr_xdg_toplevel_tag_v1.h>
 #include <xf86drm.h>
 #include "config.h"
@@ -449,6 +450,9 @@ bool server_init(struct sway_server *server) {
 		xdg_toplevel_tag_manager_v1_handle_set_tag;
 	wl_signal_add(&xdg_toplevel_tag_manager_v1->events.set_tag,
 		&server->xdg_toplevel_tag_manager_v1_set_tag);
+
+	server->xdg_toplevel_drag_manager =
+		wlr_xdg_toplevel_drag_manager_v1_create(server->wl_display, 1);
 
 	struct wlr_cursor_shape_manager_v1 *cursor_shape_manager =
 		wlr_cursor_shape_manager_v1_create(server->wl_display, 1);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1139,6 +1139,17 @@ void container_floating_translate(struct sway_container *con,
 	node_set_dirty(&con->node);
 }
 
+void container_floating_update_scene_position(struct sway_container *con) {
+	if (!container_is_floating(con) || con->scene_tree == NULL) {
+		return;
+	}
+	// Update scene position immediately using pending coordinates.
+	// This provides smoother visual feedback during drag operations
+	// by bypassing the transaction system's batching delay.
+	wlr_scene_node_set_position(&con->scene_tree->node,
+		con->pending.x, con->pending.y);
+}
+
 /**
  * Choose an output for the floating container's new position.
  *

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -871,8 +871,9 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 				wlr_xdg_toplevel_drag_v1_from_wlr_xdg_toplevel(
 					server.xdg_toplevel_drag_manager, view->wlr_xdg_toplevel);
 			if (toplevel_drag != NULL) {
-				double x = seat->cursor->cursor->x - toplevel_drag->x_offset;
-				double y = seat->cursor->cursor->y - toplevel_drag->y_offset;
+				struct wlr_box *geo = &view->geometry;
+				double x = seat->cursor->cursor->x - toplevel_drag->x_offset - geo->x;
+				double y = seat->cursor->cursor->y - toplevel_drag->y_offset - geo->y;
 				container_floating_move_to(view->container, x, y);
 			}
 		}


### PR DESCRIPTION
Hi, 

This PR implements support for xdg-toplevel-drag-v1, building on the wlroots PR [here](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5210). Largely based on Mutter's implementation, and tested with Chromium's wayland backend.

Somewhat opinionated in that all secondary toplevels are created floating, which makes sense as it won't break existing tiled layouts and seems a better fit for tool palettes etc. 

My first real deep dive into the scene graph and wlroots, so review and feedback appreciated.

https://github.com/user-attachments/assets/4f5f41fa-18c2-47f7-9483-6a70b80f422e

