### PR TITLE
Fix workspace-to-output assignment ignoring output priority order

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -202,11 +202,10 @@ static bool workspace_valid_on_output(const char *output_name,
 	}
 
 	for (int i = 0; i < wsc->outputs->length; i++) {
-		if (output_match_name_or_id(output, wsc->outputs->items[i])) {
-			return true;
-		}
-		if (output_by_name_or_id(wsc->outputs->items[i])) {
-			return false; // a higher-priority output is available
+		struct sway_output *ws_output =
+			output_by_name_or_id(wsc->outputs->items[i]);
+		if (ws_output) {
+			return ws_output == output;
 		}
 	}
 
@@ -323,14 +322,15 @@ char *workspace_next_name(const char *output_name) {
 		}
 		bool found = false;
 		for (int j = 0; j < wsc->outputs->length; ++j) {
-			if (output_match_name_or_id(output, wsc->outputs->items[j])) {
-				found = true;
-				free(target);
-				target = strdup(wsc->workspace);
+			struct sway_output *ws_output =
+				output_by_name_or_id(wsc->outputs->items[j]);
+			if (ws_output) {
+				if (ws_output == output) {
+					found = true;
+					free(target);
+					target = strdup(wsc->workspace);
+				}
 				break;
-			}
-			if (output_by_name_or_id(wsc->outputs->items[j])) {
-				break; // a higher-priority output is available
 			}
 		}
 		if (found) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -205,6 +205,9 @@ static bool workspace_valid_on_output(const char *output_name,
 		if (output_match_name_or_id(output, wsc->outputs->items[i])) {
 			return true;
 		}
+		if (output_by_name_or_id(wsc->outputs->items[i])) {
+			return false; // a higher-priority output is available
+		}
 	}
 
 	return false;
@@ -325,6 +328,9 @@ char *workspace_next_name(const char *output_name) {
 				free(target);
 				target = strdup(wsc->workspace);
 				break;
+			}
+			if (output_by_name_or_id(wsc->outputs->items[j])) {
+				break; // a higher-priority output is available
 			}
 		}
 		if (found) {


### PR DESCRIPTION
When using `workspace <name> output <output1> <output2> ...`, sway should (I think?) place the workspace on the first available output in the list - matching i3's behavior. However, `workspace_next_name()` and `workspace_valid_on_output()` only check whether the output appears *anywhere* in the workspace's output list, ignoring priority order. This allows lower-priority outputs to claim workspaces that should belong to higher-priority outputs.

**Example config:**
```
workspace 1 output HDMI-1 eDP-1
workspace 2 output HDMI-1 eDP-1
workspace 9 output eDP-1 HDMI-1
```

**Before:** When both outputs are connected and eDP-1 needs a default workspace, it scans workspace configs and claims workspace 2 because `eDP-1` appears in workspace 2's output list — even though `HDMI-1` is available and has higher priority for workspace 2.

**After (fixed):** `eDP-1` skips workspaces 1-2 because `HDMI-1` is available and listed first. It correctly finds workspace 9 (where `eDP-1` is the highest-priority available output).

The existing man page (`sway.5.scd`, lines 952-957) already documents the correct behavior, confirming this is a bug in the implementation — not a design choice:

> **workspace** \<name\> output \<outputs...\>
> Specifies that workspace _name_ should be shown on the specified _outputs_.
> Multiple outputs can be listed and the **first available** will be used. If the
> workspace gets placed on an output further down the list and an output that
> is higher on the list becomes available, the workspace will be moved to the
> higher priority output.

This PR adds a priority check in both `workspace_valid_on_output()` and the config loop in `workspace_next_name()`: when iterating through a workspace's output list, if a different available output is encountered before the current output, stop early — the workspace belongs to that higher-priority output.

This aligns sway's behavior with i3's `create_workspace_on_output()`, which calls `get_assigned_output()` and skips workspaces whose best output is not the current one.