### PR TITLE
layer-shell: handle popup reposition for unconstraining

### DIFF
--- a/include/sway/layers.h
+++ b/include/sway/layers.h
@@ -33,6 +33,7 @@ struct sway_layer_popup {
 	struct wl_listener destroy;
 	struct wl_listener new_popup;
 	struct wl_listener commit;
+	struct wl_listener reposition;
 };
 
 struct sway_output;

--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -321,6 +321,7 @@ static void popup_handle_destroy(struct wl_listener *listener, void *data) {
 	wl_list_remove(&popup->destroy.link);
 	wl_list_remove(&popup->new_popup.link);
 	wl_list_remove(&popup->commit.link);
+	wl_list_remove(&popup->reposition.link);
 	free(popup);
 }
 
@@ -356,6 +357,11 @@ static void popup_handle_commit(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void popup_handle_reposition(struct wl_listener *listener, void *data) {
+	struct sway_layer_popup *popup = wl_container_of(listener, popup, reposition);
+	popup_unconstrain(popup);
+}
+
 static void popup_handle_new_popup(struct wl_listener *listener, void *data);
 
 static struct sway_layer_popup *create_popup(struct wlr_xdg_popup *wlr_popup,
@@ -376,11 +382,13 @@ static struct sway_layer_popup *create_popup(struct wlr_xdg_popup *wlr_popup,
 	}
 
 	popup->destroy.notify = popup_handle_destroy;
-	wl_signal_add(&wlr_popup->base->events.destroy, &popup->destroy);
+	wl_signal_add(&wlr_popup->events.destroy, &popup->destroy);
 	popup->new_popup.notify = popup_handle_new_popup;
 	wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
 	popup->commit.notify = popup_handle_commit;
 	wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->commit);
+	popup->reposition.notify = popup_handle_reposition;
+	wl_signal_add(&wlr_popup->events.reposition, &popup->reposition);
 
 	return popup;
 }


### PR DESCRIPTION
  ## Summary

  Handle `xdg_popup.reposition` for layer-shell popups so unconstrained geometry is re-applied after reposition requests.

  ## Problem

  For layer-shell popups, we unconstrain on initial commit only.
  When clients (eg. GTK4) later send `xdg_popup.reposition`, wlroots updates scheduled popup geometry from the positioner again. Without handling `reposition`, the previous unconstrained placement is lost and popups can end up off-
  screen (eg. tooltips below bottom edge).

  ## Root Cause

  Layer-shell popup code was missing a `wlr_xdg_popup.events.reposition` listener.

  Additionally, popup cleanup was tied to `wlr_popup->base->events.destroy` (xdg-surface destroy), which is too late for popup-scoped listeners: wlroots asserts popup listener lists are empty during popup destroy.

  ## Fix

  - Add `reposition` listener to layer-shell popups and call `popup_unconstrain()`.
  - Move destroy listener from `wlr_popup->base->events.destroy` to `wlr_popup->events.destroy`.
  - Remove the new `reposition` listener in popup cleanup.

  ## Why `wlr_popup->events.destroy`

  `reposition` is a popup-scoped signal (`wlr_xdg_popup.events.*`), so its listener must be removed during popup destroy, not base-surface destroy.

  ## Testing

  - Reproduced with GTK4 layer-shell tooltip near output edge.
  - Before: tooltip may render outside viewport after reposition.
  - After: tooltip is constrained/flipped/slid into visible area.
  - No crash when popup is destroyed.

  Fixes #8518.

