### PR TITLE
container: Move foreign toplevel enter/leave events to view

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -91,10 +91,6 @@ struct sway_container {
 	} border;
 
 	struct wlr_scene_tree *content_tree;
-	struct wlr_scene_buffer *output_handler;
-
-	struct wl_listener outputs_update;
-	struct wl_listener output_handler_destroy;
 
 	struct sway_container_state current;
 	struct sway_container_state pending;

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -69,6 +69,9 @@ struct sway_view {
 	struct wlr_scene_tree *scene_tree;
 	struct wlr_scene_tree *content_tree;
 	struct wlr_scene_tree *saved_surface_tree;
+	struct wlr_scene_buffer *output_handler;
+
+	struct wl_listener outputs_update;
 
 	struct wlr_scene *image_capture_scene;
 	struct wlr_ext_image_capture_source_v1 *image_capture_source;

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -395,10 +395,6 @@ static void arrange_container(struct sway_container *con,
 	// make sure it's enabled for viewing
 	wlr_scene_node_set_enabled(&con->scene_tree->node, true);
 
-	if (con->output_handler) {
-		wlr_scene_buffer_set_dest_size(con->output_handler, width, height);
-	}
-
 	if (con->view) {
 		int border_top = container_titlebar_height();
 		int border_width = con->current.border_thickness;
@@ -456,6 +452,13 @@ static void arrange_container(struct sway_container *con,
 		wlr_scene_node_reparent(&con->view->scene_tree->node, con->content_tree);
 		wlr_scene_node_set_position(&con->view->scene_tree->node,
 			border_left, border_top);
+
+		// the output handler for the view wants to detect events for the entire
+		// container so give it negative coordinates to move it back over the
+		// decorations
+		wlr_scene_node_set_position(&con->view->output_handler->node,
+			-border_left, -border_top);
+		wlr_scene_buffer_set_dest_size(con->view->output_handler, width, height);
 	} else {
 		// make sure to disable the title bar if the parent is not managing it
 		if (title_bar) {
@@ -495,6 +498,11 @@ static void arrange_fullscreen(struct wlr_scene_tree *tree,
 
 		// if we only care about the view, disable any decorations
 		wlr_scene_node_set_enabled(&fs->scene_tree->node, false);
+
+		// reconfigure the output handler (for foreign toplevel) to cover the
+		// view without container decorations
+		wlr_scene_node_set_position(&fs->view->output_handler->node, 0, 0);
+		wlr_scene_buffer_set_dest_size(fs->view->output_handler, width, height);
 	} else {
 		fs_node = &fs->scene_tree->node;
 		arrange_container(fs, width, height, true, container_get_gaps(fs));

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -25,50 +25,6 @@
 #include "log.h"
 #include "stringop.h"
 
-static void handle_outputs_update(
-		struct wl_listener *listener, void *data) {
-	struct sway_container *con = wl_container_of(
-			listener, con, outputs_update);
-	struct wlr_scene_outputs_update_event *event = data;
-
-	struct wlr_foreign_toplevel_handle_v1 *toplevel = con->view->foreign_toplevel;
-	if (toplevel) {
-		struct wlr_foreign_toplevel_handle_v1_output *toplevel_output, *tmp;
-		wl_list_for_each_safe(toplevel_output, tmp, &toplevel->outputs, link) {
-			bool active = false;
-			for (size_t i = 0; i < event->size; i++) {
-				struct wlr_scene_output *scene_output = event->active[i];
-				if (scene_output->output == toplevel_output->output) {
-					active = true;
-					break;
-				}
-			}
-
-			if (!active) {
-				wlr_foreign_toplevel_handle_v1_output_leave(toplevel, toplevel_output->output);
-			}
-		}
-
-		for (size_t i = 0; i < event->size; i++) {
-			struct wlr_scene_output *scene_output = event->active[i];
-			wlr_foreign_toplevel_handle_v1_output_enter(toplevel, scene_output->output);
-		}
-	}
-}
-
-static void handle_destroy(
-		struct wl_listener *listener, void *data) {
-	struct sway_container *con = wl_container_of(
-			listener, con, output_handler_destroy);
-
-	container_begin_destroy(con);
-}
-
-static bool handle_point_accepts_input(
-		struct wlr_scene_buffer *buffer, double *x, double *y) {
-	return false;
-}
-
 static struct wlr_scene_rect *alloc_rect_node(struct wlr_scene_tree *parent,
 		bool *failed) {
 	if (*failed) {
@@ -135,22 +91,6 @@ struct sway_container *container_create(struct sway_view *view) {
 		c->border.bottom = alloc_rect_node(c->border.tree, &failed);
 		c->border.left = alloc_rect_node(c->border.tree, &failed);
 		c->border.right = alloc_rect_node(c->border.tree, &failed);
-
-		c->output_handler = wlr_scene_buffer_create(c->border.tree, NULL);
-		if (!c->output_handler) {
-			sway_log(SWAY_ERROR, "Failed to allocate a scene node");
-			failed = true;
-		}
-
-		if (!failed) {
-			c->outputs_update.notify = handle_outputs_update;
-			wl_signal_add(&c->output_handler->events.outputs_update,
-					&c->outputs_update);
-			c->output_handler_destroy.notify = handle_destroy;
-			wl_signal_add(&c->output_handler->node.events.destroy,
-					&c->output_handler_destroy);
-			c->output_handler->point_accepts_input = handle_point_accepts_input;
-		}
 	}
 
 	if (!failed && !scene_descriptor_assign(&c->scene_tree->node,
@@ -522,7 +462,6 @@ void container_destroy(struct sway_container *con) {
 
 	if (con->view && con->view->container == con) {
 		con->view->container = NULL;
-		wlr_scene_node_destroy(&con->output_handler->node);
 		if (con->view->destroying) {
 			view_destroy(con->view);
 		}
@@ -563,11 +502,6 @@ void container_begin_destroy(struct sway_container *con) {
 
 	if (con->pending.parent || con->pending.workspace) {
 		container_detach(con);
-	}
-
-	if (con->view && con->view->container == con) {
-		wl_list_remove(&con->outputs_update.link);
-		wl_list_remove(&con->output_handler_destroy.link);
 	}
 }
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -38,6 +38,41 @@
 #include "sway/xdg_decoration.h"
 #include "stringop.h"
 
+static void handle_outputs_update(
+		struct wl_listener *listener, void *data) {
+	struct sway_view *view = wl_container_of(listener, view, outputs_update);
+	struct wlr_scene_outputs_update_event *event = data;
+
+	struct wlr_foreign_toplevel_handle_v1 *toplevel = view->foreign_toplevel;
+	if (toplevel) {
+		struct wlr_foreign_toplevel_handle_v1_output *toplevel_output, *tmp;
+		wl_list_for_each_safe(toplevel_output, tmp, &toplevel->outputs, link) {
+			bool active = false;
+			for (size_t i = 0; i < event->size; i++) {
+				struct wlr_scene_output *scene_output = event->active[i];
+				if (scene_output->output == toplevel_output->output) {
+					active = true;
+					break;
+				}
+			}
+
+			if (!active) {
+				wlr_foreign_toplevel_handle_v1_output_leave(toplevel, toplevel_output->output);
+			}
+		}
+
+		for (size_t i = 0; i < event->size; i++) {
+			struct wlr_scene_output *scene_output = event->active[i];
+			wlr_foreign_toplevel_handle_v1_output_enter(toplevel, scene_output->output);
+		}
+	}
+}
+
+static bool handle_point_accepts_input(
+		struct wlr_scene_buffer *buffer, double *x, double *y) {
+	return false;
+}
+
 bool view_init(struct sway_view *view, enum sway_view_type type,
 		const struct sway_view_impl *impl) {
 	bool failed = false;
@@ -51,11 +86,22 @@ bool view_init(struct sway_view *view, enum sway_view_type type,
 		goto err;
 	}
 
+	view->output_handler = wlr_scene_buffer_create(view->scene_tree, NULL);
+	if (!view->output_handler) {
+		sway_log(SWAY_ERROR, "Failed to allocate a scene node");
+		goto err;
+	}
+
 	view->image_capture_scene = wlr_scene_create();
 	if (view->image_capture_scene == NULL) {
 		goto err;
 	}
 	view->image_capture_scene->restack_xwayland_surfaces = false;
+
+	view->outputs_update.notify = handle_outputs_update;
+	wl_signal_add(&view->output_handler->events.outputs_update,
+		&view->outputs_update);
+	view->output_handler->point_accepts_input = handle_point_accepts_input;
 
 	view->type = type;
 	view->impl = impl;
@@ -102,6 +148,7 @@ void view_begin_destroy(struct sway_view *view) {
 		return;
 	}
 	view->destroying = true;
+	wl_list_remove(&view->outputs_update.link);
 
 	if (!view->container) {
 		view_destroy(view);
@@ -1229,8 +1276,10 @@ void view_save_buffer(struct sway_view *view) {
 		return;
 	}
 
-	// Enable and disable the saved surface tree like so to atomitaclly update
-	// the tree. This will prevent over damaging or other weirdness.
+	// Make sure the output handler is placed above the saved surface so we don't send
+	// spurious events to the foreign toplevel handler. Also, make the saved surface tree
+	// is disabled until it is ready to replace the real surface.
+	wlr_scene_node_place_below(&view->saved_surface_tree->node, &view->output_handler->node);
 	wlr_scene_node_set_enabled(&view->saved_surface_tree->node, false);
 
 	wlr_scene_node_for_each_buffer(&view->content_tree->node,


### PR DESCRIPTION
It made sense to put it on the container level because the protocol cares about the toplevel and that includes its decorations. But, this breaks down when we consider if the container's view is fullscreen and the container decorations are disabled. Moving it to the view manages this expected lifetime better. Since the buffer is now part of the view, the buffer will get negative coordinates to act as if it's part of the container when we want to.

A known issue is that we will send spurious leave/enter events while we reconfigure the scene for entering/exiting fullscreen. The fix for this loops back to atomic updates to scene and that is outside of the scope of this commit.

Fixes: #9000