### PR TITLE
commands/exec: redirect child stdio to /dev/null

### DIFF
--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -52,6 +53,14 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	pid_t child = fork();
 	if (child == 0) {
 		setsid();
+
+		int devnull = open("/dev/null", O_RDWR);
+		if (devnull > STDERR_FILENO) {
+			dup2(devnull, STDIN_FILENO);
+			dup2(devnull, STDOUT_FILENO);
+			dup2(devnull, STDERR_FILENO);
+			close(devnull);
+		}
 
 		if (ctx) {
 			const char *token = launcher_ctx_get_token_name(ctx);


### PR DESCRIPTION
Children spawned via exec inherit sway's stdio pointing to the launch
TTY. wlroots puts the TTY in KD_GRAPHICS mode, where writes block,
causing programs that write to stdout/stderr on startup (e.g. Electron
apps like Signal, Discord) to hang when launched from a launcher like
fuzzel. Launching from a terminal works since it provides its own PTY.

Closes #4214
Supersedes #4221