### PR TITLE
tree/workspace: fix crash on dragging container to workspace edge

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -373,7 +373,7 @@ static void finalize_move(struct sway_seat *seat) {
 		enum sway_container_layout new_layout = edge == WLR_EDGE_TOP ||
 			edge == WLR_EDGE_BOTTOM ? L_VERT : L_HORIZ;
 		workspace_split(new_ws, new_layout);
-		workspace_insert_tiling(new_ws, con, after);
+		workspace_insert_tiling(new_ws, con, after ? new_ws->tiling->length : 0);
 	}
 
 	if (old_parent) {


### PR DESCRIPTION
Problem: when dragging a parent container to the right of its children, sway crashes. The calculated insertion index could exceed the list bounds. The move logic would compute an index based on the pre-removal list state.

Solution: Clamp the insertion index to [0, length].

fixes: #8939 