### PR TITLE
Start locked

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -15,6 +15,7 @@ struct sway_session_lock {
 	struct wlr_session_lock_v1 *lock;
 	struct wlr_surface *focused;
 	bool abandoned;
+	float background[4];
 
 	struct wl_list outputs; // struct sway_session_lock_output
 
@@ -177,6 +178,7 @@ void handle_new_output(struct wl_listener *listener, void *data);
 void handle_idle_inhibitor_v1(struct wl_listener *listener, void *data);
 void handle_layer_shell_surface(struct wl_listener *listener, void *data);
 bool sway_session_lock_init(void);
+void sway_session_lock_start_locked(void);
 void sway_session_lock_add_output(struct sway_session_lock *lock,
 	struct sway_output *output);
 bool sway_session_lock_has_surface(struct sway_session_lock *lock,

--- a/sway/lock.c
+++ b/sway/lock.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 #include "log.h"
@@ -164,12 +165,8 @@ static struct sway_session_lock_output *session_lock_output_create(
 		return NULL;
 	}
 
-	struct wlr_scene_rect *background = wlr_scene_rect_create(tree, 0, 0, (float[4]){
-		lock->abandoned ? 1.f : 0.f,
-		0.f,
-		0.f,
-		1.f,
-	});
+	struct wlr_scene_rect *background =
+		wlr_scene_rect_create(tree, 0, 0, lock->background);
 	if (!background) {
 		sway_log(SWAY_ERROR, "failed to allocate a session lock output scene background");
 		wlr_scene_node_destroy(&tree->node);
@@ -247,9 +244,10 @@ static void handle_abandon(struct wl_listener *listener, void *data) {
 	sway_log(SWAY_INFO, "session lock abandoned");
 
 	struct sway_session_lock_output *lock_output;
+	static const float crashed[4] = { 1.f, 0.f, 0.f, 1.f };
+	memcpy(lock->background, crashed, sizeof(lock->background));
 	wl_list_for_each(lock_output, &lock->outputs, link) {
-		wlr_scene_rect_set_color(lock_output->background,
-			(float[4]){ 1.f, 0.f, 0.f, 1.f });
+		wlr_scene_rect_set_color(lock_output->background, crashed);
 	}
 
 	lock->abandoned = true;
@@ -281,6 +279,7 @@ static void handle_session_lock(struct wl_listener *listener, void *data) {
 	}
 
 	wl_list_init(&sway_lock->outputs);
+	sway_lock->background[3] = 1.f;
 
 	sway_log(SWAY_DEBUG, "session locked");
 
@@ -345,6 +344,25 @@ bool sway_session_lock_has_surface(struct sway_session_lock *lock,
 	}
 
 	return false;
+}
+
+void sway_session_lock_start_locked(void) {
+	struct sway_session_lock *lock = calloc(1, sizeof(*lock));
+	if (!lock) {
+		sway_log(SWAY_ERROR, "aborting: failed to allocate the startup lock");
+		abort();
+	}
+
+	wl_list_init(&lock->outputs);
+	// No client has locked the session yet: the lock is in the same state as
+	// one whose client died, so that the first ext-session-lock client to
+	// show up replaces it instead of being refused.
+	lock->abandoned = true;
+	lock->background[3] = 1.f;
+
+	server.session_lock.lock = lock;
+
+	sway_log(SWAY_INFO, "session locked at startup, waiting for a lock client");
 }
 
 bool sway_session_lock_init(void) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -209,6 +209,7 @@ static const struct option long_options[] = {
 	{"verbose", no_argument, NULL, 'V'},
 	{"get-socketpath", no_argument, NULL, 'p'},
 	{"unsupported-gpu", no_argument, NULL, 'u'},
+	{"locked", no_argument, NULL, 'l'},
 	{0, 0, 0, 0}
 };
 
@@ -221,18 +222,20 @@ static const char usage[] =
 	"  -d, --debug            Enables full logging, including debug information.\n"
 	"  -v, --version          Show the version number and quit.\n"
 	"  -V, --verbose          Enables more verbose logging.\n"
+	"  -l, --locked           Start with the session locked, awaiting a lock client.\n"
 	"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
 	"\n";
 
 int main(int argc, char **argv) {
 	bool verbose = false, debug = false, validate = false, allow_unsupported_gpu = false;
+	bool start_locked = false;
 
 	char *config_path = NULL;
 
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hCdD:vVc:", long_options, &option_index);
+		c = getopt_long(argc, argv, "hCdD:lvVc:", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
@@ -253,6 +256,9 @@ int main(int argc, char **argv) {
 			break;
 		case 'D': // extended debug options
 			enable_debug_flag(optarg);
+			break;
+		case 'l': // locked
+			start_locked = true;
 			break;
 		case 'u':
 			allow_unsupported_gpu = true;
@@ -370,6 +376,13 @@ int main(int argc, char **argv) {
 	}
 
 	set_rr_scheduling();
+
+	// Must happen before the backend starts: outputs created afterwards are
+	// added to the lock by handle_new_output(), so no output is ever composited
+	// unlocked, and input is filtered from the very first event.
+	if (start_locked) {
+		sway_session_lock_start_locked();
+	}
 
 	if (!server_start(&server)) {
 		sway_terminate(EXIT_FAILURE);

--- a/sway/sway.1.scd
+++ b/sway/sway.1.scd
@@ -28,6 +28,13 @@ sway - An i3-compatible Wayland compositor
 *-V, --verbose*
 	Enables more verbose logging.
 
+*-l, --locked*
+	Start with the session already locked, waiting for an
+	ext-session-lock-v1 client to attach. No output is ever composited
+	unlocked and input is filtered from the first event, which closes the
+	window during which a lock client started from *exec* is still busy
+	initialising. Intended for auto-login setups.
+
 *--get-socketpath*
 	Gets the IPC socket path and prints it, then exits.
 


### PR DESCRIPTION
Intended for autologin, while preventing any access:
- Session using sway --locked
- Sway config containing 'exec swaylock' (or, anticipating swaylock failure: exec 'while ! swaylock; do sleep 1; done')