### PR TITLE
swaybar: add active_only to prevent rendering non-active workspaces.

### DIFF
--- a/include/swaybar/config.h
+++ b/include/swaybar/config.h
@@ -80,6 +80,8 @@ struct swaybar_config {
 	list_t *tray_outputs; // char *
 	int tray_padding;
 #endif
+
+  bool active_only;
 };
 
 #if HAVE_TRAY

--- a/swaybar/config.c
+++ b/swaybar/config.c
@@ -81,6 +81,8 @@ struct swaybar_config *init_config(void) {
 	wl_list_init(&config->tray_bindings);
 #endif
 
+  config->active_only = false;
+
 	return config;
 }
 

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -333,6 +333,13 @@ static bool ipc_parse_config(
 	}
 #endif
 
+	json_object *active_only =
+		json_object_object_get(bar_config, "active_only");
+	if (active_only) {
+		config->active_only =
+			json_object_get_boolean(active_only);
+	}
+
 	json_object_put(bar_config);
 	return true;
 }

--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -689,6 +689,12 @@ static uint32_t render_to_cairo(struct render_context *ctx) {
 	if (config->workspace_buttons) {
 		struct swaybar_workspace *ws;
 		wl_list_for_each(ws, &output->workspaces, link) {
+  		if (config->active_only) {
+    		if (!(ws->urgent || ws->focused || ws->visible)) {
+      		continue;
+    		}
+  		}
+
 			uint32_t h = render_workspace_button(ctx, ws, &x);
 			max_height = h > max_height ? h : max_height;
 		}


### PR DESCRIPTION
This boolean IPC configuration option makes swaybar not render workspace buttons that are neither visible nor focused. This is mainly intended for people using tons of workspace while displaying them all is not meaningful. This is especially true for people not rendering indexes / using only names.

An exception is made for urgent workspaces, which _should_ be displayed, since they require the user attention.

Usually, we would simply switch to another workspace through IPC (by listing them in a fuzzy picker, for instance).