### PR TITLE
Clamp dimensions to non-negative before wlr_scene_rect_set_size

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -435,9 +435,10 @@ static void arrange_container(struct sway_container *con,
 		int border_left = con->current.border_left ? border_width : 0;
 		int border_right = con->current.border_right ? border_width : 0;
 		int vert_border_height = MAX(0, height - border_top - border_bottom);
+		int horiz_border_width = MAX(0, width);
 
-		wlr_scene_rect_set_size(con->border.top, width, border_top);
-		wlr_scene_rect_set_size(con->border.bottom, width, border_bottom);
+		wlr_scene_rect_set_size(con->border.top, horiz_border_width, border_top);
+		wlr_scene_rect_set_size(con->border.bottom, horiz_border_width, border_bottom);
 		wlr_scene_rect_set_size(con->border.left,
 			border_left, vert_border_height);
 		wlr_scene_rect_set_size(con->border.right,
@@ -449,7 +450,7 @@ static void arrange_container(struct sway_container *con,
 		wlr_scene_node_set_position(&con->border.left->node,
 			0, border_top);
 		wlr_scene_node_set_position(&con->border.right->node,
-			width - border_right, border_top);
+			horiz_border_width - border_right, border_top);
 
 		// make sure to reparent, it's possible that the client just came out of
 		// fullscreen mode where the parent of the surface is not the container

--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -81,6 +81,8 @@ static void resize_box(struct wlr_box *box, enum wlr_edges edge,
 		box->y += thickness;
 		box->width -= thickness * 2;
 		box->height -= thickness * 2;
+		if (box->width < 0) box->width = 0;
+		if (box->height < 0) box->height = 0;
 		break;
 	}
 }
@@ -154,7 +156,9 @@ static bool split_titlebar(struct sway_node *node, struct sway_container *avoid,
 
 static void update_indicator(struct seatop_move_tiling_event *e, struct wlr_box *box) {
 	wlr_scene_node_set_position(&e->indicator_rect->node, box->x, box->y);
-	wlr_scene_rect_set_size(e->indicator_rect, box->width, box->height);
+	wlr_scene_rect_set_size(e->indicator_rect,
+		box->width > 0 ? box->width : 0,
+		box->height > 0 ? box->height : 0);
 }
 
 static void handle_motion_postthreshold(struct sway_seat *seat) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -335,7 +335,11 @@ static void update_rect_list(struct wlr_scene_tree *tree, pixman_region32_t *reg
 		if (i < len) {
 			const pixman_box32_t *box = &rects[i++];
 			wlr_scene_node_set_position(&rect->node, box->x1, box->y1);
-			wlr_scene_rect_set_size(rect, box->x2 - box->x1, box->y2 - box->y1);
+			int rect_width = box->x2 - box->x1;
+			int rect_height = box->y2 - box->y1;
+			wlr_scene_rect_set_size(rect,
+				rect_width > 0 ? rect_width : 0,
+				rect_height > 0 ? rect_height : 0);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix crash when dragging a tiled window across multiple outputs without dropping on intermediate output
- `wlr_scene_rect_set_size` assertion `width >= 0 && height >= 0` fails at `types/scene/wlr_scene.c:739`
- Same class of bug as #8120 (fixed by 62fd8c4d for height, but width was missed)

## Root Cause
During cross-output tiling drags, box dimensions can go negative via:
1. `resize_box()` subtracting `thickness * 2` from width/height (WLR_EDGE_NONE case)
2. Threshold calculations producing negative values during cross-output coordinate transforms
3. Border width passed unclamped to `wlr_scene_rect_set_size` in `arrange_container()`

## Changes
- **sway/input/seatop_move_tiling.c**: Clamp dimensions in `resize_box()` and `update_indicator()`
- **sway/desktop/transaction.c**: Clamp border width in `arrange_container()` (matches existing height clamp)
- **sway/tree/container.c**: Clamp pixman region box dimensions in `update_rect_list()`

## Environment
- Sway 1.11, wlroots 0.19.2, Mesa 26.0.2, Linux 6.19.7
- 3 monitors in non-trivial layout (mix of side-by-side and stacked)
- Reproducible: drag tiled window across outputs without releasing, particularly with a gamescope application on the intermediate monitor

## Stack Trace
```
wlr_scene.c:739: wlr_scene_rect_set_size: Assertion `width >= 0 && height >= 0' failed.
#4  wlr_scene_rect_set_size (libwlroots-0.19.so + 0x3e0de)
#5  sway+0x3b6e4
#6  wl_signal_emit_mutable (libwayland-server.so.0) x2
#7  libwlroots-0.19.so + 0x764b9
#8  wl_event_loop_dispatch → wl_display_run
```

## Test Plan
- [x] Drag tiled window across 3 outputs without dropping on intermediate
- [x] Verify crash no longer occurs
- [x] Drag windows between all monitor pairs
- [x] Create many small tiled containers and drag across outputs
- [x] Resize windows to minimum near output boundaries