### PR TITLE
feat(cli): add --security-context-allow

### DIFF
--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -26,6 +26,8 @@ struct sway_session_lock {
 
 struct sway_server {
 	struct wl_display *wl_display;
+	// Allowlisted privileged globals sandboxed clients may bind.
+	list_t *security_context_allows;
 	struct wl_event_loop *wl_event_loop;
 	char *socket;
 
@@ -166,6 +168,8 @@ extern struct sway_debug debug;
 extern bool unsupported_gpu_detected;
 
 void sway_terminate(int exit_code);
+
+bool server_add_security_context_allow(const char *arg);
 
 bool server_init(struct sway_server *server);
 void server_fini(struct sway_server *server);

--- a/sway/main.c
+++ b/sway/main.c
@@ -209,6 +209,7 @@ static const struct option long_options[] = {
 	{"verbose", no_argument, NULL, 'V'},
 	{"get-socketpath", no_argument, NULL, 'p'},
 	{"unsupported-gpu", no_argument, NULL, 'u'},
+	{"security-context-allow", required_argument, NULL, 'S'},
 	{0, 0, 0, 0}
 };
 
@@ -222,6 +223,8 @@ static const char usage[] =
 	"  -v, --version          Show the version number and quit.\n"
 	"  -V, --verbose          Enables more verbose logging.\n"
 	"      --get-socketpath   Gets the IPC socket path and prints it, then exits.\n"
+	"      --security-context-allow <app_id>:<protocol>[,<protocol>...]\n"
+	"                         Let a sandboxed app id bind privileged globals.\n"
 	"\n";
 
 int main(int argc, char **argv) {
@@ -256,6 +259,11 @@ int main(int argc, char **argv) {
 			break;
 		case 'u':
 			allow_unsupported_gpu = true;
+			break;
+		case 'S': // security-context-allow
+			if (!server_add_security_context_allow(optarg)) {
+				exit(EXIT_FAILURE);
+			}
 			break;
 		case 'v': // version
 			printf("sway version " SWAY_VERSION "\n");

--- a/sway/server.c
+++ b/sway/server.c
@@ -131,6 +131,91 @@ static bool is_privileged(const struct wl_global *global) {
 		global == server.workspace_manager_v1->global;
 }
 
+struct security_context_allow {
+	char *app_id;
+	char *protocol;
+};
+
+static void security_context_allow_destroy(
+		struct security_context_allow *rule) {
+	if (rule == NULL) {
+		return;
+	}
+	free(rule->app_id);
+	free(rule->protocol);
+	free(rule);
+}
+
+bool server_add_security_context_allow(const char *arg) {
+	const char *colon = strchr(arg, ':');
+	if (colon == NULL || colon == arg || colon[1] == '\0') {
+		sway_log(SWAY_ERROR, "Invalid --security-context-allow \"%s\": "
+			"expected <app_id>:<protocol>[,<protocol>...]", arg);
+		return false;
+	}
+
+	size_t app_id_len = colon - arg;
+	if (app_id_len == 1 && arg[0] == '*') {
+		sway_log(SWAY_ERROR, "Invalid --security-context-allow \"%s\": "
+			"wildcards are not supported", arg);
+		return false;
+	}
+
+	if (server.security_context_allows == NULL) {
+		server.security_context_allows = create_list();
+		if (server.security_context_allows == NULL) {
+			return false;
+		}
+	}
+
+	const char *proto = colon + 1;
+	while (proto != NULL) {
+		const char *comma = strchr(proto, ',');
+		size_t len = comma != NULL ? (size_t)(comma - proto) : strlen(proto);
+		if (len == 0) {
+			sway_log(SWAY_ERROR, "Invalid --security-context-allow \"%s\": "
+				"empty protocol name", arg);
+			return false;
+		}
+		struct security_context_allow *rule =
+			calloc(1, sizeof(struct security_context_allow));
+		if (rule == NULL) {
+			return false;
+		}
+		rule->app_id = strndup(arg, app_id_len);
+		rule->protocol = strndup(proto, len);
+		if (rule->app_id == NULL || rule->protocol == NULL) {
+			security_context_allow_destroy(rule);
+			return false;
+		}
+		list_add(server.security_context_allows, rule);
+		sway_log(SWAY_DEBUG, "Allowing app id \"%s\" to bind %s",
+			rule->app_id, rule->protocol);
+		proto = comma != NULL ? comma + 1 : NULL;
+	}
+
+	return true;
+}
+
+static bool security_context_allows_global(
+		const struct wlr_security_context_v1_state *security_context,
+		const struct wl_global *global) {
+	if (server.security_context_allows == NULL ||
+			security_context->app_id == NULL) {
+		return false;
+	}
+	const char *protocol = wl_global_get_interface(global)->name;
+	for (int i = 0; i < server.security_context_allows->length; i++) {
+		struct security_context_allow *rule =
+			server.security_context_allows->items[i];
+		if (strcmp(rule->app_id, security_context->app_id) == 0 &&
+				strcmp(rule->protocol, protocol) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static bool filter_global(const struct wl_client *client,
 		const struct wl_global *global, void *data) {
 #if WLR_HAS_XWAYLAND
@@ -140,13 +225,14 @@ static bool filter_global(const struct wl_client *client,
 	}
 #endif
 
-	// Restrict usage of privileged protocols to unsandboxed clients
-	// TODO: add a way for users to configure an allow-list
+	// Restrict usage of privileged protocols to unsandboxed clients,
+	// except where --security-context-allow names the app id
 	const struct wlr_security_context_v1_state *security_context =
 		wlr_security_context_manager_v1_lookup_client(
 		server.security_context_manager_v1, (struct wl_client *)client);
 	if (is_privileged(global)) {
-		return security_context == NULL;
+		return security_context == NULL ||
+			security_context_allows_global(security_context, global);
 	}
 
 	return true;
@@ -755,6 +841,13 @@ void server_fini(struct sway_server *server) {
 	wlr_backend_destroy(server->backend);
 	wl_display_destroy(server->wl_display);
 	list_free(server->dirty_nodes);
+	if (server->security_context_allows != NULL) {
+		for (int i = 0; i < server->security_context_allows->length; i++) {
+			security_context_allow_destroy(
+				server->security_context_allows->items[i]);
+		}
+		list_free(server->security_context_allows);
+	}
 	free(server->socket);
 }
 

--- a/sway/sway.1.scd
+++ b/sway/sway.1.scd
@@ -28,6 +28,11 @@ sway - An i3-compatible Wayland compositor
 *-V, --verbose*
 	Enables more verbose logging.
 
+*--security-context-allow* <app_id>:<protocol>[,<protocol>...]
+	Permit sandboxed clients whose security context is <app_id>
+	to bind the named Wayland <protocol>, which are otherwise
+	hidden from sandboxed clients.
+
 *--get-socketpath*
 	Gets the IPC socket path and prints it, then exits.
 


### PR DESCRIPTION
`filter_global()` hides privileged globals from clients that connect through a wp_security_context_manager_v1 listener. 

This PR allows for user-defined exceptions to that via CLI arg:

    sway --security-context-allow <app_id>:<protocol>[,<protocol>...]

The app ID must be exact, and currently there is no wildcard support. The flag may be specified repeatedly.

`is_privileged()` is unchanged, so behaviour without the flag is identical to before.


## Background:

This is related to https://github.com/swaywm/sway/issues/2333.

I noticed this first with Wine's `wayland` driver via a Flatpak-sandboxed app. Wine supports an env var, `WAYLANDDRV_PRIMARY_MONITOR`, which allows you to override what the `wayland` driver uses as the primary display via displayname, which is useful in cases where the built-in display ordering heuristic isn't reliable, or changes.

However, under Sway+Flatpak, this env var (e.g. `WAYLANDDRV_PRIMARY_MONITOR=DP-2` in my case) silently fails to work, because the Wayland socket handed to sandboxed apps filters out, among others, [zxdg_output_v1](https://wayland.app/protocols/xdg-output-unstable-v1#zxdg_output_v1), which is how the Wine `wayland` driver matches and selects display names.

You can observe this from the Wine debug output by running Wine from a Flatpak process with the wayland driver and `WINEDEBUG=+waylanddrv`

Running Wine outside the Flatpak doesn't have this issue, because the socket is then considered "unsandboxed" and Sway filters out none of the protocols.

I noticed that Sway has a TODO around the sandbox protocol filtering, and offers no way for a user to customize the filtering with any sort of explicit allowlisting.

`zxdg_output_v1` is a purely read-only protocol so I don't personally view it as a security risk to enable, but I understand that it does leak display positioning info to clients, and there may be good reasons for being parsimonious with it by default for sandboxed apps, so I added a `--security-context-allow` CLI flag to enable allowlisting specific protocols for sandboxed apps by appID.

Ex: `sway --security-context-allow com.heroicgameslauncher.hgl:zxdg_output_manager_v1`

With this, Wine and the `WAYLANDDRV_PRIMARY_MONITOR=DP-2` override work correctly under Flatpak, so it seems a decent compromise for now if you want to allowlist a blocked protocol for a sandboxed app, and one that requires explicit per-app opt-in by the user.

I looked at possibly doing this via Sway config instead, which would be admittedly more convenient than a CLI flag, but that is a bit trickier, since you cannot really dynamically remove protocols from a socket that has an active client, so I stopped here.

