### PR TITLE
sway/commands/move.c: negative coords move to the bottom/right edge

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -809,9 +809,10 @@ static struct cmd_results *cmd_move_to_position_pointer(
 }
 
 static const char expected_position_syntax[] =
-	"Expected 'move [absolute] position <x> [px] <y> [px]' or "
+	"Expected 'move [absolute] position <x> [px|ppt] <y> [px|ppt]' or "
 	"'move [absolute] position center' or "
-	"'move position cursor|mouse|pointer'";
+	"'move position cursor|mouse|pointer' "
+	"(negative coordinates are relative to the workspace/screen bottom-right corner)";
 
 static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	struct sway_container *container = config->handler_context.container;
@@ -941,6 +942,26 @@ static struct cmd_results *cmd_move_to_position(int argc, char **argv) {
 	case MOVEMENT_UNIT_INVALID:
 		sway_assert(false, "invalid y unit");
 		break;
+	}
+	// Negative coordinates are measured from the bottom-right corner of the
+	// screen/workspace rather than the top-left corner, so that e.g.
+	// "move position -10px -10px" places the window's bottom-right corner
+	// 10px from the screen/workspace bottom-right corner.
+	if (lx.amount < 0) {
+		if (absolute) {
+			lx.amount = root->x + root->width + lx.amount
+				- container->pending.width;
+		} else {
+			lx.amount = ws->width + lx.amount - container->pending.width;
+		}
+	}
+	if (ly.amount < 0) {
+		if (absolute) {
+			ly.amount = root->y + root->height + ly.amount
+				- container->pending.height;
+		} else {
+			ly.amount = ws->height + ly.amount - container->pending.height;
+		}
 	}
 	if (!absolute) {
 		lx.amount += ws->x;

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -241,6 +241,11 @@ set|plus|minus|toggle <amount>
 	The position can be specified in pixels or percentage points, omitting
 	the unit defaults to pixels. If _absolute_ is used, the position is
 	relative to all outputs. _absolute_ can not be used with percentage points.
+	Negative coordinates are measured from the bottom-right corner of the
+	workspace (or all outputs when _absolute_ is used): a negative value places
+	the container so that its bottom-right corner is that many pixels (or
+	percentage points of the workspace dimension) from the workspace bottom-right
+	corner.
 
 *move* [absolute] position center
 	Moves the focused container to be centered on the workspace. If _absolute_


### PR DESCRIPTION
Add a possibility to move a window to the bottom or right edge.
Sample config, tested and working:
```
for_window [app_id="whatever"] move position -1 ppt -1 ppt
```