### PR TITLE
wlr_scene: Use wlr_scene_tree_set_clip

### DIFF
--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -703,6 +703,14 @@ static void arrange_root(struct sway_root *root) {
 			wlr_scene_node_set_position(&output->layers.shell_overlay->node, output->lx, output->ly);
 			wlr_scene_node_set_position(&output->layers.session_lock->node, output->lx, output->ly);
 
+			// Prevent layer surfaces from leaking onto adjacent outputs
+			struct wlr_box clip = {0};
+			wlr_output_effective_resolution(output->wlr_output, &clip.width, &clip.height);
+			wlr_scene_tree_set_clip(output->layers.shell_background, &clip);
+			wlr_scene_tree_set_clip(output->layers.shell_bottom, &clip);
+			wlr_scene_tree_set_clip(output->layers.shell_top, &clip);
+			wlr_scene_tree_set_clip(output->layers.shell_overlay, &clip);
+
 			arrange_output(output, output->width, output->height);
 		}
 	}

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -1052,13 +1052,13 @@ void view_center_and_clip_surface(struct sway_view *view) {
 		struct wlr_box clip = {0};
 		if (clip_to_geometry) {
 			clip = (struct wlr_box){
-				.x = con->view->geometry.x,
-				.y = con->view->geometry.y,
+				.x = 0,
+				.y = 0,
 				.width = con->current.content_width,
 				.height = con->current.content_height,
 			};
 		}
-		wlr_scene_subsurface_tree_set_clip(&con->view->content_tree->node, &clip);
+		wlr_scene_tree_set_clip(con->view->content_tree, &clip);
 	}
 }
 
@@ -1281,6 +1281,8 @@ void view_save_buffer(struct sway_view *view) {
 	// is disabled until it is ready to replace the real surface.
 	wlr_scene_node_place_below(&view->saved_surface_tree->node, &view->output_handler->node);
 	wlr_scene_node_set_enabled(&view->saved_surface_tree->node, false);
+
+	wlr_scene_tree_set_clip(view->saved_surface_tree, &view->content_tree->clip);
 
 	wlr_scene_node_for_each_buffer(&view->content_tree->node,
 		view_save_buffer_iterator, view->saved_surface_tree);


### PR DESCRIPTION
Requires wlroots MR: https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5276

Switches to the more generic `wlr_scene_tree_set_clip` function instead of relying on `wlr_scene_subsurface_tree_set_clip`. The PR also adds layer-shell clipping, fixing an issue where layer surfaces could spill onto adjacent outputs (see the images visible below).

With layer-shell clipping:
<img width="544" height="361" alt="image" src="https://github.com/user-attachments/assets/1a126c44-6f61-4e42-b99b-e361bcbb6c55" />

Without layer-shell clipping:
<img width="478" height="331" alt="image" src="https://github.com/user-attachments/assets/eeb51a5a-0976-4516-8432-b30185b92bab" />