### PR TITLE
Do not use preferred mode for output when reloading config without "mode" cmd

### DIFF
--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -498,7 +498,9 @@ static void queue_output_config(struct output_config *oc,
 	} else if (oc && oc->width > 0 && oc->height > 0) {
 		set_mode(wlr_output, pending, oc->width, oc->height,
 			oc->refresh_rate, oc->custom_mode == 1);
-	} else if (!wl_list_empty(&wlr_output->modes)) {
+	} else if (!wl_list_empty(&wlr_output->modes) && !output->enabled) {
+        // Only use preferred mode when "mode" is not specified and output is
+        // not already enabled.
 		struct wlr_output_mode *preferred_mode =
 			wlr_output_preferred_mode(wlr_output);
 		wlr_output_state_set_mode(pending, preferred_mode);


### PR DESCRIPTION
If the config is reloaded while the output is already enabled and the "mode" command" is not specified, then do not default to the preferred mode.

My use case for this is that I have a script, that automatically adjusts the refresh rate of my laptop screen depending on if the battery is plugged in or not. However currently when I reload my config, the current mode settings are overwritten. This happens even if I do not run the "mode" command in my output config.

This is a little backwards incompatible I suppose? I am not familiar with sway devlopment so I am open to going another way to solve this problem.