### PR TITLE
Improve xdg activation token integration

### DIFF
--- a/completions/bash/swaymsg
+++ b/completions/bash/swaymsg
@@ -19,6 +19,7 @@ _swaymsg()
     'get_config'
     'send_tick'
     'subscribe'
+    'mint_activation_token'
   )
 
   short=(

--- a/completions/fish/swaymsg.fish
+++ b/completions/fish/swaymsg.fish
@@ -23,3 +23,5 @@ complete -c swaymsg -s t -l type -fra 'get_config' --description "Gets a JSON-en
 complete -c swaymsg -s t -l type -fra 'get_seats' --description "Gets a JSON-encoded list of all seats, its properties and all assigned devices."
 complete -c swaymsg -s t -l type -fra 'send_tick' --description "Sends a tick event to all subscribed clients."
 complete -c swaymsg -s t -l type -fra 'subscribe' --description "Subscribe to a list of event types."
+complete -c swaymsg -s t -l type -fra 'mint_activation_token' --description "Mint a new XDG activation token."
+

--- a/completions/zsh/_swaymsg
+++ b/completions/zsh/_swaymsg
@@ -27,6 +27,7 @@ types=(
 'get_config'
 'send_tick'
 'subscribe'
+'mint_activation_token'
 )
 
 _arguments -s \

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -22,20 +22,21 @@ enum ipc_command_type {
 	// sway-specific command types
 	IPC_GET_INPUTS = 100,
 	IPC_GET_SEATS = 101,
+	IPC_MINT_ACTIVATION_TOKEN = 102,
 
 	// Events sent from sway to clients. Events have the highest bits set.
-	IPC_EVENT_WORKSPACE = ((1<<31) | 0),
-	IPC_EVENT_OUTPUT = ((1<<31) | 1),
-	IPC_EVENT_MODE = ((1<<31) | 2),
-	IPC_EVENT_WINDOW = ((1<<31) | 3),
-	IPC_EVENT_BARCONFIG_UPDATE = ((1<<31) | 4),
-	IPC_EVENT_BINDING = ((1<<31) | 5),
-	IPC_EVENT_SHUTDOWN = ((1<<31) | 6),
-	IPC_EVENT_TICK = ((1<<31) | 7),
+	IPC_EVENT_WORKSPACE = ((1 << 31) | 0),
+	IPC_EVENT_OUTPUT = ((1 << 31) | 1),
+	IPC_EVENT_MODE = ((1 << 31) | 2),
+	IPC_EVENT_WINDOW = ((1 << 31) | 3),
+	IPC_EVENT_BARCONFIG_UPDATE = ((1 << 31) | 4),
+	IPC_EVENT_BINDING = ((1 << 31) | 5),
+	IPC_EVENT_SHUTDOWN = ((1 << 31) | 6),
+	IPC_EVENT_TICK = ((1 << 31) | 7),
 
 	// sway-specific event types
-	IPC_EVENT_BAR_STATE_UPDATE = ((1<<31) | 20),
-	IPC_EVENT_INPUT = ((1<<31) | 21),
+	IPC_EVENT_BAR_STATE_UPDATE = ((1 << 31) | 20),
+	IPC_EVENT_INPUT = ((1 << 31) | 21),
 };
 
 #endif

--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -102,7 +102,7 @@ struct sway_container *container_find_resize_parent(struct sway_container *con,
  * Handlers shared by exec and exec_always.
  */
 sway_cmd cmd_exec_validate;
-sway_cmd cmd_exec_process;
+struct cmd_results *cmd_exec_process(int argc, char **argv, const char *cmdlist);
 
 sway_cmd cmd_allow_tearing;
 sway_cmd cmd_assign;
@@ -138,6 +138,7 @@ sway_cmd cmd_focus_follows_mouse;
 sway_cmd cmd_focus_on_window_activation;
 sway_cmd cmd_focus_wrapping;
 sway_cmd cmd_font;
+sway_cmd cmd_for_exec_window;
 sway_cmd cmd_for_window;
 sway_cmd cmd_force_display_urgency_hint;
 sway_cmd cmd_force_focus_wrapping;

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -57,6 +57,7 @@ struct criteria {
 	struct pattern *sandbox_app_id;
 	struct pattern *sandbox_instance_id;
 	struct pattern *tag;
+	char *initial_activation_token;
 };
 
 bool criteria_is_empty(struct criteria *criteria);

--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -20,6 +20,7 @@ struct launcher_ctx {
 	struct wl_listener node_destroy;
 
 	struct wl_list link; // sway_server::pending_launcher_ctxs
+	char *cmdlist;
 };
 
 struct launcher_ctx *launcher_ctx_find_pid(pid_t pid);

--- a/include/sway/desktop/launcher.h
+++ b/include/sway/desktop/launcher.h
@@ -25,6 +25,8 @@ struct launcher_ctx {
 
 struct launcher_ctx *launcher_ctx_find_pid(pid_t pid);
 
+struct launcher_ctx *launcher_ctx_find_token(const char *token_name);
+
 struct sway_workspace *launcher_ctx_get_workspace(struct launcher_ctx *ctx);
 
 void launcher_ctx_consume(struct launcher_ctx *ctx);

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -82,6 +82,7 @@ struct sway_view {
 
 	pid_t pid;
 	struct launcher_ctx *ctx;
+	char *exec_cmdlist;
 
 	// The size the view would want to be if it weren't tiled.
 	// Used when changing a view from tiled to floating.

--- a/include/sway/tree/view.h
+++ b/include/sway/tree/view.h
@@ -83,6 +83,7 @@ struct sway_view {
 	pid_t pid;
 	struct launcher_ctx *ctx;
 	char *exec_cmdlist;
+	char *initial_activation_token;
 
 	// The size the view would want to be if it weren't tiled.
 	// Used when changing a view from tiled to floating.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -67,6 +67,7 @@ static const struct cmd_handler handlers[] = {
 	{ "focus_on_window_activation", cmd_focus_on_window_activation },
 	{ "focus_wrapping", cmd_focus_wrapping },
 	{ "font", cmd_font },
+	{ "for_exec_window", cmd_for_exec_window },
 	{ "for_window", cmd_for_window },
 	{ "force_display_urgency_hint", cmd_force_display_urgency_hint },
 	{ "force_focus_wrapping", cmd_force_focus_wrapping },
@@ -262,9 +263,8 @@ list_t *execute_command(char *_exec, struct sway_seat *seat,
 		//TODO better handling of argv
 		int argc;
 		char **argv = split_args(cmd, &argc);
-		if (strcmp(argv[0], "exec") != 0 &&
-				strcmp(argv[0], "exec_always") != 0 &&
-				strcmp(argv[0], "mode") != 0) {
+		if (strcmp(argv[0], "exec") != 0 && strcmp(argv[0], "exec_always") != 0 &&
+				strcmp(argv[0], "for_exec_window") != 0 && strcmp(argv[0], "mode") != 0) {
 			for (int i = 1; i < argc; ++i) {
 				if (*argv[i] == '\"' || *argv[i] == '\'') {
 					strip_quotes(argv[i]);
@@ -408,15 +408,12 @@ struct cmd_results *config_command(char *exec, char **new_block) {
 
 	// Strip quotes and unescape the string
 	for (int i = handler->handle == cmd_set ? 2 : 1; i < argc; ++i) {
-		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always
-				&& handler->handle != cmd_mode
-				&& handler->handle != cmd_bindsym
-				&& handler->handle != cmd_bindcode
-				&& handler->handle != cmd_bindswitch
-				&& handler->handle != cmd_bindgesture
-				&& handler->handle != cmd_set
-				&& handler->handle != cmd_for_window
-				&& (*argv[i] == '\"' || *argv[i] == '\'')) {
+		if (handler->handle != cmd_exec && handler->handle != cmd_exec_always &&
+				handler->handle != cmd_mode && handler->handle != cmd_bindsym &&
+				handler->handle != cmd_bindcode && handler->handle != cmd_bindswitch &&
+				handler->handle != cmd_bindgesture && handler->handle != cmd_set &&
+				handler->handle != cmd_for_window && handler->handle != cmd_for_exec_window &&
+				(*argv[i] == '\"' || *argv[i] == '\'')) {
 			strip_quotes(argv[i]);
 		}
 		unescape_string(argv[i]);

--- a/sway/commands/exec.c
+++ b/sway/commands/exec.c
@@ -15,5 +15,5 @@ struct cmd_results *cmd_exec(int argc, char **argv) {
 		free(args);
 		return cmd_results_new(CMD_SUCCESS, NULL);
 	}
-	return cmd_exec_process(argc, argv);
+	return cmd_exec_process(argc, argv, NULL);
 }

--- a/sway/commands/exec_always.c
+++ b/sway/commands/exec_always.c
@@ -25,7 +25,7 @@ struct cmd_results *cmd_exec_validate(int argc, char **argv) {
 	return error;
 }
 
-struct cmd_results *cmd_exec_process(int argc, char **argv) {
+struct cmd_results *cmd_exec_process(int argc, char **argv, const char *cmdlist) {
 	struct cmd_results *error = NULL;
 	char *cmd = NULL;
 	bool no_startup_id = false;
@@ -47,6 +47,10 @@ struct cmd_results *cmd_exec_process(int argc, char **argv) {
 	sway_log(SWAY_DEBUG, "Executing %s", cmd);
 
 	struct launcher_ctx *ctx = launcher_ctx_create_internal();
+	if (ctx && cmdlist) {
+		ctx->cmdlist = strdup(cmdlist);
+		sway_log(SWAY_DEBUG, "Recorded cmdlist '%s' to ctx %p", ctx->cmdlist, ctx);
+	}
 
 	// Fork process
 	pid_t child = fork();
@@ -85,5 +89,5 @@ struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	if ((error = cmd_exec_validate(argc, argv))) {
 		return error;
 	}
-	return cmd_exec_process(argc, argv);
+	return cmd_exec_process(argc, argv, NULL);
 }

--- a/sway/commands/for_exec_window.c
+++ b/sway/commands/for_exec_window.c
@@ -1,0 +1,30 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "log.h"
+#include "stringop.h"
+
+struct cmd_results *cmd_for_exec_window(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "for_exec_window", EXPECTED_AT_LEAST, 2))) {
+		return error;
+	}
+	if (!config->active || config->validating) {
+		return cmd_results_new(CMD_DEFER, NULL);
+	}
+	if (config->reloading) {
+		char *args = join_args(argv, argc);
+		sway_log(SWAY_DEBUG, "Ignoring 'for_exec_window %s' due to reload", args);
+		free(args);
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
+
+	char *cmdlist = strdup(argv[0]);
+	strip_quotes(cmdlist);
+	strip_whitespace(cmdlist);
+	sway_log(SWAY_DEBUG, "for_exec_window: cmdlist='%s'", cmdlist);
+
+	struct cmd_results *res = cmd_exec_process(argc - 1, argv + 1, cmdlist);
+	free(cmdlist);
+	return res;
+}

--- a/sway/commands/for_window.c
+++ b/sway/commands/for_window.c
@@ -4,6 +4,7 @@
 #include "list.h"
 #include "log.h"
 #include "stringop.h"
+#include "sway/desktop/launcher.h"
 
 struct cmd_results *cmd_for_window(int argc, char **argv) {
 	struct cmd_results *error = NULL;
@@ -21,6 +22,34 @@ struct cmd_results *cmd_for_window(int argc, char **argv) {
 
 	criteria->type = CT_COMMAND;
 	criteria->cmdlist = join_args(argv + 1, argc - 1);
+
+	if (criteria->initial_activation_token) {
+		char *temp_token = criteria->initial_activation_token;
+		criteria->initial_activation_token = NULL;
+		bool has_others = !criteria_is_empty(criteria);
+		criteria->initial_activation_token = temp_token;
+
+		if (has_others) {
+			criteria_destroy(criteria);
+			return cmd_results_new(CMD_INVALID,
+					"initial_activation_token criteria cannot be combined with other criteria");
+		}
+
+		struct launcher_ctx *ctx = launcher_ctx_find_token(criteria->initial_activation_token);
+		if (ctx) {
+			free(ctx->cmdlist);
+			ctx->cmdlist = strdup(criteria->cmdlist);
+			sway_log(SWAY_DEBUG, "Bound commands '%s' to activation token '%s'", ctx->cmdlist,
+					criteria->initial_activation_token);
+		} else {
+			criteria_destroy(criteria);
+			return cmd_results_new(
+					CMD_INVALID, "Activation token '%s' not found or expired", temp_token);
+		}
+
+		criteria_destroy(criteria);
+		return cmd_results_new(CMD_SUCCESS, NULL);
+	}
 
 	// Check if it already exists
 	if (criteria_already_exists(criteria)) {

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -17,28 +17,16 @@
 #include "config.h"
 
 bool criteria_is_empty(struct criteria *criteria) {
-	return !criteria->title
-		&& !criteria->shell
-		&& !criteria->all
-		&& !criteria->app_id
-		&& !criteria->con_mark
-		&& !criteria->con_id
+	return !criteria->title && !criteria->shell && !criteria->all && !criteria->app_id &&
+			!criteria->con_mark && !criteria->con_id
 #if WLR_HAS_XWAYLAND
-		&& !criteria->class
-		&& !criteria->id
-		&& !criteria->instance
-		&& !criteria->window_role
-		&& criteria->window_type == ATOM_LAST
+			&& !criteria->class && !criteria->id && !criteria->instance && !criteria->window_role &&
+			criteria->window_type == ATOM_LAST
 #endif
-		&& !criteria->floating
-		&& !criteria->tiling
-		&& !criteria->urgent
-		&& !criteria->workspace
-		&& !criteria->pid
-		&& !criteria->sandbox_engine
-		&& !criteria->sandbox_app_id
-		&& !criteria->sandbox_instance_id
-		&& !criteria->tag;
+			&& !criteria->floating && !criteria->tiling && !criteria->urgent &&
+			!criteria->workspace && !criteria->pid && !criteria->sandbox_engine &&
+			!criteria->sandbox_app_id && !criteria->sandbox_instance_id && !criteria->tag &&
+			!criteria->initial_activation_token;
 }
 
 // The error pointer is used for parsing functions, and saves having to pass it
@@ -108,6 +96,7 @@ void criteria_destroy(struct criteria *criteria) {
 	pattern_destroy(criteria->tag);
 	free(criteria->target);
 	free(criteria->cmdlist);
+	free(criteria->initial_activation_token);
 	free(criteria->raw);
 	free(criteria);
 }
@@ -337,6 +326,13 @@ static bool criteria_matches_view(struct criteria *criteria,
 				return false;
 			}
 			break;
+		}
+	}
+
+	if (criteria->initial_activation_token) {
+		const char *token = view->initial_activation_token;
+		if (!token || strcmp(token, criteria->initial_activation_token) != 0) {
+			return false;
 		}
 	}
 
@@ -571,6 +567,7 @@ enum criteria_token {
 	T_SANDBOX_APP_ID,
 	T_SANDBOX_INSTANCE_ID,
 	T_TAG,
+	T_INITIAL_ACTIVATION_TOKEN,
 
 	T_INVALID,
 };
@@ -618,6 +615,8 @@ static enum criteria_token token_from_name(char *name) {
 		return T_SANDBOX_INSTANCE_ID;
 	} else if (strcmp(name, "tag") == 0) {
 		return T_TAG;
+	} else if (strcmp(name, "initial_activation_token") == 0) {
+		return T_INITIAL_ACTIVATION_TOKEN;
 	}
 	return T_INVALID;
 }
@@ -731,6 +730,9 @@ static bool parse_token(struct criteria *criteria, char *name, char *value) {
 		break;
 	case T_TAG:
 		pattern_create(&criteria->tag, value);
+		break;
+	case T_INITIAL_ACTIVATION_TOKEN:
+		criteria->initial_activation_token = strdup(value);
 		break;
 	case T_INVALID:
 		break;

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -73,6 +73,7 @@ void launcher_ctx_destroy(struct launcher_ctx *ctx) {
 	wl_list_remove(&ctx->link);
 	wlr_xdg_activation_token_v1_destroy(ctx->token);
 	free(ctx->fallback_name);
+	free(ctx->cmdlist);
 	free(ctx);
 }
 

--- a/sway/desktop/launcher.c
+++ b/sway/desktop/launcher.c
@@ -102,6 +102,23 @@ struct launcher_ctx *launcher_ctx_find_pid(pid_t pid) {
 	return ctx;
 }
 
+struct launcher_ctx *launcher_ctx_find_token(const char *token_name) {
+	if (wl_list_empty(&server.pending_launcher_ctxs)) {
+		return NULL;
+	}
+
+	struct launcher_ctx *ctx = NULL;
+	wl_list_for_each(ctx, &server.pending_launcher_ctxs, link) {
+		if (ctx->token) {
+			const char *name = wlr_xdg_activation_token_v1_get_name(ctx->token);
+			if (name && strcmp(name, token_name) == 0) {
+				return ctx;
+			}
+		}
+	}
+	return NULL;
+}
+
 struct sway_workspace *launcher_ctx_get_workspace(
 		struct launcher_ctx *ctx) {
 	struct sway_workspace *ws = NULL;

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -586,6 +586,10 @@ static void ipc_json_describe_view(struct sway_container *c, json_object *object
 	json_object_object_add(object, "app_id",
 			app_id ? json_object_new_string(app_id) : NULL);
 
+	const char *initial_activation_token = c->view->initial_activation_token;
+	json_object_object_add(object, "initial_activation_token",
+			initial_activation_token ? json_object_new_string(initial_activation_token) : NULL);
+
 	json_object_object_add(object, "foreign_toplevel_identifier",
 		c->view->ext_foreign_toplevel ?
 			json_object_new_string(c->view->ext_foreign_toplevel->identifier) : NULL);

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -17,6 +17,7 @@
 #include "sway/commands.h"
 #include "sway/config.h"
 #include "sway/desktop/transaction.h"
+#include "sway/desktop/launcher.h"
 #include "sway/ipc-json.h"
 #include "sway/ipc-server.h"
 #include "sway/output.h"
@@ -924,6 +925,25 @@ void ipc_client_handle_command(struct ipc_client *client, uint32_t payload_lengt
 		goto exit_cleanup;
 	}
 
+	case IPC_MINT_ACTIVATION_TOKEN: {
+		struct launcher_ctx *ctx = launcher_ctx_create_internal();
+		if (!ctx) {
+			const char *error =
+					"{ \"success\": false, \"error\": \"Failed to create activation context\" }";
+			ipc_send_reply(client, payload_type, error, (uint32_t)strlen(error));
+			goto exit_cleanup;
+		}
+
+		const char *token = launcher_ctx_get_token_name(ctx);
+		json_object *reply = json_object_new_object();
+		json_object_object_add(reply, "success", json_object_new_boolean(true));
+		json_object_object_add(reply, "token", json_object_new_string(token));
+
+		const char *json_string = json_object_to_json_string(reply);
+		ipc_send_reply(client, payload_type, json_string, (uint32_t)strlen(json_string));
+		json_object_put(reply);
+		goto exit_cleanup;
+	}
 	default:
 		sway_log(SWAY_INFO, "Unknown IPC command type %x", payload_type);
 		goto exit_cleanup;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -63,6 +63,7 @@ sway_sources = files(
 	'commands/focus_on_window_activation.c',
 	'commands/focus_wrapping.c',
 	'commands/font.c',
+	'commands/for_exec_window.c',
 	'commands/for_window.c',
 	'commands/force_display_urgency_hint.c',
 	'commands/force_focus_wrapping.c',

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -389,6 +389,10 @@ node and will have the following properties:
 :  string
 :  (Only windows) For an xdg-shell window, the name of the application, if set.
    Otherwise, _null_
+|- initial_activation_token
+:  string
+:  (Only windows) The initial activation token of the window, if it was launched
+   with one. Otherwise, _null_
 |- pid
 :  integer
 :  (Only windows) The PID of the application that owns the window
@@ -718,6 +722,7 @@ node and will have the following properties:
 							"fullscreen_mode": 0,
 							"pid": 23959,
 							"app_id": null,
+							"initial_activation_token": null,
 							"visible": true,
 							"shell": "xwayland",
 							"inhibit_idle": true,
@@ -778,6 +783,7 @@ node and will have the following properties:
 							"fullscreen_mode": 0,
 							"pid": 25370,
 							"app_id": "termite",
+							"initial_activation_token": null,
 							"visible": true,
 							"shell": "xdg_shell",
 							"inhibit_idle": false,
@@ -1729,6 +1735,7 @@ The following change types are currently available:
 		"type": "con",
 		"pid": 19787,
 		"app_id": null,
+		"initial_activation_token": null,
 		"window_properties": {
 			"class": "URxvt",
 			"instance": "urxvt",

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -84,6 +84,10 @@ supported. *For all replies, any properties not listed are subject to removal.*
 |- 101
 :  GET_SEATS
 :  Get the list of seats
+|- 102
+:  MINT_ACTIVATION_TOKEN
+:  Mint a new XDG activation token
+
 
 ## 0. RUN_COMMAND
 
@@ -1474,6 +1478,35 @@ one seat. Each object has the following properties:
 		]
 	}
 ]
+```
+
+## 102. MINT_ACTIVATION_TOKEN
+
+*MESSAGE*++
+Request the compositor to mint a new XDG activation token.
+
+*REPLY*++
+An object indicating success, and the generated token string.
+
+[- *PROPERTY*
+:- *DATA TYPE*
+:- *DESCRIPTION*
+|- success
+:  boolean
+:[ Whether the request succeeded
+|- token
+:  string
+:  The generated activation token (only on success)
+|- error
+:  string
+:  A human readable error message (only on failure)
+
+*Example Reply:*
+```
+{
+  "success": true,
+  "token": "3cbaea5a9d821213fdf109503023023"
+}
 ```
 
 # EVENTS

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -777,6 +777,12 @@ The default colors are:
 	should be greater than titlebar_border_thickness. If _vertical_ value is
 	not specified it is set to the _horizontal_ value.
 
+*for_exec_window* "<commands>" <exec command>
+	Execute _exec command_ and whenever the window created by that process
+	appears, run the list of _commands_ (specified as a quoted string) on it.
+	The window is matched based on the xdg activation token, or process ID
+	(PID) as a fallback.
+
 *for_window* <criteria> <command>
 	Whenever a window that matches _criteria_ appears, run list of commands.
 	See *CRITERIA* for more details.

--- a/sway/sway.5.scd
+++ b/sway/sway.5.scd
@@ -1028,6 +1028,15 @@ The following attributes may be matched with:
 *all*
 	Matches all windows.
 
+*initial_activation_token*
+	Compare value against the initial activation token. Only exact matches are
+	supported. Can only be used with *for_window* and cannot be combined
+	with other criteria. It is used to match a window that was launched
+	with the corresponding activation token (either Wayland XDG activation
+	or X11 startup ID). Specifying this criteria makes the rule
+	automatically expire when the token expires (either because a window
+	maps and consumes it, or it times out, typically after 30 seconds).
+
 *app_id*
 	Compare value against the app id. Can be a regular expression. If value is
 	\_\_focused\_\_, then the app id must be the same as that of the currently

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -134,6 +134,7 @@ void view_destroy(struct sway_view *view) {
 	list_free(view->executed_criteria);
 
 	view_assign_ctx(view, NULL);
+	free(view->exec_cmdlist);
 	wlr_scene_node_destroy(&view->image_capture_scene->tree.node);
 	wlr_scene_node_destroy(&view->scene_tree->node);
 	if (view->impl->destroy) {
@@ -593,6 +594,27 @@ void view_execute_criteria(struct sway_view *view) {
 	list_free(criterias);
 }
 
+static void view_execute_launch_commands(struct sway_view *view) {
+	sway_log(SWAY_DEBUG, "view_execute_launch_commands: view=%p, exec_cmdlist=%s", view,
+			view->exec_cmdlist);
+	if (view->exec_cmdlist) {
+		sway_log(SWAY_DEBUG, "Executing for_exec_window commands for view %p: %s", view,
+				view->exec_cmdlist);
+		list_t *res_list = execute_command(view->exec_cmdlist, NULL, view->container);
+		while (res_list->length) {
+			struct cmd_results *res = res_list->items[0];
+			if (res->status != CMD_SUCCESS) {
+				sway_log(SWAY_ERROR, "for_exec_window command failed: %s", res->error);
+			}
+			free_cmd_results(res);
+			list_del(res_list, 0);
+		}
+		list_free(res_list);
+		free(view->exec_cmdlist);
+		view->exec_cmdlist = NULL;
+	}
+}
+
 static void view_populate_pid(struct sway_view *view) {
 	pid_t pid;
 	switch (view->type) {
@@ -621,9 +643,15 @@ void view_assign_ctx(struct sway_view *view, struct launcher_ctx *ctx) {
 	if (ctx == NULL) {
 		return;
 	}
+	free(view->exec_cmdlist);
+	view->exec_cmdlist = NULL;
+
 	launcher_ctx_consume(ctx);
 
 	view->ctx = ctx;
+	if (ctx->cmdlist) {
+		view->exec_cmdlist = strdup(ctx->cmdlist);
+	}
 }
 
 static struct sway_workspace *select_workspace(struct sway_view *view) {
@@ -941,6 +969,7 @@ void view_map(struct sway_view *view, struct wlr_surface *wlr_surface,
 	}
 
 	view_execute_criteria(view);
+	view_execute_launch_commands(view);
 
 	bool set_focus = should_focus(view);
 

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -135,6 +135,7 @@ void view_destroy(struct sway_view *view) {
 
 	view_assign_ctx(view, NULL);
 	free(view->exec_cmdlist);
+	free(view->initial_activation_token);
 	wlr_scene_node_destroy(&view->image_capture_scene->tree.node);
 	wlr_scene_node_destroy(&view->scene_tree->node);
 	if (view->impl->destroy) {
@@ -645,6 +646,12 @@ void view_assign_ctx(struct sway_view *view, struct launcher_ctx *ctx) {
 	}
 	free(view->exec_cmdlist);
 	view->exec_cmdlist = NULL;
+
+	const char *token_name = launcher_ctx_get_token_name(ctx);
+	if (token_name) {
+		free(view->initial_activation_token);
+		view->initial_activation_token = strdup(token_name);
+	}
 
 	launcher_ctx_consume(ctx);
 

--- a/sway/xdg_activation_v1.c
+++ b/sway/xdg_activation_v1.c
@@ -3,6 +3,7 @@
 #include "sway/desktop/launcher.h"
 #include "sway/tree/view.h"
 #include "sway/tree/workspace.h"
+#include "log.h"
 
 void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 		void *data) {
@@ -32,6 +33,7 @@ void xdg_activation_v1_handle_request_activate(struct wl_listener *listener,
 			return;
 		} else {
 			ctx->activated = true;
+			sway_log(SWAY_DEBUG, "Matched view %p via XDG activation token", view);
 			view_assign_ctx(view, ctx);
 		}
 		return;

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -391,8 +391,30 @@ static void pretty_print_tree(json_object *obj, int indent) {
 	}
 }
 
+static void pretty_print_mint_activation_token(json_object *r) {
+	json_object *success;
+	if (json_object_object_get_ex(r, "success", &success) && !json_object_get_boolean(success)) {
+		json_object *error;
+		if (!json_object_object_get_ex(r, "error", &error)) {
+			printf("An unknown error occurred\n");
+		} else {
+			printf("Error: %s\n", json_object_get_string(error));
+		}
+	} else {
+		json_object *token;
+		if (json_object_object_get_ex(r, "token", &token)) {
+			printf("%s\n", json_object_get_string(token));
+		} else {
+			printf("Error: Token not found in response\n");
+		}
+	}
+}
+
 static void pretty_print(int type, json_object *resp) {
 	switch (type) {
+	case IPC_MINT_ACTIVATION_TOKEN:
+		pretty_print_mint_activation_token(resp);
+		return;
 	case IPC_SEND_TICK:
 		return;
 	case IPC_GET_VERSION:
@@ -554,6 +576,8 @@ int main(int argc, char **argv) {
 		type = IPC_SEND_TICK;
 	} else if (strcasecmp(cmdtype, "subscribe") == 0) {
 		type = IPC_SUBSCRIBE;
+	} else if (strcasecmp(cmdtype, "mint_activation_token") == 0) {
+		type = IPC_MINT_ACTIVATION_TOKEN;
 	} else {
 		if (quiet) {
 			exit(EXIT_FAILURE);

--- a/swaymsg/swaymsg.1.scd
+++ b/swaymsg/swaymsg.1.scd
@@ -103,6 +103,9 @@ _swaymsg_ [options...] [message]
 *send\_tick*
 	Sends a tick event to all subscribed clients.
 
+*mint\_activation\_token*
+	Mint a new XDG activation token.
+
 *subscribe*
 	Subscribe to a list of event types. The argument for this type should be
 	provided in the form of a valid JSON array. If any of the types are invalid


### PR DESCRIPTION
The xdg activation token mechanism was designed primarily to prevent focus stealing, but also allows a "launch request" to be matched to the corresponding top-level window that is ultimately mapped as a result via the unique activation token.  While not universally supported by all applications, it is now fairly widely supported.

This PR adds a number of related improvements to the existing support in sway for the activation token protocol:

- Adds a `mint_activation_token` IPC command for creating a new activation token
- Exposes `initial_activation_token` as a property in the JSON representation, to allow IPC clients to match a window with a corresponding launch request.
- Adds `initial_activation_token` as a single-use, automatically cleaned up criteria.
- Adds a `for_exec_window` command that runs an external program, like `exec`, and also specifies a list of sway commands to run on the window once it maps.