### PR TITLE
sway-ipc(7): Clarify that the reply shown for GET_BINDING_STATE is an example

### DIFF
--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1116,7 +1116,7 @@ Returns the currently active binding mode.
 A single object that contains the property _name_, which is set to the
 currently active binding mode as a string.
 
-*Exact Reply:*
+*Example Reply:*
 ```
 {
 	"name": "default"


### PR DESCRIPTION
Fix documentation of sway-ipc. The example reply for GET_BINDIG_STATE is an example and not the exact reply. 

This bug seems to come from copy/paste from the ipc command SYNC directly above, where the the shown reply is the exact reply and not an example.