### PR TITLE
Preserving previous output

### DIFF
--- a/include/stringop.h
+++ b/include/stringop.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdarg.h>
 #include "list.h"
 
 #ifdef __GNUC__

--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -39,6 +39,8 @@ struct sway_output {
 	struct wlr_scene_rect *fullscreen_background;
 
 	struct wlr_output *wlr_output;
+	char *previous_output_name;
+
 	struct wlr_scene_output *scene_output;
 	struct sway_server *server;
 	struct wl_list link;

--- a/include/sway/tree/workspace.h
+++ b/include/sway/tree/workspace.h
@@ -45,6 +45,7 @@ struct sway_workspace {
 	struct side_gaps gaps_outer;
 
 	struct sway_output *output; // NULL if no outputs are connected
+	char *previous_output_name; // NULL if no previous output
 	list_t *floating;           // struct sway_container
 	list_t *tiling;             // struct sway_container
 	list_t *output_priority;

--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -27,6 +27,7 @@ enum wlr_direction opposite_direction(enum wlr_direction d) {
 }
 
 static void restore_workspaces(struct sway_output *output) {
+	sway_log(SWAY_DEBUG, "Restore Workspaces: restoring workspaces for output %s", output->wlr_output->name);
 	// Workspace output priority
 	for (int i = 0; i < root->outputs->length; i++) {
 		struct sway_output *other = root->outputs->items[i];
@@ -36,9 +37,13 @@ static void restore_workspaces(struct sway_output *output) {
 
 		for (int j = 0; j < other->workspaces->length; j++) {
 			struct sway_workspace *ws = other->workspaces->items[j];
+
 			struct sway_output *highest =
 				workspace_output_get_highest_available(ws);
-			if (highest == output) {
+			if (highest == output || 
+				(ws->previous_output_name != NULL &&
+				!strcmp(ws->previous_output_name, output->wlr_output->name)))
+			{
 				workspace_detach(ws);
 				output_add_workspace(output, ws);
 				ipc_event_workspace(NULL, ws, "move");

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -84,6 +84,7 @@ struct sway_workspace *workspace_create(struct sway_output *output,
 	}
 
 	ws->name = strdup(name);
+	ws->previous_output_name = NULL;
 	ws->prev_split_layout = L_NONE;
 	ws->layout = output_get_default_layout(output);
 	ws->floating = create_list();
@@ -149,6 +150,7 @@ void workspace_destroy(struct sway_workspace *workspace) {
 	wlr_scene_node_destroy(&workspace->layers.fullscreen->node);
 
 	free(workspace->name);
+	free(workspace->previous_output_name);
 	free(workspace->representation);
 	list_free_items_and_destroy(workspace->output_priority);
 	list_free(workspace->floating);
@@ -291,8 +293,6 @@ static void workspace_name_from_binding(const struct sway_binding * binding,
 }
 
 char *workspace_next_name(const char *output_name) {
-	sway_log(SWAY_DEBUG, "Workspace: Generating new workspace name for output %s",
-			output_name);
 	// Scan for available workspace names by looking through output-workspace
 	// assignments primarily, falling back to bindings and numbers.
 	struct sway_mode *mode = config->current_mode;
@@ -782,6 +782,12 @@ void workspace_detach(struct sway_workspace *workspace) {
 	if (index != -1) {
 		list_del(output->workspaces, index);
 	}
+	if (workspace->previous_output_name) {
+		free(workspace->previous_output_name);
+		workspace->previous_output_name = NULL;
+	}
+
+	workspace->previous_output_name = strdup(output->wlr_output->name);
 	workspace->output = NULL;
 
 	node_set_dirty(&workspace->node);


### PR DESCRIPTION
When displays are removed, save the display name that the current workspace was allocated to, and restore to that display when the display is added again.

This means that switching VTs or running `dm-tool lock` will not scramble all workspaces back to the primary output. Similarly, when dealing with a laptop connecting to a monitor, the workspaces assigned to that monitor will go back to the monitor.

This only saves one level of history; this fixes the repro described in #9057 but might not be fully general if there are more than two displays involved. Arguably the "previous output" should also be reset if certain operations occur; for example if after display detach, if a workspace is selected and modified (i.e. windows resized or layout changed) then it is likely that the intent is no longer for it to revert to the old display when reattached. Open to discussion on these points.

Fixes #9057