### PR TITLE
fix: check for NULL view->container in constrain_popup to prevent segfault

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -139,6 +139,9 @@ static void constrain_popup(struct sway_input_popup *popup) {
 
 	if (popup->desc.view) {
 		struct sway_view *view = popup->desc.view;
+		if (!view->container) {
+			return;
+		}
 		output = wlr_output_layout_output_at(root->output_layout,
 			view->container->pending.content_x + view->geometry.x,
 			view->container->pending.content_y + view->geometry.y);


### PR DESCRIPTION
When using an IME (Input Method Editor, e.g. fcitx, ibus, anthywl) with sway, closing a window while the IME candidate popup is still active can cause sway to crash with a segfault.

## Root Cause

The crash occurs in `constrain_popup()` in `sway/input/text_input.c`:

1. A view is unmapped and its container is freed (set to NULL)
2. The IME popup still holds a reference to the destroyed view via `popup->desc.view`
3. When the IME commits a new frame for the popup, `handle_im_popup_surface_commit()` calls `constrain_popup()`
4. `constrain_popup()` accesses `view->container->pending.content_x` without checking if `view->container` is non-NULL → **NULL pointer dereference → segfault**

## The Fix

Add a NULL guard for `view->container` before dereferencing it. If the container is NULL, the view is no longer valid and we return early rather than crashing.

## Reproduction

1. Configure sway with an IME (e.g., anthywl)
2. Open any application with a text input (e.g., gedit, Firefox)
3. Activate the IME so the candidate popup appears
4. Close the window (e.g., via keyboard shortcut)
5. Sway crashes with SIGSEGV in `constrain_popup`

## Backtrace

```
#0  constrain_popup (popup=0x...) at ../sway-1.10/sway/input/text_input.c:159
#1  0x... in handle_im_popup_surface_commit (...)
#2  0x... in wl_signal_emit_mutable (wayland-server.c)
#3  0x... in surface_commit_state (wlroots)
```

Fixes https://github.com/swaywm/sway/issues/8541