### PR TITLE
Ignore stale client commits on floating resize

### DIFF
--- a/sway/desktop/xdg_shell.c
+++ b/sway/desktop/xdg_shell.c
@@ -288,6 +288,20 @@ static const struct sway_view_impl view_impl = {
 	.destroy = destroy,
 };
 
+static bool is_commit_stale(struct sway_view *view, struct wlr_xdg_surface *xdg_surface) {
+	uint32_t latest_serial = 0;
+	if (xdg_surface->configure_idle != NULL) {
+		latest_serial = xdg_surface->scheduled_serial;
+	} else if (!wl_list_empty(&xdg_surface->configure_list)) {
+		struct wlr_xdg_surface_configure *configure =
+				wl_container_of(xdg_surface->configure_list.prev, configure, link);
+		latest_serial = configure->serial;
+	} else {
+		return false;
+	}
+	return xdg_surface->current.configure_serial < latest_serial;
+}
+
 static void handle_commit(struct wl_listener *listener, void *data) {
 	struct sway_xdg_shell_view *xdg_shell_view =
 		wl_container_of(listener, xdg_shell_view, commit);
@@ -315,20 +329,21 @@ static void handle_commit(struct wl_listener *listener, void *data) {
 			new_geo->height != view->geometry.height ||
 			new_geo->x != view->geometry.x ||
 			new_geo->y != view->geometry.y;
-
 	if (new_size) {
 		// The client changed its surface size in this commit. For floating
 		// containers, we resize the container to match. For tiling containers,
 		// we only recenter the surface.
 		memcpy(&view->geometry, new_geo, sizeof(struct wlr_box));
 		if (container_is_floating(view->container)) {
-			view_update_size(view);
-			// Only set the toplevel size the current container actually has a size.
-			if (view->container->current.width) {
-				wlr_xdg_toplevel_set_size(view->wlr_xdg_toplevel, view->geometry.width,
-					view->geometry.height);
+			if (!is_commit_stale(view, xdg_surface)) {
+				view_update_size(view);
+				// Only set the toplevel size the current container actually has a size.
+				if (view->container->current.width) {
+					wlr_xdg_toplevel_set_size(
+							view->wlr_xdg_toplevel, view->geometry.width, view->geometry.height);
+				}
+				transaction_commit_dirty_client();
 			}
-			transaction_commit_dirty_client();
 		}
 
 		view_center_and_clip_surface(view);


### PR DESCRIPTION
When a new view is mapped, criteria rules may configure its geometry (e.g. `resize set`). This configuration sends a new configure event to the client.

However, during the map event handling, we are still processing the initial commit from the client. After the map event is handled and the rule-configured geometry is applied via a transaction, the compositor's commit handler (`handle_commit`) continues.

For floating containers, `handle_commit` resizes the container to match the client's committed buffer size. If it processes the initial commit (which has the initial client size, not the configured one), it overrides the configured geometry back to the initial size.

To fix this, we introduce `is_commit_stale` helper which checks if there is a pending or scheduled configure event with a newer serial than the serial acknowledged by the current commit. If the commit is stale, we ignore its size for resizing floating containers, waiting instead for the client to acknowledge and commit the newly configured size.

How to reproduce:
1. Register the for_window rule: swaymsg 'for_window [title="Scratchpad Test"] move scratchpad, resize set 500 500'
2. Start the client: foot -T "Scratchpad Test"
3. Query the scratchpad window geometry: swaymsg -t get_tree | jq '.. | select(.name? == "__i3_scratch") | .floating_nodes[] | select(.name == "Scratchpad Test") | .rect'

   On buggy versions, this will output the client's default size instead of the configured 500x500.