### PR TITLE
layer_shell: fix reversed precedence check in handle_map

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -291,7 +291,7 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		wl_list_for_each(seat, &server.input->seats, link) {
 			// but only if the currently focused layer has a lower precedence
 			if (!seat->focused_layer ||
-					seat->focused_layer->current.layer >= layer_surface->current.layer) {
+					seat->focused_layer->current.layer <= layer_surface->current.layer) {
 				seat_set_focus_layer(seat, layer_surface);
 			}
 		}


### PR DESCRIPTION
When a new layer surface maps, Sway determines if it should steal focus
by comparing its layer level against the currently focused layer. The
previous check used `focused >= new` to determine whether to switch
focus to new, which allowed lower precedence layers to steal focus from
higher ones.

This latent issue was masked by arrange_layers() coming through
and fixing up the focus state afterwards. However it resulted in a focus
"flicker" where layer-shell surfaces briefly lost focus before having it
restored again almost immediately.

This commit changes the comparison to `<=` so that lower precedence
surfaces do not steal focus from higher precedence surfaces, and there
is no focus flicker.

The bug this fixes can be demonstrated by running this command:

```bash
fuzzel --keyboard-focus=exclusive --layer=overlay & sleep 1 && rm /run/user/$UID/fuzzel-* && fuzzel --keyboard-focus=exclusive --layer=top 
```

On master:
1. fuzzel with layer=overlay launches
2. one second later, fuzzel with layer=top launches
3. focus flickers away from the `overlay` to the `top` surface, then back to `overlay`
4. both instances exit due to losing focus.

With this patch:
1. fuzzel with layer=overlay launches
2. one second later, fuzzel with layer=top launches
3. `top` being lower precedence never receives focus. Focus is retained by the `overlay` surface. So both instances remain open.