### PR TITLE
input/seat: dirty node after unfocus

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -1285,6 +1285,7 @@ void seat_set_focus_surface(struct sway_seat *seat,
 	if (seat->has_focus && unfocus) {
 		struct sway_node *focus = seat_get_focus(seat);
 		seat_send_unfocus(focus, seat);
+		node_set_dirty(focus);
 		seat->has_focus = false;
 	}
 


### PR DESCRIPTION
Dirty the node that has been unfocused during layer focus so that the focus change is reflected in the window decorations.

The bug this fixes can be illustrated by opening a tiled terminal on a worksapce and running this command, which launches two instances of fuzzel on top of each other.

```bash
fuzzel --keyboard-focus=exclusive --layer=overlay --no-exit-on-keyboard-focus-loss & sleep 1 && rm /run/user/$UID/fuzzel-* && fuzzel --keyboard-focus=exclusive --layer=overlay
```

On master:

1. Both fuzzel instances open, one second apart.
2. The tiled terminal behind them retains its blue active focus decoration, despite not being focused.
3. Exiting the top fuzzel (e.g. press escape) causes the tiled node to be dirtied, so the terminal decoration goes grey (inactive focus).

With this patch:

1. Both fuzzel instances open, one second apart.
2. The tiled terminal behind them immediately loses its blue active focus decoration, switching to grey inactive focus, correctly indicating it no longer has focus.