### PR TITLE
tree/workspace: fix unwrapping children to avoid redundant split

### DIFF
--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -920,7 +920,7 @@ void workspace_unwrap_children(struct sway_workspace *ws,
 	while (wrap->pending.children->length) {
 		struct sway_container *child = wrap->pending.children->items[0];
 		container_detach(child);
-		workspace_add_tiling(ws, child);
+		workspace_insert_tiling_direct(ws, child, ws->tiling->length);
 	}
 }
 


### PR DESCRIPTION
Before this change, with `workspace_layout tabbed`, moving T[app app] to an empty workspace resulted in T[T[app] T[app]], as each child was individually wrapped in a new split container.

It looks like commit 92891fb1 introduced workspace_unwrap_children to fix an issue where moving a tabbed/stacked container to a new workspace with workspace_layout tabbed would incorrectly nest the container, creating T[T[app app]].

However, workspace_unwrap_children used workspace_add_tiling to add the detached children to the workspace. Since commit ece6a1d4, workspace_add_tiling checks for a configured default_layout and if it finds one, calls container_split for every added window.

This commit changes the unwrapping logic to use
workspace_insert_tiling_direct instead of workspace_add_tiling, avoiding the default_layout splitting behaviour.