### PR TITLE
Fix use-after-free of focused_inactive_child in container

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1447,6 +1447,9 @@ void container_detach(struct sway_container *child) {
 
 	struct sway_container *old_parent = child->pending.parent;
 	struct sway_workspace *old_workspace = child->pending.workspace;
+	if (old_parent && old_parent->pending.focused_inactive_child == child) {
+		old_parent->pending.focused_inactive_child = NULL;
+	}
 	list_t *siblings = container_get_siblings(child);
 	if (siblings) {
 		int index = list_find(siblings, child);


### PR DESCRIPTION
When a container is detached from its parent, we must clear it from the parent's pending focused_inactive_child pointer if it was pointing to it. Otherwise, the parent's pending focused_inactive_child remains dangling and can lead to use-after-free when container_get_active_view is called.

The transaction model keeps current.focused_inactive_child safe because it is rebuilt from seat focus stack during transaction commits. However, pending.focused_inactive_child is maintained manually and was not being cleared on detach.

To reproduce:
1. Build with AddressSanitizer enabled.
2. Open a window B.
3. Split vertically (e.g., `swaymsg split v`).
4. Open a window A (it will be split vertically with B, and focused).
5. Switch to workspace 2.
6. From workspace 2, kill window A (e.g., `swaymsg '[title="A"] kill'`).
7. Switch back to workspace 1.
8. Focus the parent container (e.g., focus B, then `focus parent`).
9. Move the container (e.g., `move left`).

This triggers a heap-use-after-free crash in `container_get_active_view` because the parent container's `focused_inactive_child` still points to the freed window A.