### PR TITLE
swaybar: add option to configure tray background

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -245,6 +245,7 @@ sway_cmd bar_colors_cmd_focused_separator;
 sway_cmd bar_colors_cmd_statusline;
 sway_cmd bar_colors_cmd_focused_statusline;
 sway_cmd bar_colors_cmd_urgent_workspace;
+sway_cmd bar_colors_cmd_tray_background;
 
 sway_cmd input_cmd_seat;
 sway_cmd input_cmd_accel_profile;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -404,6 +404,9 @@ struct bar_config {
 		char *binding_mode_border;
 		char *binding_mode_bg;
 		char *binding_mode_text;
+#if HAVE_TRAY
+		char *tray_background;
+#endif
 	} colors;
 
 #if HAVE_TRAY

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -71,6 +71,8 @@ struct swaybar_config {
 		struct box_colors inactive_workspace;
 		struct box_colors urgent_workspace;
 		struct box_colors binding_mode;
+
+		uint32_t tray_background;
 	} colors;
 
 #if HAVE_TRAY

--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -16,6 +16,9 @@ static const struct cmd_handler bar_colors_handlers[] = {
 	{ "separator", bar_colors_cmd_separator },
 	{ "statusline", bar_colors_cmd_statusline },
 	{ "urgent_workspace", bar_colors_cmd_urgent_workspace },
+#if HAVE_TRAY
+	{ "tray_background", bar_colors_cmd_tray_background },
+#endif
 };
 
 static char *hex_to_rgba_hex(const char *hex) {
@@ -150,3 +153,10 @@ struct cmd_results *bar_colors_cmd_urgent_workspace(int argc, char **argv) {
 	};
 	return parse_three_colors(colors, "urgent_workspace", argc, argv);
 }
+
+#if HAVE_TRAY
+struct cmd_results *bar_colors_cmd_tray_background(int argc, char **argv) {
+	return parse_single_color(&(config->current_bar->colors.tray_background),
+			"tray_background", argc, argv);
+}
+#endif

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -171,6 +171,7 @@ struct bar_config *default_bar_config(void) {
 	bar->colors.binding_mode_text = NULL;
 
 #if HAVE_TRAY
+	bar->colors.tray_background = NULL;
 	bar->tray_padding = 2;
 	wl_list_init(&bar->tray_bindings);
 #endif

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -172,7 +172,9 @@ struct bar_config *default_bar_config(void) {
 	bar->colors.binding_mode_text = NULL;
 
 #if HAVE_TRAY
-	bar->colors.tray_background = NULL;
+	if (!(bar->colors.tray_background = strndup("#00000000", 9))) {
+		goto cleanup;
+	}
 	bar->tray_padding = 2;
 	wl_list_init(&bar->tray_bindings);
 #endif

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -71,6 +71,7 @@ void free_bar_config(struct bar_config *bar) {
 	free(bar->colors.binding_mode_bg);
 	free(bar->colors.binding_mode_text);
 #if HAVE_TRAY
+	free(bar->colors.tray_background);
 	list_free_items_and_destroy(bar->tray_outputs);
 	free(bar->icon_theme);
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1404,6 +1404,16 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 				json_object_new_string(bar->colors.urgent_workspace_text));
 	}
 
+#if HAVE_TRAY
+	if (bar->colors.tray_background) {
+		json_object_object_add(colors, "tray_background",
+				json_object_new_string(bar->colors.tray_background));
+	} else {
+		json_object_object_add(colors, "tray_background",
+				json_object_new_string(bar->colors.background));
+	}
+#endif
+
 	json_object_object_add(json, "colors", colors);
 
 	if (bar->bindings->length > 0) {

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1405,13 +1405,8 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 	}
 
 #if HAVE_TRAY
-	if (bar->colors.tray_background) {
-		json_object_object_add(colors, "tray_background",
-				json_object_new_string(bar->colors.tray_background));
-	} else {
-		json_object_object_add(colors, "tray_background",
-				json_object_new_string(bar->colors.background));
-	}
+	json_object_object_add(colors, "tray_background",
+			json_object_new_string(bar->colors.tray_background));
 #endif
 
 	json_object_object_add(json, "colors", colors);

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -232,6 +232,9 @@ must be defined in hex: _#RRGGBB_ or _#RRGGBBAA_.
 	Border, background and text color for the binding mode indicator. If not used,
 	the colors will be taken from _urgent_workspace_.
 
+*tray_background* <color>
+	Background color of the system tray.
+
 # SEE ALSO
 
 *sway*(5) *swaybar-protocol*(7)

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -77,6 +77,7 @@ struct swaybar_config *init_config(void) {
 	config->colors.binding_mode.text = 0xFFFFFFFF;
 
 #if HAVE_TRAY
+	config->colors.tray_background = 0x000000FF;
 	config->tray_padding = 2;
 	wl_list_init(&config->tray_bindings);
 #endif

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -80,6 +80,7 @@ static void ipc_parse_colors(
 		{ "binding_mode_border", &config->colors.binding_mode.border },
 		{ "binding_mode_bg", &config->colors.binding_mode.background },
 		{ "binding_mode_text", &config->colors.binding_mode.text },
+		{ "tray_background", &config->colors.tray_background },
 	};
 
 	for (size_t i = 0; i < sizeof(properties) / sizeof(properties[i]); i++) {

--- a/swaybar/tray/item.c
+++ b/swaybar/tray/item.c
@@ -514,6 +514,9 @@ uint32_t render_sni(cairo_t *cairo, struct swaybar_output *output, double *x,
 	cairo_set_operator(cairo, CAIRO_OPERATOR_OVER);
 
 	cairo_matrix_t scale_matrix;
+	cairo_set_source_u32(cairo, output->bar->config->colors.tray_background);
+	cairo_rectangle(cairo, *x, icon_y, size, size);
+	cairo_fill(cairo);
 	cairo_pattern_t *icon_pattern = cairo_pattern_create_for_surface(icon);
 	// TODO: check cairo_pattern_status for "ENOMEM"
 	cairo_matrix_init_scale(&scale_matrix, output->scale, output->scale);


### PR DESCRIPTION
I would like to have a transparent bar. However it is irritating, that the tray is also transparent.

If no tray background color is configured, fall back to background color.