### PR TITLE
guard seat_get_focus() NULL dereferences

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1344,7 +1344,9 @@ void seat_unfocus_unless_client(struct sway_seat *seat, struct wl_client *client
 	}
 	if (seat->has_focus) {
 		struct sway_node *focus = seat_get_focus(seat);
-		if (focus && node_is_view(focus) && wl_resource_get_client(
+		if (!focus) {
+			seat->has_focus = false;
+		} else if (node_is_view(focus) && wl_resource_get_client(
 					focus->sway_container->view->surface->resource) != client) {
 			seat_set_focus(seat, NULL);
 		}

--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1136,10 +1136,12 @@ static void seat_set_workspace_focus(struct sway_seat *seat, struct sway_node *n
 
 	if (node == NULL) {
 		// Close any popups on the old focus
-		if (node_is_view(last_focus)) {
-			view_close_popups(last_focus->sway_container->view);
+		if (last_focus) {
+			if (node_is_view(last_focus)) {
+				view_close_popups(last_focus->sway_container->view);
+			}
+			seat_send_unfocus(last_focus, seat);
 		}
-		seat_send_unfocus(last_focus, seat);
 		sway_input_method_relay_set_focus(&seat->im_relay, NULL);
 		seat->has_focus = false;
 		return;
@@ -1291,7 +1293,9 @@ void seat_set_focus_surface(struct sway_seat *seat,
 		struct wlr_surface *surface, bool unfocus) {
 	if (seat->has_focus && unfocus) {
 		struct sway_node *focus = seat_get_focus(seat);
-		seat_send_unfocus(focus, seat);
+		if (focus) {
+			seat_send_unfocus(focus, seat);
+		}
 		seat->has_focus = false;
 	}
 
@@ -1340,7 +1344,7 @@ void seat_unfocus_unless_client(struct sway_seat *seat, struct wl_client *client
 	}
 	if (seat->has_focus) {
 		struct sway_node *focus = seat_get_focus(seat);
-		if (node_is_view(focus) && wl_resource_get_client(
+		if (focus && node_is_view(focus) && wl_resource_get_client(
 					focus->sway_container->view->surface->resource) != client) {
 			seat_set_focus(seat, NULL);
 		}


### PR DESCRIPTION
seat_get_focus() can return NULL when the focus stack is empty. a few call sites don't check for this and just dereference the result, which crashes sway.

this happens when a client disconnects abruptly, leaving the seat with a stale `has_focus` flag or empty focus stack. whatever touches focus next dereferences NULL. the two confirmed crash sites were `seat_set_workspace_focus` and `seat_set_focus_surface` (coredumps below). `seat_unfocus_unless_client` has the same pattern so a check was added there too for safety.

Coredumps:

I cannot remember how i triggered this one:
```
#0  seat_send_unfocus ()
#1  seat_set_workspace_focus ()
#2  seat_set_focus ()
#3  wl_signal_emit_mutable ()
#4  container_begin_destroy ()
#5  view_unmap ()
#6  handle_unmap ()
#7  wl_signal_emit_mutable ()
#8  wlr_surface_unmap ()
#9  destroy_xdg_toplevel ()
#10 destroy_xdg_surface_role_object ()
#11 destroy_xdg_surface ()
#12 xdg_client_handle_resource_destroy ()
#13 wl_client_destroy ()
```

Mouse click on empty container (clicked wallpaper, likely was just after a wallpaper engine crash or something):
```
#0  seat_send_unfocus ()
#1  seat_set_workspace_focus ()
#2  seat_set_focus ()
#3  handle_button ()
#4  wl_signal_emit_mutable ()
#5  handle_pointer_button ()
#6  handle_libinput_readable ()
#7  wl_event_loop_dispatch ()
```

IPC workspace switch (with noctalia workspace widget):
```
#0  seat_send_unfocus ()
#1  seat_set_workspace_focus ()
#2  seat_set_focus ()
#3  workspace_switch ()
#4  cmd_workspace ()
#5  execute_command ()
#6  ipc_client_handle_command ()
#7  ipc_client_handle_readable ()
#8  wl_event_loop_dispatch ()
```

Layer surface teardown (restarted noctalia shell):
```
#0  seat_send_unfocus ()
#1  seat_set_focus_surface ()
#2  seat_set_focus_layer ()
#3  handle_node_destroy ()
#4  wl_signal_emit_mutable ()
#5  sway_scene_node_destroy ()
#6  layer_surface_destroy ()
#7  surface_handle_role_resource_destroy ()
```

  
  
  i encountered this while using scroll and initially opened a pr against it https://github.com/dawsers/scroll/pull/219 