### PR TITLE
Flush IPC shutdown event

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -41,6 +41,7 @@ void sway_terminate(int exit_code) {
 		terminate_request = true;
 		exit_value = exit_code;
 		ipc_event_shutdown("exit");
+		wl_event_loop_dispatch(server.wl_event_loop, 0); // flush IPC event
 		wl_display_terminate(server.wl_display);
 	}
 }


### PR DESCRIPTION
ipc_send_reply() sets up a wl_event_source to wait for the client FD to become writable. It doesn't attempt to write immediately. As a result, ipc_event_shutdown("exit") merely queues events.

Call wl_event_loop_dispatch() with a zero timeout to flush these events before terminating.

Closes: https://github.com/swaywm/sway/issues/9216