### PR TITLE
seatop_move_tiling: clamp edge thresholds to parent box

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -234,18 +234,22 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 		if (layout == L_HORIZ || layout == L_TABBED) {
 			if (cursor->cursor->y < thresh_top) {
 				edge = WLR_EDGE_TOP;
+				if (thresh_top < box.y) thresh_top = box.y;
 				box.height = thresh_top - box.y;
 			} else if (cursor->cursor->y > thresh_bottom) {
 				edge = WLR_EDGE_BOTTOM;
+				if (thresh_bottom > box.y + box.height) thresh_bottom = box.y + box.height;
 				box.height = box.y + box.height - thresh_bottom;
 				box.y = thresh_bottom;
 			}
 		} else if (layout == L_VERT || layout == L_STACKED) {
 			if (cursor->cursor->x < thresh_left) {
 				edge = WLR_EDGE_LEFT;
+				if (thresh_left < box.x) thresh_left = box.x;
 				box.width = thresh_left - box.x;
 			} else if (cursor->cursor->x > thresh_right) {
 				edge = WLR_EDGE_RIGHT;
+				if (thresh_right > box.x + box.width) thresh_right = box.x + box.width;
 				box.width = box.x + box.width - thresh_right;
 				box.x = thresh_right;
 			}


### PR DESCRIPTION
When a fullscreen view is present on a workspace that has panels (e.g. a bar with exclusive zone), the view's content geometry extends beyond the workspace's usable area. The edge-detection thresholds computed from the view's content_x/content_width could then lie outside the parent container's box, causing the indicator width or height to become negative. This triggered an assertion in wlr_scene_rect_set_size.  Fix this by clamping the threshold coordinates to the parent container's boundaries before using them to size the drop indicator.

fixes #9102