### PR TITLE
bar_cmd_colors: fix crash on incorrect usage

### DIFF
--- a/sway/commands/bar/colors.c
+++ b/sway/commands/bar/colors.c
@@ -72,6 +72,10 @@ static struct cmd_results *parse_three_colors(char ***colors,
 }
 
 struct cmd_results *bar_cmd_colors(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "colors", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
 	return config_subcommand(argv, argc, bar_colors_handlers,
 			sizeof(bar_colors_handlers));
 }


### PR DESCRIPTION
should display error message instead to be consistent with other subcommands.

fixes #9015 