### PR TITLE
seatop_move_tiling: fix stack overflow when dropping container into itself

### DIFF
--- a/sway/input/seatop_move_tiling.c
+++ b/sway/input/seatop_move_tiling.c
@@ -252,8 +252,9 @@ static void handle_motion_postthreshold(struct sway_seat *seat) {
 		}
 		if (edge) {
 			e->target_node = node_get_parent(&con->node);
-			if (e->target_node == &e->con->node) {
-				e->target_node = node_get_parent(e->target_node);
+			if (e->target_node && (e->target_node == &e->con->node ||
+					node_has_ancestor(e->target_node, &e->con->node))) {
+				e->target_node = node_get_parent(&e->con->node);
 			}
 			e->target_edge = edge;
 			update_indicator(e, &box);


### PR DESCRIPTION
This change avoids a cyclic reference in the window tree when dragging a container and dropping it into one of its descendants.

The drop target resolution logic previously only checked if the target node was the container itself, but missed checking if the target was a descendant of the dragged container.

Fixes: #7949