### PR TITLE
sway/input/cursor: fix crash on first stylus tap after reboot via null check

### DIFF
--- a/sway/input/cursor.c
+++ b/sway/input/cursor.c
@@ -644,6 +644,11 @@ static void handle_tool_tip(struct wl_listener *listener, void *data) {
 	cursor_handle_activity_from_device(cursor, &event->tablet->base);
 
 	struct sway_tablet_tool *sway_tool = event->tool->data;
+	if (!sway_tool) {
+		sway_log(SWAY_DEBUG, "tool tip before proximity");
+		return;
+	}
+
 	struct wlr_tablet_v2_tablet *tablet_v2 = sway_tool->tablet->tablet_v2;
 	struct sway_seat *seat = cursor->seat;
 


### PR DESCRIPTION
`handle_tool_tip()` previously used `event->tool->data` without checking for `NULL`. When launching sway for the first time after a reboot, and then tapping with a USI 2.0 stylus, the tool tip event is fired before the tool proximity event. As `event->tool` is initialized during the tool proximity handler `handle_tool_proximity()`, this was causing a crash.

The fix adds a `NULL` check before accessing the fields of `event->tool->data`. In case of a `NULL`, a log message is emitted indicating that the tool tip event fired before proximity. This new logic is identical to the logic that was already in `handle_tool_axis()`.

Fixes #8907