### PR TITLE
libinput: add three-finger drag config support

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -272,6 +272,7 @@ sway_cmd input_cmd_scroll_button_lock;
 sway_cmd input_cmd_scroll_method;
 sway_cmd input_cmd_tap;
 sway_cmd input_cmd_tap_button_map;
+sway_cmd input_cmd_three_finger_drag;
 sway_cmd input_cmd_tool_mode;
 sway_cmd input_cmd_xkb_capslock;
 sway_cmd input_cmd_xkb_file;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -152,6 +152,7 @@ struct input_config {
 	int clickfinger_button_map;
 	int drag;
 	int drag_lock;
+	int three_finger_drag;
 	int dwt;
 	int dwtp;
 	int left_handed;

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ conf_data.set10('HAVE_LIBSYSTEMD', sdbus.found() and sdbus.name() == 'libsystemd
 conf_data.set10('HAVE_LIBELOGIND', sdbus.found() and sdbus.name() == 'libelogind')
 conf_data.set10('HAVE_BASU', sdbus.found() and sdbus.name() == 'basu')
 conf_data.set10('HAVE_TRAY', have_tray)
-foreach sym : ['LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM', 'LIBINPUT_CONFIG_DRAG_LOCK_ENABLED_STICKY', 'LIBINPUT_SWITCH_KEYPAD_SLIDE']
+foreach sym : ['LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM', 'LIBINPUT_CONFIG_DRAG_LOCK_ENABLED_STICKY', 'LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG', 'LIBINPUT_SWITCH_KEYPAD_SLIDE']
 	conf_data.set10('HAVE_' + sym, cc.has_header_symbol('libinput.h', sym, dependencies: libinput))
 endforeach
 

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -33,6 +33,7 @@ static const struct cmd_handler input_handlers[] = {
 	{ "scroll_method", input_cmd_scroll_method },
 	{ "tap", input_cmd_tap },
 	{ "tap_button_map", input_cmd_tap_button_map },
+	{ "three_finger_drag", input_cmd_three_finger_drag },
 	{ "tool_mode", input_cmd_tool_mode },
 	{ "xkb_file", input_cmd_xkb_file },
 	{ "xkb_layout", input_cmd_xkb_layout },

--- a/sway/config/input.c
+++ b/sway/config/input.c
@@ -24,6 +24,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->tap_button_map = INT_MIN;
 	input->drag = INT_MIN;
 	input->drag_lock = INT_MIN;
+	input->three_finger_drag = INT_MIN;
 	input->dwt = INT_MIN;
 	input->dwtp = INT_MIN;
 	input->send_events = INT_MIN;
@@ -64,6 +65,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 	}
 	if (src->drag_lock != INT_MIN) {
 		dst->drag_lock = src->drag_lock;
+	}
+	if (src->three_finger_drag != INT_MIN) {
+		dst->three_finger_drag = src->three_finger_drag;
 	}
 	if (src->dwt != INT_MIN) {
 		dst->dwt = src->dwt;

--- a/sway/input/libinput.c
+++ b/sway/input/libinput.c
@@ -69,6 +69,23 @@ static bool set_tap_drag_lock(struct libinput_device *device,
 	return true;
 }
 
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+static bool set_3fg_drag(struct libinput_device *device,
+		enum libinput_config_3fg_drag_state drag) {
+	int fingers = libinput_device_config_3fg_drag_get_finger_count(device);
+	if (fingers <= 0 ||
+			libinput_device_config_3fg_drag_get_enabled(device) == drag) {
+		return false;
+	}
+	if (drag == LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG && fingers < 4) {
+		return false;
+	}
+	sway_log(SWAY_DEBUG, "3fg_drag_set_enabled(%d)", drag);
+	log_status(libinput_device_config_3fg_drag_set_enabled(device, drag));
+	return true;
+}
+#endif
+
 static bool set_accel_speed(struct libinput_device *device, double speed) {
 	if (!libinput_device_config_accel_is_available(device) ||
 			libinput_device_config_accel_get_speed(device) == speed) {
@@ -273,6 +290,11 @@ bool sway_input_configure_libinput_device(struct sway_input_device *input_device
 	if (ic->drag_lock != INT_MIN) {
 		changed |= set_tap_drag_lock(device, ic->drag_lock);
 	}
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+	if (ic->three_finger_drag != INT_MIN) {
+		changed |= set_3fg_drag(device, ic->three_finger_drag);
+	}
+#endif
 	if (ic->pointer_accel != FLT_MIN) {
 		changed |= set_accel_speed(device, ic->pointer_accel);
 	}
@@ -356,6 +378,10 @@ void sway_input_reset_libinput_device(struct sway_input_device *input_device) {
 		libinput_device_config_tap_get_default_drag_enabled(device));
 	changed |= set_tap_drag_lock(device,
 		libinput_device_config_tap_get_default_drag_lock_enabled(device));
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+	changed |= set_3fg_drag(device,
+		libinput_device_config_3fg_drag_get_default_enabled(device));
+#endif
 	changed |= set_accel_speed(device,
 		libinput_device_config_accel_get_default_speed(device));
 	changed |= set_rotation_angle(device,

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -969,6 +969,25 @@ static json_object *describe_libinput_device(struct libinput_device *device) {
 				json_object_new_string(drag_lock));
 	}
 
+#if HAVE_LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG
+	if (libinput_device_config_3fg_drag_get_finger_count(device) > 0) {
+		const char *three_finger_drag = "unknown";
+		switch (libinput_device_config_3fg_drag_get_enabled(device)) {
+		case LIBINPUT_CONFIG_3FG_DRAG_DISABLED:
+			three_finger_drag = "disabled";
+			break;
+		case LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG:
+			three_finger_drag = "enabled_3fg";
+			break;
+		case LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG:
+			three_finger_drag = "enabled_4fg";
+			break;
+		}
+		json_object_object_add(object, "three_finger_drag",
+				json_object_new_string(three_finger_drag));
+	}
+#endif
+
 	if (libinput_device_config_accel_is_available(device)) {
 		double accel = libinput_device_config_accel_get_speed(device);
 		json_object_object_add(object, "accel_speed",

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -178,6 +178,7 @@ sway_sources = files(
 	'commands/input/scroll_method.c',
 	'commands/input/tap.c',
 	'commands/input/tap_button_map.c',
+	'commands/input/three_finger_drag.c',
 	'commands/input/tool_mode.c',
 	'commands/input/xkb_capslock.c',
 	'commands/input/xkb_file.c',

--- a/sway/sway-input.5.scd
+++ b/sway/sway-input.5.scd
@@ -156,6 +156,11 @@ The following commands may only be used in the configuration file.
 	Enables or disables drag lock for specified input device. The default is
 	_disabled_.
 
+*input* <identifier> three_finger_drag enabled|disabled|3|4
+	Enables or disables 3/4 finger drag for specified touchpads. _enabled_ is
+	shorthand for _3_. When enabled, 3/4 finger swipes are converted into a
+	button down + motion + button up sequence.
+
 *input* <identifier> dwt enabled|disabled
 	Enables or disables disable-while-typing for the specified input device.
 


### PR DESCRIPTION
https://wayland.freedesktop.org/libinput/doc/latest/drag-3fg.html 

Add a new three_finger_drag input option backed by libinput’s 3‑finger drag. Wire it into config handling, libinput apply/reset, IPC, and the docs.

closes #8967 