### PR TITLE
color-management: Advertise relative colorimetric support

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -447,6 +447,7 @@ bool server_init(struct sway_server *server) {
 	if (server->renderer->features.input_color_transform) {
 		const enum wp_color_manager_v1_render_intent render_intents[] = {
 			WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL,
+			WP_COLOR_MANAGER_V1_RENDER_INTENT_RELATIVE,
 		};
 		size_t transfer_functions_len = 0;
 		enum wp_color_manager_v1_transfer_function *transfer_functions =


### PR DESCRIPTION
While we are required to offer perceptual support, we wlr_scene does not support any kind of tone mapping in the current moment. As such, we might as well advertise relative colorimetric support.

As we only support sRGB and BT.2020 right now which share the D65 whitepoint, we could also advertise absolute and absolute_no_adaption if we wanted to.