### PR TITLE
sway/server: set fallback gamma size for software gamma fallback

### DIFF
--- a/sway/server.c
+++ b/sway/server.c
@@ -333,6 +333,8 @@ bool server_init(struct sway_server *server) {
 		sway_log(SWAY_ERROR, "Failed to create gamma control manager");
 		return false;
 	}
+
+	server->gamma_control_manager_v1->fallback_gamma_size = 512;
 	wlr_scene_set_gamma_control_manager_v1(root->root_scene,
 		server->gamma_control_manager_v1);
 


### PR DESCRIPTION
Useful for Asahi where GAMMA_LUT drm property isn't supported.

This was added to wlroots in https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5166