### PR TITLE
Re-evaluate "default_orientation auto" when workspaces change outputs

### DIFF
--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -166,4 +166,6 @@ bool sway_ext_workspace_init(void);
 void sway_ext_workspace_output_enable(struct sway_output *output);
 void sway_ext_workspace_output_disable(struct sway_output *output);
 
+void workspace_reorient_auto(struct sway_workspace *ws);
+
 #endif

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -21,6 +21,7 @@
 #include "sway/server.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/root.h"
+#include "sway/tree/workspace.h"
 #include "log.h"
 #include "util.h"
 
@@ -1088,6 +1089,10 @@ static bool apply_resolved_output_configs(struct matched_output_config *configs,
 		struct matched_output_config *cfg = &configs[idx];
 		output_update_position(cfg->output);
 		arrange_layers(cfg->output);
+		for (int i = 0; i < cfg->output->workspaces->length; i++) {
+			struct sway_workspace *ws = cfg->output->workspaces->items[i];
+			workspace_reorient_auto(ws);
+		}
 	}
 
 	arrange_root();

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -43,6 +43,7 @@ static void restore_workspaces(struct sway_output *output) {
 			if (highest == output) {
 				workspace_detach(ws);
 				output_add_workspace(output, ws);
+				workspace_reorient_auto(ws);
 				ipc_event_workspace(NULL, ws, "move");
 				j--;
 			}
@@ -61,6 +62,7 @@ static void restore_workspaces(struct sway_output *output) {
 		struct sway_workspace *ws = root->fallback_output->workspaces->items[0];
 		workspace_detach(ws);
 		output_add_workspace(output, ws);
+		workspace_reorient_auto(ws);
 
 		// If the floater was made floating while on the NOOP output, its width
 		// and height will be zero and it should be reinitialized as a floating
@@ -175,11 +177,8 @@ void output_enable(struct sway_output *output) {
 		ipc_event_workspace(NULL, ws, "init");
 	}
 
-	if (ws && config->default_orientation == L_NONE) {
-		// Since the output transformation and resolution could have changed
-		// due to applying the output config, the previously set layout for the
-		// created workspace may not be correct for `default_orientation auto`
-		ws->layout = output_get_default_layout(output);
+	if (ws) {
+		workspace_reorient_auto(ws);
 	}
 
 	wl_signal_emit_mutable(&root->events.new_node, &output->node);
@@ -244,6 +243,7 @@ static void output_evacuate(struct sway_output *output) {
 
 		workspace_output_add_priority(workspace, new_output);
 		output_add_workspace(new_output, workspace);
+		workspace_reorient_auto(workspace);
 		output_sort_workspaces(new_output);
 		ipc_event_workspace(NULL, workspace, "move");
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -1142,6 +1142,7 @@ void workspace_move_to_output(struct sway_workspace *workspace,
 	}
 
 	output_add_workspace(output, workspace);
+	workspace_reorient_auto(workspace);
 
 	// If moving the last workspace from the old output, create a new workspace
 	// on the old output
@@ -1158,4 +1159,35 @@ void workspace_move_to_output(struct sway_workspace *workspace,
 	output_sort_workspaces(output);
 	workspace_output_raise_priority(workspace, old_output, output);
 	ipc_event_workspace(NULL, workspace, "move");
+}
+
+void workspace_reorient_auto(struct sway_workspace *ws) {
+	if (config->default_orientation != L_NONE) {
+		return;
+	}
+	if (!ws->output) {
+		return;
+	}
+	if (ws->tiling->length > 1) {
+		return;
+	}
+	if (ws->layout == L_TABBED || ws->layout == L_STACKED) {
+		return;
+	}
+
+	enum sway_container_layout new_layout = output_get_default_layout(ws->output);
+	if (ws->layout == new_layout) {
+		return;
+	}
+	ws->layout = new_layout;
+	workspace_update_representation(ws);
+
+	if (ws->tiling->length == 1) {
+		struct sway_container *child = ws->tiling->items[0];
+		if (!child->view &&
+				(child->pending.layout == L_HORIZ || child->pending.layout == L_VERT)) {
+			child->pending.layout = new_layout;
+			container_update_representation(child);
+		}
+	}
 }


### PR DESCRIPTION
When `default_orientation auto` is set, workspace layout (horizontal vs vertical) is determined by output dimensions _at creation time_ but never re-evaluated. This means a workspace created on a landscape display keeps `L_HORIZ` even after moving to a portrait display, which defeats the
purpose of auto orientation in multi-monitor setups.

This patch adds `workspace_reorient_auto()` which re-evaluates the layout based on the _current_ output's aspect ratio. It is called when:

- A workspace is moved to a different output (`move workspace to output`)
- An output is disconnected and workspaces evacuate
- An output is reconnected and workspaces restore back
- An output's mode or transform changes (e.g. rotation)

The function is conservative and only acts when:

- `default_orientation` is `auto` (explicit horizontal/vertical is never touched)
- The workspace has at most 1 tiling child (existing multi-window layouts are preserved)
- The workspace is not tabbed or stacked