### PR TITLE
input/seat: prevent layer surfaces from focusing under session lock

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1312,6 +1312,9 @@ void seat_set_focus_layer(struct sway_seat *seat,
 	} else if (!layer) {
 		return;
 	}
+	if (server.session_lock.lock) {
+		return;
+	}
 	assert(layer->surface->mapped);
 	if (layer->current.layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP &&
 			layer->current.keyboard_interactive


### PR DESCRIPTION
When the screen is locked, `server.session_lock.lock` is active and
keyboard input must be forced to the screen lock surface. While
`seat_set_focus` checked for an active session lock and redirected
focus, `seat_set_focus_layer` was missing the same check. This allowed
layer surfaces to steal keyboard input while the screen lock was active.

This commit adds the missing session check to `seat_set_focus_layer`.

The bug this fixes can be reproduced on master by:

1. run `sleep 1 && fuzzel & swaylock`
2. type the name of some app e.g. `transmission` and hit enter. Notice that swaylock doesn't respond
3. type your password to unlock swaylock
4. upon unlock, notice the app has opened under the lockscreen