### PR TITLE
input: fix cursor updates on rebase and layer surface commit

### DIFF
--- a/sway/desktop/layer_shell.c
+++ b/sway/desktop/layer_shell.c
@@ -273,6 +273,7 @@ static void handle_surface_commit(struct wl_listener *listener, void *data) {
 		surface->mapped = layer_surface->surface->mapped;
 		arrange_layers(surface->output);
 		transaction_commit_dirty();
+		cursor_rebase_all();
 	}
 }
 
@@ -297,8 +298,6 @@ static void handle_map(struct wl_listener *listener, void *data) {
 		}
 		arrange_layers(surface->output);
 	}
-
-	cursor_rebase_all();
 }
 
 static void handle_unmap(struct wl_listener *listener, void *data) {

--- a/sway/input/seatop_default.c
+++ b/sway/input/seatop_default.c
@@ -1114,6 +1114,7 @@ static void handle_rebase(struct sway_seat *seat, uint32_t time_msec) {
 		if (seat_is_input_allowed(seat, surface) && !cursor->hidden) {
 			wlr_seat_pointer_notify_enter(seat->wlr_seat, surface, sx, sy);
 			wlr_seat_pointer_notify_motion(seat->wlr_seat, time_msec, sx, sy);
+			wlr_seat_pointer_notify_frame(seat->wlr_seat);
 		}
 	} else {
 		cursor_update_image(cursor, e->previous_node);


### PR DESCRIPTION
Previously a cursor rebase could send pointer motion events without a trailing frame event. A client could queue events indefinitely instead of processing them. In addition, cursor rebase during layer surface mapping occurred before the layer surface received its geometry in the scene graph.

This change adds a frame notification after cursor rebase, and moves cursor_rebase_all() for layer surfaces from handle_map to handle_surface_commit so it occurs after geometry is assigned.

Fixes: #3080 
Probably also fixes: #8679 
Fixes: #8146 