### PR TITLE
sway/server: scene-based output image capture

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -43,6 +43,8 @@ struct sway_output {
 	struct sway_server *server;
 	struct wl_list link;
 
+	struct wlr_ext_image_capture_source_v1 *image_capture_source;
+
 	struct wlr_box usable_area;
 
 	int lx, ly; // layout coords

--- a/include/sway/server.h
+++ b/include/sway/server.h
@@ -112,6 +112,9 @@ struct sway_server {
 	struct wlr_export_dmabuf_manager_v1 *export_dmabuf_manager_v1;
 	struct wlr_security_context_manager_v1 *security_context_manager_v1;
 
+	struct wlr_ext_output_image_capture_source_manager_v1 *ext_output_image_capture_source_manager_v1;
+	struct wl_listener new_output_capture_request;
+
 	struct wlr_ext_foreign_toplevel_image_capture_source_manager_v1 *ext_foreign_toplevel_image_capture_source_manager_v1;
 	struct wl_listener new_foreign_toplevel_capture_request;
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -149,12 +149,14 @@ static void send_frame_done_iterator(struct wlr_scene_buffer *buffer,
 	struct sway_output *output = data->output;
 	int view_max_render_time = 0;
 
-	if (buffer->primary_output != data->output->scene_output) {
+	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
+	if (scene_surface == NULL) {
 		return;
 	}
 
-	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
-	if (scene_surface == NULL) {
+	struct wlr_output *pacing_output = wlr_surface_get_frame_pacing_output(
+		scene_surface->surface);
+	if (pacing_output != data->output->wlr_output) {
 		return;
 	}
 

--- a/sway/server.c
+++ b/sway/server.c
@@ -243,6 +243,19 @@ static void handle_new_foreign_toplevel_capture_request(struct wl_listener *list
 	wlr_ext_foreign_toplevel_image_capture_source_manager_v1_request_accept(request, view->image_capture_source);
 }
 
+static void handle_new_output_capture_request(struct wl_listener *listener, void *data) {
+	struct wlr_ext_output_image_capture_source_manager_v1_request_event *request = data;
+
+	struct wlr_ext_image_capture_source_v1 *source =
+		wlr_ext_image_capture_source_v1_create_with_raw_output(request->output);
+	if (source == NULL) {
+		wl_client_post_no_memory(request->client);
+		return;
+	}
+
+	wlr_ext_output_image_capture_source_manager_v1_request_accept(request, source);
+}
+
 bool server_init(struct sway_server *server) {
 	sway_log(SWAY_DEBUG, "Initializing Wayland server");
 	server->wl_display = wl_display_create();
@@ -518,10 +531,6 @@ bool server_init(struct sway_server *server) {
 		sway_log(SWAY_ERROR, "Failed to create ext image copy capture manager");
 		return false;
 	}
-	if (!wlr_ext_output_image_capture_source_manager_v1_create(server->wl_display, 1)) {
-		sway_log(SWAY_ERROR, "Failed to create ext output image capture source manager");
-		return false;
-	}
 	server->wlr_data_control_manager_v1 = wlr_data_control_manager_v1_create(server->wl_display);
 	if (!server->wlr_data_control_manager_v1) {
 		sway_log(SWAY_ERROR, "Failed to create data control manager");
@@ -555,6 +564,15 @@ bool server_init(struct sway_server *server) {
 		sway_log(SWAY_ERROR, "Failed to create fractional scale manager");
 		return false;
 	}
+
+	server->ext_output_image_capture_source_manager_v1 = wlr_ext_output_image_capture_source_manager_v1_create(server->wl_display, 1);
+	if (!server->ext_output_image_capture_source_manager_v1) {
+		sway_log(SWAY_ERROR, "Failed to create ext output image capture source manager");
+		return false;
+	}
+	server->new_output_capture_request.notify = handle_new_output_capture_request;
+	wl_signal_add(&server->ext_output_image_capture_source_manager_v1->events.capture_request,
+		&server->new_output_capture_request);
 
 	server->ext_foreign_toplevel_image_capture_source_manager_v1 =
 		wlr_ext_foreign_toplevel_image_capture_source_manager_v1_create(server->wl_display, 1);
@@ -739,6 +757,7 @@ void server_fini(struct sway_server *server) {
 	wl_list_remove(&server->xdg_activation_v1_new_token.link);
 	wl_list_remove(&server->xdg_toplevel_tag_manager_v1_set_tag.link);
 	wl_list_remove(&server->request_set_cursor_shape.link);
+	wl_list_remove(&server->new_output_capture_request.link);
 	wl_list_remove(&server->new_foreign_toplevel_capture_request.link);
 	wl_list_remove(&server->workspace_manager_v1_commit.link);
 	input_manager_finish(server->input);

--- a/sway/server.c
+++ b/sway/server.c
@@ -245,15 +245,29 @@ static void handle_new_foreign_toplevel_capture_request(struct wl_listener *list
 
 static void handle_new_output_capture_request(struct wl_listener *listener, void *data) {
 	struct wlr_ext_output_image_capture_source_manager_v1_request_event *request = data;
+	struct sway_output *output = request->output->data;
 
-	struct wlr_ext_image_capture_source_v1 *source =
-		wlr_ext_image_capture_source_v1_create_with_raw_output(request->output);
-	if (source == NULL) {
-		wl_client_post_no_memory(request->client);
-		return;
+	if (output->image_capture_source == NULL) {
+		// We can't know if the gamma_control_manager_v1 shader fallback will get used
+		// during the capture
+		bool color_management = server.renderer->features.output_color_transform;
+
+		struct wlr_ext_image_capture_source_v1 *source;
+		if (color_management) {
+			source = wlr_ext_image_capture_source_v1_create_with_scene_output(root->root_scene,
+				request->output, root->output_layout);
+		} else {
+			source = wlr_ext_image_capture_source_v1_create_with_raw_output(request->output);
+		}
+		if (source == NULL) {
+			wl_client_post_no_memory(request->client);
+			return;
+		}
+		output->image_capture_source = source;
 	}
 
-	wlr_ext_output_image_capture_source_manager_v1_request_accept(request, source);
+	wlr_ext_output_image_capture_source_manager_v1_request_accept(request,
+		output->image_capture_source);
 }
 
 bool server_init(struct sway_server *server) {


### PR DESCRIPTION
Draft because this depends on https://github.com/swaywm/sway/pull/9208 and https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5443

Uses a virtual output for screen capture, which is unaffected by the color management parameters of the real output

Related issues: https://github.com/swaywm/sway/issues/9136, https://github.com/swaywm/sway/issues/9141

About keeping using raw capture when possible : it is just for sports, to use the flexibility of https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5411. I have no data comparing the speeds of the two methods

Scene capture currently lacks pointer sessions