### PR TITLE
Fix scratchpad double reap and redundant parent operations

### DIFF
--- a/sway/tree/root.c
+++ b/sway/tree/root.c
@@ -119,6 +119,11 @@ void root_scratchpad_add_container(struct sway_container *con, struct sway_works
 	}
 
 	container_detach(con);
+	// parent might have been reaped and destroyed in container_set_floating.
+	// Verify it is not destroying before using it.
+	if (parent && parent->node.destroying) {
+		parent = NULL;
+	}
 	con->scratchpad = true;
 	list_add(root->scratchpad, con);
 	if (ws) {


### PR DESCRIPTION
This commit fixes a double-reap and redundant operations when sending a tiled container to the scratchpad.
When the container is tiled, `root_scratchpad_add_container` calls `container_set_floating`, which detaches the container from its tiled parent and reaps the parent if it becomes empty.
However, `root_scratchpad_add_container` was then:
1. Calling `container_reap_empty` on the parent again, causing a redundant/double-reap.
2. Calling `arrange_container(parent)` on the parent even if it has already been marked for destruction and is about to be reaped.

We fix this by:
1. Removing the redundant `container_reap_empty(parent)` call, as the parent is already reaped in `container_set_floating` (if it was tiled) or it is NULL (if it was already floating).
2. Checking the `parent->node.destroying` flag directly to verify if the parent container is being destroyed. If it is being destroyed, we set `parent` to `NULL` to avoid arranging it, falling back to arranging the workspace instead.