### PR TITLE
sway/desktop/transaction: null check node before accessing node

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -171,7 +171,7 @@ static void transaction_add_node(struct sway_transaction *transaction,
 
 	// Check if we have an instruction for this node already, in which case we
 	// update that instead of creating a new one.
-	if (node->ntxnrefs > 0) {
+	if (node && node->ntxnrefs > 0) {
 		for (int idx = 0; idx < transaction->instructions->length; idx++) {
 			struct sway_transaction_instruction *other =
 				transaction->instructions->items[idx];


### PR DESCRIPTION
It's possible for this to be null when powering on display from a powered off state.

```
==1947040==ERROR: AddressSanitizer: heap-use-after-free on address 0x7ce3d56a7c60 at pc 0x00000048d0c4 bp 0x7ffc25f0a5b0 sp 0x7ffc25f0a5a8 READ of size 8 at 0x7ce3d56a7c60 thread T0
    #0 0x00000048d0c3 in transaction_add_node ../sway/desktop/transaction.c:174
    #1 0x00000048d0c3 in _transaction_commit_dirty ../sway/desktop/transaction.c:955
    #2 0x00000048d0c3 in _transaction_commit_dirty ../sway/desktop/transaction.c:941
    #3 0x000000522581 in apply_resolved_output_configs ../sway/config/output.c:1022
    #4 0x000000522581 in apply_output_configs ../sway/config/output.c:1070
    #5 0x00000047445f in timer_modeset_handle ../sway/desktop/output.c:407
    #6 0x7fa3d8b1e4bc in wl_timer_heap_dispatch ../src/event-loop.c:529
    #7 0x7fa3d8b1e4bc in wl_event_loop_dispatch ../src/event-loop.c:1052
    #8 0x7fa3d8b200b4 in wl_display_run ../src/wayland-server.c:1584
    #9 0x00000041fc45 in main ../sway/main.c:376
    #10 0x7fa3d702b2fa in __libc_start_call_main (/lib64/libc.so.6+0x2b2fa) (BuildId: 8523b213e7586a93ab00f6dd476418b1e521e62c)
    #11 0x7fa3d702b3ca in __libc_start_main_impl (/lib64/libc.so.6+0x2b3ca) (BuildId: 8523b213e7586a93ab00f6dd476418b1e521e62c)
    #12 0x000000421cb4 in _start ../sysdeps/x86_64/start.S:115
0x7ce3d56a7c60 is located 32 bytes inside of 424-byte region [0x7ce3d56a7c40,0x7ce3d56a7de8) freed by thread T0 here:
    #0 0x7fa3d93208eb  (/lib64/libasan.so.8+0x1208eb) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #1 0x00000048701f in transaction_destroy ../sway/desktop/transaction.c:68
    #2 0x00000048701f in transaction_progress ../sway/desktop/transaction.c:766
    #3 0x000000487185 in transaction_commit_pending ../sway/desktop/transaction.c:884
    #4 0x000000487185 in transaction_commit_pending ../sway/desktop/transaction.c:876
    #5 0x000000487185 in transaction_progress ../sway/desktop/transaction.c:774
    #6 0x00000048ba69 in handle_timeout ../sway/desktop/transaction.c:782
    #7 0x7fa3d8b1e4bc in wl_timer_heap_dispatch ../src/event-loop.c:529
    #8 0x7fa3d8b1e4bc in wl_event_loop_dispatch ../src/event-loop.c:1052
previously allocated by thread T0 here:
    #0 0x7fa3d93215a3 in calloc (/lib64/libasan.so.8+0x1215a3) (BuildId: cbfe49f3b7600c4f194d4c54774c977296e9d98a)
    #1 0x0000005ed71c in output_create ../sway/tree/output.c:105
    #2 0x00000047bfa4 in handle_new_output ../sway/desktop/output.c:572
    #3 0x7fa3d8b1c73b in wl_signal_emit_mutable ../src/wayland-server.c:2369
    #4 0x7ffc25f0a63f  ([stack]+0x2963f)
SUMMARY: AddressSanitizer: heap-use-after-free ../sway/desktop/transaction.c:174 in transaction_add_node
```