### PR TITLE
Visually improving sway main config file

### DIFF
--- a/config.in
+++ b/config.in
@@ -4,32 +4,43 @@
 #
 # Read `man 5 sway` for a complete reference.
 
-### Variables
-#
+
+###################################
+# ========== Variables ========== #
+###################################
+
+
 # Logo key. Use Mod1 for Alt.
 set $mod Mod4
+
 # Home row direction keys, like vim
 set $left h
 set $down j
 set $up k
 set $right l
+
 # Your preferred terminal emulator
 set $term foot
+
 # Your preferred application launcher
 set $menu wmenu-run
 
-### Output configuration
-#
-# Default wallpaper (more resolutions are available in @datadir@/backgrounds/sway/)
-output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
-#
+
+##############################################
+# ========== Output configuration ========== #
+##############################################
+
+
+# Default wallpaper (more resolutions are available in /usr/share/backgrounds/sway/)
+output * bg /usr/share/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
+
 # Example configuration:
 #
 #   output HDMI-A-1 resolution 1920x1080 position 1920,0
 #
 # You can get the names of your outputs by running: swaymsg -t get_outputs
 
-### Idle configuration
+# ~========== Idle configuration ==========~
 #
 # Example configuration:
 #
@@ -42,7 +53,7 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 # your displays after another 300 seconds, and turn your screens back on when
 # resumed. It will also lock your screen before your computer goes to sleep.
 
-### Input configuration
+# ~========== Input configuration ==========~
 #
 # Example configuration:
 #
@@ -60,10 +71,14 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 # You can also configure each device individually.
 # Read `man 5 sway-input` for more information about this section.
 
-### Key bindings
-#
-# Basics:
-#
+
+######################################
+# ========== Key bindings ========== #
+######################################
+
+
+# ~========== Basics ==========~
+
     # Start a terminal
     bindsym $mod+Return exec $term
 
@@ -85,9 +100,9 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 
     # Exit sway (logs you out of your Wayland session)
     bindsym $mod+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -B 'Yes, exit sway' 'swaymsg exit'
-#
-# Moving around:
-#
+
+# ~========== Moving around ==========~
+
     # Move your focus around
     bindsym $mod+$left focus left
     bindsym $mod+$down focus down
@@ -109,9 +124,9 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
     bindsym $mod+Shift+Down move down
     bindsym $mod+Shift+Up move up
     bindsym $mod+Shift+Right move right
-#
-# Workspaces:
-#
+
+# ~==========  Workspaces ==========~
+
     # Switch to workspace
     bindsym $mod+1 workspace number 1
     bindsym $mod+2 workspace number 2
@@ -123,6 +138,17 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
     bindsym $mod+8 workspace number 8
     bindsym $mod+9 workspace number 9
     bindsym $mod+0 workspace number 10
+    # for azerty keyboards: 
+    # 1 = amperstand
+    # 2 = eacute
+    # 3 = quotedbl
+    # 4 = apostrophe
+    # 5 = parentleft
+    # 6 = minus
+    # 7 = egrave
+    # 8 = underscore
+    # 9 = ccedilla
+    # 0 = agrave
     # Move focused container to workspace
     bindsym $mod+Shift+1 move container to workspace number 1
     bindsym $mod+Shift+2 move container to workspace number 2
@@ -136,9 +162,9 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
     bindsym $mod+Shift+0 move container to workspace number 10
     # Note: workspaces can have any name you want, not just numbers.
     # We just use 1-10 as the default.
-#
-# Layout stuff:
-#
+
+# ~========== Layout stuff ==========~
+
     # You can "split" the current object of your focus with
     # $mod+b or $mod+v, for horizontal and vertical splits
     # respectively.
@@ -161,9 +187,9 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 
     # Move focus to the parent container
     bindsym $mod+a focus parent
-#
-# Scratchpad:
-#
+
+# ~========== Scratchpad ==========~
+
     # Sway has a "scratchpad", which is a bag of holding for windows.
     # You can send windows there and get them back later.
 
@@ -173,9 +199,9 @@ output * bg @datadir@/backgrounds/sway/Sway_Wallpaper_Blue_1920x1080.png fill
     # Show the next scratchpad window or hide the focused scratchpad window.
     # If there are multiple scratchpad windows, this command cycles through them.
     bindsym $mod+minus scratchpad show
-#
-# Resizing containers:
-#
+
+# ~========== Resizing containers ==========~
+
 mode "resize" {
     # left will shrink the containers width
     # right will grow the containers width
@@ -197,21 +223,14 @@ mode "resize" {
     bindsym Escape mode "default"
 }
 bindsym $mod+r mode "resize"
-#
-# Utilities:
-#
+
+# ~========== Utilities ==========~
+
     # Special keys to adjust volume via PulseAudio
     bindsym --locked XF86AudioMute exec pactl set-sink-mute \@DEFAULT_SINK@ toggle
     bindsym --locked XF86AudioLowerVolume exec pactl set-sink-volume \@DEFAULT_SINK@ -5%
     bindsym --locked XF86AudioRaiseVolume exec pactl set-sink-volume \@DEFAULT_SINK@ +5%
     bindsym --locked XF86AudioMicMute exec pactl set-source-mute \@DEFAULT_SOURCE@ toggle
-
-    # Special keys to control media via playerctl
-    bindsym --locked XF86AudioPlay exec playerctl play-pause
-    bindsym --locked XF86AudioPause exec playerctl play-pause
-    bindsym --locked XF86AudioPrev exec playerctl previous
-    bindsym --locked XF86AudioNext exec playerctl next
-    bindsym --locked XF86AudioStop exec playerctl stop
 
     # Special keys to adjust brightness via brightnessctl
     bindsym --locked XF86MonBrightnessDown exec brightnessctl set 5%-
@@ -220,9 +239,12 @@ bindsym $mod+r mode "resize"
     # Special key to take a screenshot with grim
     bindsym Print exec grim
 
-#
-# Status Bar:
-#
+
+####################################
+# ========== Status Bar ========== #
+####################################
+
+
 # Read `man 5 sway-bar` for more information about this section.
 bar {
     position top
@@ -238,4 +260,4 @@ bar {
     }
 }
 
-include @sysconfdir@/sway/config.d/*
+include /etc/sway/config.d/*


### PR DESCRIPTION
I rewrote the titles and the subtitles to make it more readable and understandable. 
I also made a whole comment to explain how to bind the number keys on azerty keyboards because the numbers only works with their equivalent name (amperstand, eacute, quotedbl, apostrophe, parentleft, minus, egrave, underscore, ccedilla and agrave).
I'm not sure this feature should be in the main config but I believe that it should be explained somewhere.
I also wanted you to know that for some reason, the part of the code with the fonctions keys don't work with some azerty keyboards