### PR TITLE
Fix crash on PROTON_WAYLAND_ENABLE

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -196,6 +196,10 @@ static bool criteria_matches_view(struct criteria *criteria,
 	struct sway_container *focus = seat_get_focused_container(seat);
 	struct sway_view *focused = focus ? focus->view : NULL;
 
+	if (!view->container) {
+		return false;
+	}
+
 	if (criteria->title) {
 		const char *title = view_get_title(view);
 		if (!title) {


### PR DESCRIPTION
work-around for: https://github.com/swaywm/sway/issues/9042

Based on the patch proposed here: https://github.com/swaywm/sway/issues/8853#issuecomment-3239422972

The main issue is that this `view->container` pointer is NULL. The patch is just a work-around. I'm completely unsure of what to do in those situation. The whole function should be probably re-evaluated by someone how knows about it. Or maybe the pointer being NULL is a broader problem?