### PR TITLE
input/seatop_default: focus view on workspace switch

### DIFF
--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -565,7 +565,9 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 		struct sway_output *hovered_output = wlr_output->data;
 		if (focus && hovered_output != node_get_output(focus)) {
 			struct sway_workspace *ws = output_get_active_workspace(hovered_output);
-			seat_set_focus(seat, &ws->node);
+			struct sway_container *con = seat_get_focus_inactive_view(seat, &ws->node);
+			struct sway_node *next = con ? &con->node : seat_get_focus_inactive(seat, &ws->node);
+			seat_set_focus(seat, next);
 			transaction_commit_dirty();
 		}
 		return;
@@ -577,7 +579,9 @@ static void check_focus_follows_mouse(struct sway_seat *seat,
 		struct sway_output *focused_output = node_get_output(focus);
 		struct sway_output *hovered_output = node_get_output(hovered_node);
 		if (hovered_output != focused_output) {
-			seat_set_focus(seat, seat_get_focus_inactive(seat, hovered_node));
+			struct sway_container *con = seat_get_focus_inactive_view(seat, hovered_node);
+			struct sway_node *next = con ? &con->node : seat_get_focus_inactive(seat, hovered_node);
+			seat_set_focus(seat, next);
 			transaction_commit_dirty();
 		}
 		return;

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -733,7 +733,8 @@ bool workspace_switch(struct sway_workspace *workspace) {
 
 	sway_log(SWAY_DEBUG, "Switching to workspace %p:%s",
 		workspace, workspace->name);
-	struct sway_node *next = seat_get_focus_inactive(seat, &workspace->node);
+	struct sway_container *con = seat_get_focus_inactive_view(seat, &workspace->node);
+	struct sway_node *next = con ? &con->node : seat_get_focus_inactive(seat, &workspace->node);
 	if (next == NULL) {
 		next = &workspace->node;
 	}


### PR DESCRIPTION
When `focus_follows_mouse` is enabled and the cursor moves from one
output to a layer surface (such as swaybar) on another output, Sway
would previously focus the workspace node.

This change updates workspace switching using either the mouse or
`workspace_switch` to use `seat_get_focus_inactive_view` first, ensuring
that the previously focused view on the target workspace receives focus.

Fixes: #8177 