### PR TITLE
input/seatop_default: fix focus on layer surface output switch

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -565,7 +565,7 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 		struct sway_output *hovered_output = wlr_output->data;
 		if (focus && hovered_output != node_get_output(focus)) {
 			struct sway_workspace *ws = output_get_active_workspace(hovered_output);
-			seat_set_focus(seat, &ws->node);
+			seat_set_focus(seat, seat_get_focus_inactive(seat, &ws->node));
 			transaction_commit_dirty();
 		}
 		return;


### PR DESCRIPTION
When `focus_follows_mouse` is enabled and the cursor moves from one output to a layer surface (such as swaybar) on another output, Sway would previously focus the workspace node.

This updates `check_focus_follows_mouse` to use
`seat_get_focus_inactive()`, ensuring that the previously focused window on that workspace receives focus instead.

---

The bug this fixes is visible if you run your mouse pointer across the top of a two-output setup with swaybar at the opt of both outputs.

Reviewer note: this is the first time I have touched sway code in a long time so please let me know if something is amiss in my commit message or understanding of the bug and its fix.