### PR TITLE
layer_shell: fix focus stealing for ON_DEMAND surfaces

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -132,7 +132,7 @@ void arrange_layers(struct sway_output *output) {
 			seat_set_focus_layer(seat, topmost->layer_surface);
 		} else if (seat->focused_layer &&
 				seat->focused_layer->current.keyboard_interactive
-					!= ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE) {
+					== ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {
 			seat_set_focus_layer(seat, NULL);
 		}
 	}


### PR DESCRIPTION
arrange_layers was stripping focus from any surface that wasn't strictly EXCLUSIVE. This caused ON_DEMAND surfaces like
`fuzzel --keyboard-focus=on-demand` to immediately lose focus upon receiving it.

Update the check to only strip focus if the surface explicitly requests NONE keyboard interactivity.

Before this patch, opening a tiled terminal and running `fuzzel --keyboard-focus=on-demand` didn't work at all - fuzzel exited immediately after being focused and immediatly unfocused.

I suspect that this fixes: #8100
It might also fix: #8560