### PR TITLE
common/pango: get_text_size out pointers may be NULL

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -84,7 +84,15 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const PangoFontDescription *desc,
 
 void get_text_size(cairo_t *cairo, const PangoFontDescription *desc, int *width, int *height,
 		int *baseline, double scale, bool markup, const char *fmt, ...) {
-	*width = *height = *baseline = 0;
+	if (width) {
+		*width = 0;
+	}
+	if (height) {
+		*height = 0;
+	}
+	if (baseline) {
+		*baseline = 0;
+	}
 
 	va_list args;
 	va_start(args, fmt);


### PR DESCRIPTION
Fixes: 2c2a2ec38055092f368b44d4affefdfa8df17ff9
Closes: https://github.com/swaywm/sway/issues/9082