### PR TITLE
tree/node: add and use node_finish in destroy functions

### DIFF
--- a/include/sway/tree/node.h
+++ b/include/sway/tree/node.h
@@ -60,6 +60,8 @@ const char *node_type_to_str(enum sway_node_type type);
  */
 void node_set_dirty(struct sway_node *node);
 
+void node_finish(struct sway_node *node);
+
 bool node_is_view(struct sway_node *node);
 
 char *node_get_name(struct sway_node *node);

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -530,6 +530,7 @@ void container_destroy(struct sway_container *con) {
 
 	scene_node_disown_children(con->content_tree);
 	wlr_scene_node_destroy(&con->scene_tree->node);
+	node_finish(&con->node);
 	free(con);
 }
 

--- a/sway/tree/node.c
+++ b/sway/tree/node.c
@@ -36,6 +36,13 @@ void node_set_dirty(struct sway_node *node) {
 	list_add(server.dirty_nodes, node);
 }
 
+void node_finish(struct sway_node *node) {
+	int dirty_idx = list_find(server.dirty_nodes, node);
+	if (dirty_idx >= 0) {
+		list_del(server.dirty_nodes, dirty_idx);
+	}
+}
+
 bool node_is_view(struct sway_node *node) {
 	return node->type == N_CONTAINER && node->sway_container->view;
 }

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -273,6 +273,7 @@ void output_destroy(struct sway_output *output) {
 	list_free(output->workspaces);
 	list_free(output->current.workspaces);
 	wlr_color_transform_unref(output->color_transform);
+	node_finish(&output->node);
 	free(output);
 }
 

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -292,6 +292,7 @@ void workspace_destroy(struct sway_workspace *workspace) {
 	list_free(workspace->tiling);
 	list_free(workspace->current.floating);
 	list_free(workspace->current.tiling);
+	node_finish(&workspace->node);
 	free(workspace);
 }
 


### PR DESCRIPTION
Otherwise we might try to modset on an output that is already removed. This happens because of the timer from request_modeset call in begin_destroy firing at inconvenient times

Correct fix to https://github.com/swaywm/sway/pull/8969