### PR TITLE
swaybar: add option to show tray left of status

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -226,6 +226,7 @@ sway_cmd bar_cmd_strip_workspace_name;
 sway_cmd bar_cmd_swaybar_command;
 sway_cmd bar_cmd_tray_bindcode;
 sway_cmd bar_cmd_tray_bindsym;
+sway_cmd bar_cmd_tray_last;
 sway_cmd bar_cmd_tray_output;
 sway_cmd bar_cmd_tray_padding;
 sway_cmd bar_cmd_unbindcode;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -411,6 +411,7 @@ struct bar_config {
 	struct wl_list tray_bindings; // struct tray_binding::link
 	list_t *tray_outputs; // char *
 	int tray_padding;
+	bool tray_last;
 #endif
 };
 

--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -79,6 +79,7 @@ struct swaybar_config {
 	bool tray_hidden;
 	list_t *tray_outputs; // char *
 	int tray_padding;
+	bool tray_last;
 #endif
 };
 

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -30,6 +30,7 @@ static const struct cmd_handler bar_handlers[] = {
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
 	{ "tray_bindcode", bar_cmd_tray_bindcode },
 	{ "tray_bindsym", bar_cmd_tray_bindsym },
+        { "tray_last", bar_cmd_tray_last },
 	{ "tray_output", bar_cmd_tray_output },
 	{ "tray_padding", bar_cmd_tray_padding },
 	{ "unbindcode", bar_cmd_unbindcode },

--- a/sway/commands/bar.c
+++ b/sway/commands/bar.c
@@ -30,7 +30,7 @@ static const struct cmd_handler bar_handlers[] = {
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
 	{ "tray_bindcode", bar_cmd_tray_bindcode },
 	{ "tray_bindsym", bar_cmd_tray_bindsym },
-        { "tray_last", bar_cmd_tray_last },
+	{ "tray_last", bar_cmd_tray_last },
 	{ "tray_output", bar_cmd_tray_output },
 	{ "tray_padding", bar_cmd_tray_padding },
 	{ "unbindcode", bar_cmd_unbindcode },

--- a/sway/commands/bar/tray_last.c
+++ b/sway/commands/bar/tray_last.c
@@ -1,0 +1,29 @@
+#include <string.h>
+#include <strings.h>
+#include "sway/commands.h"
+#include "log.h"
+#include "util.h"
+
+struct cmd_results *bar_cmd_tray_last(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+        sway_log(SWAY_DEBUG, "Checking tray_last command");
+	if ((error = checkarg(argc,
+				"tray_last", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	config->current_bar->tray_last =
+		parse_boolean(argv[0], config->current_bar->tray_last);
+
+	if (config->current_bar->tray_last) {
+		config->current_bar->tray_last = true;
+
+		sway_log(SWAY_DEBUG, "Making tray the last item on the bar: %s",
+				config->current_bar->id);
+	} else {
+		sway_log(SWAY_DEBUG, "Making tray the before last item on the bar: %s",
+				config->current_bar->id);
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/commands/bar/tray_last.c
+++ b/sway/commands/bar/tray_last.c
@@ -5,6 +5,7 @@
 #include "util.h"
 
 struct cmd_results *bar_cmd_tray_last(int argc, char **argv) {
+#if HAVE_TRAY
 	struct cmd_results *error = NULL;
         sway_log(SWAY_DEBUG, "Checking tray_last command");
 	if ((error = checkarg(argc,
@@ -26,4 +27,8 @@ struct cmd_results *bar_cmd_tray_last(int argc, char **argv) {
 	}
 
 	return cmd_results_new(CMD_SUCCESS, NULL);
+#else
+	return cmd_results_new(CMD_INVALID,
+			"Sway has been compiled without tray support");
+#endif
 }

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -172,7 +172,7 @@ struct bar_config *default_bar_config(void) {
 
 #if HAVE_TRAY
 	bar->tray_padding = 2;
-        bar->tray_last = true;
+	bar->tray_last = true;
 	wl_list_init(&bar->tray_bindings);
 #endif
 

--- a/sway/config/bar.c
+++ b/sway/config/bar.c
@@ -172,6 +172,7 @@ struct bar_config *default_bar_config(void) {
 
 #if HAVE_TRAY
 	bar->tray_padding = 2;
+        bar->tray_last = true;
 	wl_list_init(&bar->tray_bindings);
 #endif
 

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1469,7 +1469,7 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 
 	json_object_object_add(json, "tray_padding",
 			json_object_new_int(bar->tray_padding));
-        json_object_object_add(json, "tray_last", json_object_new_boolean(bar->tray_last));
+	json_object_object_add(json, "tray_last", json_object_new_boolean(bar->tray_last));
 #endif
 	return json;
 }

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -1469,6 +1469,7 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar) {
 
 	json_object_object_add(json, "tray_padding",
 			json_object_new_int(bar->tray_padding));
+        json_object_object_add(json, "tray_last", json_object_new_boolean(bar->tray_last));
 #endif
 	return json;
 }

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -147,6 +147,7 @@ sway_sources = files(
 	'commands/bar/strip_workspace_name.c',
 	'commands/bar/swaybar_command.c',
 	'commands/bar/tray_bind.c',
+        'commands/bar/tray_last.c',
 	'commands/bar/tray_output.c',
 	'commands/bar/tray_padding.c',
 	'commands/bar/workspace_buttons.c',

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -147,7 +147,7 @@ sway_sources = files(
 	'commands/bar/strip_workspace_name.c',
 	'commands/bar/swaybar_command.c',
 	'commands/bar/tray_bind.c',
-        'commands/bar/tray_last.c',
+	'commands/bar/tray_last.c',
 	'commands/bar/tray_output.c',
 	'commands/bar/tray_padding.c',
 	'commands/bar/workspace_buttons.c',

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -169,7 +169,8 @@ ContextMenu|Activate|SecondaryActivate|ScrollDown|ScrollLeft|ScrollRight|ScrollU
 	for button3).
 
 *tray_last* yes|no
-            Sets the tray icons to appear as the last element in the bar. If _no_, the tray will appear to the left of the status command. Default is _yes_.
+	Sets the tray icons to appear as the last element in the bar. If _no_, the
+	tray will appear to the left of the status command. Default is _yes_.
 
 *tray_padding* <px> [px]
 	Sets the pixel padding of the system tray. This padding will surround the

--- a/sway/sway-bar.5.scd
+++ b/sway/sway-bar.5.scd
@@ -168,6 +168,9 @@ ContextMenu|Activate|SecondaryActivate|ScrollDown|ScrollLeft|ScrollRight|ScrollU
 	action (Activate for button1, ContextMenu for button2 and SecondaryActivate
 	for button3).
 
+*tray_last* yes|no
+            Sets the tray icons to appear as the last element in the bar. If _no_, the tray will appear to the left of the status command. Default is _yes_.
+
 *tray_padding* <px> [px]
 	Sets the pixel padding of the system tray. This padding will surround the
 	tray on all sides and between each item. The default value for _px_ is 2.

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -78,7 +78,7 @@ struct swaybar_config *init_config(void) {
 
 #if HAVE_TRAY
 	config->tray_padding = 2;
-        config->tray_last = true;
+	config->tray_last = true;
 	wl_list_init(&config->tray_bindings);
 #endif
 

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -78,6 +78,7 @@ struct swaybar_config *init_config(void) {
 
 #if HAVE_TRAY
 	config->tray_padding = 2;
+        config->tray_last = true;
 	wl_list_init(&config->tray_bindings);
 #endif
 

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -308,9 +308,9 @@ static bool ipc_parse_config(
 		config->tray_padding = json_object_get_int(tray_padding);
 	}
 
-        if ((json_object_object_get_ex(bar_config, "tray_last", &tray_last))) {
-          config->tray_last = json_object_get_boolean(tray_last);       
-        }
+	if ((json_object_object_get_ex(bar_config, "tray_last", &tray_last))) {
+		config->tray_last = json_object_get_boolean(tray_last);
+	}
 
 	struct tray_binding *tray_bind = NULL, *tmp_tray_bind = NULL;
 	wl_list_for_each_safe(tray_bind, tmp_tray_bind, &config->tray_bindings,

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -283,7 +283,7 @@ static bool ipc_parse_config(
 		config->wrap_scroll = json_object_get_boolean(wrap_scroll);
 	}
 #if HAVE_TRAY
-	json_object *tray_outputs, *tray_padding, *tray_bindings, *icon_theme;
+	json_object *tray_outputs, *tray_padding, *tray_last, *tray_bindings, *icon_theme;
 
 	if (config->tray_outputs && config->tray_outputs->length) {
 		list_free_items_and_destroy(config->tray_outputs);
@@ -307,6 +307,10 @@ static bool ipc_parse_config(
 	if ((json_object_object_get_ex(bar_config, "tray_padding", &tray_padding))) {
 		config->tray_padding = json_object_get_int(tray_padding);
 	}
+
+        if ((json_object_object_get_ex(bar_config, "tray_last", &tray_last))) {
+          config->tray_last = json_object_get_boolean(tray_last);       
+        }
 
 	struct tray_binding *tray_bind = NULL, *tmp_tray_bind = NULL;
 	wl_list_for_each_safe(tray_bind, tmp_tray_bind, &config->tray_bindings,

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -675,14 +675,14 @@ static uint32_t render_to_cairo(struct render_context *ctx) {
 	 * utilize the available space.
 	 */
 	double x = output->width;
-        /* config->tray_last = false; */
+
 #if HAVE_TRAY
 	if (bar->tray && config->tray_last) {
 		uint32_t h = render_tray(cairo, output, &x);
 		max_height = h > max_height ? h : max_height;
 	}
 #endif
-       	if (bar->status) {
+	if (bar->status) {
 		uint32_t h = render_status_line(ctx, &x);
 		max_height = h > max_height ? h : max_height;
 	}
@@ -692,6 +692,7 @@ static uint32_t render_to_cairo(struct render_context *ctx) {
 		max_height = h > max_height ? h : max_height;
 	}
 #endif
+
 	x = 0;
 	if (config->workspace_buttons) {
 		struct swaybar_workspace *ws;

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -675,16 +675,23 @@ static uint32_t render_to_cairo(struct render_context *ctx) {
 	 * utilize the available space.
 	 */
 	double x = output->width;
+        /* config->tray_last = false; */
 #if HAVE_TRAY
-	if (bar->tray) {
+	if (bar->tray && config->tray_last) {
 		uint32_t h = render_tray(cairo, output, &x);
 		max_height = h > max_height ? h : max_height;
 	}
 #endif
-	if (bar->status) {
+       	if (bar->status) {
 		uint32_t h = render_status_line(ctx, &x);
 		max_height = h > max_height ? h : max_height;
 	}
+#if HAVE_TRAY
+	if (bar->tray && !config->tray_last) {
+		uint32_t h = render_tray(cairo, output, &x);
+		max_height = h > max_height ? h : max_height;
+	}
+#endif
 	x = 0;
 	if (config->workspace_buttons) {
 		struct swaybar_workspace *ws;


### PR DESCRIPTION
Adding an option `tray_last yes|no` to show the tray as the last element in the swaybar or not.

Default (current implementation) is `yes`, putting the tray at the right most.

With `no`, the tray is positioned before the status command.
