### PR TITLE
pango: don't use cairo_create(NULL) for text metrics

### DIFF
--- a/common/pango.c
+++ b/common/pango.c
@@ -123,7 +123,8 @@ out:
 }
 
 void get_text_metrics(const PangoFontDescription *description, int *height, int *baseline) {
-	cairo_t *cairo = cairo_create(NULL);
+	cairo_surface_t *dummy_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
+	cairo_t *cairo = cairo_create(dummy_surface);
 	PangoContext *pango = pango_cairo_create_context(cairo);
 	pango_context_set_round_glyph_positions(pango, false);
 	// When passing NULL as a language, pango uses the current locale.
@@ -135,6 +136,7 @@ void get_text_metrics(const PangoFontDescription *description, int *height, int 
 	pango_font_metrics_unref(metrics);
 	g_object_unref(pango);
 	cairo_destroy(cairo);
+	cairo_surface_destroy(dummy_surface);
 }
 
 void render_text(cairo_t *cairo, const PangoFontDescription *desc,

--- a/sway/sway_text_node.c
+++ b/sway/sway_text_node.c
@@ -198,7 +198,8 @@ static void handle_destroy(struct wl_listener *listener, void *data) {
 static void text_calc_size(struct text_buffer *buffer) {
 	struct sway_text_node *props = &buffer->props;
 
-	cairo_t *c = cairo_create(NULL);
+	cairo_surface_t *dummy_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
+	cairo_t *c = cairo_create(dummy_surface);
 	if (!c) {
 		sway_log(SWAY_ERROR, "cairo_t allocation failed");
 		return;
@@ -208,6 +209,7 @@ static void text_calc_size(struct text_buffer *buffer) {
 	get_text_size(c, config->font_description, &props->width, NULL,
 		&props->baseline, 1, props->pango_markup, "%s", buffer->text);
 	cairo_destroy(c);
+	cairo_surface_destroy(dummy_surface);
 
 	wlr_scene_buffer_set_dest_size(buffer->buffer_node,
 		get_text_width(props), props->height);

--- a/sway/sway_text_node.c
+++ b/sway/sway_text_node.c
@@ -107,8 +107,10 @@ static void render_backing_buffer(struct text_buffer *buffer) {
 	}
 
 	cairo_t *cairo = cairo_create(surface);
-	if (!cairo) {
-		sway_log(SWAY_ERROR, "cairo_create failed");
+	status = cairo_status(cairo);
+	if (status != CAIRO_STATUS_SUCCESS) {
+		sway_log(SWAY_ERROR, "cairo_create() failed: %s",
+			cairo_status_to_string(status));
 		free(cairo_buffer);
 		goto err;
 	}
@@ -200,8 +202,10 @@ static void text_calc_size(struct text_buffer *buffer) {
 
 	cairo_surface_t *dummy_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
 	cairo_t *c = cairo_create(dummy_surface);
-	if (!c) {
-		sway_log(SWAY_ERROR, "cairo_t allocation failed");
+	cairo_status_t status = cairo_status(c);
+	if (status != CAIRO_STATUS_SUCCESS) {
+		sway_log(SWAY_ERROR, "cairo_create() failed: %s",
+			cairo_status_to_string(status));
 		return;
 	}
 


### PR DESCRIPTION
This returns a context in an error state, and pango won't work with it without also reporting errors.

Create a temporary 1x1 image instead

Close https://github.com/swaywm/sway/issues/9084