### PR TITLE
tree/workspace: update workspace status on changing outputs

### DIFF
--- a/sway/tree/output.c
+++ b/sway/tree/output.c
@@ -335,12 +335,22 @@ void output_add_workspace(struct sway_output *output,
 	if (workspace->output) {
 		workspace_detach(workspace);
 	}
+
+	struct sway_workspace *old_active = output_get_active_workspace(output);
 	list_add(output->workspaces, workspace);
 	workspace->output = output;
 	if (workspace->output && workspace->output->ext_workspace_group) {
 		wlr_ext_workspace_handle_v1_set_group(workspace->ext_workspace,
 			workspace->output->ext_workspace_group);
 	}
+
+	struct sway_workspace *new_active = output_get_active_workspace(output);
+	if (old_active && old_active != new_active) {
+		wlr_ext_workspace_handle_v1_set_active(old_active->ext_workspace, false);
+	}
+	wlr_ext_workspace_handle_v1_set_active(workspace->ext_workspace,
+		workspace == new_active);
+
 	node_set_dirty(&output->node);
 	node_set_dirty(&workspace->node);
 }

--- a/sway/tree/workspace.c
+++ b/sway/tree/workspace.c
@@ -932,6 +932,11 @@ void workspace_detach(struct sway_workspace *workspace) {
 	}
 	workspace->output = NULL;
 
+	struct sway_workspace *new_active = output_get_active_workspace(output);
+	if (new_active) {
+		wlr_ext_workspace_handle_v1_set_active(new_active->ext_workspace, true);
+	}
+
 	node_set_dirty(&workspace->node);
 	node_set_dirty(&output->node);
 }


### PR DESCRIPTION
There are two cases when sway does not update ext-workspace-v1 status:
1. Disabling an output.
2. Moving a workspace to another output (e.g. with the `move workspace output` command).

In case 1, all workspaces from the disabled output should move to an enabled output as inactive, unless the new output has an empty workspace.

In case 2, the focused workspace should move to the new output and remain active, making the previous active workspace inactive.

Both cases can be fixed by comparing the current active workspaces of the old and new outputs.