### PR TITLE
tree/view: create a workspace instead of aborting when there is none

### DIFF
--- a/sway/tree/view.c
+++ b/sway/tree/view.c
@@ -680,10 +680,21 @@ static struct sway_workspace *select_workspace(struct sway_view *view) {
 		return node->sway_container->pending.workspace;
 	}
 
-	// When there's no outputs connected, the above should match a workspace on
-	// the noop output.
-	sway_assert(false, "Expected to find a workspace");
-	return NULL;
+	// With no outputs connected the fallback output is supposed to hold the
+	// workspaces, but output_evacuate() destroys an evacuated workspace when it
+	// is empty, so losing the last output with nothing open leaves the tree
+	// without a workspace anywhere.
+	struct sway_output *output = root->outputs->length > 0 ?
+		root->outputs->items[0] : root->fallback_output;
+	char *ws_name = workspace_next_name(output->wlr_output->name);
+	sway_log(SWAY_DEBUG, "No workspace to map onto, creating %s on output %s",
+			ws_name, output->wlr_output->name);
+	ws = workspace_create(output, ws_name);
+	free(ws_name);
+	if (ws) {
+		ipc_event_workspace(NULL, ws, "init");
+	}
+	return ws;
 }
 
 static void update_ext_foreign_toplevel(struct sway_view *view) {

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -441,6 +441,14 @@ char *workspace_next_name(const char *output_name) {
 	struct sway_mode *mode = config->current_mode;
 
 	struct sway_output *output = output_by_name_or_id(output_name);
+	if (!output && root->fallback_output && output_match_name_or_id(
+				root->fallback_output, output_name)) {
+		// The fallback output holds the workspaces while no real output is
+		// connected, but it is not part of root->outputs so the lookup above
+		// cannot find it. No workspace config can name it either, which leaves
+		// the numeric fall back below as the only source of a name.
+		output = root->fallback_output;
+	}
 	if (!output) {
 		return NULL;
 	}


### PR DESCRIPTION
select_workspace() aborts the compositor with "Expected to find a workspace" when a view maps and nothing focusable exists. The comment there assumes the fallback output still holds a workspace once the last real output is gone, but output_evacuate() destroys an evacuated workspace when it is empty, so losing the last output with no windows open leaves the tree without a workspace anywhere. The next client to map a window then takes the whole session down.

Create a workspace on the fallback output instead, which is what that comment already claimed happens. workspace_next_name() has to learn about the fallback output for this: it resolves names through output_by_name_or_id(), which searches only root->outputs, so it returned NULL for the fallback output and workspace_create() tripped its own assert on the NULL name.

Reproduced with `WLR_BACKENDS=headless sway`, `swaymsg output HEADLESS-1 disable` and then starting any client. Re-enabling the output afterwards migrates the workspace and its window back onto it.

References: https://github.com/swaywm/sway/issues/8811