### PR TITLE
Fix #8949

### DIFF
--- a/sway/commands/scratchpad.c
+++ b/sway/commands/scratchpad.c
@@ -121,7 +121,7 @@ struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 		// we'll return an error. The same is true if the
 		// overridden node is not a container.
 		if (!con || !con->scratchpad) {
-			return cmd_results_new(CMD_INVALID, "Container is not in scratchpad.");
+			return cmd_results_new(CMD_FAILURE, NULL);
 		}
 		scratchpad_toggle_container(con);
 	} else {


### PR DESCRIPTION
We don't do any scratchpad filtering in criterias so non-scratchpad containers are expected in ```cmd_scratchpad```. 
we currently error on the first non-scratchpad window. This patch matches the behavior in i3 which does not error if at least one scratchpad container is found. 

Fixes https://github.com/swaywm/sway/issues/8949
