### PR TITLE
Support libinputs 3fg_drag option

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -251,6 +251,7 @@ sway_cmd input_cmd_accel_profile;
 sway_cmd input_cmd_calibration_matrix;
 sway_cmd input_cmd_click_method;
 sway_cmd input_cmd_clickfinger_button_map;
+sway_cmd input_cmd_three_finger_drag;
 sway_cmd input_cmd_drag;
 sway_cmd input_cmd_drag_lock;
 sway_cmd input_cmd_dwt;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -150,6 +150,7 @@ struct input_config {
 	struct calibration_matrix calibration_matrix;
 	int click_method;
 	int clickfinger_button_map;
+	int drag_3fg;
 	int drag;
 	int drag_lock;
 	int dwt;

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -33,6 +33,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
 	{ "tap_button_map", input_cmd_tap_button_map },
+	{ "three_finger_drag", input_cmd_three_finger_drag },
 	{ "tool_mode", input_cmd_tool_mode },
 	{ "xkb_file", input_cmd_xkb_file },
 	{ "xkb_layout", input_cmd_xkb_layout },

--- a/sway/commands/input/three_finger_drag.c
+++ b/sway/commands/input/three_finger_drag.c
@@ -1,0 +1,32 @@
+#include <libinput.h>
+#include <string.h>
+#include <strings.h>
+#include "sway/config.h"
+#include "sway/commands.h"
+#include "sway/input/input-manager.h"
+#include "util.h"
+
+struct cmd_results *input_cmd_three_finger_drag(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "three_finger_drag", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	struct input_config *ic = config->handler_context.input_config;
+	if (!ic) {
+		return cmd_results_new(CMD_FAILURE, "No input device defined.");
+	}
+
+	
+	if (strcasecmp(argv[0], "three_finger") == 0) {
+		ic->drag_3fg = LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG;
+	} else if (strcasecmp(argv[0], "four_finger") == 0) {
+		ic->drag_3fg = LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG;
+	} else if (strcasecmp(argv[0], "disabled") == 0) {
+		ic->drag_3fg = LIBINPUT_CONFIG_3FG_DRAG_DISABLED;
+	} else {
+		return cmd_results_new(CMD_INVALID,
+			"Expected 'three_finger_drag <three_finger|four_finger|disabled>'");
+	}
+
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -22,6 +22,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->input_type = NULL;
 	input->tap = INT_MIN;
 	input->tap_button_map = INT_MIN;
+	input->drag_3fg = INT_MIN;
 	input->drag = INT_MIN;
 	input->drag_lock = INT_MIN;
 	input->dwt = INT_MIN;
@@ -58,6 +59,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->clickfinger_button_map != INT_MIN) {
 		dst->clickfinger_button_map = src->clickfinger_button_map;
+	}
+	if (src->drag_3fg != INT_MIN) {
+		dst->drag_3fg = src->drag_3fg;
 	}
 	if (src->drag != INT_MIN) {
 		dst->drag = src->drag;

--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -47,6 +47,16 @@ static bool set_tap_button_map(struct libinput_device *device,
 	return true;
 }
 
+static bool set_3fg_drag(struct libinput_device *device,
+		enum libinput_config_3fg_drag_state drag_3fg) {
+	if (libinput_device_config_3fg_drag_get_enabled(device) == drag_3fg) {
+		return false;
+	}
+	sway_log(SWAY_DEBUG, "3fg_drag_set_enabled(%d)", drag_3fg);
+	log_status(libinput_device_config_3fg_drag_set_enabled(device, drag_3fg));
+	return true;
+}
+
 static bool set_tap_drag(struct libinput_device *device,
 		enum libinput_config_drag_state drag) {
 	if (libinput_device_config_tap_get_finger_count(device) <= 0 ||
@@ -267,6 +277,9 @@ bool sway_input_configure_libinput_device(struct sway_input_device *input_device
 	if (ic->tap_button_map != INT_MIN) {
 		changed |= set_tap_button_map(device, ic->tap_button_map);
 	}
+	if (ic->drag_3fg != INT_MIN) {
+		changed |= set_3fg_drag(device, ic->drag_3fg);
+	}
 	if (ic->drag != INT_MIN) {
 		changed |= set_tap_drag(device, ic->drag);
 	}
@@ -352,6 +365,8 @@ void sway_input_reset_libinput_device(struct sway_input_device *input_device) {
 		libinput_device_config_tap_get_default_enabled(device));
 	changed |= set_tap_button_map(device,
 		libinput_device_config_tap_get_default_button_map(device));
+	changed |= set_3fg_drag(device,
+		libinput_device_config_3fg_drag_get_default_enabled(device));
 	changed |= set_tap_drag(device,
 		libinput_device_config_tap_get_default_drag_enabled(device));
 	changed |= set_tap_drag_lock(device,

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -939,6 +939,21 @@ static json_object *describe_libinput_device(struct libinput_device *device) {
 		json_object_object_add(object, "tap_button_map",
 				json_object_new_string(button_map));
 
+		const char *drag_3fg = "unknown";
+		switch (libinput_device_config_3fg_drag_get_enabled(device)) {
+		case LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG:
+			drag_3fg = "three_finger";
+			break;
+		case LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG:
+			drag_3fg = "four_finger";
+			break;
+		case LIBINPUT_CONFIG_3FG_DRAG_DISABLED:
+			drag_3fg = "disabled";
+			break;
+		}
+		json_object_object_add(object, "three_finger_drag",
+			json_object_new_string(drag_3fg));
+
 		const char* drag = "unknown";
 		switch (libinput_device_config_tap_get_drag_enabled(device)) {
 		case LIBINPUT_CONFIG_DRAG_ENABLED:

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -157,6 +157,7 @@ sway_sources = files(
 	'commands/input/calibration_matrix.c',
 	'commands/input/click_method.c',
 	'commands/input/clickfinger_button_map.c',
+	'commands/input/three_finger_drag.c',
 	'commands/input/drag.c',
 	'commands/input/drag_lock.c',
 	'commands/input/dwt.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -149,6 +149,10 @@ The following commands may only be used in the configuration file.
 	treats 1 finger as left click, 2 fingers as middle click, and 3 fingers as
 	right click.
 
+*input* <identifier> three_finger_drag three_finger|four_finger|disabled
+	Enables three-finger-drag for the specified input device, with either
+	three fingers or four fingers.
+
 *input* <identifier> drag enabled|disabled
 	Enables or disables tap-and-drag for specified input device.
 

--- a/sway/sway-ipc.7.scd
+++ b/sway/sway-ipc.7.scd
@@ -1189,6 +1189,9 @@ following properties will be included for devices that support them:
 |- tap_button_map
 :  string
 :  The finger to button mapping in use for tapping. It can be _lmr_ or _lrm_
+|- three_finger_drag
+:  string
+:  Whether three-finger-drag is enabled. It can be _three_finger_, _four_finger_ or _disabled_
 |- tap_drag
 :  string
 :  Whether tap-and-drag is enabled. It can be _enabled_ or _disabled_
@@ -1265,6 +1268,7 @@ following properties will be included for devices that support them:
 			"send_events": "enabled",
 			"tap": "enabled",
 			"tap_button_map": "lmr",
+			"three_finger_drag": "three_finger",
 			"tap_drag": "enabled",
 			"tap_drag_lock": "disabled",
 			"accel_speed": 0.0,
@@ -1393,6 +1397,7 @@ one seat. Each object has the following properties:
 					"send_events": "enabled",
 					"tap": "enabled",
 					"tap_button_map": "lmr",
+					"three_finger_drag": "three_finger",
 					"tap_drag": "enabled",
 					"tap_drag_lock": "disabled",
 					"accel_speed": 0.0,


### PR DESCRIPTION
Support the 3fg_drag option in libinput, allowing users to drag-and-drop with three (or four) fingers on a touchpad.
See:
https://gitlab.freedesktop.org/libinput/libinput/-/commit/1d9e307e2b92322a5102add55641f953d8e952fe

Fixes #8967 