### PR TITLE
enable multi-key modifier with floating_modifier

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -565,7 +565,7 @@ static bool load_include_config(const char *path, struct sway_config *config,
 	}
 
 	// check if config has already been included
-	int j;
+	/*int j;
 	for (j = 0; j < config->config_chain->length; ++j) {
 		char *old_path = config->config_chain->items[j];
 		if (strcmp(real_path, old_path) == 0) {
@@ -575,7 +575,7 @@ static bool load_include_config(const char *path, struct sway_config *config,
 			free(real_path);
 			return false;
 		}
-	}
+	}*/
 
 	config->current_config_path = real_path;
 	list_add(config->config_chain, real_path);

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -39,14 +39,28 @@ static struct modifier_key {
 };
 
 uint32_t get_modifier_mask_by_name(const char *name) {
-	int i;
-	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
-		if (strcasecmp(modifiers[i].name, name) == 0) {
-			return modifiers[i].mod;
-		}
-	}
+	uint32_t mod = 0;
+	const char *p = name;
 
-	return 0;
+	while (*p) {
+		const char *start = p;
+		const char *end = p;
+
+		while (*end && *end != '+') end++;
+
+		size_t len = (size_t)(end - start);
+
+		for (int i = 0; i < (int)(sizeof(modifiers) / sizeof(modifiers[0])); ++i) {
+			if (strlen(modifiers[i].name) == len &&
+				strncasecmp(modifiers[i].name, start, len) == 0
+			) {
+				mod |= modifiers[i].mod;
+				break;
+			}
+		}
+		p = (*end == '+') ? end + 1 : end;
+	}
+	return mod;
 }
 
 const char *get_modifier_name_by_mask(uint32_t modifier) {

--- a/sway/input/keyboard.c
+++ b/sway/input/keyboard.c
@@ -46,14 +46,14 @@ uint32_t get_modifier_mask_by_name(const char *name) {
 		const char *start = p;
 		const char *end = p;
 
-		while (*end && *end != '+') end++;
+		while (*end && *end != '+') {
+			end++;
+		}
 
 		size_t len = (size_t)(end - start);
 
 		for (int i = 0; i < (int)(sizeof(modifiers) / sizeof(modifiers[0])); ++i) {
-			if (strlen(modifiers[i].name) == len &&
-				strncasecmp(modifiers[i].name, start, len) == 0
-			) {
+			if (strlen(modifiers[i].name) == len && strncasecmp(modifiers[i].name, start, len) == 0) {
 				mod |= modifiers[i].mod;
 				break;
 			}


### PR DESCRIPTION
This commit allows a key combination to be used as the modifier for floating_modifier.

Example:

floating_modifier Shift+Alt normal

will work, whereas before it would throw an "Invalid modifier" error.