### PR TITLE
Sync downstream fix: prevent crash from stale fullscreen pointer in overview mode

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -538,6 +538,12 @@ void container_begin_destroy(struct sway_container *con) {
 	if (con->pending.fullscreen_mode == FULLSCREEN_WORKSPACE && con->pending.workspace) {
 		con->pending.workspace->fullscreen = NULL;
 	}
+
+	// If the container was the one stored in the overview's fullscreen memory, clear it.
+	if (con->pending.workspace && con->pending.workspace->layout.fullscreen == con) {
+		con->pending.workspace->layout.fullscreen = NULL;
+	}
+
 	if (con->scratchpad && con->pending.fullscreen_mode == FULLSCREEN_GLOBAL) {
 		container_fullscreen_disable(con);
 	}


### PR DESCRIPTION
## Background

We are developing a research tool that scans downstream forks to identify valuable commits
that have not yet been merged back into upstream projects.  
The goal is to help upstream maintainers discover useful fixes that may otherwise remain
isolated in forks.

During this process, we found this commit in a downstream fork, and it has already been
validated and merged there.

## What this change does

This commit fixes a crash that occurs when a fullscreen container is destroyed while the
system is in overview mode.

### Root cause
When a fullscreen container is closed in overview mode, the workspace layout may still keep
a reference to that container in `layout.fullscreen`.  
This creates a stale (dangling) pointer, which can later be dereferenced when exiting
overview mode, leading to a crash.

### Fix
The patch explicitly clears the fullscreen reference when:
- the container being destroyed
- is the same container stored in the overview layout fullscreen state

This prevents stale pointers and avoids invalid memory access.

## Why this matters

This issue is:
- reproducible
- user-visible (crash)
- related to lifecycle management of containers
- consistent with issue #125

The fix is minimal, safe, and localized, and has already been proven in a downstream fork.

## Additional context

This PR is part of our effort to upstream valuable downstream contributions discovered via
our analysis tool.  
All commits are manually reviewed and technically validated before submission.

We hope this contribution is helpful.  
If there are any concerns about the change itself or suggestions on how our tool or workflow
could be improved, we would greatly appreciate your feedback.

---

Related issue: [#125  ](https://github.com/dawsers/scroll/issues/125)
Downstream reference commit: f42701e