### PR TITLE
Fix crash when config not initialized when seat is destroyed

### DIFF
--- a/sway/input/seat.c
+++ b/sway/input/seat.c
@@ -73,7 +73,7 @@ void seat_destroy(struct sway_seat *seat) {
 static void handle_seat_destroy(struct wl_listener *listener, void *data) {
 	struct sway_seat *seat = wl_container_of(listener, seat, destroy);
 
-	if (seat == config->handler_context.seat) {
+	if (config != NULL && seat == config->handler_context.seat) {
 		config->handler_context.seat = input_manager_get_default_seat();
 	}
 	struct sway_seat_device *seat_device, *next;


### PR DESCRIPTION
To reproduce: `sway -c NONE` (where `NONE` does not exist).