### PR TITLE
tiling_resize: fix use-after-free on view unmap during resize

### DIFF
--- a/sway/input/seatop_resize_tiling.c
+++ b/sway/input/seatop_resize_tiling.c
@@ -105,10 +105,7 @@ static void handle_pointer_motion(struct sway_seat *seat, uint32_t time_msec) {
 
 static void handle_unref(struct sway_seat *seat, struct sway_container *con) {
 	struct seatop_resize_tiling_event *e = seat->seatop_data;
-	if (e->con == con) {
-		seatop_begin_default(seat);
-	}
-	if (e->h_sib == con || e->v_sib == con) {
+	if (e->con == con || e->h_sib == con || e->v_sib == con) {
 		seatop_begin_default(seat);
 	}
 }


### PR DESCRIPTION
Closing a tiled window (mod+shift+q) while resizing (mod+click) causes an use-after-free in handle_unref.

Both conditions can be true in this case, which will result in dereferencing `e` on the second check after it has already been freed by the first `seatop_begin_default`.

Fix by combining separate checks for the main container and its horizontal/vertical siblings into a single condition.

The second check was added in 9e272a7986aa586a73951069aa76068e408a2c3f and I've checked that this fix does not regress that issue.