### PR TITLE
lock: commit transaction after unlock

### DIFF
--- a/sway/lock.c
+++ b/sway/lock.c
@@ -9,6 +9,7 @@
 #include "sway/output.h"
 #include "sway/server.h"
 #include "sway/lock.h"
+#include "sway/desktop/transaction.h"
 
 struct sway_session_lock_output {
 	struct wlr_scene_tree *tree;
@@ -237,6 +238,8 @@ static void handle_unlock(struct wl_listener *listener, void *data) {
 
 	// Views are now visible, so check if we need to activate inhibition again.
 	sway_idle_inhibit_v1_check_active();
+
+	transaction_commit_dirty();
 }
 
 static void handle_abandon(struct wl_listener *listener, void *data) {


### PR DESCRIPTION
This ensures focus changes are correctly reflected when unlocking the screen.

To reproduce the bug this fixes, open a terminal tiled on a workspace, run `swaylock & sleep 1 && fuzzel`, and unlock the screen.

On master: keyboard focus is on fuzzel, but the window behind it still has a blue active focus decoration.

With this patch: keyboard focus is on fuzzel, and the window behind it has a grey inactive focus decoration.