### PR TITLE
Fix #9217 and #8292

### DIFF
--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -139,6 +139,13 @@ static void container_move_to_container_from_direction(
 		return;
 	}
 
+	struct sway_seat *seat = config->handler_context.seat;
+	if (seat_get_focus(seat) == &container->node) {
+		sway_log(SWAY_DEBUG, "Moving a focused container");
+		seat_set_raw_focus(seat, &destination->node);
+		seat_set_raw_focus(seat, &container->node);
+	}
+
 	if (is_parallel(destination->pending.layout, move_dir)) {
 		sway_log(SWAY_DEBUG, "Reparenting container (parallel)");
 		int index =
@@ -153,7 +160,7 @@ static void container_move_to_container_from_direction(
 
 	sway_log(SWAY_DEBUG, "Reparenting container (perpendicular)");
 	struct sway_node *focus_inactive = seat_get_active_tiling_child(
-			config->handler_context.seat, &destination->node);
+			seat, &destination->node);
 	if (!focus_inactive || focus_inactive == &destination->node) {
 		// The container has no children
 		container_add_child(destination, container);


### PR DESCRIPTION
When a focused node is moved out of a container into a sibling container of that container, the focus stack and the focused node can become out of sync. Prevent this by moving the focused node to the top of the focus stack whenever it is moved.

This commit fixes the mentioned issues without addressing the core of the problem: that the interface for modifying the layout is not sufficiently encapsulated and does not keep the focused node and focus stack in sync (see discussion in PR #8526). That would require a lot of work. Get this out now until we have a cleaner solution.

As of now, I have been daily driving this patch for almost a month. I hadn't opened a PR until now since I wrote it kind of hastily and don't think it is quite ready. I'm making this PR for the sake of conversation. Beyond the refactoring work I alluded to, I have not tested this when moving to or from a deeply nested container. There should probably be a loop over all of the ancestor nodes to focus. 

This commit based off of f0731de by WhyNotHugo and the discussion around that PR.