### PR TITLE
input/text_input: fix NULL dereference in constrain_popup when no text input focused

### DIFF
--- a/sway/input/text_input.c
+++ b/sway/input/text_input.c
@@ -127,7 +127,7 @@ static void constrain_popup(struct sway_input_popup *popup) {
 	struct sway_text_input *text_input =
 		relay_get_focused_text_input(popup->relay);
 
-	if (!popup->desc.relative) {
+	if (!text_input || !popup->desc.relative) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

`constrain_popup()` calls `relay_get_focused_text_input()` which can return `NULL` when no text input currently has focus on the seat. While other callers of this function (e.g. `relay_send_im_state`, `handle_im_popup_surface_map`) correctly check for `NULL`, `constrain_popup` was missing this check, leading to a **NULL pointer dereference** at line 159 of `sway/input/text_input.c`:

```c
bool cursor_rect = text_input->input->current.features &
    WLR_TEXT_INPUT_V3_FEATURE_CURSOR_RECTANGLE;
```

This causes sway to crash with SIGSEGV.

## Root Cause

The crash happens when an input method popup surface commits (`handle_im_popup_surface_commit` → `constrain_popup`) but the focused text input has already been disabled or destroyed. The `popup->desc.relative` node is still valid (the popup surface exists), but `text_input` is NULL.

## Fix

Add `!text_input` to the existing early-return guard alongside `!popup->desc.relative`:

```diff
-	if (!popup->desc.relative) {
+	if (!text_input || !popup->desc.relative) {
 		return;
 	}
```

## Reproduction

1. Open any application that uses text-input-v3 (e.g. GTK4 text entry with fcitx5 input method)
2. Focus a text field (activates text-input) then rapidly switch focus away
3. If an input method popup (e.g. candidate window) was created and commits after the text input loses focus, sway crashes

The crash was confirmed via coredump analysis on Fedora 42 with sway 1.10.1.

## Backtrace

```
#0  constrain_popup (popup=0x55aedf0aa4f0) at ../sway/input/text_input.c:159
#1  0x... wl_signal_emit_mutable (libwayland-server)
#2  0x... surface_commit_state (libwlroots-0.18)
#3  0x... ffi_call_unix64 (libffi)
#4  0x... wl_closure_invoke (libwayland-server)
#5  0x... wl_client_connection_data (libwayland-server)
#6  0x... wl_event_loop_dispatch (libwayland-server)
#7  0x... wl_display_run (libwayland-server)
#8  0x... main (sway)
```

## Testing

- [x] The fix is minimal (1 line change)
- [x] Matches the NULL-check pattern used by all other callers in the same file
- [x] Builds cleanly with meson
- [x] No new warnings