### PR TITLE
Fix sticky window focus and decorations when switching workspace

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1127,6 +1127,16 @@ void seat_set_raw_focus(struct sway_seat *seat, struct sway_node *node) {
 	}
 }
 
+// Rebuild the focus stack for a given container by pushing its ancestors
+// and then the container itself to the top of the stack.
+static void seat_rebuild_focus_stack(struct sway_seat *seat, struct sway_container *con) {
+	if (!con) {
+		return;
+	}
+	seat_rebuild_focus_stack(seat, con->pending.parent);
+	seat_set_raw_focus(seat, &con->node);
+}
+
 static void seat_set_workspace_focus(struct sway_seat *seat, struct sway_node *node) {
 	struct sway_node *last_focus = seat_get_focus(seat);
 	if (last_focus == node) {
@@ -1164,8 +1174,14 @@ static void seat_set_workspace_focus(struct sway_seat *seat, struct sway_node *n
 		node_set_dirty(&new_output->node);
 	}
 
+	struct sway_container *last_focus_con = last_focus && last_focus->type == N_CONTAINER ?
+		last_focus->sway_container : NULL;
+	bool sticky_has_focus_on_switch = last_focus_con && container_is_sticky_or_child(last_focus_con) &&
+		new_workspace && last_workspace && new_workspace != last_workspace &&
+		last_focus_con->pending.workspace == last_workspace;
+
 	// Unfocus the previous focus
-	if (last_focus) {
+	if (last_focus && !sticky_has_focus_on_switch) {
 		seat_send_unfocus(last_focus, seat);
 		node_set_dirty(last_focus);
 		struct sway_node *parent = node_get_parent(last_focus);
@@ -1176,24 +1192,23 @@ static void seat_set_workspace_focus(struct sway_seat *seat, struct sway_node *n
 
 	// Put the container parents on the focus stack, then the workspace, then
 	// the focused container.
-	if (container) {
-		struct sway_container *parent = container->pending.parent;
-		while (parent) {
-			seat_set_raw_focus(seat, &parent->node);
-			parent = parent->pending.parent;
-		}
-	}
 	if (new_workspace) {
 		seat_set_raw_focus(seat, &new_workspace->node);
 	}
 	if (container) {
-		seat_set_raw_focus(seat, &container->node);
-		seat_send_focus(&container->node, seat);
+		seat_rebuild_focus_stack(seat, container);
+		if (!sticky_has_focus_on_switch) {
+			seat_send_focus(&container->node, seat);
+		}
+	}
+
+	if (sticky_has_focus_on_switch) {
+		seat_rebuild_focus_stack(seat, last_focus_con);
 	}
 
 	// emit ipc events
 	set_workspace(seat, new_workspace);
-	if (container && container->view) {
+	if (container && container->view && !sticky_has_focus_on_switch) {
 		ipc_event_window(container, "focus");
 	}
 
@@ -1221,8 +1236,8 @@ static void seat_set_workspace_focus(struct sway_seat *seat, struct sway_node *n
 	}
 
 	// If urgent, either unset the urgency or start a timer to unset it
-	if (container && container->view && view_is_urgent(container->view) &&
-			!container->view->urgent_timer) {
+	if (container && container->view && !sticky_has_focus_on_switch &&
+			view_is_urgent(container->view) && !container->view->urgent_timer) {
 		struct sway_view *view = container->view;
 		if (last_workspace && last_workspace != new_workspace &&
 				config->urgent_timeout > 0) {

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -126,6 +126,17 @@ static bool container_is_focused(struct sway_container *con, void *data) {
 	return con->current.focused;
 }
 
+static bool container_is_current_floating(struct sway_container *container) {
+	if (!container->current.parent && container->current.workspace &&
+			list_find(container->current.workspace->floating, container) != -1) {
+		return true;
+	}
+	if (container->scratchpad) {
+		return true;
+	}
+	return false;
+}
+
 static bool container_has_focused_child(struct sway_container *con) {
 	return container_find_child(con, container_is_focused, NULL);
 }
@@ -134,7 +145,7 @@ static bool container_is_current_parent_focused(struct sway_container *con) {
 	if (con->current.parent) {
 		struct sway_container *parent = con->current.parent;
 		return parent->current.focused || container_is_current_parent_focused(parent);
-	} else if (con->current.workspace) {
+	} else if (con->current.workspace && !container_is_current_floating(con)) {
 		struct sway_workspace *ws = con->current.workspace;
 		return ws->current.focused;
 	}
@@ -171,17 +182,6 @@ static struct border_colors *container_get_current_colors(
 	}
 
 	return colors;
-}
-
-static bool container_is_current_floating(struct sway_container *container) {
-	if (!container->current.parent && container->current.workspace &&
-			list_find(container->current.workspace->floating, container) != -1) {
-		return true;
-	}
-	if (container->scratchpad) {
-		return true;
-	}
-	return false;
 }
 
 // scene rect wants premultiplied colors


### PR DESCRIPTION
See individual commits.

Fixes: #8924
Fixes: #5089