### PR TITLE
tree/container: guard NULL workspace on detach

### DIFF
--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -1438,7 +1438,8 @@ void container_add_child(struct sway_container *parent,
 }
 
 void container_detach(struct sway_container *child) {
-	if (child->pending.fullscreen_mode == FULLSCREEN_WORKSPACE) {
+	if (child->pending.fullscreen_mode == FULLSCREEN_WORKSPACE &&
+			child->pending.workspace) {
 		child->pending.workspace->fullscreen = NULL;
 	}
 	if (child->pending.fullscreen_mode == FULLSCREEN_GLOBAL) {


### PR DESCRIPTION
Fixes #9210

`container_detach()` dereferenced `child->pending.workspace` without a NULL check when the detached container is `FULLSCREEN_WORKSPACE`. Moving a non-leaf container that has a fullscreen descendant to an empty workspace crashes: the first `container_detach()` recursively clears the descendants' `pending.workspace` (via `set_workspace`), then `workspace_unwrap_children()` detaches the still-fullscreen child and writes to `NULL + offsetof(struct sway_workspace, fullscreen)`.

This adds the same guard `container_begin_destroy()` already uses for the identical statement. See #9210 for the full analysis, deterministic `swaymsg` reproducer, and why games that use true (exclusive) fullscreen make this easy to hit in practice.

## Test plan

Reproducer from #9210 in a nested headless instance (`WLR_BACKENDS=headless … -c /dev/null`). Two windows are required — with a single window `splitv` only changes the workspace layout and never creates the wrapper container:

```sh
m() { swaymsg -s "$SOCK" "$@"; }  # $SOCK = the nested instance's IPC socket
m create_output
m exec foot; m exec foot; sleep 2
A=$(m -t get_tree | jq '[.. | objects | select(.app_id? == "foot") | .id] | min')
m "[con_id=$A] focus"; m splitv   # wrap A in a split container P
P=$(m -t get_tree | jq --argjson a "$A" '[.. | objects | select(.nodes? and ([.nodes[].id] | index($a)))] | last | .id')
m workspace 3
m "[con_id=$A] fullscreen enable"
m "[con_id=$P] move container to workspace 4"   # 4 = empty
```

Before (master f3b6431, debug build): SIGSEGV — `#0 container_detach at sway/tree/container.c:1442` ← `workspace_unwrap_children` (workspace.c:922) ← `container_move_to_workspace` (move.c:224) ← `cmd_move`; full symbolized backtrace in #9210. After (this patch on the same master build): the command succeeds, the fullscreen view lands on the target workspace still fullscreen (`fullscreen_mode: 1`), and the sibling stays behind on the original workspace. The same fix was previously verified on a sway 1.11-based tree (swayfx), which I run as my daily compositor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
