### PR TITLE
commands/focus: focus floating windows when moving across outputs

### DIFF
--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -132,7 +132,7 @@ static struct sway_node *get_node_in_output_direction(
 		return &container->node;
 	}
 
-	return &ws->node;
+	return seat_get_focus_inactive(seat, &ws->node);
 }
 
 static struct sway_node *node_get_in_direction_tiling(


### PR DESCRIPTION
Moving focus directionally to an output containing only floating windows would previously focus the workspace instead of the previously focused floating window. This change falls back to the inactive focus, to match the behaviour of workspace_switch().

Fixes: #8002 