### PR TITLE
Fix con_id criteria and move-to-mark for workspaces in i3 RPC

### DIFF
--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -84,8 +84,9 @@ struct criteria *criteria_parse(char *raw, char **error);
 list_t *criteria_for_view(struct sway_view *view, enum criteria_type types);
 
 /**
- * Compile a list of containers matching the given criteria.
+ * Compile a list of nodes matching the given criteria.
+ * Returns a list of struct sway_node *.
  */
-list_t *criteria_get_containers(struct criteria *criteria);
+list_t *criteria_get_nodes(struct criteria *criteria);
 
 #endif

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -48,6 +48,7 @@ struct sway_workspace {
 	list_t *floating;           // struct sway_container
 	list_t *tiling;             // struct sway_container
 	list_t *output_priority;
+	list_t *marks;              // char *
 	bool urgent;
 
 	struct sway_workspace_state current;
@@ -156,5 +157,15 @@ size_t workspace_num_sticky_containers(struct sway_workspace *ws);
  * redundant H/V splits that are children of the workspace.
  */
 void workspace_squash(struct sway_workspace *workspace);
+
+bool workspace_has_mark(struct sway_workspace *ws, char *mark);
+
+void workspace_add_mark(struct sway_workspace *ws, char *mark);
+
+void workspace_clear_marks(struct sway_workspace *ws);
+
+bool workspace_find_and_unmark(char *mark);
+
+struct sway_workspace *workspace_find_mark(char *mark);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -206,7 +206,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 		struct sway_container *con) {
 	char *cmd;
 	char matched_delim = ';';
-	list_t *containers = NULL;
+	list_t *nodes = NULL;
 	bool using_criteria = false;
 
 	if (seat == NULL) {
@@ -241,8 +241,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 					free(error);
 					goto cleanup;
 				}
-				list_free(containers);
-				containers = criteria_get_containers(criteria);
+				list_free(nodes);
+				nodes = criteria_get_nodes(criteria);
 				head += strlen(criteria->raw);
 				criteria_destroy(criteria);
 				using_criteria = true;
@@ -298,14 +298,14 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 				free_argv(argc, argv);
 				goto cleanup;
 			}
-		} else if (containers->length == 0) {
+		} else if (nodes->length == 0) {
 			list_add(res_list,
 					cmd_results_new(CMD_FAILURE, "No matching node."));
 		} else {
 			struct cmd_results *fail_res = NULL;
-			for (int i = 0; i < containers->length; ++i) {
-				struct sway_container *container = containers->items[i];
-				set_config_node(&container->node, true);
+			for (int i = 0; i < nodes->length; ++i) {
+				struct sway_node *node = nodes->items[i];
+				set_config_node(node, true);
 				struct cmd_results *res = handler->handle(argc-1, argv+1);
 				if (res->status == CMD_SUCCESS) {
 					free_cmd_results(res);
@@ -329,7 +329,7 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 	} while(head);
 cleanup:
 	free(exec);
-	list_free(containers);
+	list_free(nodes);
 	return res_list;
 }
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -566,8 +566,33 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 		root_scratchpad_show(container);
 	}
 	switch (destination->type) {
-	case N_WORKSPACE:
-		container_move_to_workspace(container, destination->sway_workspace);
+	case N_WORKSPACE: {
+			struct sway_workspace *dest_ws = destination->sway_workspace;
+			// Match i3's con_move_to_target behavior:
+			// - Empty workspace: move directly to workspace
+			// - Non-empty workspace: descend to focused child, add as sibling
+			//   (i3's _con_move_to_con goes up to parent, making con a sibling)
+			if (workspace_is_empty(dest_ws)) {
+				container_move_to_workspace(container, dest_ws);
+			} else {
+				struct sway_node *focus =
+					seat_get_focus_inactive(seat, destination);
+				if (focus && focus->type == N_CONTAINER) {
+					struct sway_container *focus_con = focus->sway_container;
+					// Match i3: add as sibling of focused child, not as child of it
+					if (container != focus_con &&
+							!container_has_ancestor(focus_con, container)) {
+						container_detach(container);
+						container->pending.width = container->pending.height = 0;
+						container->width_fraction = container->height_fraction = 0;
+						container_add_sibling(focus_con, container, 1);
+						if (container->view) {
+							ipc_event_window(container, "move");
+						}
+					}
+				}
+			}
+		}
 		break;
 	case N_OUTPUT: {
 			struct sway_output *output = destination->sway_output;
@@ -579,8 +604,32 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 			container_move_to_workspace(container, ws);
 		}
 		break;
-	case N_CONTAINER:
-		container_move_to_container(container, destination->sway_container);
+	case N_CONTAINER: {
+			struct sway_container *dest_con = destination->sway_container;
+			// Match i3's con_move_to_target behavior:
+			// If destination is a split (not a leaf), descend to focused child
+			// and add as sibling of that child
+			if (!dest_con->view) {
+				struct sway_node *focus =
+					seat_get_focus_inactive(seat, destination);
+				if (focus && focus->type == N_CONTAINER) {
+					struct sway_container *focus_con = focus->sway_container;
+					// Add as sibling of focused child
+					if (container != focus_con &&
+							!container_has_ancestor(focus_con, container)) {
+						container_detach(container);
+						container->pending.width = container->pending.height = 0;
+						container->width_fraction = container->height_fraction = 0;
+						container_add_sibling(focus_con, container, 1);
+						if (container->view) {
+							ipc_event_window(container, "move");
+						}
+					}
+				}
+			} else {
+				container_move_to_container(container, dest_con);
+			}
+		}
 		break;
 	case N_ROOT:
 		break;

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -525,11 +525,17 @@ static struct cmd_results *cmd_move_container(bool no_auto_back_and_forth,
 		destination = seat_get_focus_inactive(seat, &new_output->node);
 	} else if (strcasecmp(argv[0], "mark") == 0) {
 		struct sway_container *dest_con = container_find_mark(argv[1]);
-		if (dest_con == NULL) {
-			return cmd_results_new(CMD_FAILURE,
-					"Mark '%s' not found", argv[1]);
+		if (dest_con) {
+			destination = &dest_con->node;
+		} else {
+			struct sway_workspace *dest_ws = workspace_find_mark(argv[1]);
+			if (dest_ws) {
+				destination = &dest_ws->node;
+			} else {
+				return cmd_results_new(CMD_FAILURE,
+						"Mark '%s' not found", argv[1]);
+			}
 		}
-		destination = &dest_con->node;
 	} else {
 		return cmd_results_new(CMD_INVALID, "%s", expected_syntax);
 	}

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -3,29 +3,38 @@
 #include "sway/config.h"
 #include "sway/tree/root.h"
 #include "sway/tree/view.h"
+#include "sway/tree/workspace.h"
 #include "list.h"
 #include "log.h"
 #include "stringop.h"
 
-static void remove_mark(struct sway_container *con) {
+static void remove_container_mark(struct sway_container *con) {
 	container_clear_marks(con);
 	container_update_marks(con);
 }
 
-static void remove_all_marks_iterator(struct sway_container *con, void *data) {
-	remove_mark(con);
+static void remove_all_container_marks_iterator(struct sway_container *con, void *data) {
+	remove_container_mark(con);
 }
 
-// unmark                  Remove all marks from all views
-// unmark foo              Remove single mark from whichever view has it
-// [criteria] unmark       Remove all marks from matched view
-// [criteria] unmark foo   Remove single mark from matched view
+static void remove_all_workspace_marks_iterator(struct sway_workspace *ws, void *data) {
+	workspace_clear_marks(ws);
+}
+
+// unmark                  Remove all marks from all views/workspaces
+// unmark foo              Remove single mark from whichever view/workspace has it
+// [criteria] unmark       Remove all marks from matched view/workspace
+// [criteria] unmark foo   Remove single mark from matched view/workspace
 
 struct cmd_results *cmd_unmark(int argc, char **argv) {
-	// Determine the container
+	// Determine the container or workspace
 	struct sway_container *con = NULL;
+	struct sway_workspace *ws = NULL;
 	if (config->handler_context.node_overridden) {
 		con = config->handler_context.container;
+		if (!con) {
+			ws = config->handler_context.workspace;
+		}
 	}
 
 	// Determine the mark
@@ -41,13 +50,23 @@ struct cmd_results *cmd_unmark(int argc, char **argv) {
 		}
 	} else if (con && !mark) {
 		// Clear all marks from the given container
-		remove_mark(con);
-	} else if (!con && mark) {
-		// Remove mark from whichever container has it
+		remove_container_mark(con);
+	} else if (ws && mark) {
+		// Remove the mark from the given workspace
+		if (workspace_has_mark(ws, mark)) {
+			workspace_find_and_unmark(mark);
+		}
+	} else if (ws && !mark) {
+		// Clear all marks from the given workspace
+		workspace_clear_marks(ws);
+	} else if (!con && !ws && mark) {
+		// Remove mark from whichever container/workspace has it
 		container_find_and_unmark(mark);
+		workspace_find_and_unmark(mark);
 	} else {
-		// Remove all marks from all containers
-		root_for_each_container(remove_all_marks_iterator, NULL);
+		// Remove all marks from all containers and workspaces
+		root_for_each_container(remove_all_container_marks_iterator, NULL);
+		root_for_each_workspace(remove_all_workspace_marks_iterator, NULL);
 	}
 	free(mark);
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -530,6 +530,14 @@ static void ipc_json_describe_workspace(struct sway_workspace *workspace,
 			json_object_new_string(
 				ipc_json_orientation_description(workspace->layout)));
 
+	// Marks
+	json_object *marks = json_object_new_array();
+	for (int i = 0; i < workspace->marks->length; ++i) {
+		json_object_array_add(marks,
+				json_object_new_string(workspace->marks->items[i]));
+	}
+	json_object_object_add(object, "marks", marks);
+
 	// Floating
 	json_object *floating_array = json_object_new_array();
 	for (int i = 0; i < workspace->floating->length; ++i) {


### PR DESCRIPTION
## Summary

This PR fixes `[con_id=X]` criteria to match workspace nodes, bringing sway's behavior in line with i3. It also adds marks support for workspaces and fixes `move container to mark` behavior for split targets.

## Problem

In i3, `[con_id=X]` works for all node types including workspaces. In sway, it only matches containers, breaking scripts that rely on targeting workspaces by their internal ID.

**Reproduce on master:**
```bash
# Get a workspace ID
swaymsg -t get_tree | jq '.. | objects | select(.type == "workspace") | {name, id}' | head -8

# Try to mark it (fails)
swaymsg '[con_id=<workspace_id>] mark test'
# Returns: "No matching node."
```

## Use Case

A "move to parent" helper that reparents a container to be a sibling of its current parent:

```bash
# Move focused container up one level in the tree
[con_id=$grandparent] mark --replace _target
[con_id=$parent] focus
[con_id=$container] move container to mark _target
unmark _target
[con_id=$container] focus
```

This works in i3 but fails in sway when the grandparent is a workspace.

## Changes

1. **fix(criteria): allow con_id to match workspaces** - Extend `criteria_get_nodes()` to iterate workspaces when `con_id` is specified

2. **feat(workspace): add marks support to workspaces** - Workspaces can now have marks like containers, enabling the full "move to mark" pattern

3. **fix(move): match i3 behavior for move-to-mark on split targets** - When moving to a mark on a workspace or split container, descend to the focused child and add as sibling (matching i3's `con_move_to_target` behavior)

## Test Plan

```bash
# 1. Get workspace ID
WS_ID=$(swaymsg -t get_tree | jq '[.. | objects | select(.type == "workspace" and .name != "__i3_scratch")][0].id')

# 2. Test con_id matching (should succeed)
swaymsg "[con_id=$WS_ID] mark test_ws"

# 3. Verify mark was added
swaymsg -t get_tree | jq ".. | objects | select(.id == $WS_ID) | .marks"
# Should output: ["test_ws"]

# 4. Test move to workspace mark
# Create a split with nested container, then:
swaymsg "[con_id=$WS_ID] mark parent"
swaymsg "move container to mark parent"
# Container should become direct child of workspace

# 5. Test move to container mark (split target)
# Mark a split container, move a nested container to it
# Container should become sibling of focused child, not nested deeper

# 6. Cleanup
swaymsg "unmark test_ws; unmark parent"
```
