### PR TITLE
input/seatop_default: do not focus workspace if clicking a layer surface

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -370,7 +370,7 @@ static void handle_button(struct sway_seat *seat, uint32_t time_msec,
 	}
 
 	// Handle clicking an empty workspace
-	if (node && node->type == N_WORKSPACE) {
+	if (node && node->type == N_WORKSPACE && surface == NULL) {
 		if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
 			seat_set_focus(seat, node);
 			transaction_commit_dirty();


### PR DESCRIPTION
Previously, the pointer handler in `seatop_default` would focus the workspace, regardless of whether a surface intercepted the click.

This commit adds a check for `surface == NULL`, allowing the click event to fall through to the layer surface handler.