### PR TITLE
Centre fullscreen surfaces smaller than output

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -988,7 +988,7 @@ void view_center_and_clip_surface(struct sway_view *view) {
 
 	bool clip_to_geometry = true;
 
-	if (container_is_floating(con)) {
+	if (container_is_floating(con) || con->pending.fullscreen_mode != FULLSCREEN_NONE) {
 		// We always center the current coordinates rather than the next, as the
 		// geometry immediately affects the currently active rendering.
 		int x = (int) fmax(0, (con->current.content_width - view->geometry.width) / 2);


### PR DESCRIPTION
Sway renders fullscreen surfaces smaller than the output left-aligned.

From xdg-shell:

> If the surface doesn't cover the whole output, the compositor will
> position the surface in the center of the output and compensate with
> with border fill covering the rest of the output. The content of the
> border fill is undefined, but should be assumed to be in some way that
> attempts to blend into the surrounding area (e.g. solid black).

Render surfaces smaller than the output centred. Can be tested easily with:

    weston-simple-egl -f -r

Fixes: https://github.com/swaywm/sway/issues/8845