### PR TITLE
tree/container: make formatted_title double buffered

### DIFF
--- a/include/sway/tree/container.h
+++ b/include/sway/tree/container.h
@@ -63,6 +63,8 @@ struct sway_container_state {
 	// These are in layout coordinates.
 	double content_x, content_y;
 	double content_width, content_height;
+
+	char *formatted_title; // The title displayed in the title bar
 };
 
 struct sway_container {
@@ -96,7 +98,6 @@ struct sway_container {
 	struct sway_container_state pending;
 
 	char *title;           // The view's title (unformatted)
-	char *formatted_title; // The title displayed in the title bar
 	int title_width;
 
 	char *title_format;
@@ -178,6 +179,8 @@ void container_reap_empty(struct sway_container *con);
 struct sway_container *container_flatten(struct sway_container *container);
 
 void container_update_title_bar(struct sway_container *container);
+
+void container_update_title_text(struct sway_container *container);
 
 void container_update_marks(struct sway_container *container);
 

--- a/sway/desktop/transaction.c
+++ b/sway/desktop/transaction.c
@@ -59,6 +59,9 @@ static void transaction_destroy(struct sway_transaction *transaction) {
 		if (node->instruction == instruction) {
 			node->instruction = NULL;
 		}
+		if (node->type == N_CONTAINER) {
+			free(instruction->container_state.formatted_title);
+		}
 		if (node->destroying && node->ntxnrefs == 0 && !node->dirty) {
 			switch (node->type) {
 			case N_ROOT:
@@ -143,8 +146,18 @@ static void copy_container_state(struct sway_container *container,
 	if (state->children) {
 		list_free(state->children);
 	}
+	if (state->formatted_title) {
+		free(state->formatted_title);
+	}
 
 	memcpy(state, &container->pending, sizeof(struct sway_container_state));
+	state->formatted_title = NULL;
+
+	if (container->pending.formatted_title) {
+		state->formatted_title = strdup(container->pending.formatted_title);
+		sway_assert(state->formatted_title,
+				"Unable to allocate formatted title");
+	}
 
 	if (!container->view) {
 		// We store a copy of the child list to avoid having it mutated after
@@ -234,8 +247,10 @@ static void apply_container_state(struct sway_container *container,
 	// Any child containers which are being deleted will be cleaned up in
 	// transaction_destroy().
 	list_free(container->current.children);
+	free(container->current.formatted_title);
 
 	memcpy(&container->current, state, sizeof(struct sway_container_state));
+	state->formatted_title = NULL;
 
 	if (view) {
 		if (view->saved_surface_tree) {
@@ -250,6 +265,10 @@ static void apply_container_state(struct sway_container *container,
 		if (view->surface) {
 			view_center_and_clip_surface(view);
 		}
+	}
+
+	if (!container->node.destroying) {
+		container_update_title_text(container);
 	}
 }
 

--- a/sway/tree/container.c
+++ b/sway/tree/container.c
@@ -417,20 +417,36 @@ void container_update_marks(struct sway_container *con) {
 	free(buffer);
 }
 
-void container_update_title_bar(struct sway_container *con) {
-	if (!con->formatted_title) {
+void container_update_title_text(struct sway_container *con) {
+	if (!con->current.formatted_title || !*con->current.formatted_title) {
+		if (con->title_bar.title_text) {
+			wlr_scene_node_destroy(con->title_bar.title_text->node);
+			con->title_bar.title_text = NULL;
+		}
 		return;
 	}
 
-	struct border_colors *colors = container_get_current_colors(con);
+	if (!con->title_bar.title_text) {
+		struct border_colors *colors = container_get_current_colors(con);
+		con->title_bar.title_text = sway_text_node_create(con->title_bar.tree,
+			con->current.formatted_title, colors->text, config->pango_markup);
+	} else {
+		sway_text_node_set_text(con->title_bar.title_text,
+			con->current.formatted_title);
+	}
+}
 
+void container_update_title_bar(struct sway_container *con) {
 	if (con->title_bar.title_text) {
 		wlr_scene_node_destroy(con->title_bar.title_text->node);
 		con->title_bar.title_text = NULL;
 	}
 
-	con->title_bar.title_text = sway_text_node_create(con->title_bar.tree,
-		con->formatted_title, colors->text, config->pango_markup);
+	if (con->current.formatted_title && *con->current.formatted_title) {
+		struct border_colors *colors = container_get_current_colors(con);
+		con->title_bar.title_text = sway_text_node_create(con->title_bar.tree,
+			con->current.formatted_title, colors->text, config->pango_markup);
+	}
 
 	// we always have to remake these text buffers completely for text font
 	// changes etc...
@@ -453,7 +469,8 @@ void container_destroy(struct sway_container *con) {
 		return;
 	}
 	free(con->title);
-	free(con->formatted_title);
+	free(con->pending.formatted_title);
+	free(con->current.formatted_title);
 	free(con->title_format);
 	list_free(con->pending.children);
 	list_free(con->current.children);
@@ -732,7 +749,7 @@ size_t container_build_representation(enum sway_container_layout layout,
 				identifier = view_get_app_id(child->view);
 			}
 		} else {
-			identifier = child->formatted_title;
+			identifier = child->pending.formatted_title;
 		}
 		if (identifier) {
 			len += strlen(identifier);
@@ -750,20 +767,17 @@ size_t container_build_representation(enum sway_container_layout layout,
 void container_update_representation(struct sway_container *con) {
 	if (!con->view) {
 		size_t len = parse_title_format(con, NULL);
-		free(con->formatted_title);
-		con->formatted_title = calloc(len + 1, sizeof(char));
-		if (!sway_assert(con->formatted_title,
-					"Unable to allocate title string")) {
-			return;
+		free(con->pending.formatted_title);
+		con->pending.formatted_title = NULL;
+		if (len) {
+			con->pending.formatted_title = calloc(len + 1, sizeof(char));
+			if (!sway_assert(con->pending.formatted_title,
+						"Unable to allocate title string")) {
+				return;
+			}
+			parse_title_format(con, con->pending.formatted_title);
 		}
-		parse_title_format(con, con->formatted_title);
-
-		if (con->title_bar.title_text) {
-			sway_text_node_set_text(con->title_bar.title_text, con->formatted_title);
-			container_arrange_title_bar(con);
-		} else {
-			container_update_title_bar(con);
-		}
+		node_set_dirty(&con->node);
 	}
 	if (con->pending.parent) {
 		container_update_representation(con->pending.parent);

--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -29,7 +29,6 @@
 #include "sway/input/seat.h"
 #include "sway/scene_descriptor.h"
 #include "sway/server.h"
-#include "sway/sway_text_node.h"
 #include "sway/tree/arrange.h"
 #include "sway/tree/container.h"
 #include "sway/tree/view.h"
@@ -1116,7 +1115,9 @@ void view_update_title(struct sway_view *view, bool force) {
 	}
 
 	free(view->container->title);
-	free(view->container->formatted_title);
+	view->container->title = NULL;
+	free(view->container->pending.formatted_title);
+	view->container->pending.formatted_title = NULL;
 
 	size_t len = parse_title_format(view->container, NULL);
 
@@ -1127,21 +1128,12 @@ void view_update_title(struct sway_view *view, bool force) {
 		}
 
 		parse_title_format(view->container, buffer);
-		view->container->formatted_title = buffer;
-	} else {
-		view->container->formatted_title = NULL;
+		view->container->pending.formatted_title = buffer;
 	}
 
 	view->container->title = title ? strdup(title) : NULL;
 
-	// Update title after the global font height is updated
-	if (view->container->title_bar.title_text && len) {
-		sway_text_node_set_text(view->container->title_bar.title_text,
-			view->container->formatted_title);
-		container_arrange_title_bar(view->container);
-	} else {
-		container_update_title_bar(view->container);
-	}
+	node_set_dirty(&view->container->node);
 
 	ipc_event_window(view->container, "title");
 


### PR DESCRIPTION
Previously, container titles were updated before a transaction committed, leading to a brief flicker of a window having an updated (incorrect) title when changing the container tree layout.

This commit moves the formatted_title field into sway_container_state and title updates are now done in apply_container_state so that container titles are updated synchronously with other visual changes during transactions.

---

Here's a demonstration of the bug this fixes. This is a screen recording of a view being moved right and left a couple of times (in and out of a split) on `master`:

[title-flicker-clip.webm](https://github.com/user-attachments/assets/6337e0d0-8705-4652-b433-12460141937d)

If you step through this recording you'll see that frame 175 (moving the view out of the split) looks like this:

<img width="1272" height="920" alt="mpv-shot0001" src="https://github.com/user-attachments/assets/0f43ddde-091b-456a-bebf-416a4ef3bbc8" />

The title of the split container has been updated _before_ the container has moved. In the next frame, the tree catches up with the title change:

<img width="1272" height="920" alt="mpv-shot0002" src="https://github.com/user-attachments/assets/0df00abe-e4ab-44fe-8c10-ac7f5a2affd4" />

Similarly when moving the view back into the split, at frame 256 the title is updated before the tree:

<img width="1272" height="920" alt="mpv-shot0003" src="https://github.com/user-attachments/assets/fd8d23e8-3727-4e24-aeb2-e8e3290d6d49" />

And then on the next frame the tree "catches up":

<img width="1272" height="920" alt="mpv-shot0004" src="https://github.com/user-attachments/assets/75ebb158-5f32-4b63-b3c5-c1b1914f7d39" />

---

Here's the same recording with the patch in this PR:

[title-noflicker-clip.webm](https://github.com/user-attachments/assets/74484d73-fb75-43ca-b9b8-6b5e51d5a70f)

If you step through it frame-by-frame you'll see that the title and tree updates are atomic. The intermediate state where the title doesn't match the tree is no longer visible.