### PR TITLE
xdg_shell: handle_commit() could receive new geometry of size outside of the toplevel set boundaries (#9130)

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -311,6 +311,24 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 	}
 
 	struct wlr_box *new_geo = &xdg_surface->geometry;
+
+	if (view->wlr_xdg_toplevel->current.min_width > 0 &&
+		new_geo->width < view->wlr_xdg_toplevel->current.min_width) {
+		new_geo->width = view->wlr_xdg_toplevel->current.min_width;
+	}
+	if (view->wlr_xdg_toplevel->current.min_height > 0 &&
+		new_geo->height < view->wlr_xdg_toplevel->current.min_height) {
+		new_geo->height = view->wlr_xdg_toplevel->current.min_height;
+	}
+	if (view->wlr_xdg_toplevel->current.max_width > 0 &&
+		new_geo->width > view->wlr_xdg_toplevel->current.max_width) {
+		new_geo->width = view->wlr_xdg_toplevel->current.max_width;
+	}
+	if (view->wlr_xdg_toplevel->current.max_height > 0 &&
+		new_geo->height < view->wlr_xdg_toplevel->current.max_height) {
+		new_geo->height = view->wlr_xdg_toplevel->current.max_height;
+	}
+
 	bool new_size = new_geo->width != view->geometry.width ||
 			new_geo->height != view->geometry.height ||
 			new_geo->x != view->geometry.x ||

--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -325,7 +325,7 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 		new_geo->width = view->wlr_xdg_toplevel->current.max_width;
 	}
 	if (view->wlr_xdg_toplevel->current.max_height > 0 &&
-		new_geo->height < view->wlr_xdg_toplevel->current.max_height) {
+		new_geo->height > view->wlr_xdg_toplevel->current.max_height) {
 		new_geo->height = view->wlr_xdg_toplevel->current.max_height;
 	}
 


### PR DESCRIPTION
I don't know if this PR can have unintended consequences, but it fixes #9130 

I think this is a bug in Qt, because they set the minimum size and then commit a surface with smaller geometry than the minimum size, but using this workaround that I think should be valid in general, we can "fix" it.

The client was setting a minimum size for the toplevel, and then committing a geometry with a smaller size. `handle_commit()` was seeing the new size and calling `wlr_xdg_toplevel_set_size()` that was sending a new configure with the smaller size. This was creating a loop where the client would alternate sending commits with the smaller and the bigger size, resulting in flickering of the window.