### PR TITLE
config/output: update output manager configuration on commit failure

### DIFF
--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -697,7 +697,7 @@ struct output_config *new_output_config(const char *name);
 bool apply_output_configs(struct output_config **ocs, size_t ocs_len,
 		bool test_only, bool degrade_to_off);
 
-void apply_stored_output_configs(void);
+bool apply_stored_output_configs(void);
 
 /**
  * store_output_config stores a new output config. An output may be matched by

--- a/sway/config/output.c
+++ b/sway/config/output.c
@@ -1152,8 +1152,8 @@ bool apply_output_configs(struct output_config **ocs, size_t ocs_len,
 	return ok;
 }
 
-void apply_stored_output_configs(void) {
-	apply_output_configs((struct output_config **)config->output_configs->items,
+bool apply_stored_output_configs(void) {
+	return apply_output_configs((struct output_config **)config->output_configs->items,
 			config->output_configs->length, false, true);
 }
 

--- a/sway/desktop/output.c
+++ b/sway/desktop/output.c
@@ -404,7 +404,12 @@ static int timer_modeset_handle(void *data) {
 	wl_event_source_remove(server->delayed_modeset);
 	server->delayed_modeset = NULL;
 
-	apply_stored_output_configs();
+	if (!apply_stored_output_configs()) {
+		// If applying output config fails, update output manager state so
+		// clients are notified of added/removed heads. On success, this
+		// is already handled in apply_resolved_output_configs().
+		update_output_manager_config(server);
+	}
 	return 0;
 }
 
@@ -425,7 +430,9 @@ void force_modeset(void) {
 		wl_event_source_remove(server.delayed_modeset);
 		server.delayed_modeset = NULL;
 	}
-	apply_stored_output_configs();
+	if (!apply_stored_output_configs()) {
+		update_output_manager_config(&server);
+	}
 }
 
 static void begin_destroy(struct sway_output *output) {


### PR DESCRIPTION
Ensure output manager clients (like kanshi) are notified of output changes even if applying the configuration fails.

This fixes a bug I was seeing where sometimes when unplugging from my dock (with two external screens) a commit would fail and kanshi wouldn't get the event to trigger an output reconfigure. So my laptop's built-in screen would never get enabled. I could still SSH into the laptop and send kanshi `SIGHUP` to recover. Logs looked like this:

```
00:01:38.306 [DEBUG] [wlr] [backend/session/session.c:189] udev event for card0 (change)
00:01:38.307 [DEBUG] [wlr] [backend/session/session.c:222] DRM device card0 changed
00:01:38.307 [DEBUG] [wlr] [backend/drm/backend.c:139] Received hotplug event for /dev/dri/card0
00:01:38.307 [INFO] [wlr] [backend/drm/drm.c:1779] Scanning DRM connector 459 on /dev/dri/card0
00:01:38.307 [INFO] [wlr] [backend/drm/drm.c:1890] 'DP-12' disappeared
00:01:38.309 [DEBUG] [wlr] [backend/session/session.c:189] udev event for card0-DP-10 (remove)
00:01:38.310 [DEBUG] [wlr] [backend/session/session.c:189] udev event for card0-DP-12 (remove)
00:01:38.312 [DEBUG] [wlr] [backend/session/session.c:189] udev event for card0 (change)
00:01:38.312 [DEBUG] [wlr] [backend/session/session.c:222] DRM device card0 changed
00:01:38.312 [DEBUG] [wlr] [backend/drm/backend.c:139] Received hotplug event for /dev/dri/card0
00:01:38.312 [INFO] [wlr] [backend/drm/drm.c:1782] Scanning DRM connectors on /dev/dri/card0
00:01:38.313 [INFO] [wlr] [backend/drm/drm.c:1871] 'DP-10' disconnected
00:01:38.314 [DEBUG] [sway/tree/output.c:288] Disabling output 'DP-10'
00:01:38.314 [DEBUG] [sway/ipc-server.c:300] Sending workspace::move event
00:01:38.314 [DEBUG] [sway/tree/workspace.c:300] Destroying workspace '3'
00:01:38.314 [DEBUG] [sway/ipc-server.c:300] Sending workspace::empty event
00:01:38.314 [DEBUG] [sway/tree/output.c:305] Destroying output 'DP-10'
00:01:38.319 [DEBUG] [wlr] [backend/drm/drm.c:1378] connector DP-10: De-allocating CRTC 428
00:01:38.319 [INFO] [wlr] [backend/drm/drm.c:985] connector DP-10: Turning off
00:01:38.475 [INFO] [wlr] [backend/drm/drm.c:1871] 'DP-13' disconnected
00:01:38.475 [DEBUG] [sway/tree/output.c:288] Disabling output 'DP-13'
00:01:38.475 [DEBUG] [sway/ipc-server.c:300] Sending workspace::move event
00:01:38.475 [DEBUG] [sway/tree/output.c:305] Destroying output 'DP-13'
00:01:38.479 [DEBUG] [wlr] [backend/drm/drm.c:1378] connector DP-13: De-allocating CRTC 432
00:01:38.479 [INFO] [wlr] [backend/drm/drm.c:985] connector DP-13: Turning off
2026-09-07 16:04:18 - [main.c:251] Destroying output DP-10 (Samsung Electric Company LU28R55 H4ZR801088)
2026-09-07 16:04:18 - [main.c:251] Destroying output DP-13 (Samsung Electric Company LU28R55 H4ZMB00199)
00:01:38.633 [DEBUG] [sway/config/output.c:1008] Committing 1 outputs
00:01:38.633 [DEBUG] [sway/config/output.c:769] Output state for eDP-1
00:01:38.633 [DEBUG] [sway/config/output.c:771]     enabled:       no
00:01:38.633 [DEBUG] [wlr] [types/wlr_output_swapchain_manager.c:164] Preparing test commit for 1 outputs with explicit modifiers
00:01:38.633 [DEBUG] [wlr] [types/wlr_output_swapchain_manager.c:185] Test commit for 1 outputs succeeded
00:01:38.633 [ERROR] [wlr] [backend/drm/atomic.c:83] connector eDP-1: Atomic commit failed: Invalid argument
00:01:38.633 [DEBUG] [wlr] [backend/drm/atomic.c:88] (Atomic commit flags: PAGE_FLIP_EVENT | ATOMIC_ALLOW_MODESET)
00:01:38.633 [ERROR] [sway/config/output.c:1068] Backend commit failed
```

I've tested this manually by plugging/unplugging the dock several times and it _seems_ to have fixed the problem. kanshi now receives the output event and reliably enables the built-in laptop screen on dock unplug even after a commit failure.

I think the change makes sense, since as I understand it output state change should not be coupled to commit success?