### PR TITLE
config: add include_one directive for override-safe config includes

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -145,6 +145,7 @@ sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
 sway_cmd cmd_hide_edge_borders;
 sway_cmd cmd_include;
+sway_cmd cmd_include_one;
 sway_cmd cmd_inhibit_idle;
 sway_cmd cmd_input;
 sway_cmd cmd_seat;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -103,6 +103,7 @@ static const struct cmd_handler handlers[] = {
 static const struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "include", cmd_include },
+	{ "include_one", cmd_include_one },
 	{ "primary_selection", cmd_primary_selection },
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },

--- a/sway/commands/include_one.c
+++ b/sway/commands/include_one.c
@@ -1,0 +1,111 @@
+#define _XOPEN_SOURCE 700
+#include <libgen.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <wordexp.h>
+#include "list.h"
+#include "log.h"
+#include "sway/commands.h"
+#include "sway/config.h"
+
+static bool basename_in_list(list_t *basenames, const char *path) {
+	char *path_copy = strdup(path);
+	if (!path_copy) {
+		return false;
+	}
+	char *base = basename(path_copy);
+
+	for (int i = 0; i < basenames->length; ++i) {
+		if (strcmp(basenames->items[i], base) == 0) {
+			free(path_copy);
+			return true;
+		}
+	}
+	free(path_copy);
+	return false;
+}
+
+static char *get_basename_copy(const char *path) {
+	char *path_copy = strdup(path);
+	if (!path_copy) {
+		return NULL;
+	}
+	char *base = basename(path_copy);
+	char *result = strdup(base);
+	free(path_copy);
+	return result;
+}
+
+struct cmd_results *cmd_include_one(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "include_one", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+
+	list_t *included_basenames = create_list();
+	if (!included_basenames) {
+		return cmd_results_new(CMD_FAILURE,
+			"Unable to allocate basename list");
+	}
+
+	char *wd = getcwd(NULL, 0);
+	char *parent_path = strdup(config->current_config_path);
+	if (!wd || !parent_path) {
+		free(wd);
+		free(parent_path);
+		list_free(included_basenames);
+		sway_log(SWAY_ERROR, "Unable to allocate memory for include_one");
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+	const char *parent_dir = dirname(parent_path);
+
+	if (chdir(parent_dir) < 0) {
+		sway_log(SWAY_ERROR, "failed to change working directory");
+		goto cleanup;
+	}
+
+	for (int glob_idx = 0; glob_idx < argc; ++glob_idx) {
+		wordexp_t p;
+		if (wordexp(argv[glob_idx], &p, 0) != 0) {
+			continue;
+		}
+
+		for (size_t i = 0; i < p.we_wordc; ++i) {
+			const char *path = p.we_wordv[i];
+
+			// For subsequent globs (not the first), skip files whose
+			// basename was already included
+			if (glob_idx > 0 && basename_in_list(included_basenames, path)) {
+				sway_log(SWAY_DEBUG,
+					"include_one: skipping %s (basename already included)",
+					path);
+				continue;
+			}
+
+			// Record the basename before including
+			char *base_copy = get_basename_copy(path);
+			if (base_copy) {
+				list_add(included_basenames, base_copy);
+			}
+
+			// Use the existing load_include_configs mechanism for a single file
+			// We call it directly with the path, it will handle the inclusion
+			load_include_configs(path, config, &config->swaynag_config_errors);
+		}
+
+		wordfree(&p);
+	}
+
+	// Attempt to restore working directory before returning.
+	if (chdir(wd) < 0) {
+		sway_log(SWAY_ERROR, "failed to change working directory");
+	}
+
+cleanup:
+	free(parent_path);
+	free(wd);
+	list_free_items_and_destroy(included_basenames);
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -76,6 +76,7 @@ sway_sources = files(
 	'commands/max_render_time.c',
 	'commands/opacity.c',
 	'commands/include.c',
+	'commands/include_one.c',
 	'commands/input.c',
 	'commands/layout.c',
 	'commands/mode.c',


### PR DESCRIPTION
### Summary

This PR adds a new configuration directive called `include_one` to sway.

The directive allows multiple include globs to be processed left-to-right,
including all files from the first glob and skipping files from subsequent
globs whose basenames were already included earlier. This makes it possible
to layer configuration directories cleanly without duplicate overrides.

---

### Motivation

Sway (and i3) support including partial configuration files from directories,
which is commonly used to layer system-wide defaults and user overrides.

For example (Regolith use case):

include /usr/share/regolith/sway/config.d/*
include $HOME/.config/regolith2/sway/config.d/*


In practice, these directories often overlap, and the same filenames may
exist in both locations. While ordering helps, there is no way to express
"include system defaults unless the user already provided an override".

This PR introduces a new directive to solve that problem explicitly.

---

### New directive: `include_one`

include_one <glob1> <glob2> [<glob3> ...]


Behavior:
- Globs are processed from left to right.
- All files from the first glob are included.
- For subsequent globs, files are included **only if their basename**
  (filename without path) has not already been included.
- Ordering is preserved.
- Duplicate basenames are skipped silently.
- If a glob matches no files, behavior matches the existing `include` command.

Example:

include_one $HOME/.config/regolith2/sway/config.d/*
/usr/share/regolith/sway/config.d/*


If both directories contain a file named `70_bar`, the version from the
user directory is included and the system one is skipped.

---

### Implementation details

- The implementation reuses sway’s existing include logic and glob expansion.
- Deduplication is performed per-file using basenames only.
- Existing `include` behavior is unchanged.
- Error paths and memory ownership are handled explicitly to avoid undefined
  behavior on allocation failure.
- The new command is registered alongside the existing `include` directive.

---

### Notes

This change is isolated to configuration parsing and does not affect compositor
or wlroots internals. It was implemented and built against sway 1.9 using Meson;
rebasing to newer versions should only require minor mechanical adjustments due
to config code refactors.

---

### Status

So if the user has [~/.config/regolith2/sway/config.d/70_bar](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the system-wide /usr/share/regolith/sway/config.d/70_bar will be skipped, allowing user overrides.

This change was implemented as part of a qualification task and is submitted
for review and discussion.