### PR TITLE
ipc: fix workspace `focused`/`visible` reported outside get_workspaces

### DIFF
--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -501,6 +501,14 @@ static json_object *ipc_json_describe_scratchpad_output(void) {
 
 static void ipc_json_describe_workspace(struct sway_workspace *workspace,
 		json_object *object) {
+	// Override the default focused indicator because it's set differently
+	struct sway_seat *seat = input_manager_get_default_seat();
+	json_object_object_del(object, "focused");
+	json_object_object_add(object, "focused", json_object_new_boolean(
+			workspace == seat_get_focused_workspace(seat)));
+	json_object_object_add(object, "visible",
+			json_object_new_boolean(workspace_is_visible(workspace)));
+
 	int num;
 	if (isdigit(workspace->name[0])) {
 		errno = 0;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -584,21 +584,8 @@ void ipc_client_disconnect(struct ipc_client *client) {
 
 static void ipc_get_workspaces_callback(struct sway_workspace *workspace,
 		void *data) {
-	json_object *workspace_json = ipc_json_describe_node(&workspace->node);
-	// override the default focused indicator because
-	// it's set differently for the get_workspaces reply
-	struct sway_seat *seat = input_manager_get_default_seat();
-	struct sway_workspace *focused_ws = seat_get_focused_workspace(seat);
-	bool focused = workspace == focused_ws;
-	json_object_object_del(workspace_json, "focused");
-	json_object_object_add(workspace_json, "focused",
-			json_object_new_boolean(focused));
-	json_object_array_add((json_object *)data, workspace_json);
-
-	focused_ws = output_get_active_workspace(workspace->output);
-	bool visible = workspace == focused_ws;
-	json_object_object_add(workspace_json, "visible",
-			json_object_new_boolean(visible));
+	json_object_array_add((json_object *)data,
+			ipc_json_describe_node(&workspace->node));
 }
 
 static void ipc_get_marks_callback(struct sway_container *con, void *data) {


### PR DESCRIPTION
`ipc_json_describe_workspace` now sets `focused` and adds `visible` itself. The default `focused` from `ipc_json_create_node` compares the focused node to the workspace node, which misses the common case where a window of that workspace is focused.

As a result, `workspace` IPC events reported `focused: false` for every workspace and were missing `visible` entirely, even though `get_workspaces` overrode them.